### PR TITLE
docs(p217): #160 OPP-160.B dispatched — 3 engagement_termo_due notifications

### DIFF
--- a/docs/audit/P162_GAP_OPPORTUNITY_LOG.md
+++ b/docs/audit/P162_GAP_OPPORTUNITY_LOG.md
@@ -1176,9 +1176,9 @@ Itens 1, 2, 3, 4, 7, 8, 10, 11, 12 = P2 ou maior. Items 3 + 4 + 12 são pré-con
 - **Issue #160 status:** partially closed — 8 ambassadors now authoritative (including Herlon's ambassador role); Herlon's `study_group_owner / leader` engagement remains pending termo (handed off to OPP-160.B).
 - **Cross-ref:** Issue #160, Issue #182 (lifecycle mapping unblocked), ADR-0006, migration 20260803000001, test file engagement-kinds-catalog-invariants.test.mjs, P162 #133 (parent decision), P162 #135 (sibling — remaining 4-person batch).
 
-### 135. OPP-160.B — R3-C3 Termo notification batch for the 4 remaining real-termo engagements (3 distinct members)
+### 135. OPP-160.B — R3-C3 Termo notification batch for the 4 remaining real-termo engagements (3 distinct members) [**DISPATCHED 2026-05-21 p217 — see #138**]
 - **Tipo:** notification batch / operational follow-up · **Severity:** MED · **Effort:** S (1-2h: 4 individual notifications + 4 self-signs + 4 GP countersigns)
