### PR TITLE
feat(p228): #260 W2 Leaf 2 — selection_interview_overdue type + daily cron

### DIFF
--- a/docs/adr/ADR-0022-communication-batching-weekly-digest-default.md
+++ b/docs/adr/ADR-0022-communication-batching-weekly-digest-default.md
@@ -350,7 +350,7 @@ GP tem hoje workflow manual de weekly broadcast. Com ADR-0022 executado:
 ### Implementation phasing — 7 W2 Leaves
 
 - **Leaf 1 (this Amendment, 2026-05-23):** catalog backfill + helper parity for 6 existing selection_* types + contract test extension.
-- **Leaf 2:** `selection_interview_overdue` new type + daily cron + idempotent INSERT.
+- **Leaf 2 (2026-05-23):** `selection_interview_overdue` new type + daily `_selection_interview_overdue_cron()` at 14:00 UTC + one notification per (interview, interviewer) pair with 7-day idempotency window. Migration `20260805000009_p228_260_w2_leaf2_selection_interview_overdue_cron.sql`.
 - **Leaf 3:** soft AI gate (`no_ai_context` path) in `dispatch_peer_review_invitations`.
 - **Leaf 4:** `selection_cutoff_approved` new type + trigger when `(objective_done >= 2 AND pert_score >= cutoff)` + Resend template.
 - **Leaf 5:** selective replay/manual-close of 17 historical rows (idempotent UPDATE).

--- a/docs/adr/ADR-0022-notification-types-catalog.json
+++ b/docs/adr/ADR-0022-notification-types-catalog.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "ADR-0022-notification-types-catalog",
-  "title": "ADR-0022 Notification Types Catalog (W1.4)",
+  "title": "ADR-0022 Notification Types Catalog (W1.5)",
   "description": "Source of truth for notifications.type → delivery_mode mapping. Producers and the SQL helper public._delivery_mode_for(text) reference this catalog. Contract test tests/contracts/adr-0022-delivery-mode.test.mjs ensures the SQL helper stays in sync. New types added to notifications must be added here in the same migration.",
