### PR TITLE
fix(p225): #281 endpoint env fallback — SUPABASE_URL via import.meta.env

### DIFF
--- a/src/pages/api/internal/cert-pdf-render/[id].ts
+++ b/src/pages/api/internal/cert-pdf-render/[id].ts
@@ -137,8 +137,11 @@ export const POST: APIRoute = async ({ params, request }) => {
   }
 
   // 2. Service-role Supabase client (bypass RLS for cert + members read + storage upload)
-  const supabaseUrl = (cfEnv as any)?.SUPABASE_URL as string | undefined;
-  const serviceRoleKey = (cfEnv as any)?.SUPABASE_SERVICE_ROLE_KEY as string | undefined;
+  // Pattern matches src/pages/api/calendar-webhook.ts + src/pages/api/admin/import-pmi-vep-json.ts:
+  // SUPABASE_URL falls back to import.meta.env.PUBLIC_SUPABASE_URL (build-time from .env);
+  // SUPABASE_SERVICE_ROLE_KEY is runtime only (wrangler secret).
+  const supabaseUrl = (cfEnv as any)?.SUPABASE_URL || import.meta.env.PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = (cfEnv as any)?.SUPABASE_SERVICE_ROLE_KEY;
   if (!supabaseUrl || !serviceRoleKey) {
     return new Response(
       JSON.stringify({ error: 'server_misconfig', detail: 'SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY not set' }),


### PR DESCRIPTION
Smoke test discovery: endpoint reached but server_misconfig because cfEnv.SUPABASE_URL is not set as a runtime binding — it's build-time injected via import.meta.env.PUBLIC_SUPABASE_URL. Mirroring the dual-source pattern from src/pages/api/calendar-webhook.ts + src/pages/api/admin/import-pmi-vep-json.ts.

Pre-fix verified pipeline reachability via pg_net._http_response: HTTP 500 + exact error message captured.

Post-merge: Cloudflare Pages auto-deploys; I'll re-INSERT test cert (vc TEST-P225-281-002) and verify end-to-end.

Refs #281.