-- **Trigger:** P162 #133 DECISION-160 path A' step 2 (deferred from p217 close to a dedicated session). Backlog after RESOLVED-160.A: 4 engagements / 3 distinct members.
+- **Trigger:** P162 #133 DECISION-160 path A' step 2 (originally deferred from p217 close to a dedicated session, but PM picked "OPP-160.B agora" mid-session — see #138 for dispatch record). Backlog after RESOLVED-160.A: 4 engagements / 3 distinct members.
 - **Description:** Pending real-termo engagements (per `get_pending_agreement_engagements()` post p217 catalog fix):
   - Herlon Alves de Sousa (PMI-CE) — `study_group_owner / leader` for CPMAI (the original #160 case)
   - Fernando Maquiaveli (PMI-DF) — `study_group_participant / participant`
@@ -1216,4 +1216,24 @@ Itens 1, 2, 3, 4, 7, 8, 10, 11, 12 = P2 ou maior. Items 3 + 4 + 12 são pré-con
   - Inline comment noting the MERGE gap + codebase status (zero MERGE usage today).
 - **Backlog item:** Add MERGE coverage when the first migration adopts MERGE patterns. Until then, accepted gap.
 - **Cross-ref:** PR #250 platform-guardian LOW-1, code-reviewer LOW (table row 2-3), tests/contracts/engagement-kinds-catalog-invariants.test.mjs line 105-117.
+
+### 138. DISPATCH-160.B — Notification batch sent for OPP-160.B (3 notifications, 3 members, transactional_immediate)
+- **Tipo:** notification dispatch / operational milestone · **Severity:** N/A (action record) · **Effort:** XS (~15min — completed)
+- **Trigger:** PM ABCD pick mid-p217 session "OPP-160.B agora — batch R3-C3 para os 4 (Recommended)" after PR #250 merge. Replaces the originally-deferred timing in #135.
+- **Description:** 3 rows inserted into `public.notifications` table 2026-05-21 23:43 UTC with type=`engagement_termo_due`, link=`/volunteer-agreement`, delivery_mode=`transactional_immediate`, actor_id=Vitor Maia Rodovalho (PM-initiated dispatch):
+  - **Herlon Alves de Sousa** (`c8e76355-...`) — notification id `8bc80cec-b808-4408-a60d-f51132ef7b65` — body references CPMAI study_group_owner role
+  - **Fernando Maquiaveli** (`c8b930c3-...`) — notification id `166280fa-a30a-43f9-a4cf-ccd885eb9873` — body references CPMAI study_group_participant role
+  - **Vitor Maia Rodovalho** (`880f736c-...`) — notification id `7da2bf52-e109-4fdc-bcd8-cb15c7e9aa4c` — body references both volunteer engagements (LATAM LIM 2026 + CPMAI) + notes single signature covers both
+- **Pre-dispatch idempotency:** confirmed 0 prior `engagement_termo_due` notifications in last 30 days for these 3 recipients (no duplicate spam).
+- **Body strategy:** per-member contextualized body (mentions specific initiative + role) rather than generic template — keeps message actionable for N=3 without building a full `campaign_templates` row (overkill per PM's path A' framing).
+- **Email delivery:** `transactional_immediate` mode triggers the platform's outbound email pipeline (Resend integration). `email_sent_at` will populate when the cron/EF processes the queue. Manual verification possible via `SELECT email_sent_at FROM notifications WHERE id IN (...)` in 5-10 minutes.
+- **Expected next flow (per ADR-0039 volunteer agreement countersign subsystem):**
+  1. Recipient clicks notification link → `/volunteer-agreement` UI
+  2. Recipient reviews termo + clicks "Sign" → triggers `sign_volunteer_agreement(language, ip, ua)` RPC
+  3. RPC creates a `certificates` row + sets `engagements.agreement_certificate_id`
+  4. GP (PM) sees pending countersign via `get_pending_countersign()` → calls `counter_sign_certificate(cert_id, ip, ua)`
+  5. `auth_engagements.is_authoritative` flips to `true` for that engagement
+  6. When all 4 engagements have signed+countersigned certs, OPP-160.B becomes RESOLVED-160.B and Issue #160 fully closes.
+- **Note on Vitor self-cert:** As member + PM (GP) of the platform, Vitor signs his own termo via member flow, then countersigns via GP flow. Whether the system permits self-countersign depends on ADR-0039 countersign chain rules — not investigated this session (PM territory, low-impact if requires another GP).
+- **Cross-ref:** Issue #160, OPP-160.B (#135 — original entry, marked DISPATCHED), DECISION-160 (#133), RESOLVED-160.A (#134), `public.notifications` rows 8bc80cec / 166280fa / 7da2bf52, governance_documents.id `a78311fd-cf87-4bee-b0f1-e117a36095c5` (R3-C3 template).
 

--- a/docs/project-governance/ISSUE_REGISTRY.md
+++ b/docs/project-governance/ISSUE_REGISTRY.md
@@ -58,6 +58,7 @@ Status values:
 | #217 | ready-leaf | Frontend / Integration | #212 v1 | none | welcome email link smoke: `/initiative/` not `/iniciativas/` | Close after route/link smoke |
 | #205 | ready-leaf | Foundation | #210, #212 G1/G2 | none | migration + `resolve_member_by_email` RPC smoke | Close after contract tests and docs |
 | #224 | ready-leaf | Frontend / Integration / QA | VEP JSON import confidence | reproducible sample JSON from PM | `/admin/selection` JSON dry-run/apply shows actual worker errors inline, plus `cron_run_log` lookup path or run id | File issue, reproduce with failing JSON, then close after UI/error contract smoke |
+| #251 | ready-leaf | QA / Foundation | Cycle 4 selection trust | production read-only audit | Henrique visibility and William dual-track evaluation state explained with SQL evidence; remediation plan split if needed | Close after root cause is documented and data/code fix issue is created or applied with PM approval |
 | #211 | blocked | Frontend | #212 G3 | #212 PM signoff if broader scope applies | metadata UI smoke | Do not start until scope is confirmed standalone vs #212 child |
 | #194 | ready-leaf | QA | curatorship p197 confidence | p197 test fixtures | contract tests for review flow pass | Close after tests land |
 | #193 | ready-leaf | Foundation | curatorship status consistency | none | migration/audit confirms phantom states removed | Close after migration + rollback docs |


### PR DESCRIPTION
## Summary

Governance-only PR documenting the OPP-160.B notification dispatch executed via `execute_sql` in p217 session. PM picked "OPP-160.B agora" mid-session after PR #250 merge (Issue #160 path A' step 1).

**No migration / no code change.** Pure operational dispatch (data INSERT) + P162 governance log update.

## What was dispatched (live, pre-PR)

3 rows inserted into `public.notifications` at 2026-05-21 23:43 UTC:

| Recipient | Engagement context | Notification id |
|---|---|---|
| Herlon Alves de Sousa (PMI-CE) | CPMAI Ciclo 3 — `study_group_owner / leader` | `8bc80cec-b808-4408-a60d-f51132ef7b65` |
| Fernando Maquiaveli (PMI-DF) | CPMAI Ciclo 3 — `study_group_participant / participant` | `166280fa-a30a-43f9-a4cf-ccd885eb9873` |
| Vitor Maia Rodovalho (PMI-GO) | LATAM LIM 2026 + CPMAI Ciclo 3 — `volunteer/coordinator` + `volunteer/manager` (single signature covers both) | `7da2bf52-e109-4fdc-bcd8-cb15c7e9aa4c` |

All `type='engagement_termo_due'`, `link='/volunteer-agreement'`, `delivery_mode='transactional_immediate'`, `actor_id=Vitor` (PM-initiated).

## What this PR adds to the repo

- **P162 entry #135 (OPP-160.B)** marked `[DISPATCHED 2026-05-21 p217 — see #138]`
- **P162 new entry #138 (DISPATCH-160.B)** — full dispatch record with notification IDs + expected flow per ADR-0039 + email delivery note + Vitor self-cert caveat

## Why governance PR (and not direct main commit)

Per p209 governance protocol (`.claude/rules/bypass-protocol.md`): governance updates go through PR even for docs-only changes. Direct push to main would count as a bypass event in the weekly audit. Lightweight PR keeps the audit trail clean.

## Pre-dispatch verification

- ✅ Idempotency: 0 prior `engagement_termo_due` notifications in last 30 days for these 3 recipients
- ✅ Body strategy: per-member contextualized (initiative + role) — appropriate for N=3 batch (vs building a full `campaign_templates` row, which is overkill at this scale)
- ✅ Email pipeline: `transactional_immediate` triggers Resend; `email_sent_at` will populate when the cron/EF processes the queue

## Expected next flow (per ADR-0039 countersign subsystem)

1. Recipient clicks notification link → `/volunteer-agreement` UI
2. Recipient reviews termo + clicks "Sign" → `sign_volunteer_agreement(language, ip, ua)` RPC
3. RPC creates a `certificates` row + sets `engagements.agreement_certificate_id`
4. GP (PM) sees pending countersign via `get_pending_countersign()` → calls `counter_sign_certificate(cert_id, ip, ua)`
5. `auth_engagements.is_authoritative` flips to `true` for that engagement
6. When all 4 engagements have signed + countersigned certs: **OPP-160.B becomes RESOLVED-160.B and Issue #160 fully closes**.

## Issue #160 status (stays OPEN)

Per QA window pattern: issue #160 stays OPEN through full sign+countersign completion for all 4 engagements. Branch preserved.

## Test plan

- [x] 3 notifications successfully inserted (RETURNING confirms 3 rows + IDs)
- [x] No additional code changes (governance doc only)
- [x] No CI risk (no migration, no RPC change, no test added)
- [ ] PM verifies email arrived (in 5-10 min — Vitor's own notification will land in his inbox at vitor.rodovalho@outlook.com)
- [ ] PM signs his own termo via `/volunteer-agreement` (covers his 2 volunteer engagements)
- [ ] PM countersigns own cert (verify whether self-countersign permitted by ADR-0039 chain rules; if not, requires another GP)

## Cross-ref

- PR #250 (Issue #160 path A' step 1 — RESOLVED-160.A)
- Issue #160 (parent) + Issue #182 (downstream consumer)
- P162 #133 DECISION-160 + #134 RESOLVED-160.A + #135 OPP-160.B + #138 DISPATCH-160.B
- ADR-0039 (volunteer agreement countersign subsystem)
- ADR-0006 §"Reconciliação de catálogo" 2026-05-21
- governance_documents.id `a78311fd-cf87-4bee-b0f1-e117a36095c5` (R3-C3 template)

🤖 Assisted by Claude (Anthropic)