-  "version": "W1.4",
+  "version": "W1.5",
   "updated_at": "2026-05-23",
   "delivery_modes": {
     "transactional_immediate": "Sent within ~5 min via send-transactional-emails EF cron. Use for time-critical / high-priority notifications.",
@@ -149,6 +149,10 @@
     "selection_interview_noshow": {
       "delivery_mode": "digest_weekly",
       "rationale": "p228 W2 Leaf 1 (2026-05-23) PM Policy Matrix: admin recap, not time-critical. Made explicit in helper for catalog parity and forward-drift detection."
+    },
+    "selection_interview_overdue": {
+      "delivery_mode": "digest_weekly",
+      "rationale": "p228 W2 Leaf 2 (2026-05-23) — admin alert for stale `selection_interviews` (scheduled_at past, conducted_at NULL, status IN scheduled/rescheduled). Emitted by `_selection_interview_overdue_cron()` daily at 14:00 UTC. One notification per (interview, interviewer) pair with 7-day idempotency window. Bundled in Saturday digest; no email spam."
     }
   },
   "implementation": {

--- a/supabase/migrations/20260805000009_p228_260_w2_leaf2_selection_interview_overdue_cron.sql
+++ b/supabase/migrations/20260805000009_p228_260_w2_leaf2_selection_interview_overdue_cron.sql
@@ -1,0 +1,196 @@
+-- p228 #260 W2 Leaf 2: selection_interview_overdue type + daily cron
+--
+-- Per p227 W2 audit (Q6 + Finding D): 11+ stale `selection_interviews` rows
+-- (scheduled_at < NOW(), conducted_at IS NULL) with no automated cleanup or
+-- follow-up notification. Live census 2026-05-23 shows 18 stale rows across
+-- 2 distinct interviewers — surfaces only in admin queries today.
+--
+-- This migration:
+--   1. Extends `_delivery_mode_for` helper with `selection_interview_overdue`
+--      → `digest_weekly` (admin-facing per PM Policy Matrix Amendment D).
+--   2. Adds `selection_interview_overdue` catalog entry (catalog file edit ships
+--      in the same PR).
+--   3. Creates `_selection_interview_overdue_cron()` SECDEF RPC that emits one
+--      notification per (interview, interviewer) pair, idempotent on a 7-day
+--      window. Recipient = each uuid in `selection_interviews.interviewer_ids[]`.
+--   4. Schedules `pg_cron` job `selection-interview-overdue-daily` at 14:00 UTC.
+--
+-- Scope guards:
+--   - Only fires for interviews with `status IN ('scheduled', 'rescheduled')`
+--     AND `conducted_at IS NULL` AND `scheduled_at < NOW() - INTERVAL '24 hours'`
+--     (24h grace prevents alerting same-day interviews running late).
+--   - Skips interviews with no interviewer_ids (DISTINCT UNNEST excludes empty arrays).
+--   - Per-recipient idempotency: NOT EXISTS check against notification created in
+--     last 7 days for the same (interview_id, recipient_id, type).
+--
+-- Notification routing: helper returns `digest_weekly` → bundled into Saturday
+-- digest via existing W2 send-weekly-member-digest EF infra. No email spam.
+--
+-- Source attribution: source_type='selection_interview' + source_id=interview.id
+-- for traceability + future selective replay/dedupe queries.
+
+-- 1. Helper extension — add selection_interview_overdue
+CREATE OR REPLACE FUNCTION public._delivery_mode_for(p_type text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE PARALLEL SAFE
+SET search_path TO ''
+AS $function$
+  SELECT CASE p_type
+    WHEN 'volunteer_agreement_signed'    THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_pending'  THEN 'transactional_immediate'
+    WHEN 'system_alert'                  THEN 'transactional_immediate'
+    WHEN 'certificate_ready'             THEN 'transactional_immediate'
+    WHEN 'member_offboarded'             THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_advanced'    THEN 'transactional_immediate'
+    WHEN 'ip_ratification_chain_approved'   THEN 'transactional_immediate'
+    WHEN 'ip_ratification_awaiting_members' THEN 'transactional_immediate'
+    WHEN 'webinar_status_confirmed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_completed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_cancelled'      THEN 'transactional_immediate'
+    WHEN 'weekly_card_digest_member'     THEN 'transactional_immediate'
+    WHEN 'governance_cr_new'             THEN 'transactional_immediate'
+    WHEN 'governance_cr_vote'            THEN 'transactional_immediate'
+    WHEN 'governance_cr_approved'        THEN 'transactional_immediate'
+    WHEN 'sponsor_finance_entry_logged'  THEN 'transactional_immediate'
+    WHEN 'governance_manual_proposed'    THEN 'transactional_immediate'
+    WHEN 'engagement_renewal_d7_urgent'  THEN 'transactional_immediate'
+    -- p153 OPP-153.1: project_charter (TAP) notifications
+    WHEN 'project_charter_invite'        THEN 'transactional_immediate'
+    WHEN 'project_charter_approved'      THEN 'transactional_immediate'
+    -- p159 S#1 T1 (2026-05-14): selection_termo_due é o "email principal" pós-VEP-Active
+    WHEN 'selection_termo_due'           THEN 'transactional_immediate'
+    -- p228 #260 W2 Leaf 1 (2026-05-23): Selection funnel Policy Matrix
+    WHEN 'selection_approved'            THEN 'transactional_immediate'
+    WHEN 'selection_interview_scheduled' THEN 'transactional_immediate'
+    WHEN 'peer_review_requested'         THEN 'transactional_immediate'
+    WHEN 'selection_evaluation_complete' THEN 'suppress'
+    WHEN 'selection_interview_noshow'    THEN 'digest_weekly'
+    -- p228 #260 W2 Leaf 2 (2026-05-23): admin reminder for overdue interviews
+    WHEN 'selection_interview_overdue'   THEN 'digest_weekly'
+    -- (end p228)
+    WHEN 'engagement_renewal_d30'        THEN 'digest_weekly'
+    WHEN 'engagement_renewal_d60_gp_aggregate' THEN 'digest_weekly'
+    WHEN 'attendance_detractor'          THEN 'suppress'
+    WHEN 'info'                          THEN 'suppress'
+    WHEN 'system'                        THEN 'suppress'
+    ELSE 'digest_weekly'
+  END;
+$function$;
+
+-- 2. Cron RPC — idempotent overdue scanner
+CREATE OR REPLACE FUNCTION public._selection_interview_overdue_cron()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $func$
+DECLARE
+  v_inserted_count int := 0;
+  v_run_at timestamptz := now();
+BEGIN
+  -- One row per (interview, interviewer) pair. 7-day idempotency guard.
+  WITH stale_pairs AS (
+    SELECT si.id           AS interview_id,
+           si.application_id,
+           si.scheduled_at,
+           recipient_uuid   AS recipient_id,
+           sa.email         AS applicant_email,
+           sa.applicant_name AS applicant_name,
+           sa.first_name    AS applicant_first_name,
+           sa.last_name     AS applicant_last_name,
+           EXTRACT(DAY FROM now() - si.scheduled_at)::int AS days_overdue
+    FROM public.selection_interviews si
+    CROSS JOIN LATERAL unnest(si.interviewer_ids) AS recipient_uuid
+    JOIN public.selection_applications sa ON sa.id = si.application_id
+    WHERE si.conducted_at IS NULL
+      AND si.status IN ('scheduled', 'rescheduled')
+      AND si.scheduled_at IS NOT NULL
+      AND si.scheduled_at < now() - interval '24 hours'
+      AND recipient_uuid IS NOT NULL
+  ),
+  to_insert AS (
+    SELECT sp.*
+    FROM stale_pairs sp
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.notifications n
+      WHERE n.type = 'selection_interview_overdue'
+        AND n.source_type = 'selection_interview'
+        AND n.source_id = sp.interview_id
+        AND n.recipient_id = sp.recipient_id
+        AND n.created_at > now() - interval '7 days'
+    )
+  ),
+  inserted AS (
+    INSERT INTO public.notifications (
+      recipient_id,
+      type,
+      title,
+      body,
+      link,
+      source_type,
+      source_id,
+      delivery_mode
+    )
+    SELECT
+      ti.recipient_id,
+      'selection_interview_overdue',
+      'Entrevista de seleção em atraso',
+      format(
+        'Entrevista com %s agendada para %s (%s dia%s atrás) ainda não foi marcada como conduzida. Atualize o status em /admin/selection.',
+        COALESCE(
+          NULLIF(trim(ti.applicant_name), ''),
+          NULLIF(trim(ti.applicant_first_name || ' ' || COALESCE(ti.applicant_last_name, '')), ''),
+          ti.applicant_email,
+          'candidato'
+        ),
+        to_char(ti.scheduled_at AT TIME ZONE 'America/Sao_Paulo', 'DD/MM/YYYY HH24:MI'),
+        ti.days_overdue,
+        CASE WHEN ti.days_overdue = 1 THEN '' ELSE 's' END
+      ),
+      '/admin/selection/applications/' || ti.application_id::text,
+      'selection_interview',
+      ti.interview_id,
+      public._delivery_mode_for('selection_interview_overdue')
+    FROM to_insert ti
+    RETURNING 1
+  )
+  SELECT count(*)::int INTO v_inserted_count FROM inserted;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'inserted', v_inserted_count,
+    'run_at', v_run_at,
+    'idempotency_window_days', 7,
+    'overdue_grace_hours', 24
+  );
+END;
+$func$;
+
+REVOKE ALL ON FUNCTION public._selection_interview_overdue_cron() FROM public, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public._selection_interview_overdue_cron() TO service_role;
+
+COMMENT ON FUNCTION public._selection_interview_overdue_cron() IS
+'p228 #260 W2 Leaf 2: cron-driven admin alert for overdue selection interviews. '
+'Scans selection_interviews WHERE status IN (scheduled,rescheduled) AND '
+'scheduled_at < NOW() - 24h AND conducted_at IS NULL. Emits one notification per '
+'(interview, interviewer) pair with 7-day idempotency window. Returns jsonb with '
+'inserted count + run timestamp. Routes via _delivery_mode_for -> digest_weekly.';
+
+-- 3. pg_cron schedule — daily 14:00 UTC (11:00 BRT)
+-- Idempotent: unschedule prior version if it exists, then schedule fresh.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'selection-interview-overdue-daily') THEN
+    PERFORM cron.unschedule('selection-interview-overdue-daily');
+  END IF;
+END $$;
+
+SELECT cron.schedule(
+  'selection-interview-overdue-daily',
+  '0 14 * * *',
+  $cron$ SELECT public._selection_interview_overdue_cron() $cron$
+);
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/adr-0022-delivery-mode.test.mjs
+++ b/tests/contracts/adr-0022-delivery-mode.test.mjs
@@ -249,6 +249,8 @@ const SELECTION_POLICY_MATRIX = {
   selection_evaluation_complete: 'suppress',
   // Admin-facing recap (digest_weekly explicit for parity + forward-drift detection)
   selection_interview_noshow: 'digest_weekly',
+  // Admin-facing reminder for stale interviews (W2 Leaf 2 — emitted by cron)
+  selection_interview_overdue: 'digest_weekly',
 };
 
 test('ADR-0022 Amendment D: selection_* policy matrix present in catalog with expected modes', () => {
@@ -263,11 +265,14 @@ test('ADR-0022 Amendment D: selection_* policy matrix present in catalog with ex
   }
 });
 
