### PR TITLE
feat(p204): V4 graph invariants for volunteer authority (#180)

### DIFF
--- a/.claude/agents/platform-guardian.md
+++ b/.claude/agents/platform-guardian.md
@@ -20,7 +20,7 @@ Predecessor: `refactor-guardian.md` (LEGACY — cobria apenas V4 em curso). Para
 
 ## Invariantes que NUNCA podem ser violados
 
-1. **`check_schema_invariants()` retorna 16 invariantes em 0 violations** (A1/A2/A3/B/C/D/E/F/J/K/L/M/N/O/P/Q — Q added p170 via VEP→engagement FK hardening). Se alguma ≠ 0, **BLOQUEIE** — significa drift silenciosa em produção.
+1. **`check_schema_invariants()` retorna 18 invariantes em 0 violations** (A1/A2/A3/B/C/D/E/F/J/K/L/M/N/O/P/Q/R/S — R+S added p204 via Issue #180 V4 graph hardening: approved app→member, approved member→person_id). Q added p170 via VEP→engagement FK hardening. Se alguma ≠ 0, **BLOQUEIE** — significa drift silenciosa em produção.
 2. **`npm test` passa em 100%** (baseline atual offline: 1449 pass, 0 fail, 46 skipped; DB-aware: ~1501 pass, 0 fail, 5 skipped — fonte: deploy/session audit p198-p201)
 3. **`npx astro build` passa sem novos erros**
 4. **Nenhuma RPC nova (migration ≥ 20260424040000) usa role list hardcoded** — deve usar `can()`/`can_by_member()`/`rls_can()` (ADR-0011). Contract test `tests/contracts/rpc-v4-auth.test.mjs` enforça.
@@ -34,7 +34,7 @@ Se qualquer invariante ≠ OK, **pare e reporte imediatamente**.
 
 ### 1. Live DB invariants (crítico)
 - Via MCP `execute_sql`: `SELECT * FROM public.check_schema_invariants() ORDER BY invariant_name;`
-- Esperado: 16 rows, violation_count = 0 em todas.
+- Esperado: 18 rows, violation_count = 0 em todas (16 original A1-Q + R/S added p204).
 - Se qualquer > 0, reportar invariant_name, severity, sample_ids; NÃO tentar corrigir sem decisão humana
 - Atalho: skill `/invariants` roda a verificação e interpreta o resultado
 

--- a/supabase/migrations/20260727000000_p204_issue_180_volunteer_authority_invariants.sql
+++ b/supabase/migrations/20260727000000_p204_issue_180_volunteer_authority_invariants.sql
@@ -1,0 +1,354 @@
+-- p204 / Issue #180 — V4 graph invariants for volunteer authority
+--
+-- INTENT
+-- ──────
+-- Extend `check_schema_invariants()` from 16 → 18 invariants by adding two
+-- gates that prevent silent V4-graph drift in the volunteer approval path:
+--
+--   R_approved_application_has_member
+--     status='approved' applications MUST have a matching `members` row
+--     (case-insensitive email). Today: 0 violations (36 approved, all matched).
+--     status='converted' is INTENTIONALLY scoped out — that status reflects
+--     a dual-track conversion offer (researcher → leader); it is a stateful
+--     intermediate not an authority assertion. The single converted-without-
+--     member case in production (Adalberto Neris, application
+--     eb9c4795-5a75-4184-83c0-318bace1a1b5) has `conversion_reason =
+--     'Aplicou como pesquisador e líder, convertido mas não ativo'` —
+--     explicit non-active state, documented in the row.
+--
+--   S_approved_member_has_person_id
+--     Members tied to an approved application MUST have `person_id NOT NULL`.
+--     Today: 0 violations (all 36 approved members are V4-linked).
+--
+-- Both invariants are forward-defenses against the regression that #179's
+-- canonical RPC (`approve_selection_application`) is designed to prevent.
+-- If a future code path bypasses the canonical RPC and creates an approved
+-- application without orchestrating member/person, R + S will surface it
+-- in the next invariant audit (boot + close per platform-guardian).
+--
+-- HERLON-CLASS INVARIANT (out-of-scope, computed at view level)
+-- ─────────────────────
+-- "Approved volunteers stay non-authoritative until counter-signature" is
+-- ALREADY enforced by `auth_engagements.is_authoritative` — a COMPUTED column
+-- in the view that requires either `agreement_certificate_id NOT NULL` OR
+-- `kind.requires_agreement = false`. No table-level invariant needed; the
+-- view definition is the contract.
+--
+-- ROLLBACK
+-- ────────
+-- CREATE OR REPLACE FUNCTION public.check_schema_invariants() — restore
+-- prior 16-invariant body (capture via pg_get_functiondef before merge).
+-- Tests in `tests/contracts/volunteer-authority-invariants.test.mjs` will
+-- start failing if R or S are removed without replacement.
+-- ─────────────────────────────────────────────────────────────────────────────
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.check_schema_invariants()
+ RETURNS TABLE(invariant_name text, description text, severity text, violation_count integer, sample_ids uuid[])
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL
+     AND current_setting('role', true) NOT IN ('service_role', 'postgres')
+     AND current_user NOT IN ('postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'Unauthorized: check_schema_invariants requires authentication';
+  END IF;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'alumni' AND operational_role IS DISTINCT FROM 'alumni'
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'A1_alumni_role_consistency'::text,
+         'member_status=alumni must coerce operational_role=alumni (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'observer' AND operational_role NOT IN ('observer','guest','none')
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'A2_observer_role_consistency'::text,
+         'member_status=observer must coerce operational_role IN (observer,guest,none) (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH computed AS (
+    SELECT m.id AS member_id,
+      CASE
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'co_gp')          THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'deputy_manager') THEN 'deputy_manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+        WHEN bool_or(
+          (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+          OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+              AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+          OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+              AND ae.role IN ('leader','co_leader','owner','coordinator'))
+        ) THEN 'researcher'
+        WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+        WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+        WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+        WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+        WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+        WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+        ELSE 'guest'
+      END AS expected_role
+    FROM public.members m
+    LEFT JOIN public.auth_engagements ae ON ae.person_id = m.person_id AND ae.is_authoritative = true
+    WHERE m.member_status='active' AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT c.member_id FROM computed c
+    JOIN public.members m ON m.id = c.member_id
+    WHERE m.operational_role IS DISTINCT FROM c.expected_role
+  )
+  SELECT 'A3_active_role_engagement_derivation'::text,
+         'active member operational_role must equal priority-ladder derivation from active engagements (cache trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE ((member_status='active' AND is_active=false) OR (member_status IN ('observer','alumni','inactive') AND is_active=true))
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'B_is_active_status_mismatch'::text,
+         'members.is_active must match member_status mapping (active=true, terminal=false)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND designations IS NOT NULL AND array_length(designations,1)>0
+  )
+  SELECT 'C_designations_in_terminal_status'::text,
+         'members.designations must be empty when member_status is observer/alumni/inactive'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    JOIN public.persons p ON p.id = m.person_id
+    WHERE m.auth_id IS NOT NULL AND p.auth_id IS NOT NULL AND m.auth_id IS DISTINCT FROM p.auth_id
+  )
+  SELECT 'D_auth_id_mismatch_person_member'::text,
+         'persons.auth_id and members.auth_id must agree when both are set (ghost resolution sync)'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ae.engagement_id AS e_id FROM public.auth_engagements ae
+    JOIN public.members m ON m.person_id = ae.person_id
+    WHERE ae.status='active' AND m.member_status IN ('observer','alumni','inactive')
+      AND ae.kind NOT IN ('observer','alumni','external_signer','sponsor','chapter_board','partner_contact')
+  )
+  SELECT 'E_engagement_active_with_terminal_member'::text,
+         'engagement.status=active is inconsistent with member.member_status in (observer/alumni/inactive) unless kind matches'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(e_id ORDER BY e_id) FROM (SELECT e_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT i.id AS initiative_id FROM public.initiatives i
+    WHERE i.legacy_tribe_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.tribes t WHERE t.id = i.legacy_tribe_id)
+  )
+  SELECT 'F_initiative_legacy_tribe_orphan'::text,
+         'initiatives.legacy_tribe_id must point to an existing tribe (bridge integrity)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(initiative_id ORDER BY initiative_id) FROM (SELECT initiative_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- J refinement (p173): chain-aware — ignore docs with an open approval_chain
+  -- (status IN review/approved/activated AND closed_at IS NULL). The chain
+  -- close trigger will lock the version; mid-flight docs are correctly
+  -- pointing at unlocked versions.
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    LEFT JOIN public.document_versions dv ON dv.id = gd.current_version_id
+    WHERE gd.current_version_id IS NOT NULL
+      AND (dv.id IS NULL OR dv.locked_at IS NULL)
+      AND NOT EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status IN ('review','approved','activated')
+          AND ac.closed_at IS NULL
+      )
+  )
+  SELECT 'J_current_version_published'::text,
+         'governance_documents.current_version_id must point to a document_versions row with locked_at IS NOT NULL — unless an open approval_chain (review/approved/activated, closed_at NULL) is in flight that will lock the version on close (Phase IP-1, chain-aware).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.operational_role='external_signer'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.auth_engagements ae
+        WHERE ae.person_id=m.person_id AND ae.kind='external_signer' AND ae.status='active' AND ae.is_authoritative=true
+      )
+  )
+  SELECT 'K_external_signer_integrity'::text,
+         'members.operational_role=external_signer must have an active auth_engagements row with kind=external_signer (Phase IP-1).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.member_status IN ('alumni','observer','inactive') AND m.anonymized_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM public.member_offboarding_records r WHERE r.member_id=m.id)
+  )
+  SELECT 'L_offboarding_record_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have a member_offboarding_records row (#91 G3 trigger).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH expected AS (
+    SELECT a.id AS application_id, a.research_score AS cached,
+      CASE
+        WHEN e.obj_avg IS NOT NULL AND e.int_avg IS NOT NULL THEN round(e.obj_avg + e.int_avg, 2)
+        WHEN e.obj_avg IS NOT NULL THEN round(e.obj_avg, 2)
+        ELSE NULL
+      END AS expected
+    FROM public.selection_applications a
+    CROSS JOIN LATERAL (
+      SELECT AVG(weighted_subtotal) FILTER (WHERE evaluation_type='objective' AND submitted_at IS NOT NULL) AS obj_avg,
+        AVG(weighted_subtotal) FILTER (WHERE evaluation_type='interview' AND submitted_at IS NOT NULL) AS int_avg
+      FROM public.selection_evaluations WHERE application_id=a.id
+    ) e
+  ),
+  drift AS (
+    SELECT application_id FROM expected
+    WHERE (cached IS NULL) IS DISTINCT FROM (expected IS NULL)
+       OR (cached IS NOT NULL AND expected IS NOT NULL AND ABS(cached - expected) > 0.01)
+  )
+  SELECT 'M_application_score_consistency'::text,
+         'selection_applications.research_score must equal compute_application_scores(application_id) derivation (sync trigger trg_recompute_application_scores).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive')
+      AND offboarded_at IS NULL AND anonymized_at IS NULL
+      AND name <> 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'N_terminal_status_offboarded_at_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have offboarded_at NOT NULL (ARM-9 G6 defense-in-depth complement to L).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ma.id AS artifact_id FROM public.meeting_artifacts ma
+    WHERE ma.event_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.id = ma.event_id)
+  )
+  SELECT 'O_meeting_artifact_event_orphan'::text,
+         'meeting_artifacts.event_id must point to an existing event when not NULL (FK defense).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(artifact_id ORDER BY artifact_id) FROM (SELECT artifact_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  SELECT 'P_tribe_initiative_bridge_complete'::text,
+         'tribes.is_active=true must have at least one initiative.legacy_tribe_id pointing to it (V3-V4 bridge; cron leader digest depends).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM public.tribes t
+          WHERE t.is_active = true
+            AND NOT EXISTS (SELECT 1 FROM public.initiatives i WHERE i.legacy_tribe_id = t.id)),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS engagement_id FROM public.engagements
+    WHERE status = 'expired' AND end_date > CURRENT_DATE
+  )
+  SELECT 'Q_expired_engagement_end_date'::text,
+         'engagements.status=expired requires end_date <= CURRENT_DATE (impossible to be expired in the future; VEP service_latest_end_date is source of truth).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- ─────────────────────────────────────────────────────────────────────────
+  -- R (p204, #180): Approved application must have matching members row.
+  -- Status='converted' is intentionally NOT included — converted reflects a
+  -- dual-track conversion offer (e.g., researcher → leader), which may not
+  -- have been accepted. Production: 36 approved (0 missing) + 2 converted (1
+  -- intentional non-active state). Forward-defense vs. bypassing the canonical
+  -- approve_selection_application() RPC (Issue #179).
+  -- ─────────────────────────────────────────────────────────────────────────
+  RETURN QUERY
+  WITH drift AS (
+    SELECT a.id AS application_id
+    FROM public.selection_applications a
+    WHERE a.status = 'approved'
+      AND a.email IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.members m WHERE lower(m.email) = lower(a.email)
+      )
+  )
+  SELECT 'R_approved_application_has_member'::text,
+         'selection_applications.status=approved must have a matching members row by lower(email). Bypass of approve_selection_application() canonical RPC creates this drift (Issue #180).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- ─────────────────────────────────────────────────────────────────────────
+  -- S (p204, #180): Approved members must have person_id (V4 graph anchor).
+  -- The canonical RPC always links person_id post-approval; any approved member
+  -- without person_id indicates a legacy/manual creation path that skipped V4.
+  -- ─────────────────────────────────────────────────────────────────────────
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id
+    FROM public.selection_applications a
+    JOIN public.members m ON lower(m.email) = lower(a.email)
+    WHERE a.status = 'approved' AND m.person_id IS NULL
+  )
+  SELECT 'S_approved_member_has_person_id'::text,
+         'members tied to an approved selection_applications row must have person_id NOT NULL (V4 graph anchor for engagements). Issue #180.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+END;
+$function$;
+
+COMMENT ON FUNCTION public.check_schema_invariants() IS
+'18 schema invariants (A1-A3, B-F, J-Q, R, S — last extended p204 Issue #180). R + S enforce V4 graph integrity for the volunteer selection path: every approved application must have a member, every approved member must have person_id. Forward-defense vs. bypass of approve_selection_application() canonical RPC (Issue #179).';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260727000000_p204_issue_180_volunteer_authority_invariants.sql
+++ b/supabase/migrations/20260727000000_p204_issue_180_volunteer_authority_invariants.sql
@@ -329,10 +329,13 @@ BEGIN
   -- S (p204, #180): Approved members must have person_id (V4 graph anchor).
   -- The canonical RPC always links person_id post-approval; any approved member
   -- without person_id indicates a legacy/manual creation path that skipped V4.
+  --
+  -- Council fix: DISTINCT in drift CTE — a member with multiple approved
+  -- applications across cycles would otherwise be counted N times.
   -- ─────────────────────────────────────────────────────────────────────────
   RETURN QUERY
   WITH drift AS (
-    SELECT m.id AS member_id
+    SELECT DISTINCT m.id AS member_id
     FROM public.selection_applications a
     JOIN public.members m ON lower(m.email) = lower(a.email)
     WHERE a.status = 'approved' AND m.person_id IS NULL

--- a/tests/contracts/volunteer-authority-invariants.test.mjs
+++ b/tests/contracts/volunteer-authority-invariants.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Issue #180 / p204 — V4 graph invariants for volunteer authority (static contract)
+ *
+ * Verifies that `check_schema_invariants()` defines TWO new invariants:
+ *   R_approved_application_has_member — status=approved must map to a member row
+ *   S_approved_member_has_person_id   — approved member must be V4-graph-anchored
+ *
+ * Both are forward-defenses against bypass of the canonical
+ * `approve_selection_application()` RPC introduced in Issue #179. Production
+ * baseline at p204 close: both invariants 0 violations.
+ *
+ * Scope note: status='converted' is INTENTIONALLY out-of-scope for R. The 1
+ * converted-without-member case in production (Adalberto Neris) is an explicit
+ * non-active state documented in `conversion_reason`. See migration header.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve, join } from 'node:path';
+
+const ROOT = process.cwd();
+const MIGRATIONS_DIR = resolve(ROOT, 'supabase/migrations');
+
+function loadAllMigrations() {
+  const files = readdirSync(MIGRATIONS_DIR).filter(f => f.endsWith('.sql')).sort();
+  return files.map(f => ({ name: f, content: readFileSync(join(MIGRATIONS_DIR, f), 'utf8') }));
+}
+
+function findFunctionBody(funcName, sql) {
+  const escaped = funcName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const regex = new RegExp(
+    `CREATE\\s+OR\\s+REPLACE\\s+FUNCTION\\s+(?:public\\.)?${escaped}\\s*\\([^)]*\\)[\\s\\S]*?AS\\s+\\$(\\w*)\\$([\\s\\S]*?)\\$\\1\\$`,
+    'gi'
+  );
+  const matches = [...sql.matchAll(regex)];
+  return matches.length > 0 ? matches[matches.length - 1][2] : null;
+}
+
+const migrations = loadAllMigrations();
+const allSQL = migrations.map(m => m.content).join('\n');
+const checkBody = findFunctionBody('check_schema_invariants', allSQL);
+
+// ─── 1. Both new invariants are defined in the latest body ───
+test('check_schema_invariants includes R_approved_application_has_member', () => {
+  assert.ok(checkBody, 'check_schema_invariants function body must be present');
+  assert.ok(/'R_approved_application_has_member'::text/.test(checkBody),
+    'Missing R invariant label. Did the latest migration regress check_schema_invariants?');
+});
+
+test('check_schema_invariants includes S_approved_member_has_person_id', () => {
+  assert.ok(/'S_approved_member_has_person_id'::text/.test(checkBody),
+    'Missing S invariant label');
+});
+
+// Helper: capture the WITH-drift-AS block immediately preceding the labelled SELECT.
+// (Non-greedy regex would match from A1's WITH all the way to R's SELECT, picking up
+// every interim invariant body and breaking scope assertions.)
+function captureInvariantBlock(label) {
+  const labelIdx = checkBody.indexOf(`'${label}'::text`);
+  if (labelIdx < 0) return null;
+  const upToLabel = checkBody.slice(0, labelIdx);
+  const withIdx = upToLabel.lastIndexOf('WITH drift AS (');
+  if (withIdx < 0) return null;
+  return checkBody.slice(withIdx, labelIdx);
+}
+
+// ─── 2. R correctly scopes to status=approved only (NOT converted) ───
+test('R invariant scopes to status=approved only — converted is intentionally excluded', () => {
+  const rWith = captureInvariantBlock('R_approved_application_has_member');
+  assert.ok(rWith, 'R WITH drift block not found');
+  assert.ok(/a\.status\s*=\s*'approved'/.test(rWith),
+    'R must filter on status=\'approved\' (singular, not approved/converted)');
+  assert.ok(!/'converted'/.test(rWith),
+    'R must NOT include status=\'converted\' — that\'s a dual-track conversion offer state, see migration header');
+});
+
+// ─── 3. R uses case-insensitive email lookup ───
+test('R uses lower(email) for case-insensitive member match', () => {
+  const rWith = captureInvariantBlock('R_approved_application_has_member');
+  assert.ok(/lower\(m\.email\)\s*=\s*lower\(a\.email\)/.test(rWith),
+    'R must match by lower(m.email) = lower(a.email)');
+});
+
+// ─── 4. S checks person_id NOT NULL on members of approved applications ───
+test('S checks members.person_id IS NULL for approved members', () => {
+  const sWith = captureInvariantBlock('S_approved_member_has_person_id');
+  assert.ok(sWith, 'S WITH drift block not found');
+  assert.ok(/a\.status\s*=\s*'approved'/.test(sWith),
+    'S must filter applications by status=approved');
+  assert.ok(/m\.person_id IS NULL/.test(sWith),
+    'S must detect person_id IS NULL on the joined member');
+});
+
+// Helper: capture the SELECT projection (label + description + severity) for a labelled invariant
+function captureInvariantSelect(label) {
+  const re = new RegExp(`'${label}'::text,([\\s\\S]+?)FROM drift`);
+  const m = re.exec(checkBody);
+  return m ? m[1] : null;
+}
+
+// ─── 5. Both invariants are 'high' severity (V4 graph integrity is critical) ───
+test('R and S are tagged high severity', () => {
+  const rSel = captureInvariantSelect('R_approved_application_has_member');
+  const sSel = captureInvariantSelect('S_approved_member_has_person_id');
+  assert.ok(/'high'::text/.test(rSel), 'R must be high severity');
+  assert.ok(/'high'::text/.test(sSel), 'S must be high severity');
+});
+
+// ─── 6. Invariants reference Issue #180 in description (auditability) ───
+test('R and S descriptions reference Issue #180 for traceability', () => {
+  const rSel = captureInvariantSelect('R_approved_application_has_member');
+  const sSel = captureInvariantSelect('S_approved_member_has_person_id');
+  assert.ok(/#180/.test(rSel), 'R description must reference Issue #180');
+  assert.ok(/#180/.test(sSel), 'S description must reference Issue #180');
+});
+
+// ─── 7. R description references the canonical RPC from #179 (forward-defense framing) ───
+test('R description names approve_selection_application as the canonical contract being defended', () => {
+  const rSel = captureInvariantSelect('R_approved_application_has_member');
+  assert.ok(/approve_selection_application/.test(rSel),
+    'R must reference approve_selection_application (the canonical RPC it defends)');
+});
+
+// ─── 8. Function COMMENT cites the new count (18 invariants) ───
+test('check_schema_invariants COMMENT cites 18 invariants', () => {
+  // Multiple migrations may COMMENT ON the function; pick the LATEST
+  // (highest-timestamp migration that sets the comment).
+  const commentMatches = [...allSQL.matchAll(/COMMENT ON FUNCTION public\.check_schema_invariants\(\)\s+IS\s+'([^']+)'/g)];
+  assert.ok(commentMatches.length > 0, 'COMMENT ON FUNCTION must be set in some migration');
+  const latest = commentMatches[commentMatches.length - 1];
+  assert.ok(/18 schema invariants/i.test(latest[1]),
+    'Latest COMMENT must reflect the new count (16 → 18); got: ' + latest[1].slice(0, 80));
+  assert.ok(/Issue #180/.test(latest[1]),
+    'Latest COMMENT must reference Issue #180 as the source of R + S');
+});
+
+// ─── 9. Invariant block ordering: R + S come after the original 16 ───
+test('R appears AFTER the original Q invariant (preserves naming order)', () => {
+  const qIndex = checkBody.indexOf("'Q_expired_engagement_end_date'");
+  const rIndex = checkBody.indexOf("'R_approved_application_has_member'");
+  const sIndex = checkBody.indexOf("'S_approved_member_has_person_id'");
+  assert.ok(qIndex > 0, 'Q invariant must still exist');
+  assert.ok(rIndex > qIndex, 'R must appear after Q (alphabetical order)');
+  assert.ok(sIndex > rIndex, 'S must appear after R');
+});


### PR DESCRIPTION
## Summary
Extends `check_schema_invariants()` from 16 → 18 invariants with two new gates that prevent silent V4-graph drift in the volunteer approval path. Forward-defense vs. bypass of the canonical `approve_selection_application()` RPC introduced in #179.

## New invariants

**R_approved_application_has_member**
- `status='approved'` applications MUST have a matching `members` row (case-insensitive email).
- Production at p204 close: **36 approved, 0 missing**.
- **Status `'converted'` is INTENTIONALLY scoped out** — that status represents a dual-track conversion offer (e.g., researcher → leader) which may not have been accepted. The 1 converted-without-member case in production (Adalberto Neris, application `eb9c4795-…`) has explicit `conversion_reason = 'Aplicou como pesquisador e líder, convertido mas não ativo'` — a documented non-active state.

**S_approved_member_has_person_id**
- Members tied to an approved application MUST have `person_id NOT NULL` (V4 graph anchor for engagements).
- Production at p204 close: **0 violations**.

## What about the Herlon-class pending invariant?
"Approved volunteers stay non-authoritative until counter-signature" is **already enforced** by `auth_engagements.is_authoritative` — a COMPUTED column in the view that requires `agreement_certificate_id NOT NULL OR NOT requires_agreement`. No table-level invariant needed; the view definition is the contract.

## Migration shape
- DDL: `CREATE OR REPLACE FUNCTION public.check_schema_invariants()` with body verbatim from prior + 2 new `RETURN QUERY` blocks at the end (alphabetical order R, S after Q).
- `COMMENT ON FUNCTION` updated to cite 18 invariants + Issue #180.
- `NOTIFY pgrst, 'reload schema'` at end.

## Test plan
- [x] 10 new static contract tests in `tests/contracts/volunteer-authority-invariants.test.mjs`
- [x] All 10 pass + 43/43 invariants+approval+engagement contract tests offline
- [x] `npx astro build` green
- [x] **Live verification: 18/18 invariants, 0 violations** (incl. R=0, S=0)
- [x] Migration registered in `supabase_migrations.schema_migrations` (20260727000000)
- [ ] After merge: handoff + memory updates for "18/18=0" claim (was "16/16=0" throughout p177-p203 sediment)

## Implications for downstream artifacts (handoff)
- `.claude/rules/mcp.md` references "16 invariants" — update at next session close
- `feedback_handoff_invariants_verify_on_boot.md` references "16/16=0" — update to "18/18=0"
- platform-guardian boot check should now expect 18 rows

## Refs
- Spec: `docs/project-governance/P202_VOLUNTEER_LIFECYCLE_REMEDIATION_SPEC.md`
- Pairs with #179 (canonical approval orchestration via `approve_selection_application`)
- Closes #180

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>