### PR TITLE
chore(claude): CLAUDE.md → Opus 4.8 (STANDBY — não mergear sem confirmar /model)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ Refactor arquitetural completo: 6 ADRs (0004-0009), 30 migrations, 7 fases. Ver 
 - **Supabase:** `ldrfrvwhxsmgaabwmaik` (sa-east-1)
 - **Stack:** Astro v6 (Cloudflare Workers) · Supabase Postgres + Edge Functions (Deno) · Cloudflare worker `pmi-vep-sync` (wrangler 4.x)
 - **MCP server:** `nucleo-mcp` em `supabase/functions/nucleo-mcp/` — OAuth 2.1 + custom domain `nucleoia.vitormr.dev/mcp` (ver `.claude/rules/mcp.md`)
-- **AI Model:** Claude Opus 4.7 (`claude-opus-4-7`) — released 2026-04-16. xhigh effort level. Updated tokenizer (1.0-1.35x token mapping). `/ultrareview` for code review.
+- **AI Model:** Claude Opus 4.8 (`claude-opus-4-8`) — released 2026-05-28. xhigh effort level. `/ultrareview` for code review.
 - **Wiki:** GitHub org `nucleo-ia-gp` — repos `wiki` (private, Obsidian vault) + `frameworks` (public, CC-BY-SA / MIT). Synced to `wiki_pages` table via FTS. Scope: narrative knowledge only (ADR-0010) — operational data stays in SQL.
 - **LGPD:** Art. 18 cycle complete (consent gate + export + delete + anonymize cron 5y).
 - **Current state (counts, last commits, session handoffs):** NOT pinned in CLAUDE.md (per Anthropic guidance — frequently-changing data bloats context). Use `/audit` skill, MCP tools `get_admin_dashboard` / `get_invitation_health`, or read `memory/handoff_p*.md` + `git log` when needed.


### PR DESCRIPTION
## Status: 🟡 DRAFT / STANDBY

Não mergear até você ter pessoalmente confirmado que `claude-opus-4-8` aparece no `/model` picker da sua CLI.

## What

Atualiza 1 linha em `CLAUDE.md`:

```diff
- **AI Model:** Claude Opus 4.7 (`claude-opus-4-7`) — released 2026-04-16. xhigh effort level. Updated tokenizer (1.0-1.35x token mapping). `/ultrareview` for code review.
+ **AI Model:** Claude Opus 4.8 (`claude-opus-4-8`) — released 2026-05-28. xhigh effort level. `/ultrareview` for code review.
```

Removida a nota do tokenizer 1.0-1.35x (era específica do 4.7; reintroduzir só se as release notes do 4.8 confirmarem mudança).

## Why

Anúncio https://www.anthropic.com/news/claude-opus-4-8 (28/mai/2026). WebFetch da URL retornou sumário consistente com release real, mas **não foi possível cross-verificar de dentro de uma sessão Opus 4.7**.

## Verify antes de mergear

```bash
# 1. Atualizar CLI (se aplicável ao seu install method)
claude --version

# 2. Abrir picker dentro de uma sessão
/model
# Esperado: `claude-opus-4-8` aparece na lista

# 3. Se aparecer, mergear este PR.
# Se NÃO aparecer:
#  - aguardar 2-4h (lag típico CLI vs API);
#  - re-tentar update + /model;
#  - se ainda não houver após 24h, fechar este PR como "premature" e reabrir com data correta.
```

## Risk

Baixo. Edit é doc-only em CLAUDE.md, não toca código, schema, ou MCP.

## Out of scope

- Atualizar `system prompt` da harness (não é editável daqui).
- Atualizar memory/handoff (são snapshots históricos por design).
- Rodar `npm test` / `npx astro build` (doc-only, não afeta build).

## Refs

- p276 handoff (sessão atual)
- URL anúncio: https://www.anthropic.com/news/claude-opus-4-8
- Issues backlog abertas hoje: #414, #415, #416