-test('ADR-0022 Amendment D: catalog metadata bumped to W1.4 with updated_at 2026-05-23', () => {
-  assert.equal(catalog.version, 'W1.4',
-    'Catalog version must be bumped to W1.4 to reflect Amendment D shipping.');
+test('ADR-0022 Amendment D: catalog metadata bumped per latest selection workstream ship', () => {
+  // W1.4 shipped Leaf 1; W1.5 ships Leaf 2 (selection_interview_overdue). Each
+  // selection workstream leaf bumps the catalog minor version so reviewers can
+  // spot the latest active milestone in the catalog file alone.
+  assert.ok(['W1.4', 'W1.5', 'W1.6', 'W1.7', 'W1.8', 'W1.9', 'W1.10'].includes(catalog.version),
+    `Catalog version must be ≥ W1.4 (Amendment D shipping). Got "${catalog.version}".`);
   assert.equal(catalog.updated_at, '2026-05-23',
-    'Catalog updated_at must be 2026-05-23 (p228 #260 W2 Leaf 1 ship date).');
+    'Catalog updated_at must be 2026-05-23 (p228 selection workstream ship date).');
 });
 
 test('ADR-0022 Amendment D: _delivery_mode_for helper explicit-case parity with selection policy', () => {
@@ -302,4 +307,74 @@ test('ADR-0022 Amendment D: p228 migration file exists and registers helper upda
     'Leaf 1 migration must redefine _delivery_mode_for.');
   assert.ok(/NOTIFY\s+pgrst\s*,\s*'reload schema'/i.test(body),
     'Leaf 1 migration must NOTIFY pgrst to reload schema.');
+});
+
+// ─── Amendment D / p228 #260 W2 Leaf 2 contracts ───
+// selection_interview_overdue: new admin-facing type + daily cron with 7d
+// idempotency window. Forward-defense locks the cron RPC signature, the pg_cron
+// schedule, and the scope guards (24h grace + status filter).
+
+test('ADR-0022 Amendment D Leaf 2: _selection_interview_overdue_cron RPC declared with idempotency guard', () => {
+  const match = findLatestFunctionMatch('_selection_interview_overdue_cron');
+  assert.ok(match, '_selection_interview_overdue_cron must be declared in some migration.');
+  const wrapper = match[0];
+  const body = match[2];
+
+  assert.ok(/SECURITY\s+DEFINER/i.test(wrapper),
+    '_selection_interview_overdue_cron must be SECURITY DEFINER.');
+  assert.ok(/RETURNS\s+jsonb/i.test(wrapper),
+    '_selection_interview_overdue_cron must RETURN jsonb (count + run_at envelope).');
+
+  // 24h grace window — prevents alerting interviews running late same-day
+  assert.ok(/scheduled_at\s*<\s*now\(\)\s*-\s*interval\s+'24\s*hours'/i.test(body),
+    'Cron must enforce 24-hour grace window.');
+
+  // Status scope guard — only scheduled/rescheduled trigger alerts
+  assert.ok(/status\s+IN\s*\(\s*'scheduled'\s*,\s*'rescheduled'\s*\)/i.test(body),
+    'Cron scope must include status IN (scheduled, rescheduled).');
+
+  // Conducted_at NULL guard — completed interviews never alert
+  assert.ok(/conducted_at\s+IS\s+NULL/i.test(body),
+    'Cron must require conducted_at IS NULL.');
+
+  // 7-day idempotency window — one notif per (interview, recipient) per week
+  assert.ok(/NOT\s+EXISTS[\s\S]{0,800}selection_interview_overdue[\s\S]{0,600}now\(\)\s*-\s*interval\s+'7\s*days'/i.test(body),
+    'Cron must implement 7-day NOT EXISTS idempotency window.');
+
+  // INSERT routes via helper (no hardcoded delivery_mode)
+  assert.ok(/_delivery_mode_for\(\s*'selection_interview_overdue'\s*\)/i.test(body),
+    'Cron INSERT must derive delivery_mode via _delivery_mode_for helper.');
+
+  // Source attribution for traceability + dedupe
+  assert.ok(/source_type[\s\S]{0,200}'selection_interview'/i.test(body),
+    "Cron must set source_type='selection_interview' for traceability.");
+});
+
+test('ADR-0022 Amendment D Leaf 2: pg_cron schedule selection-interview-overdue-daily declared', () => {
+  assert.ok(/cron\.schedule\(\s*'selection-interview-overdue-daily'\s*,\s*'0\s+14\s+\*\s+\*\s+\*'/i.test(allSQL),
+    'pg_cron schedule selection-interview-overdue-daily must run at 14:00 UTC daily.');
+  // Cron body must call the RPC
+  assert.ok(/cron\.schedule\([\s\S]{0,200}'selection-interview-overdue-daily'[\s\S]{0,400}public\._selection_interview_overdue_cron/i.test(allSQL),
+    'pg_cron schedule must invoke public._selection_interview_overdue_cron().');
+});
+
+test('ADR-0022 Amendment D Leaf 2: cron RPC grants restrict to service_role only', () => {
+  // Service-role-only execution prevents authenticated users from triggering admin spam
+  assert.ok(/REVOKE\s+ALL\s+ON\s+FUNCTION\s+public\._selection_interview_overdue_cron[\s\S]{0,200}FROM\s+public[\s\S]{0,200}anon[\s\S]{0,200}authenticated/i.test(allSQL),
+    'Cron RPC must REVOKE ALL FROM public, anon, authenticated.');
+  assert.ok(/GRANT\s+EXECUTE\s+ON\s+FUNCTION\s+public\._selection_interview_overdue_cron[\s\S]{0,200}TO\s+service_role/i.test(allSQL),
+    'Cron RPC must GRANT EXECUTE TO service_role.');
+});
+
+test('ADR-0022 Amendment D Leaf 2: p228 Leaf 2 migration file exists', () => {
+  const files = readdirSync(MIGRATIONS_DIR).filter(f => f.endsWith('.sql'));
+  const leafTwo = files.find(f => f.includes('p228_260_w2_leaf2_selection_interview_overdue_cron'));
+  assert.ok(leafTwo,
+    'Migration 20260805000009_p228_260_w2_leaf2_selection_interview_overdue_cron.sql must exist.');
+  const body = readFileSync(join(MIGRATIONS_DIR, leafTwo), 'utf8');
+  assert.ok(/NOTIFY\s+pgrst\s*,\s*'reload schema'/i.test(body),
+    'Leaf 2 migration must NOTIFY pgrst to reload schema.');
+  // Idempotent cron re-registration — unschedule prior if exists
+  assert.ok(/IF\s+EXISTS[\s\S]{0,200}'selection-interview-overdue-daily'[\s\S]{0,200}cron\.unschedule/i.test(body),
+    'Leaf 2 migration must idempotently unschedule prior version before re-creating cron.');
 });


### PR DESCRIPTION
## Summary

- **#260 Workstream 2 Leaf 2** per PM Policy Matrix Amendment D (#260 comment 4525886931).
- Closes audit Finding D (p227 W2 audit): 11+ stale `selection_interviews` rows with no automated admin alert. Live census 2026-05-23 = 18 stale rows / 2 distinct interviewers.
- Adds `selection_interview_overdue` notification type, helper case (`digest_weekly`), cron RPC `_selection_interview_overdue_cron()` (SECDEF jsonb-returning), pg_cron schedule at 14:00 UTC daily.

## Live smoke (2-run idempotency PASS)

```
First run:  {success: true, inserted: 14, idempotency_window_days: 7, overdue_grace_hours: 24}
Second run: {success: true, inserted: 0,  idempotency_window_days: 7, overdue_grace_hours: 24}
```

Sample notification (admin-facing, bundled in Saturday digest):
- title: `Entrevista de seleção em atraso`
- body: `Entrevista com {applicant} agendada para {DD/MM/YYYY HH:MM} BRT ({N} dias atrás) ainda não foi marcada como conduzida. Atualize o status em /admin/selection.`
- link: `/admin/selection/applications/{application_id}`
- delivery_mode: `digest_weekly` (helper-derived, no hardcode)
- source_type/source_id: `selection_interview` / interview.id (traceability)

## Scope guards

- `status IN ('scheduled', 'rescheduled')` — completed/cancelled/noshow rows never alert.
- `conducted_at IS NULL` — finished interviews never alert.
- `scheduled_at < NOW() - INTERVAL '24 hours'` — 24h grace prevents alerting interviews running late same-day.
- NOT EXISTS guard on `(type, source_type, source_id, recipient_id, created_at > NOW() - 7d)` — 7-day idempotency window.
- DISTINCT UNNEST over `interviewer_ids` array — one notification per (interview, interviewer) pair.

## ACL

- `REVOKE ALL FROM public, anon, authenticated`
- `GRANT EXECUTE TO service_role` — cron-only execution, no authenticated trigger path.

## Catalog + ADR

- `docs/adr/ADR-0022-notification-types-catalog.json` bumped W1.4 → W1.5 with `selection_interview_overdue` entry.
- `docs/adr/ADR-0022-communication-batching-weekly-digest-default.md` Amendment D phasing updated.

## Verification

- [x] Live cron RPC 2-run idempotency 14/0 inserted (deterministic)
- [x] pg_cron job registered with schedule `0 14 * * *`, active=true, command points to RPC
- [x] `node --test tests/contracts/adr-0022-delivery-mode.test.mjs` (23/23 pass — 15 W1/W2/W3 + 4 Amendment D Leaf 1 + 4 Amendment D Leaf 2)
- [x] `npm test` (1767 total / 1719 pass / 0 fail / 48 skip)
- [x] Schema invariants 19/19 = 0 violations
- [x] Shadow row `20260523162230` cleaned per SEDIMENT-227.A; canonical version `20260805000009` registered via `supabase migration repair`

## Test plan

- [x] Cron RPC dry-run with 0 → expected behavior (count=0)
- [x] Cron RPC populated state → 14 inserts on first invocation
- [x] Idempotency window honored on consecutive runs
- [x] pg_cron schedule active=true
- [x] No regression in adr-0022-delivery-mode contract test suite

Cross-ref:
- #260 (parent, W2 audit Finding D + PM Policy Matrix)
- #292 (Selection Reliability sprint umbrella)
- PR #305 (Leaf 1 — catalog/helper parity, merged 25c4a472)
- Migration `20260611000000_p152_interview_reminder_1h_cron.sql` (cron pattern reference)