### PR TITLE
fix(p207): import t() in profile.astro inline script (#216 — real fix, diagnosis revised)

### DIFF
--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -240,6 +240,15 @@ const PROFILE_I18N = {
   import { shouldRedirectFromProfile } from '../lib/routing';
   import { normalizeCredlyUrl } from '../lib/credly';
   import { normalizeMemberCycleHistory } from '../lib/cycle-history';
+  // p207 (Issue #216, 2026-05-20): import t() runtime translator. The script body
+  // below calls t('profile.xp.howToEarn', lang) etc ~25 times at runtime (XP pillars
+  // + champions + journey labels). Frontmatter `import { t } from '../i18n/utils'`
+  // is SERVER-side only; this inline <script> runs in the browser and needs its
+  // own client-side import. Without this line, minified bundle has unresolved `t`
+  // calls → "ReferenceError: t is not defined". Note: this is a DIFFERENT class
+  // than p158/p184 (those were TDZ + TS-annotation issues on `lp`, see comments
+  // around `const lp` below).
+  import { t } from '../i18n/utils';
 
   const PROFILE_I18N = (typeof window !== 'undefined' && (window as any).__PROFILE_I18N) || {};
   // p158 hotfix#8 (Fixes AI-PM-RESEARCH-HUB-1P): module-level so myWeekHtml + renderProfile +


### PR DESCRIPTION
Resolves [Issue #216](https://github.com/VitorMRodovalho/ai-pm-research-hub/issues/216).

## TL;DR

**One-line fix**: `import { t } from '../i18n/utils';` at top of inline `<script>` in `src/pages/profile.astro`.

**Diagnosis was REVISED at execution time** — the spec originally hypothesized TS annotation × Vite minification (3rd recurrence of p158/p184 lp class), but byte-identical bundle proved that was wrong. Real cause documented below + in commit message.

## Summary
- 1 file changed: `src/pages/profile.astro` (+9 lines: 1 import + 8-line comment)
- 0 deps changes, 0 migrations, 0 RPC changes

## What was actually wrong

The inline `<script>` block (line 237+) makes ~25 runtime calls to `t('profile.xp.howToEarn', lang)` and similar translation lookups for XP pillars + champion section + journey labels. The frontmatter imports `t()` server-side, but the inline `<script>` runs CLIENT-side and needs its own import. Without it, the minified bundle has unresolved `t` calls → runtime `ReferenceError: t is not defined`.

## How the original spec diagnosis was wrong

Spec hypothesized 3rd recurrence of TS-annotation × Vite-minify trap (p158 fixed `lp` initially; p184 stripped its TS annotation). Spec scoped ~22 module-level annotations to strip in profile.astro.

**Empirical disproof at execution time**: stripped all 22 annotations + ran `astro build`. New bundle byte-identical to broken prod bundle:
- Hash: `v3Zqq7wC.js` (same)
- Size: 75086 bytes (same)
- md5: `418784e95fc0830e2c749c305a109485` (same)

This proves esbuild strips TS annotations BEFORE Vite minification. Source-level annotations are no-op for output. The strips were reverted, and investigation continued.

## Real fix verified

With `import { t } from '../i18n/utils';` added:
- New bundle hash: `CGuhpcmD.js` (CHANGED)
- Bundle includes `import{t as x}from"./utils.CUL6moXM.js"` at top
- Bundle size +40 bytes
- `astro build` PASS
- `astro preview /profile` returns HTTP 200 + 70KB rendered HTML

## Test plan
- [x] \`npx astro build\` PASS
- [x] \`astro preview\` serves /profile with HTTP 200
- [x] Bundle hash changed (proves fix took effect)
- [ ] **PM browser smoke**: navigate to /profile as signed-in member; confirm no ReferenceError in console, XP pillars + champion section + journey labels render
- [x] EN/ES variants checked (11-line redirect pages — no script of their own, no fix needed)

## Out-of-scope (deferred to backlog)

OPP-207.B (forward defense audit script) was originally scoped for the WRONG bug class. Will be reframed as: contract test or pre-commit gate that audits inline \`<script>\` blocks for runtime-bound identifiers (t, lp, etc.) that are used but not imported/defined in same scope. Spec doc + P162 #93 to be updated post-merge.

## QA window state (per PM rule)

- Branch \`agent/issue-216\`: PRESERVED post-merge
- Worktree: PRESERVED
- Issue #216: stays OPEN during QA window
- Don't use --delete-branch

## CI note

This PR will fail \`browser_guards\` for pre-existing env reason — see Issue #220 / BUG-207.C. \`--admin\` merge bypass justified.

## Handoff

\`\`\`
Issue: #216
Branch: agent/issue-216
Escopo: 1-line import + 8-line comment in src/pages/profile.astro
Arquivos: src/pages/profile.astro
Validação: astro build + astro preview /profile 200 + bundle hash changed
Riscos: zero runtime (additive import only)
Rollback: git revert 15e44465
Docs: PR description supersedes spec diagnosis; spec + P162 to revise post-merge
Próximo passo: PM browser smoke /profile → merge → QA window
\`\`\`

---

Closes #216

🤖 Generated by Claude (p207). Diagnosis revised at execution time via empirical bundle byte-comparison.
Assisted-By: Claude (Anthropic) <noreply@anthropic.com>