### PR TITLE
fix(494): remove confusing 'recorrente' option from the single-event modal

### DIFF
--- a/src/components/attendance/NewEventModal.astro
+++ b/src/components/attendance/NewEventModal.astro
@@ -64,13 +64,10 @@ const lang: Lang = getLangFromURL(Astro.url.pathname);
           <label class="text-[12px] font-semibold text-[var(--text-secondary)]">{t('attendance.modal.nature', lang)}</label>
           <select id="ev-nature" class="px-3 py-2 rounded-lg border-[1.5px] border-[var(--border-default)] text-[13px] bg-[var(--surface-card)]">
             <option value="avulsa">Avulsa</option>
-            <option value="recorrente">Recorrente</option>
             <option value="kickoff">Kickoff</option>
             <option value="encerramento">Encerramento</option>
             <option value="workshop">Workshop</option>
           </select>
-          <button type="button" id="ev-nature-hint" data-action="switch-to-recurring"
-                  class="hidden text-left text-[10px] text-amber-600 dark:text-amber-400 hover:underline cursor-pointer bg-transparent border-0 p-0">{t('attendance.modal.natureRecurringHint', lang)}</button>
         </div>
         <div class="flex flex-col gap-1.5">
           <label class="text-[12px] font-semibold text-[var(--text-secondary)]">{t('attendance.modal.date', lang)}</label>

--- a/src/pages/attendance.astro
+++ b/src/pages/attendance.astro
@@ -1096,11 +1096,6 @@ const i18nBundle = buildPageI18n(['attendance', 'meetings', 'comp.common', 'comp
         case 'open-recurring':
           openRecurringModal();
           break;
-        case 'switch-to-recurring':
-          // From the single-event modal's 'recorrente' hint → jump to the weekly-series modal.
-          closeModal('modal-new-event');
-          openRecurringModal();
-          break;
         case 'refresh-events':
           loadEvents();
           break;
@@ -1639,12 +1634,6 @@ const i18nBundle = buildPageI18n(['attendance', 'meetings', 'comp.common', 'comp
       typeSelect.disabled = false;
       tribeSelCreate.disabled = false;
     }
-    // Discoverability: 'recorrente' nature is a label only — point users to the 'Criar Série' tab.
-    const natureSelect = document.getElementById('ev-nature') as HTMLSelectElement;
-    const natureHint = document.getElementById('ev-nature-hint');
-    const syncNatureHint = () => natureHint?.classList.toggle('hidden', natureSelect.value !== 'recorrente');
-    natureSelect.onchange = syncNatureHint;
-    syncNatureHint();
     openModal('modal-new-event');
   }
 

--- a/tests/contracts/p492-recurring-modal-type-and-tribe.test.mjs
+++ b/tests/contracts/p492-recurring-modal-type-and-tribe.test.mjs
@@ -55,3 +55,10 @@ test('#492 static: tribe-picker is populated + toggled by audience', () => {
   assert.match(attRaw, /function toggleRecTribePicker/, 'toggleRecTribePicker exists');
   assert.match(attRaw, /target\.id === 'rec-audience'/, 'audience change toggles the picker');
 });
+
+test('#494 stopgap: single-event modal no longer offers "recorrente" as a nature (recurring = the dedicated Criar Série journey)', () => {
+  const NEM = resolve(ROOT, 'src/components/attendance/NewEventModal.astro');
+  const nemRaw = existsSync(NEM) ? readFileSync(NEM, 'utf8') : '';
+  assert.ok(nemRaw, 'NewEventModal.astro readable');
+  assert.doesNotMatch(nemRaw, /<option value="recorrente"/, 'single-event nature dropdown must not offer recorrente');
+});


### PR DESCRIPTION
## #494 stopgap (PM-requested)

The single-event ("reunião unitária") modal's `ev-nature` dropdown offered **`recorrente`**, but selecting it does **not** create a series — it just labels one event, which confused users. Recurring is the dedicated **"Criar Série"** journey (its own button).

**Change (frontend-only):** removed the `recorrente` option (`NewEventModal.astro`) + the now-orphaned `switch-to-recurring` hint button & handler (`attendance.astro`) — the hint only ever showed when `recorrente` was selected. The **edit** modal keeps `recorrente` (it must display existing series events). Recurring stays discoverable via the "Criar Recorrente" button.

Regression guard added to `p492` test (single-event modal must not offer `recorrente`). Build ✅.

The full initiative-picker + journey-unify work remains in **#494** (needs spec). ⚠️ Needs a platform deploy.

Refs #494