### PR TITLE
chore: pin production Cloudflare account_id in wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,4 +1,10 @@
 name = "platform"
+# Pin the production Cloudflare account so `wrangler deploy` fails fast on a wrong-account
+# login instead of half-uploading assets then erroring on a "missing KV" (code 10041).
+# SEDIMENT-WRANGLER-ACCOUNT (2026-06-05): prod `platform` + SESSION KV 6ffb04524d66… ("platform-session")
+# live under vitor.rodovalho@outlook.com's account 67d4c226…, NOT the personal gmail account
+# 4afb554f… (which has 0 KV namespaces). account_id is not a secret (it appears in dashboard URLs).
+account_id = "67d4c2262aebde75efb5fb6a1bb12cd2"
 main = "@astrojs/cloudflare/entrypoints/server"
 compatibility_date = "2025-01-01"
 compatibility_flags = ["nodejs_compat"]


### PR DESCRIPTION
## Why
On 2026-06-05 a `wrangler deploy` failed mid-flight: `wrangler login` had landed on the **personal gmail account** (`4afb554f…`, **0 KV namespaces**), so wrangler uploaded all 287 assets then errored binding `env.SESSION` → `KV namespace '6ffb…' not found [code 10041]`. Production was unharmed (deploy aborts before publishing), but the failure was confusing and the half-deploy targeted the wrong account (risking the `*/*` personal-site route hijack).

## Fix
Pin `account_id = "67d4c2262aebde75efb5fb6a1bb12cd2"` (prod, `vitor.rodovalho@outlook.com`) so a wrong-account `wrangler deploy` **fails fast with a clear account mismatch** instead of half-deploying a stub.

Verified the prod account owns both:
- the `platform` worker (live, serving nucleoia.vitormr.dev), and
- the SESSION KV `6ffb04524d664228b19ce1595d08cbc5` ("platform-session")

via `wrangler whoami` + `wrangler kv namespace list` + the Cloudflare-Pages CI dashboard URL (`/67d4c226…/pages/...`).

`account_id` is **not a secret** (it appears in dashboard URLs). Config-only; no code/build change.

**Pre-deploy check going forward:** `wrangler whoami` must show `67d4c226…` (not gmail `4afb554f…`).