### PR TITLE
fix: strip schema from MCP tools/list for Perplexity

### DIFF
--- a/src/pages/mcp.ts
+++ b/src/pages/mcp.ts
@@ -152,13 +152,20 @@ export const ALL: APIRoute = async ({ request }) => {
   }
 
   // p220: detect tools/list so we can post-process the response to strip
-  // the non-MCP-spec `execution.taskSupport` field added by @modelcontextprotocol/sdk@1.29.0.
+  // fields known to break stricter MCP clients.
+  //
+  // 1) `execution.taskSupport` is a non-MCP-spec field added by
+  // @modelcontextprotocol/sdk@1.29.0.
+  // 2) `$schema` inside each inputSchema is valid JSON Schema, but Perplexity's
+  // connector still rejects the 299-tool catalog after the execution strip.
+  // Keep the public tools/list payload conservative: type/properties/required
+  // are enough for clients to render and call tools.
   // Stricter MCP clients (Perplexity) silently drop the entire tools array when
   // unknown top-level fields appear on each tool — symptom: "No tools to display"
   // despite tools/list returning 200 with all 299 tools. The field is Anthropic-
   // internal (Claude Managed Agents task scheduling hint) and not part of the
   // public MCP spec (https://spec.modelcontextprotocol.io). Strip universally so
-  // every client sees a spec-compliant payload.
+  // every client sees a spec-compliant, minimal payload.
   const isToolsList = typeof reqBody === 'string' && /"method"\s*:\s*"tools\/list"/.test(reqBody);
 
   try {
@@ -183,12 +190,14 @@ export const ALL: APIRoute = async ({ request }) => {
     // because the field's JSON serialization is constant).
     if (isToolsList) {
       const rawBody = await res.text();
-      // Match optional leading/trailing comma + the constant execution object.
-      // The SDK always emits this field with the exact taskSupport:"forbidden"
-      // value, so a literal regex is safe (no parser cost).
+      // Match optional leading/trailing comma + constant fields emitted by the
+      // SDK/Zod serializer. Literal regexes avoid parsing a large SSE payload on
+      // the hot path.
       const cleanedBody = rawBody
         .replace(/,\s*"execution"\s*:\s*\{\s*"taskSupport"\s*:\s*"forbidden"\s*\}/g, '')
-        .replace(/"execution"\s*:\s*\{\s*"taskSupport"\s*:\s*"forbidden"\s*\}\s*,?/g, '');
+        .replace(/"execution"\s*:\s*\{\s*"taskSupport"\s*:\s*"forbidden"\s*\}\s*,?/g, '')
+        .replace(/,\s*"\$schema"\s*:\s*"http:\/\/json-schema\.org\/draft-07\/schema#"/g, '')
+        .replace(/"\$schema"\s*:\s*"http:\/\/json-schema\.org\/draft-07\/schema#"\s*,?/g, '');
       const respHeadersOut = new Headers(respHeaders);
       respHeadersOut.delete('content-length'); // length changed after strip
       await kvLog("mcp-upstream-tools-list", {

--- a/tests/contracts/mcp-tools-list-execution-strip.test.mjs
+++ b/tests/contracts/mcp-tools-list-execution-strip.test.mjs
@@ -1,6 +1,6 @@
 /**
  * Forward-defense: MCP /mcp worker proxy strips non-spec `execution.taskSupport`
- * field from tools/list responses for spec-strict clients (Perplexity).
+ * and inputSchema `$schema` fields from tools/list responses for spec-strict clients (Perplexity).
  *
  * Origin: p220 session (2026-05-22) — after fixing the OAuth allowlist
  * (Perplexity subdomain coverage via host endsWith), the connector
@@ -13,8 +13,8 @@
  * drop the entire tools array on unknown top-level fields.
  *
  * Fix: post-process tools/list responses in the Worker proxy at src/pages/mcp.ts.
- * The SDK serializes the field with a constant value, so a literal regex is
- * safe and avoids JSON parse cost on the hot path.
+ * The SDK serializes `execution` with a constant value, and Zod emits a constant
+ * draft-07 `$schema` URI; literal regexes avoid JSON parse cost on the hot path.
  *
  * Cross-ref:
  *   - src/pages/mcp.ts (the proxy with the strip)
@@ -24,10 +24,11 @@
  * Static-only bundle: source-code checks (no SSE parser to run).
  *   1. Detection of tools/list method via regex on request body
  *   2. Strip applied universally (not gated on client User-Agent — defensive)
- *   3. Two regex variants cover leading-comma + trailing-comma positions
- *   4. content-length header deleted so client receives correct length
- *   5. Strip happens BEFORE the SSE streaming branch (so SSE tools/list also cleaned)
- *   6. kvLog instrumented to record rawLen/cleanedLen/stripped delta
+ *   3. Two regex variants cover leading-comma + trailing-comma positions for execution
+ *   4. `$schema` is also stripped from inputSchema payloads for Perplexity compatibility
+ *   5. content-length header deleted so client receives correct length
+ *   6. Strip happens BEFORE the SSE streaming branch (so SSE tools/list also cleaned)
+ *   7. kvLog instrumented to record rawLen/cleanedLen/stripped delta
  */
 
 import test from 'node:test';
@@ -50,6 +51,14 @@ test('mcp proxy: strips execution field with leading-comma variant', () => {
 test('mcp proxy: strips execution field with trailing-comma variant', () => {
   assert.match(SRC, /\.replace\(\s*\/"execution"\\s\*:\\s\*\\\{\\s\*"taskSupport"\\s\*:\\s\*"forbidden"\\s\*\\\}\\s\*,\?\/g/,
     'Must also strip "execution:{taskSupport:forbidden}" with optional trailing comma (field appears at start of object)');
+});
+
+test('mcp proxy: strips inputSchema $schema with both comma-position variants', () => {
+  const schemaStripCount = (SRC.match(/json-schema\\.org\\\/draft-07\\\/schema#/g) || []).length;
+  assert.ok(schemaStripCount >= 2,
+    'Must strip draft-07 $schema in both leading-comma and trailing-comma positions');
+  assert.ok(SRC.includes('"\\$schema"'),
+    'Strip regex must target the literal $schema key');
 });
 
 test('mcp proxy: deletes content-length header after strip (length mismatch prevention)', () => {


### PR DESCRIPTION
## Summary

Follow-up to #277 after PM retested Perplexity post-#275/#276. The connector still shows connected account but no tools, and chat returns a generic failure.

This applies the next low-risk H1 compatibility attempt from #277: during `/mcp` `tools/list` proxying, strip the draft-07 `$schema` field from each `inputSchema`, in addition to the existing `execution.taskSupport` strip. The public payload remains MCP-compatible and more conservative for strict clients.

## Why

- OAuth callback allowlist is already fixed (#275).
- Non-spec `execution.taskSupport` is already stripped (#276).
- Perplexity still rejects the catalog.
- `$schema` is valid JSON Schema but may be outside what Perplexity expects inside MCP `inputSchema`.

## Validation

- `node --test tests/contracts/mcp-tools-list-execution-strip.test.mjs tests/contracts/oauth-redirect-uri-allowlist.test.mjs` → 18/18 pass
- `PUBLIC_SUPABASE_URL=https://mock.supabase.co PUBLIC_SUPABASE_ANON_KEY=mock-key-for-build npm run build` → pass

## Post-deploy smoke

PM should disconnect/reconnect Perplexity again and verify whether the tools tab populates. If still empty, next likely path is H2/H7 from #277: Perplexity may reject very large catalogs, so we should create a curated `/mcp-lite` or client-profile filtered tools/list.

Closes no issue yet; advances #277 H1.
