### PR TITLE
docs(p277): #419 metric 3 PR9 — ADR-0100 two-metric attendance revision

### DIFF
--- a/docs/adr/ADR-0100-canonical-metric-definitions.md
+++ b/docs/adr/ADR-0100-canonical-metric-definitions.md
@@ -2,13 +2,13 @@
 
 | Field | Value |
 |---|---|
-| Status | Proposed (2026-05-28) — spec; implementation deferred to per-metric PRs (Bucket B of the 2026-05-28 disparity audit) |
-| Date | 2026-05-28 |
+| Status | Accepted (2026-05-28; revised 2026-05-30) — dictionary spec + **active per-metric rollout**. Metric 1 (impact_hours), metric 2 (active_member), and **metric 3 (attendance — two-metric model, this revision)** shipped; metrics 4-8 + the p175 gate (PR10) + the seal track (PR11) in progress (Bucket B of the 2026-05-28 disparity audit) |
+| Date | 2026-05-28 (revised 2026-05-30 — metric 3) |
 | Author | Vitor Maia Rodovalho (Assisted-By: Claude (Anthropic)) |
 | Supersedes | none |
 | Amends | none |
-| Related | [[ADR-0096]] (impact_hours_total view — accepted-risk; this ADR proposes to make it canonical and retire the looser parallel) · [[ADR-0005]] (initiatives primitive / tribes-as-bridge) · [[ADR-0007]] (`can()` authority) · [[ADR-0050]] (gamification visibility opt-out) · [[ADR-0097]] (migration drift amnesty + ratchet — the p175 gate this ADR extends) · `docs/audit/METRIC_DISPARITY_AUDIT_2026-05-28.md` (Bucket B findings) |
-| Migrations | none (spec-only) — implementation lands one metric per PR |
+| Related | [[ADR-0096]] (impact_hours_total view — accepted-risk; this ADR proposes to make it canonical and retire the looser parallel) · [[ADR-0005]] (initiatives primitive / tribes-as-bridge) · [[ADR-0007]] (`can()` authority) · [[ADR-0050]] (gamification visibility opt-out) · [[ADR-0097]] (migration drift amnesty + ratchet — the p175 gate this ADR extends) · `docs/audit/METRIC_DISPARITY_AUDIT_2026-05-28.md` (Bucket B findings) · `docs/specs/SPEC_419_M3_ATTENDANCE_TWO_METRIC.md` (metric 3 two-metric design + the D1–D10 ratification) |
+| Migrations | none spec-side — implementation lands one metric per PR. Metric 3 (attendance) shipped in `20260805000064`–`20260805000075` (eligibility primitive + engagement/reliability summaries + 8 surface convergences) |
 
 ---
 
@@ -70,7 +70,8 @@ code (`'cycle3-2026'`). This single rule retires D10, D11, and the YTD-literal f
 |---|---|---|---|
 | **active_member** | `is_active = true AND current_cycle_active = true` | current cycle | n/a |
 | **impact_hours** | `SUM(COALESCE(duration_actual, duration_minutes)/60) FILTER (present = true AND excused IS NOT TRUE)`, ROUND 1; **no** 60-min fallback | param window (default current cycle) | n/a |
-| **attendance_rate** | per `(member, event)`: `present=true`; denominator = eligible events where status ∈ (present, absent), **excused excluded**; emit as fraction 0..1 ROUND 2 at the data layer (surfaces format ×100) | param scope (member / tribe / initiative / global), current cycle | n/a |
+| **attendance_engagement** *(Participação — the headline; every audience surface)* | per `(member, event)` `present=true`; denominator = **eligible** past non-cancelled events from `_attendance_eligible_events` — a no-show that left **no row still counts as absent**; **excused excluded** (neutral, D1); fraction 0..1 ROUND 2 (surfaces ×100); cohort aggregate = **AVG-of-member-rates** (D2). Live global **76.9%** (cohort 37). | `cycles.is_current` (open ⇒ `CURRENT_DATE`), type set `{geral,kickoff,tribo,lideranca}` | n/a |
+| **attendance_reliability** *(Confiabilidade de registro — ops/self diagnostic, NEVER a headline until roster sealing)* | `present=true` over events that **have a recorded** non-excused row (`a.id exists AND excused IS NOT TRUE`); excused removed both sides. **There is no `attendance.status` column** — both metrics use the `present`/`excused` pair. Structurally ≈100% until absent-row capture (live **99.2%**, only **5** genuine absent rows cohort-wide). **Visibility (D10):** member-self + admin only, **always with raw present/absent/excused counts**; public/headline **BANNED** until `seal_event_attendance` coverage is real (PR10 hard-gate). | same window + type set | n/a |
 | **tribe_roster / member_count** | DISTINCT persons with an **active, non-observer** engagement on the initiative, `is_active`; resolve legacy `tribe_id` ↔ engagements onto **engagements** (ADR-0005) | current cycle | n/a |
 | **lifetime_xp** | `SUM(gamification_points.points)` all-time | all-time | honored on member + public surfaces; admin carve-out documented |
 | **cycle_xp + rank** | cycle points = points in window; rank `ORDER BY cycle_points DESC` **in cycle mode** (not lifetime), deterministic tiebreak `member_id`; pool = `gamification_opt_out=false AND eligible-this-cycle` | current cycle | honored except admin carve-out |
