### PR TITLE
docs(155): supabase CLI fork-bomb guard + version floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ npm run dev -- --host 0.0.0.0 --port 4321
 npm test
 ```
 
-**Prerequisites:** Node.js 24+ (nvm), Supabase CLI, Wrangler CLI. See `.env.example` for variables.
+**Prerequisites:** Node.js 24+ (nvm), Supabase CLI (**≥ 2.100.1** — earlier versions fork-bomb on `migration repair`, see issue #155 / `docs/RUNBOOK.md`), Wrangler CLI. See `.env.example` for variables.
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -65,14 +65,21 @@ NOTIFY pgrst, 'reload schema';
 
 ### Migrations
 
+> **Supabase CLI floor: ≥ 2.100.1.** Versions ≤ 2.100.0 fork-bomb during
+> `migration repair`/`list` when the `supabase-go` binary is not co-located with
+> the shim (upstream supabase/cli#5282 — OOM-killed two sessions on 2026-05-19,
+> issue #155). Check `supabase --version`; if below the floor, upgrade before
+> running any migration command. Defense-in-depth: run the CLI under a memory/task
+> cap (below) so a future runaway is contained instead of taking down the host.
+
 ```bash
-# Ver estado das migrations
-npx supabase migration list
+# Ver estado das migrations (memory/task-capped — guards against the #155 fork-bomb)
+systemd-run --user --scope -p MemoryMax=2G -p TasksMax=20 -- npx supabase migration list
 
 # Se aplicou SQL direto no Dashboard, criar migration de repair:
 # 1. Salvar o SQL em supabase/migrations/YYYYMMDDHHMMSS_descricao.sql
-# 2. Marcar como aplicada:
-npx supabase migration repair YYYYMMDDHHMMSS --status applied
+# 2. Marcar como aplicada (também capped):
+systemd-run --user --scope -p MemoryMax=2G -p TasksMax=20 -- npx supabase migration repair YYYYMMDDHHMMSS --status applied
 ```
 
 ### Backup


### PR DESCRIPTION
## #155 — supabase CLI v2.100.0 fork-bomb

Docs-only. Lands action items 3+4 from #155.

### Already resolved (verified live 2026-06-03)
- **Item 1 (CLI upgrade):** local `supabase --version` = **2.101.0** (>= 2.100.1), with `supabase-go` co-located at `~/.local/bin/` (the exact fix for supabase/cli#5282).
- **Item 2 (migration state):** `supabase_migrations.schema_migrations` has both `20260721000000` and `20260722000000`; local files present; DB/file consistent (the interrupted repair completed).

### This PR (items 3+4)
- `docs/RUNBOOK.md` §Migrations — wrap `npx supabase migration list/repair` in a `systemd-run --user --scope -p MemoryMax=2G -p TasksMax=20` memory/task cap + 1-line incident rationale + supabase-go co-location note.
- `README.md` + RUNBOOK — state the supabase CLI floor **>= 2.100.1** so a fresh install can't regress to the fork-bombing 2.100.0.

No code/migration/deploy. CI does not install the supabase CLI (verified across all 15 workflows), so there is no CI version to pin — the doc floor is the sufficient guard.
