### PR TITLE
fix(selection): #365 objective PERT column uses objective_score

### DIFF
--- a/src/pages/admin/selection.astro
+++ b/src/pages/admin/selection.astro
@@ -346,7 +346,7 @@ const SEL_I18N = {
                   <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)] cursor-pointer hover:text-navy" data-sort="applicant_name">{t('admin.selection.colName', lang)}</th>
                   <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)]">{t('admin.selection.colTrack', lang)}</th>
                   <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)]">{t('admin.selection.chapter', lang)}</th>
-                  <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)] cursor-pointer hover:text-navy" data-sort="research_score">{t('admin.selection.colResearch', lang)}</th>
+                  <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)] cursor-pointer hover:text-navy" data-sort="objective_score">{t('admin.selection.colResearch', lang)}</th>
                   <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)] cursor-pointer hover:text-navy" data-sort="leader_score">{t('admin.selection.colLeaderShort', lang)}</th>
                   <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)] cursor-pointer hover:text-navy" data-sort="interview_score" title={t('admin.selection.colInterviewScoreHint', lang)}>{t('admin.selection.colInterviewScore', lang)}</th>
                   <th class="px-4 py-2.5 font-bold text-[var(--text-secondary)] cursor-pointer hover:text-navy" data-sort="final_score" title={t('admin.selection.colFinalHint', lang)}>{t('admin.selection.colFinal', lang)}</th>