@@ -85,7 +86,12 @@ code (`'cycle3-2026'`). This single rule retires D10, D11, and the YTD-literal f
 - `get_impact_hours_canonical(p_scope, p_window)` — **already exists** (ADR-0096); parameterize
   by scope/window and make **every** hours surface call it. Retire/rename
   `impact_hours_summary` to signal non-canonical.
-- `get_attendance_rate(p_member_id, p_scope, p_cycle)` — one per-(member,event) definition.
+- **Attendance (metric 3) — 4 primitives + shared eligibility + seal precondition** (two-metric model, §7 ratification 2026-05-30):
+  - `_attendance_eligible_events(p_member_id, p_cycle_start)` → TABLE — the **single** eligibility source (type-based `{geral,kickoff,tribo,lideranca}`, §3b Canonical Eligibility Principle); consumed by **both** engagement RPCs **and** the seal track. No surface may reintroduce a parallel (tag-based / `event_audience_rules`) eligibility model.
+  - `get_attendance_engagement_rate(p_member_id, p_cycle_start)` → numeric · `get_attendance_engagement_summary(p_scope, p_scope_id, p_cycle_start, p_chapter)` → jsonb — **ENGAGEMENT** (the headline); the summary replaces 4 divergent inline aggregates.
+  - `get_attendance_rate(p_member_id, p_cycle_start)` → numeric · `get_attendance_reliability_summary(p_scope, p_scope_id, p_cycle_start, p_chapter)` → jsonb — **RELIABILITY** (diagnostic); `get_attendance_rate` was type-scoped in PR6 so reliability shares the eligibility set and can converge with engagement once sealing materializes absent rows.
+  - **Invariant: engagement ≤ reliability** (CI-asserted) — reliability conditions on complete data, so it systematically over-states vs the expected-denominator engagement.
+  - `seal_event_attendance(p_event_id)` + `events.roster_sealed_at` — **deferred PR11** (separate track): materializes absent rows for eligible no-shows; the precondition before reliability may be promoted from diagnostic to a shown indicator.
 - `v_tribe_roster(initiative_id)` — the §2.2 roster predicate, resolving the legacy
   `tribe_id` vs V4 `engagements` fork onto engagements (ADR-0005).
 - one **pillar-bucketing helper** keyed on `gamification_rules` (retires the raw-category-string
@@ -108,8 +114,10 @@ One metric per PR, smallest-blast-radius first:
 1. `active_member` → `v_active_members`, migrate the 6 RPCs. (lowest risk; predicate-only)
 2. `impact_hours` → all hours surfaces call `get_impact_hours_canonical`; retire
    `impact_hours_summary`.
-3. `attendance_rate` → `get_attendance_rate`; also fix the D6 `a.id IS NOT NULL` present-detection
-   bug and the D12 attendee-count bug in the same pass.
+3. `attendance_rate` → **expanded into the two-metric model** (engagement + reliability) — see the
+   §2.2 rows, the §2.3 four-primitive set, and the 2026-05-30 §7 ratification. Shipped across PR1–PR8
+   (eligibility primitive + both summaries + 8 surface convergences); also fixed the D6 `a.id IS NOT NULL`
+   present-detection bug and the D12 attendee-count bug. PR10 (gate) + PR11 (seal) remain.
 4. `tribe_roster` → `v_tribe_roster` + V4 bridge delegation (D15/D18).
 5. XP rank/pillar → pillar helper + cycle-mode ordering + deterministic tiebreak (D8/D9).
 6. trail_completion + cpmai_certified → dictionary picks the single source; native-initiative
@@ -190,3 +198,45 @@ A live-DB gamification integrity probe (audit doc §"GAMIFICATION PROBE") found 
   headline). The `active_member` canonical convergence therefore applies to ORG-LEVEL headcounts only;
   chapter/admin member_status counts are out of scope by design. Revisit only if the chapter program
   decides its dashboards should track cycle-activity instead of lifecycle.
