### PR TITLE
fix(p228): Leaf 5 hotfix — 3 dormant bugs in _replay_selection_notifications_p228

### DIFF
--- a/supabase/migrations/20260805000015_p228_leaf5_hotfix_returning_into_to_get_diagnostics.sql
+++ b/supabase/migrations/20260805000015_p228_leaf5_hotfix_returning_into_to_get_diagnostics.sql
@@ -1,0 +1,258 @@
+-- p228 Leaf 5 hotfix: replace UPDATE ... RETURNING 1 INTO v_updated_count
+-- with plain UPDATE + GET DIAGNOSTICS ROW_COUNT.
+--
+-- Bug (caught by PM post-p228 close, pre-execution): the prior Leaf 5 body
+-- (migration 20260805000012) used:
+--
+--   UPDATE public.notifications
+--   SET delivery_mode = 'transactional_immediate',
+--       digest_delivered_at = NULL,
+--       digest_batch_id = NULL
+--   WHERE id = ANY(v_eligible_ids)
+--     AND email_sent_at IS NULL
+--   RETURNING 1 INTO v_updated_count;
+--
+--   GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+--
+-- PostgreSQL semantics: `RETURNING ... INTO <scalar>` in plpgsql expects
+-- EXACTLY ONE row. When the UPDATE touches 2+ rows, the runtime raises
+-- "query returned more than one row" (SQLSTATE 21000), short-circuiting
+-- BEFORE the GET DIAGNOSTICS line, BEFORE the admin_audit_log INSERT, and
+-- BEFORE the RETURN jsonb. The bug is dormant whenever v_eligible_count
+-- equals 0 (block skipped) or exactly 1 (RETURNING INTO succeeds), but
+-- live state has v_eligible_count = 2 — so any call with p_dry_run=false
+-- would have errored.
+--
+-- Live dry-run smoke (p_dry_run=true) had been masking this — the dry_run
+-- branch never enters the IF NOT p_dry_run guard. The bug only surfaces on
+-- actual UPDATE execution.
+--
+-- Fix: drop the `RETURNING 1 INTO v_updated_count` clause entirely. The
+-- subsequent `GET DIAGNOSTICS v_updated_count = ROW_COUNT` was already
+-- present and gives the correct multi-row UPDATE count without raising.
+--
+-- Forward-defense: contract test asserts that the body of
+-- _replay_selection_notifications_p228 does NOT contain any RETURNING ... INTO
+-- pattern (`tests/contracts/adr-0022-delivery-mode.test.mjs`). Regression
+-- guard.
+--
+-- Second bug caught during live smoke of p_dry_run=false (same code path,
+-- service_role context): `v_caller record;` was declared but never assigned
+-- when auth.uid() is NULL (service_role bypass). The audit log INSERT then
+-- tried `COALESCE(v_caller.id, ...)` and Postgres raised
+-- "record v_caller is not assigned yet" (SQLSTATE 55000). Same pre-execution
+-- dormancy pattern as the RETURNING bug — masked by dry-run smoke that
+-- never enters the IF NOT p_dry_run branch.
+--
+-- Fix: replace the unassigned-record-access pattern with a scalar
+-- `v_caller_id uuid := NULL;`. Three references swap from `v_caller.id` to
+-- `v_caller_id`. Forward-defense contract test asserts the safe pattern.
+--
+-- Third bug caught during live smoke of p_dry_run=false (same code path,
+-- service_role context): `admin_audit_log.actor_id` has a NOT NULL FK to
+-- `members(id)`. Earlier code used
+-- `COALESCE(v_caller_id, '00000000-...zero-uuid...')` as sentinel for the
+-- service_role bypass — but the zero-uuid is not a real member, so the
+-- INSERT raised `23503 violates admin_audit_log_actor_id_fkey`. Same
+-- dormancy pattern: dry_run skips the audit log entirely; only surfaces on
+-- actual UPDATE execution from service_role context.
+--
+-- Fix: gate the admin_audit_log INSERT on `v_caller_id IS NOT NULL`.
+-- service_role / cron invocations track via different mechanisms
+-- (postgres logs, cron_run_log) — admin_audit_log is intentionally
+-- member-scoped per the action.actor_id semantics. Forward-defense
+-- contract test asserts the gate.
+
+CREATE OR REPLACE FUNCTION public._replay_selection_notifications_p228(
+  p_dry_run boolean DEFAULT true
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public'
+AS $func$
+DECLARE
+  v_caller_id uuid := NULL;
+  v_window_start date := '2026-05-01';
+  v_window_end   date := '2026-05-20';
+  v_eligible_ids uuid[] := ARRAY[]::uuid[];
+  v_eligible_count int := 0;
+  v_manual_close_count int := 0;
+  v_eligible_payload jsonb := '[]'::jsonb;
+  v_manual_close_payload jsonb := '[]'::jsonb;
+  v_updated_count int := 0;
+  v_row record;
+BEGIN
+  -- Authority gate: admin path only (or service_role bypass).
+  -- Hotfix p228: use scalar v_caller_id (uuid) so the audit log INSERT below
+  -- can safely COALESCE without tripping the unassigned-record trap on
+  -- service_role calls (auth.uid() IS NULL → branch skipped entirely).
+  IF auth.uid() IS NOT NULL THEN
+    SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+    IF v_caller_id IS NULL THEN
+      RAISE EXCEPTION 'Unauthorized: member not found';
+    END IF;
+    IF NOT (public.can_by_member(v_caller_id, 'manage_member'::text)
+            OR public.can_by_member(v_caller_id, 'manage_platform'::text)) THEN
+      RAISE EXCEPTION 'Unauthorized: requires manage_member or manage_platform';
+    END IF;
+  END IF;
+  -- service_role (auth.uid() IS NULL) bypasses the member-side check; intended
+  -- for one-shot cron invocation if PM later schedules this. v_caller_id stays
+  -- NULL in that path; COALESCE in audit log uses the zero-uuid sentinel.
+
+  -- Classify the 17 historical rows
+  FOR v_row IN
+    SELECT n.id, n.type, n.recipient_id, n.source_id, n.created_at,
+           n.delivery_mode, n.email_sent_at, n.digest_delivered_at,
+           m.member_status,
+           m.id AS member_id_exists
+    FROM public.notifications n
+    LEFT JOIN public.members m ON m.id = n.recipient_id
+    WHERE n.type IN ('selection_termo_due', 'selection_approved', 'selection_interview_scheduled')
+      AND n.created_at >= v_window_start::timestamptz
+      AND n.created_at < v_window_end::timestamptz
+      AND n.email_sent_at IS NULL
+      AND n.digest_delivered_at IS NOT NULL
+    ORDER BY n.created_at
+  LOOP
+    DECLARE
+      v_should_replay boolean := false;
+      v_reason text;
+      v_pending_term boolean;
+      v_future_interview boolean;
+      v_app_record record;
+    BEGIN
+      IF v_row.type = 'selection_termo_due' THEN
+        -- Replay only if member has a selection_application approved AND has not yet
+        -- signed the volunteer agreement (tracked via certificates.type='volunteer_agreement'
+        -- + status='issued' — see sign_volunteer_agreement() RPC body).
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.selection_applications sa
+          JOIN public.members m ON lower(m.email) = lower(sa.email)
+          WHERE m.id = v_row.recipient_id
+            AND sa.status = 'approved'
+            AND NOT EXISTS (
+              SELECT 1 FROM public.certificates c
+              WHERE c.member_id = m.id
+                AND c.type = 'volunteer_agreement'
+                AND c.status = 'issued'
+            )
+        ) INTO v_pending_term;
+
+        v_should_replay := COALESCE(v_pending_term, false);
+        v_reason := CASE WHEN v_should_replay
+          THEN 'pending_term_action_exists'
+          ELSE 'no_pending_term_or_already_signed'
+        END;
+
+      ELSIF v_row.type = 'selection_approved' THEN
+        -- Replay if within 30d AND member is active (still in onboarding window)
+        v_should_replay := (
+          (now() - v_row.created_at) < interval '30 days'
+          AND v_row.member_id_exists IS NOT NULL
+          AND v_row.member_status = 'active'
+        );
+        v_reason := CASE WHEN v_should_replay
+          THEN 'recent_and_active_member'
+          ELSE 'stale_or_inactive'
+        END;
+
+      ELSIF v_row.type = 'selection_interview_scheduled' THEN
+        -- Replay if associated interview is in the future (date info still actionable)
+        SELECT EXISTS (
+          SELECT 1
+          FROM public.selection_interviews si
+          WHERE si.application_id = v_row.source_id
+            AND si.scheduled_at > now()
+            AND si.conducted_at IS NULL
+        ) INTO v_future_interview;
+
+        v_should_replay := COALESCE(v_future_interview, false);
+        v_reason := CASE WHEN v_should_replay
+          THEN 'interview_still_upcoming'
+          ELSE 'interview_past_or_completed'
+        END;
+      END IF;
+
+      IF v_should_replay THEN
+        v_eligible_ids := array_append(v_eligible_ids, v_row.id);
+        v_eligible_count := v_eligible_count + 1;
+        v_eligible_payload := v_eligible_payload || jsonb_build_object(
+          'notification_id', v_row.id,
+          'type', v_row.type,
+          'created_at', v_row.created_at,
+          'reason', v_reason
+        );
+      ELSE
+        v_manual_close_count := v_manual_close_count + 1;
+        v_manual_close_payload := v_manual_close_payload || jsonb_build_object(
+          'notification_id', v_row.id,
+          'type', v_row.type,
+          'created_at', v_row.created_at,
+          'reason', v_reason
+        );
+      END IF;
+    END;
+  END LOOP;
+
+  -- Apply UPDATE if not dry_run. Hotfix p228 (see migration 20260805000015):
+  -- plain UPDATE + GET DIAGNOSTICS ROW_COUNT is the correct multi-row count
+  -- primitive. Earlier code used the scalar-into clause which raises 21000
+  -- on 2+ rows; the contract test in adr-0022-delivery-mode.test.mjs guards
+  -- against the broken pattern returning.
+  IF NOT p_dry_run AND v_eligible_count > 0 THEN
+    UPDATE public.notifications
+    SET delivery_mode = 'transactional_immediate',
+        digest_delivered_at = NULL,
+        digest_batch_id = NULL
+    WHERE id = ANY(v_eligible_ids)
+      AND email_sent_at IS NULL;  -- defense-in-depth idempotency
+
+    GET DIAGNOSTICS v_updated_count = ROW_COUNT;
+
+    -- Audit log — gated on v_caller_id IS NOT NULL. admin_audit_log.actor_id
+    -- has a NOT NULL FK to members(id); service_role (auth.uid() NULL) lacks a
+    -- valid actor, and there is no system-member sentinel to COALESCE to.
+    -- service_role / cron invocations are tracked via postgres logs +
+    -- cron_run_log; admin_audit_log stays member-scoped.
+    IF v_caller_id IS NOT NULL THEN
+      INSERT INTO public.admin_audit_log (
+        actor_id, action, target_type, target_id, changes, metadata
+      ) VALUES (
+        v_caller_id,
+        'selection.notifications_replay_p228',
+        'notifications',
+        NULL,
+        jsonb_build_object(
+          'eligible_replay_count', v_eligible_count,
+          'manual_close_count', v_manual_close_count,
+          'updated_count', v_updated_count,
+          'eligible_ids', v_eligible_ids
+        ),
+        jsonb_build_object(
+          'window_start', v_window_start,
+          'window_end', v_window_end,
+          'dry_run', p_dry_run,
+          'rpc_version', 'p228_w2_leaf5_hotfix_diag_rowcount'
+        )
+      );
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'dry_run', p_dry_run,
+    'window_start', v_window_start,
+    'window_end', v_window_end,
+    'eligible_replay_count', v_eligible_count,
+    'manual_close_count', v_manual_close_count,
+    'updated_count', v_updated_count,
+    'eligible_replay', v_eligible_payload,
+    'manual_close', v_manual_close_payload
+  );
+END;
+$func$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/adr-0022-delivery-mode.test.mjs
+++ b/tests/contracts/adr-0022-delivery-mode.test.mjs
@@ -639,6 +639,81 @@ test('ADR-0022 Amendment D Leaf 5: p228 Leaf 5 migration file exists', () => {
     'Leaf 5 migration must NOTIFY pgrst to reload schema.');
 });
 
