### PR TITLE
fix(health): /mcp tool count 301 → 304 to match runtime tools/list

### DIFF
--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -1,5 +1,8 @@
 // supabase/functions/nucleo-mcp/index.ts
-// MCP server v2.80.0 — /mcp 301 tools + 4 prompts + 3 resources + /semantic 3 tools (bridge alpha)
+// MCP server v2.80.0 — /mcp 304 tools + 4 prompts + 3 resources + /semantic 3 tools (bridge alpha)
+// /health count correction (backlog "/health 301→304"): /mcp tools 301 → 304 to match the runtime
+//   tools/list (304 live 2026-06-05); +3 net since #332 from the #411 selection-cutoff MCP exposure.
+//   Count-only — no serverInfo version bump (stays 2.79.0). Contract tests pin 304.
 // v2.80.0 (p239b #332 W3 LGPD Art. 18 §IV retroactive operator surface): +2 tools wrapping the
 //   p238b audit-log infrastructure RPCs so PM can invoke from authenticated MCP-Claude session
 //   (RPCs gate on auth.uid() → can_by_member('manage_member'), which the service-role MCP exec_sql
@@ -7385,7 +7388,7 @@ app.get("/health", (c) => c.json({
   status: "ok",
   ef_version: "2.80.0",
   surfaces: {
-    "/mcp": { server: "nucleo-ia-hub", version: "2.79.0", tools: 301 },
+    "/mcp": { server: "nucleo-ia-hub", version: "2.79.0", tools: 304 },
     "/semantic": { server: "nucleo-ia-semantic", version: "0.1.0", tools: 3 },
   },
   transport: "native-streamable-http",

--- a/tests/contracts/mcp-lgpd-retroactive-operator-tools.test.mjs
+++ b/tests/contracts/mcp-lgpd-retroactive-operator-tools.test.mjs
@@ -214,11 +214,11 @@ test('p239b #332: ef_version bumped to 2.80.0 (was 2.79.1 pre-p239b)', () => {
   assert.match(EF, /ef_version:\s*"2\.80\.0"/, '/health must report ef_version 2.80.0');
 });
 
-test('p239b #332: /health surface declares /mcp tools: 301 + version 2.79.0', () => {
+test('p239b #332 + #411: /health surface declares /mcp tools: 304 + version 2.79.0', () => {
   assert.match(
     EF,
-    /"\/mcp":\s*\{\s*server:\s*"nucleo-ia-hub"\s*,\s*version:\s*"2\.79\.0"\s*,\s*tools:\s*301\s*\}/,
-    '/health surface report must show 301 tools + version 2.79.0 on /mcp'
+    /"\/mcp":\s*\{\s*server:\s*"nucleo-ia-hub"\s*,\s*version:\s*"2\.79\.0"\s*,\s*tools:\s*304\s*\}/,
+    '/health surface report must show 304 tools + version 2.79.0 on /mcp (301 → 304 via #411 exposure)'
   );
 });
 

--- a/tests/contracts/mcp-semantic-gateway-bridge.test.mjs
+++ b/tests/contracts/mcp-semantic-gateway-bridge.test.mjs
@@ -191,8 +191,9 @@ test('/health endpoint reports both /mcp and /semantic surfaces', () => {
   assert.match(m[0], /"nucleo-ia-hub"/, '/health should report /mcp server name');
   assert.match(m[0], /"nucleo-ia-semantic"/, '/health should report /semantic server name');
   assert.match(m[0], /tools:\s*3/, '/health should report 3 tools on /semantic');
-  // p239b: /mcp grew 299 → 301 via +2 LGPD retroactive operator tools (#332 close).
-  assert.match(m[0], /tools:\s*301/, '/health should report 301 tools on /mcp (was 299 pre-p239b)');
+  // p239b: /mcp grew 299 → 301 via +2 LGPD retroactive operator tools (#332 close);
+  // then 301 → 304 via the #411 selection-cutoff MCP exposure (+3, live tools/list 304).
+  assert.match(m[0], /tools:\s*304/, '/health should report 304 tools on /mcp (was 301 pre-#411 exposure)');
 });
 
 // ─── 7. /mcp regression-safety guarantee ──────────────────────────────────────

--- a/tests/contracts/member-emails-write-surface.test.mjs
+++ b/tests/contracts/member-emails-write-surface.test.mjs
@@ -215,8 +215,9 @@ test('GAP-205.D: McpServer version is bumped past p215 (>= 2.78.0)', () => {
 // so the regex now targets the surfaces."/mcp".tools field specifically (was: greedy first
 // `tools: N` after /health which picked up /semantic.tools=3 after the restructure).
 // p239b #332 update: ratchet 299 → 301 to absorb +2 LGPD retroactive operator tools.
-// History: 296 (p215) → 299 (GAP-205.D) → 301 (p239b #332).
-test('GAP-205.D + p239b #332: /health endpoint reports /mcp tools = 301 (matches catalog ratchet)', () => {
+// /health-301→304 update: ratchet 301 → 304 to absorb +3 from the #411 selection-cutoff MCP exposure.
+// History: 296 (p215) → 299 (GAP-205.D) → 301 (p239b #332) → 304 (#411 exposure).
+test('GAP-205.D + #411: /health endpoint reports /mcp tools = 304 (matches catalog ratchet)', () => {
   const healthBlockRe = /app\.get\s*\(\s*"\/health"[\s\S]{0,800}?\}\)\s*\)\s*;/;
   const block = mcpIndex.match(healthBlockRe);
   assert.ok(block, 'Could not find /health endpoint block in nucleo-mcp/index.ts');
@@ -225,9 +226,9 @@ test('GAP-205.D + p239b #332: /health endpoint reports /mcp tools = 301 (matches
   const m = block[0].match(mcpToolsRe);
   assert.ok(m, 'Could not find "/mcp" surface tools count in /health endpoint');
   const count = Number(m[1]);
-  assert.equal(count, 301,
-    `/health /mcp surface tools count must equal 301 (= 296 at p215 close + 3 GAP-205.D + 2 p239b #332 ` +
-    `LGPD retroactive operator tools). Source-of-truth is the runtime tools/list, but the /health label ` +
+  assert.equal(count, 304,
+    `/health /mcp surface tools count must equal 304 (= 296 at p215 close + 3 GAP-205.D + 2 p239b #332 ` +
+    `LGPD retroactive operator tools + 3 #411 selection-cutoff exposure). Source-of-truth is the runtime tools/list, but the /health label ` +
     `should track to avoid the WATCH-205.G drift class.`);
 });
 


### PR DESCRIPTION
## Drift
The EF `/health` surface hardcoded `tools: 301` (`supabase/functions/nucleo-mcp/index.ts:7388`) — **stale by 3** vs the live runtime `tools/list` (**304**, re-grounded 2026-06-05). The static count reconciles: `grep -c 'mcp.tool('` = 307, minus the 3 `/semantic` bridge tools = **304**.

The +3 net since the p239b #332 ratchet (301) came from the **#411 selection-cutoff MCP exposure**.

## Fix
**Count-only** — no serverInfo version bump (stays `2.79.0`; bumping it cross-cuts the p239b version tests and the PM did not request it). Updated:
- EF header summary (line 2) + the `/health` literal (line 7388): `301 → 304`
- the 3 contract assertions that pin the `/health` count: `mcp-semantic-gateway-bridge`, `member-emails-write-surface`, `mcp-lgpd-retroactive-operator-tools`

## Verification
- 71/71 tests across the 3 touched contract files pass.
- MCP pre-deploy duplicate-tool-name check clean; **no tool registrations changed** (no Zod surface touched).
- No stray `tools: 301` remaining.

⚠️ **Requires an EF deploy** (`supabase functions deploy nucleo-mcp --no-verify-jwt`) to update the live `/health` response — deferred for confirmation + full post-deploy smoke (initialize + tools/list).