### PR TITLE
fix(ui): chapter logos on uniform white box (TeamSection)

### DIFF
--- a/src/components/sections/TeamSection.astro
+++ b/src/components/sections/TeamSection.astro
@@ -263,8 +263,10 @@ const ROLE_COLORS: Record<string, string> = {
     const inner = sorted.map(ch => {
       const logo = CHAPTER_LOGOS[ch];
       const logoEl = logo
-        ? `<img src="${logo}" class="h-9 max-w-[120px] object-contain mb-2" alt="${ch}" onerror="this.style.display='none';this.nextElementSibling.style.display='block'">
-           <div style="display:none" class="text-[.85rem] font-extrabold mb-2" style="color:${HEADING_COLORS.crimson}">${ch}</div>`
+        ? `<div class="bg-white rounded-lg inline-flex items-center justify-center px-3 mb-2" style="height:48px;min-width:120px">
+             <img src="${logo}" class="max-h-8 max-w-[140px] object-contain" alt="${ch}" onerror="this.parentElement.style.display='none';this.parentElement.nextElementSibling.style.display='block'">
+           </div>
+           <div style="display:none;color:${HEADING_COLORS.crimson}" class="text-[.85rem] font-extrabold mb-2">${ch}</div>`
         : `<div class="text-[.8rem] font-extrabold mb-2" style="color:${HEADING_COLORS.crimson}">${ch}</div>`;
       return `<div class="bg-white/5 border border-white/10 rounded-2xl px-5 py-4 min-w-[160px]">
         <div class="text-center mb-3">${logoEl}</div>


### PR DESCRIPTION
Chapter cards used `bg-white/5` (translucent over the dark section) → transparent logos (incl. the new official PMI-GO) read as dark/blue and looked smaller; only PMI-CE looked clean (its JPG bakes white in). Now every chapter logo sits in a **white box** (h=48px, min-w=120px, object-contain) → consistent white bg + size across all chapters, matching the PMI-CE look. onerror fallback retargets to the wrapper. No data change. astro build ✓. Needs wrangler deploy to go live.