+// ─── Amendment D / p228 Leaf 5 hotfix contracts ───
+// PM-caught regression guard: `RETURNING ... INTO <scalar>` in plpgsql expects
+// EXACTLY ONE row and raises "query returned more than one row" (SQLSTATE
+// 21000) when an UPDATE touches 2+ rows. Initial Leaf 5 body shipped with
+// `UPDATE ... RETURNING 1 INTO v_updated_count` which would have errored on
+// real execution given live state had v_eligible_count=2. Replaced with plain
+// UPDATE + pre-existing GET DIAGNOSTICS ROW_COUNT. This contract test prevents
+// the broken pattern from coming back.
+
+test('ADR-0022 Amendment D Leaf 5 hotfix: _replay_selection_notifications_p228 body has no RETURNING ... INTO', () => {
+  const match = findLatestFunctionMatch('_replay_selection_notifications_p228');
+  assert.ok(match, '_replay_selection_notifications_p228 must be declared.');
+  const body = match[2];
+
+  // Regression guard: the broken pattern is `RETURNING <something> INTO
+  // <scalar>`. `GET DIAGNOSTICS ... = ROW_COUNT` is the correct multi-row
+  // count primitive.
+  assert.ok(!/RETURNING[\s\S]{0,200}INTO\b/i.test(body),
+    'Leaf 5 hotfix: body must NOT contain `RETURNING ... INTO` — multi-row UPDATE raises "query returned more than one row". Use GET DIAGNOSTICS ROW_COUNT instead.');
+
+  // Sanity: the correct pattern is in place
+  assert.ok(/GET\s+DIAGNOSTICS\s+v_updated_count\s*=\s*ROW_COUNT/i.test(body),
+    'Leaf 5 hotfix: body must use GET DIAGNOSTICS v_updated_count = ROW_COUNT (correct multi-row count primitive).');
+});
+
+test('ADR-0022 Amendment D Leaf 5 hotfix: v_caller declared as scalar uuid (not unassigned record)', () => {
+  // Second bug fixed in same hotfix: `v_caller record;` was declared but never
+  // assigned when service_role calls the RPC (auth.uid() IS NULL → IF block
+  // skipped). The downstream COALESCE(v_caller.id, ...) raised "record is not
+  // assigned yet" (SQLSTATE 55000). Fix: replace with `v_caller_id uuid := NULL;`
+  // scalar so the COALESCE works on the unassigned-cron path.
+  const match = findLatestFunctionMatch('_replay_selection_notifications_p228');
+  assert.ok(match);
+  const body = match[2];
+
+  assert.ok(!/v_caller\s+record\s*;/i.test(body),
+    'Leaf 5 hotfix: must NOT declare v_caller as `record` (unassigned-record-access trap on service_role path). Use scalar uuid instead.');
+  assert.ok(/v_caller_id\s+uuid\s*:=\s*NULL/i.test(body),
+    'Leaf 5 hotfix: must declare `v_caller_id uuid := NULL;` for safe COALESCE on the service_role unassigned path.');
+  assert.ok(!/v_caller\.id/i.test(body),
+    'Leaf 5 hotfix: must not reference v_caller.id (record syntax). Use v_caller_id scalar.');
+});
+
+test('ADR-0022 Amendment D Leaf 5 hotfix: admin_audit_log INSERT gated on v_caller_id IS NOT NULL', () => {
+  // Third bug fixed in same hotfix: admin_audit_log.actor_id has a NOT NULL FK
+  // to members(id). Earlier code used COALESCE(v_caller_id, '00000000-...zero
+  // uuid...') as sentinel for service_role bypass, but the zero-uuid is not a
+  // real member → FK violation 23503 on actual UPDATE execution. Fix: gate
+  // INSERT on `IF v_caller_id IS NOT NULL THEN`; service_role / cron tracks
+  // elsewhere (postgres logs, cron_run_log).
+  const match = findLatestFunctionMatch('_replay_selection_notifications_p228');
+  assert.ok(match);
+  const body = match[2];
+
+  // Zero-uuid sentinel pattern must be gone
+  assert.ok(!/COALESCE\(\s*v_caller_id\s*,\s*'00000000-0000-0000-0000-000000000000'/i.test(body),
+    'Leaf 5 hotfix: must NOT use zero-uuid sentinel via COALESCE(v_caller_id, ...) — violates admin_audit_log_actor_id_fkey. Gate INSERT on v_caller_id IS NOT NULL instead.');
+
+  // The conditional gate must precede the INSERT
+  assert.ok(/IF\s+v_caller_id\s+IS\s+NOT\s+NULL\s+THEN[\s\S]{0,800}INSERT\s+INTO\s+public\.admin_audit_log/i.test(body),
+    'Leaf 5 hotfix: admin_audit_log INSERT must be gated on `IF v_caller_id IS NOT NULL THEN` to skip on service_role / cron context.');
+});
+
+test('ADR-0022 Amendment D Leaf 5 hotfix: hotfix migration file exists', () => {
+  const files = readdirSync(MIGRATIONS_DIR).filter(f => f.endsWith('.sql'));
+  const hotfix = files.find(f => f.includes('p228_leaf5_hotfix_returning_into_to_get_diagnostics'));
+  assert.ok(hotfix,
+    'Migration 20260805000015_p228_leaf5_hotfix_returning_into_to_get_diagnostics.sql must exist.');
+  const body = readFileSync(join(MIGRATIONS_DIR, hotfix), 'utf8');
+  assert.ok(/CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\._replay_selection_notifications_p228/i.test(body),
+    'Hotfix migration must redefine _replay_selection_notifications_p228.');
+  assert.ok(/NOTIFY\s+pgrst\s*,\s*'reload schema'/i.test(body),
+    'Hotfix migration must NOTIFY pgrst.');
+});
+
 // ─── Amendment D / p228 #260 W2 Leaf 6 contracts ───
 // Operational suppress_all bypass: SQL helper + EF parity in lock-step.
 


### PR DESCRIPTION
## Summary

PM-caught regression in Leaf 5 selective-replay RPC. The dry_run path masked **three distinct pre-execution bugs** in the `IF NOT p_dry_run AND v_eligible_count > 0` branch. All three are fixed in a single hotfix migration `20260805000015`.

## The 3 dormant bugs

### Bug #1 — `RETURNING 1 INTO v_updated_count`
PostgreSQL `RETURNING ... INTO <scalar>` in plpgsql requires EXACTLY ONE row; raises SQLSTATE 21000 ("query returned more than one row") on 2+ matches. Live state has `v_eligible_count=2` so any `p_dry_run=false` call would have errored. **Fix:** drop the RETURNING clause; existing `GET DIAGNOSTICS ROW_COUNT` already gives the correct count.

### Bug #2 — `v_caller record` unassigned
Declared but never assigned when `auth.uid() IS NULL` (service_role bypass path). Downstream `COALESCE(v_caller.id, ...)` raised SQLSTATE 55000 "record is not assigned yet". **Fix:** scalar `v_caller_id uuid := NULL;` populated only inside the `IF auth.uid() IS NOT NULL` branch.

### Bug #3 — `admin_audit_log_actor_id_fkey` violation
Zero-uuid sentinel `'00000000-...'` used as COALESCE fallback is not a real `members` row; FK constraint raised SQLSTATE 23503 on service_role invocations. **Fix:** gate audit INSERT on `IF v_caller_id IS NOT NULL THEN`. service_role / cron tracks via postgres logs + cron_run_log.

## Live smoke (both modes, post-fix)

```
p_dry_run=true:  {success: true, eligible_replay_count: 2, manual_close_count: 15, updated_count: 0}
p_dry_run=false: {success: true, eligible_replay_count: 2, manual_close_count: 15, updated_count: 2}
```

Row-level verification — both selection_approved rows flipped:
- `1470e6ce-f927-466d-a795-d04074e6a32c`: delivery_mode='transactional_immediate', digest_delivered_at=NULL ✓
- `6338a42d-158a-45a1-bc2d-c3aadd6986ea`: delivery_mode='transactional_immediate', digest_delivered_at=NULL ✓

`send-notification-email` cron (every 5 min) will dispatch real Resend emails to the 2 candidates within the next 5-10 min.

## Forward-defense (3 new contract assertions)

- `_replay_selection_notifications_p228` body has no `RETURNING ... INTO`
- `v_caller` declared as scalar uuid (not unassigned `record`)
- `admin_audit_log` INSERT gated on `v_caller_id IS NOT NULL`

## Verification

- [x] `node --test tests/contracts/adr-0022-delivery-mode.test.mjs` — 49/49 pass
- [x] `npm test` — 1793/1745/0/48 (+9 vs post-Leaf-7 baseline 1784)
- [x] Phase C body-hash drift gate PASS (live = file md5)
- [x] Schema invariants 19/19 = 0
- [x] Canonical migration `20260805000015` registered; shadow rows (3 retry attempts) cleaned
- [x] 2/17 historical mis-routed rows replayed live (per PM Policy Matrix D-sel-2)

## Sediment to log

- **SEDIMENT-228.D**: when a code path is only exercised under a non-default parameter (here `p_dry_run=false`), the test plan MUST include both paths in live smoke before merge. dry_run-only smoke masked 3 production bugs in this RPC.
- **SEDIMENT-228.E**: PostgreSQL `record` declarations are unassigned until first SELECT/INSERT ... INTO populates them. Accessing `.field` on unassigned record raises 55000. Prefer scalar variables for caller_id patterns where the assignment branch may be skipped.
- **SEDIMENT-228.F**: `admin_audit_log.actor_id` is NOT NULL FK to `members(id)`; there is no system-member sentinel for service_role/cron context. Gate the INSERT on a real actor or skip it.

## Cross-ref

- #260 (parent, W2 Leaf 5)
- PR #309 (p228 close docs — will merge AFTER this hotfix lands per PM dispatch)
- 17 historical mis-routed rows: 2 replayed live, 15 documented as manual_close