+
+- **2026-05-30 — metric 3 (attendance): TWO-metric model ratified + shipped (PR1–PR8 of 11).**
+  PM ratified **Option C**: two canonical indicators — **engagement/*Participação*** (the headline, on every
+  audience surface) and **reliability/*Confiabilidade de registro*** (an ops/self diagnostic, never a headline
+  until roster sealing). The single §2.2 `attendance_rate` row is replaced by the two dictionary rows above;
+  §2.3 now lists the four primitives + shared eligibility + the seal precondition. Full design + grounding:
+  `docs/specs/SPEC_419_M3_ATTENDANCE_TWO_METRIC.md`.
+
+  **§3b CANONICAL ELIGIBILITY PRINCIPLE (prerequisite for ALL future attendance metrics).**
+  `public._attendance_eligible_events(member, cycle_start)` is the SINGLE source of attendance eligibility —
+  **type-based**: candidates are `{geral,kickoff,tribo,lideranca}` in the `cycles.is_current` window
+  (open ⇒ `CURRENT_DATE`); per-member scoping is `geral/kickoff` → all operational, `tribo` → own tribe via
+  `get_member_tribe` (resolved through `initiatives.legacy_tribe_id`; events has **no** tribe column),
+  `lideranca` → `can_by_member('manage_event')`. **No surface may reintroduce a parallel eligibility model** —
+  not the tag-based one (`general_meeting`/`tribe_meeting`) nor `event_audience_rules`/`is_event_mandatory_for_member`.
+  Both were live and produced a divergent global number (panel **70.5%** vs canonical **76.2%** at PR7 time) because
+  they select different candidate events and scope eligibility differently. **Decision (Option B): type-based wins**;
+  PR7 converged the last hold-out (`get_attendance_panel`) onto it and dropped the orphan `get_attendance_summary`.
+  The PR10 p175 gate forward-defends this (no new tag/audience-rule attendance eligibility in any RPC).
+
+  **The ten ratified business-rule decisions** (SPEC §6; recommended defaults adopted as ratified):
+  - **D1** — excused is **removed** from the engagement denominator (neutral; both metrics treat excused identically — an org-sanctioned absence must not penalize a recognition KPI). Extended in PR8: excused is also neutral for dropout-risk flagging.
+  - **D2** — cohort = the **37-member operational union** {researcher, tribe_leader, manager} (curator kept); aggregate = **AVG-of-member-rates** (not pooled present/expected).
+  - **D3** — `lideranca` eligibility = `can_by_member('manage_event')` (single V4 authority basis); the phantom `deputy_manager` is dropped.
+  - **D4** — `tribo` eligibility = **own-tribe only**; the org-manager is excluded from the tribo dimension; the legacy `tribe_id` ↔ engagements **bridge bug** (Roberto Macêdo: `tribe_id=8` but `get_member_tribe=NULL`) is treated V4-consistently (tribe-8 excluded from his eligible set; the data/intent question stays the PM's).
+  - **D5** — 1-on-1 events **excluded** (coaching artifact, no roster).
+  - **D6** — `evento_externo` / comms types **excluded** (neither type exists live; the comms branch stays dormant).
+  - **D7** — *(superseded by PM Option B / §3b)* the original "hybrid: delegate to `is_event_mandatory_for_member`" was reversed; **type-based eligibility is canonical**.
+  - **D8** — point-in-time eligibility for late joiners/changers is **as-of event date, but shipped OFF/parameterized** until separately ratified (the `created_at` proxy is useless — all 37 share 2026-03-05).
+  - **D9** — `get_attendance_summary`'s hidden 0.4/0.6 weighting is **dropped to flat present/expected**; the orphan was retired in PR7.
+  - **D10** — reliability **visibility**: member-self + admin only, **mandatory raw present/absent/excused counts**, public/headline **BANNED** until `seal_event_attendance` coverage is real; window open ⇒ `CURRENT_DATE` / closed ⇒ `cycle_end`, no date literal. The PR10 hard-gate enforces this.
+
+  **antes → depois (live-grounded 2026-05-30, `cycle_3` from `cycles.is_current`):**
+  - **Home hero** (`calc_attendance_pct` → engagement): **64.4%** (a buggy hybrid denominator, PR-time per SPEC §1/§5) → canonical engagement, **live 76.9%** (was 76.2% at PR2 merge — the same metric drifts up as attendance accrues; home now == `engagement_global`).
+  - **Engagement global** (`get_attendance_engagement_summary('global',…)`): **76.9%** (`0.7686`, AVG-of-rates, cohort_n=37, at_risk_count=4, coverage `ok`; present 576 / expected 734 / excused 53).
+  - **Reliability global** (`get_attendance_reliability_summary('global',…)`): **99.2%** (`0.9916`, cohort_n=37, coverage `partial`) — structurally pinned near 100% because **absences are never written**: only **5** genuine absent rows cohort-wide vs 583 present (54 excused). This is exactly why reliability must stay a diagnostic until the seal track materializes absent rows.
+  - There is **no `attendance.status` column** live — both metrics operate on the `present`/`excused` pair.
+
+  **Remaining:** PR10 (p175 gate extension — inline-rate forward-defense + the D10 reliability-visibility hard-gate +
+  grant ladder) and PR11 (seal track — `events.roster_sealed_at` + `seal_event_attendance`, coordinating
+  `sync_attendance_points` no-XP-for-sealed-absents + `detect_and_notify_detractors`). Only after real seal coverage
+  may reliability be promoted from diagnostic to a shown indicator.


### PR DESCRIPTION
## #419 metric 3 — PR9: ADR-0100 two-metric attendance revision (docs only)

Records the now-shipped two-metric attendance model in the canonical-metrics ADR. **No code** — the implementation landed across PR1–PR8 (#429–#439); this PR makes ADR-0100 reflect it.

### What changed in ADR-0100
- **§2.2 dictionary** — the single `attendance_rate` row → **two rows**: `attendance_engagement` (*Participação*, eligible-denominator **headline**) + `attendance_reliability` (*Confiabilidade de registro*, recorded-denominator **diagnostic**, never a headline until roster sealing). Both note there is **no `attendance.status` column** (present/excused pair).
- **§2.3** — the single `get_attendance_rate` line → the **4 primitives** (`_attendance_eligible_events` shared source + engagement rate/summary + reliability rate/summary) + the **engagement ≤ reliability** invariant + the deferred `seal_event_attendance` precondition.
- **§7** — new 2026-05-30 ratification: the **§3b Canonical Eligibility Principle** (type-based wins; no parallel tag/`event_audience_rules` model) + the **ten ratified decisions D1–D10** + the antes→depois record.
- Header → *Accepted / per-metric rollout in progress*; Related/Migrations cite the SPEC + metric-3 migrations; §3 plan item 3 annotated.

### antes → depois (live-grounded this turn — `cycle_3`, `cycles.is_current`, start 2026-03-01)

| surface | antes (PR-time, SPEC provenance) | depois (live now) |
|---|---|---|
| Home hero `calc_attendance_pct` → engagement | **64.4%** (buggy hybrid denominator) | **76.9%** (canonical engagement; was 76.2% at PR2 — drifts up as attendance accrues; == `engagement_global`) |
| Engagement global `get_attendance_engagement_summary` | — | **76.9%** (`0.7686`, AVG-of-rates, cohort 37, at_risk 4; present 576 / expected 734 / excused 53, coverage `ok`) |
| Reliability global `get_attendance_reliability_summary` | — | **99.2%** (`0.9916`, cohort 37; present 583 / **absent only 5** / excused 54, coverage `partial`) |
| Eligibility model (panel) | **70.5%** tag/audience-rule (PR7-time) | **76.2%** canonical type-based (PR7 converged) |

The depois numbers are re-queried live in this turn (not recited from the spec — the canonical engagement has drifted 76.2 → 76.9 since PR2). The antes are PR-time historical with SPEC §1/§5/§3b provenance, not presented as current measurements. D8 rationale verified live: all **37** operational members share `created_at = 2026-03-05`.

### Validation
- `astro build` clean (ADR is a standalone doc — not in the build/test graph; `npm test` unaffected, zero code/test files changed).
- No ADR-content validation test exists; this is docs-only.

`#419` remains **OPEN** — metrics 4-8 + PR10 (p175 gate) + PR11 (seal track) remain.

🤖 Assisted by Claude (Anthropic)