@@ -1561,7 +1561,7 @@ const SEL_I18N = {
 
     tbody.innerHTML = displayRows.map(r => {
       const sb2 = STATUS_BADGE[r.status] || STATUS_BADGE.submitted;
-      const researchScore = r.research_score != null ? Number(r.research_score).toFixed(1) : '—';
+      const objectiveScore = r.objective_score != null ? Number(r.objective_score).toFixed(1) : '—';
       const leaderScore = r.leader_score != null ? Number(r.leader_score).toFixed(1) : '—';
       // Track-aware rank
       let rankDisplay: string;
@@ -1642,9 +1642,9 @@ const SEL_I18N = {
         <td class="px-4 py-2.5 font-semibold text-[var(--text-primary)]">${esc(r.applicant_name)}${noMembership ? ' <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-amber-50 text-amber-700" title="Sem membership PMI">!M</span>' : ''}${r.is_returning_member ? ' <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-blue-50 text-blue-700" title="Retornante (ex-voluntário do Núcleo)">R</span>' : ''}${r.consent_ai_status === 'pending' ? ` <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-700" title="${esc(T.consentPendingTooltip)}">🔒 ${esc(T.consentPendingBadge)}</span>` : ''}${r.consent_ai_status === 'revoked' ? ` <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-red-100 text-red-700" title="${esc(T.consentRevokedTooltip)}">🔒 ${esc(T.consentRevokedBadge)}</span>` : ''}${r.extra_flags?.pdf_likely_invalid ? ` <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-orange-100 text-orange-700" title="${esc(T.pdfInvalidTooltip)}">${esc(T.pdfInvalidBadge)}</span>` : ''}${reApplicantBadge(r)}${briefingBadge(r)}${aiTriageBadge(r)}${vepBadge(r)}</td>
         <td class="px-4 py-2.5 text-[12px]">${trackBadge}</td>
         <td class="px-4 py-2.5 text-[12px] text-[var(--text-secondary)]" title="${esc(chapterTooltip)}">${esc(chapterDisplay)}${chapterSourceBadge}${chapterDivergentBadge} ${memberBadge}</td>
-        <td class="px-4 py-2.5 text-[12px] font-mono" title="${esc(pertFullTooltip(r.research_score, currentCycle?.pert_cutoff))}">
-          <div class="${r.research_score != null ? `font-semibold ${bandColorClass(r.research_score, currentCycle?.pert_cutoff) || 'text-[var(--text-primary)]'}` : 'text-[var(--text-muted)]'} px-1.5 py-0.5 rounded inline-block">${researchScore}</div>
-          ${pertBandChip(r.research_score, currentCycle?.pert_cutoff)}
+        <td class="px-4 py-2.5 text-[12px] font-mono" title="${esc(pertFullTooltip(r.objective_score, currentCycle?.pert_cutoff))}">
+          <div class="${r.objective_score != null ? `font-semibold ${bandColorClass(r.objective_score, currentCycle?.pert_cutoff) || 'text-[var(--text-primary)]'}` : 'text-[var(--text-muted)]'} px-1.5 py-0.5 rounded inline-block">${objectiveScore}</div>
+          ${pertBandChip(r.objective_score, currentCycle?.pert_cutoff)}
         </td>
         <td class="px-4 py-2.5 text-[12px] font-mono">
           <div class="${r.leader_score != null ? 'font-bold text-[var(--text-primary)]' : 'text-[var(--text-muted)]'}">${leaderScore}</div>

--- a/tests/contracts/per-candidate-pert-classification.test.mjs
+++ b/tests/contracts/per-candidate-pert-classification.test.mjs
@@ -67,19 +67,25 @@ describe('p245 #229a per-candidate PERT classification', () => {
   });
 
   describe('per-app TD render', () => {
-    it('research_score TD calls pertBandChip(r.research_score, currentCycle?.pert_cutoff)', () => {
+    // p249 #365 hotfix: the objective PERT column ("Pesquisa") must read r.objective_score
+    // (selection_applications.objective_score_avg via p246 dashboard payload), NOT
+    // r.research_score. Researcher-track research_score became composite (objective +
+    // interview ≡ final_score) after the score canonicalization work, so feeding it into
+    // the objective PERT helpers makes the chip color/band/delta compare the final score
+    // against the objective cutoff — silently misleading PM cut/no-cut decisions.
+    it('objective_score TD calls pertBandChip(r.objective_score, currentCycle?.pert_cutoff)', () => {
       assert.match(
         SELECTION_PAGE,
-        /\$\{pertBandChip\(r\.research_score, currentCycle\?\.pert_cutoff\)\}/,
-        'research_score TD must call pertBandChip with cycle pert_cutoff (objective rule)'
+        /\$\{pertBandChip\(r\.objective_score, currentCycle\?\.pert_cutoff\)\}/,
+        'objective_score TD must call pertBandChip with cycle pert_cutoff (objective rule)'
       );
     });
 
-    it('research_score TD uses pertFullTooltip in TD title', () => {
+    it('objective_score TD uses pertFullTooltip in TD title', () => {
       assert.match(
         SELECTION_PAGE,
-        /<td class="px-4 py-2\.5 text-\[12px\] font-mono" title="\$\{esc\(pertFullTooltip\(r\.research_score, currentCycle\?\.pert_cutoff\)\)\}"/,
-        'research_score TD title must use pertFullTooltip helper (enriched: target + banda + cohort + method)'
+        /<td class="px-4 py-2\.5 text-\[12px\] font-mono" title="\$\{esc\(pertFullTooltip\(r\.objective_score, currentCycle\?\.pert_cutoff\)\)\}"/,
+        'objective_score TD title must use pertFullTooltip helper (enriched: target + banda + cohort + method)'
       );
     });
 
@@ -103,6 +109,31 @@ describe('p245 #229a per-candidate PERT classification', () => {
         SELECTION_PAGE,
         /bandClassify\(r\.leader_score, currentCycle\?\.pert_cutoff\)/,
         'PM rule (#229a): leader_score must NOT be classified against pert_cutoff'
+      );
+    });
+
+    // p249 #365 forward-defense: the bug at the root of #365 was that the objective PERT
+    // helpers were fed r.research_score (which is now researcher-track composite ≡
+    // objective + interview ≡ final_score for interviewed rows). Re-introducing this
+    // mapping silently miscolors the objective band chip — verified live on cycle4-2026
+    // 2026-05-25 with 10 researcher rows where research_score - objective_score_avg
+    // equals interview_score exactly. Lock the regression class: neither pertBandChip nor
+    // bandColorClass nor pertFullTooltip may receive r.research_score against pert_cutoff.
+    it('objective PERT helpers must NOT receive r.research_score against currentCycle?.pert_cutoff (#365 hotfix)', () => {
+      assert.doesNotMatch(
+        SELECTION_PAGE,
+        /pertBandChip\(r\.research_score, currentCycle\?\.pert_cutoff\)/,
+        '#365: pertBandChip must NOT be fed r.research_score (composite ≡ final) against the objective cutoff'
+      );
+      assert.doesNotMatch(
+        SELECTION_PAGE,
+        /bandColorClass\(r\.research_score, currentCycle\?\.pert_cutoff\)/,
+        '#365: bandColorClass must NOT be fed r.research_score (composite ≡ final) against the objective cutoff'
+      );
+      assert.doesNotMatch(
+        SELECTION_PAGE,
+        /pertFullTooltip\(r\.research_score, currentCycle\?\.pert_cutoff\)/,
+        '#365: pertFullTooltip must NOT be fed r.research_score (composite ≡ final) against the objective cutoff'
       );
     });
   });


### PR DESCRIPTION
## Summary

Frontend-only hotfix for issue #365. The "Pesquisa"/objective column on `/admin/selection` was reading `r.research_score`, which became composite (`objective + interview == final_score` for interviewed researcher rows) after the score canonicalization work. The PERT chip color/band/delta was therefore comparing the **final score against the objective cutoff**, silently misleading PM cut/no-cut decisions on cycle 4.

Flip the column to `r.objective_score` (sourced from `selection_applications.objective_score_avg` via the p246 `get_selection_dashboard` payload). Entrevista (`r.interview_score`) and Final (`r.final_score` + `finalScoreChip`) stay unchanged.

## Scope

- frontend-only hotfix
- no migration, no RPC change, no data write
- corrects the "Pesquisa/Objetiva" column number, sort key, tooltip, color class, and objective PERT chip
- keeps Entrevista (`r.interview_score`) and Final (`r.final_score` + `finalScoreChip`) intact
- adds forward-defense regressions: `pertBandChip` / `bandColorClass` / `pertFullTooltip` must **not** receive `r.research_score` against `currentCycle?.pert_cutoff`

## Expected visual outcome (Flavio Oliveira, cycle4-2026)

| Column | Before | After |
|---|---:|---:|
| Pesquisa | 288.5 (wrong, composite) | **184.5** ✓ |
| Entrevista | 104.0 | **104.0** (unchanged) |
| Final | 288.5 | **288.5** (unchanged) |

Objective PERT chip color/band now compares 184.5 against the objective cutoff (was comparing 288.5). The other 9 cycle4 researchers with the same misclassification are corrected by the same flip.

## Live DB evidence (read-only, cycle4-2026)

| Candidato | objective_score_avg | research_score | interview_score | final_score | Δ research−objective |
|---|---:|---:|---:|---:|---:|
| Flavio Oliveira | **184.50** | 288.50 | 104.00 | 288.50 | 104.00 |
| Luíse Quintana | **124.50** | 222.50 | 98.00 | 222.50 | 98.00 |
| Maria Araújo | **149.50** | 214.50 | 65.00 | 214.50 | 65.00 |
| William Junio | **145.00** | 207.00 | 62.00 | 207.00 | 62.00 |
| Marcio Pimenta | **93.50** | 203.50 | 110.00 | 203.50 | 110.00 |

`research_score - objective_score_avg == interview_score` for all 5 — confirming `research_score` is composite for interviewed researcher rows. 10 cycle4 researcher rows total with `research_score ≠ objective_score_avg` (delta 48 → 110, avg 75.7).

## Changes

**`src/pages/admin/selection.astro` — 5 surgical edits in the objective TD block:**

| Line | Before | After |
|---|---|---|
| 349 | `data-sort="research_score"` | `data-sort="objective_score"` |
| 1564 | `const researchScore = r.research_score …` | `const objectiveScore = r.objective_score …` |
| 1645 | `pertFullTooltip(r.research_score, …)` | `pertFullTooltip(r.objective_score, …)` |
| 1646 | `r.research_score` (×2) + `${researchScore}` | `r.objective_score` (×2) + `${objectiveScore}` |
| 1647 | `pertBandChip(r.research_score, …)` | `pertBandChip(r.objective_score, …)` |

Sort comparator at L1422 is generic `a[sortCol]` — `'objective_score'` works because the payload already exposes that field (verified live on `get_selection_dashboard.prosrc`).

**`tests/contracts/per-candidate-pert-classification.test.mjs` — 2 flips + 3 forward-defense:**

- Flipped 2 existing TD assertions from `r.research_score` to `r.objective_score`
- New `it('objective PERT helpers must NOT receive r.research_score …')` asserts `assert.doesNotMatch` for `pertBandChip` / `bandColorClass` / `pertFullTooltip` against `r.research_score` + `currentCycle?.pert_cutoff` — locks the regression class permanently in CI

## Test plan

- [x] `npx astro build` — 0 new errors (warning on `var(--text-primary/secondary/muted)` is pre-existing CSS noise unrelated to this hotfix)
- [x] `node --test tests/contracts/per-candidate-pert-classification.test.mjs` — **31/31 pass** (was 28; +3 forward-defense)
- [x] `npm test` offline — **2728 total / 2613 pass / 0 fail / 115 skip**
- [x] Cross-file `grep -rnE 'research_score' tests/` — no other test cravava the UI mapping (other matches are SQL canonical reconciliation + backend payload assertion + descriptive comments)
- [x] Live `get_selection_dashboard.prosrc` confirms `objective_score`, `research_score`, `interview_score`, `final_score` all exposed as separate payload keys (no backend change needed)
- [ ] Post-merge visual smoke on `/admin/selection` Cycle 4 view — Flavio row shows Pesquisa **184.5** (was 288.5), chip color recomputed against objective cutoff

## Refs

#365 (PM audit + scope direction)
