### PR TITLE
fix(529): TribeAttendanceTab ⋮ excused affordance parity (keyboard + click) — closes #529

### DIFF
--- a/src/components/tribes/TribeAttendanceTab.tsx
+++ b/src/components/tribes/TribeAttendanceTab.tsx
@@ -212,6 +212,15 @@ export default function TribeAttendanceTab({ tribeId, initiativeId }: Props) {
     })();
   }, [data]);
 
+  // #529 parity: the excused modal is now keyboard-openable (focused ⋮ + Enter/Space),
+  // so it must be keyboard-closable too — Escape closes it (mirror of the backdrop click).
+  useEffect(() => {
+    if (!excusedModal) return;
+    const onEsc = (e: KeyboardEvent) => { if (e.key === 'Escape') setExcusedModal(null); };
+    document.addEventListener('keydown', onEsc);
+    return () => document.removeEventListener('keydown', onEsc);
+  }, [excusedModal]);
+
   const startLongPress = useCallback((eventId: string, memberId: string, memberName: string, current: CellStatus) => {
     longPressFiredRef.current = false;
     if (longPressTimerRef.current) clearTimeout(longPressTimerRef.current);
@@ -460,8 +469,8 @@ export default function TribeAttendanceTab({ tribeId, initiativeId }: Props) {
           <div>
             <strong>{t('attendance.helpTitle', 'Como marcar presença')}:</strong>{' '}
             {t('attendance.helpClick', 'Clique rápido alterna entre Presente ✅ e Ausente ❌.')}{' '}
-            <strong>{t('attendance.helpLongPress', 'Toque longo (300ms) ou segure o mouse')}</strong>{' '}
-            {t('attendance.helpLongPressDetail', 'abre menu com Falta Justificada ⚠️ + campo de motivo (opcional, recomendado).')}
+            <strong>{t('attendance.helpExcuse', 'O botão ⋮ na célula (ou toque longo)')}</strong>{' '}
+            {t('attendance.helpExcuseDetail', 'abre o menu com Falta Justificada ⚠️ + campo de motivo (opcional, recomendado).')}
           </div>
         </div>
       )}
@@ -548,6 +557,12 @@ export default function TribeAttendanceTab({ tribeId, initiativeId }: Props) {
                       />
                     );
 
+                    // #529 parity: open the excused modal from the visible ⋮ affordance (keyboard + click)
+                    const openExcusedModal = () => {
+                      setExcusedModal({ eventId: ev.id, memberId: member.id, memberName: member.name, current: status });
+                      setReasonDraft(excuseReasons[cellKey] || '');
+                    };
+
                     return (
                       <td
                         key={ev.id}
@@ -556,7 +571,7 @@ export default function TribeAttendanceTab({ tribeId, initiativeId }: Props) {
                       >
                         {canToggleAttendance && status !== 'na' && status !== 'scheduled' ? (
                           <span
-                            className="inline-block select-none"
+                            className="relative inline-block select-none"
                             onPointerDown={() => startLongPress(ev.id, member.id, member.name, status)}
                             onPointerUp={cancelLongPress}
                             onPointerCancel={cancelLongPress}
@@ -565,6 +580,18 @@ export default function TribeAttendanceTab({ tribeId, initiativeId }: Props) {
                           >
                             {cellContent}
                             {reason && <sup className="text-[9px] text-blue-600 ml-0.5" title={reason}>*</sup>}
+                            {/* #529 parity: visible ⋮ excused affordance (keyboard + click), mirrors AttendanceGridTab */}
+                            <span
+                              data-excuse-affordance
+                              role="button"
+                              tabIndex={0}
+                              aria-label={t('attendance.grid.cellMenu', 'Marcar: Presente / Ausente / Falta justificada (com motivo)')}
+                              title={t('attendance.grid.cellMenu', 'Marcar: Presente / Ausente / Falta justificada (com motivo)')}
+                              onPointerDown={(e) => e.stopPropagation()}
+                              onClick={(e) => { e.stopPropagation(); openExcusedModal(); }}
+                              onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openExcusedModal(); } }}
+                              className="absolute top-0 right-0 px-0.5 text-[10px] leading-none font-bold text-[var(--text-muted)] hover:text-navy cursor-pointer select-none rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-navy/50"
+                            >⋮</span>
                           </span>
                         ) : cellContent}
                       </td>
@@ -615,6 +642,7 @@ export default function TribeAttendanceTab({ tribeId, initiativeId }: Props) {
             <div className="space-y-2">
               <button
                 type="button"
+                autoFocus
                 onClick={() => handleSetState('present')}
                 className="w-full bg-green-50 hover:bg-green-100 dark:bg-green-900/20 dark:hover:bg-green-900/40 text-green-800 dark:text-green-200 px-4 py-3 rounded-lg flex items-center gap-2 font-semibold border border-green-200 dark:border-green-800 transition-colors"
               >

--- a/tests/contracts/p519-visible-excused-affordance.test.mjs
+++ b/tests/contracts/p519-visible-excused-affordance.test.mjs
@@ -84,3 +84,24 @@ test('#529: attendance excused/help i18n keys are registered in all 3 locales', 
     }
   }
 });
+
+// ── #529 part 2: TribeAttendanceTab ⋮ parity ──
+
+test('#529: TribeAttendanceTab has the ⋮ excused affordance (keyboard + click parity)', () => {
+  const tribeSrc = readFileSync(resolve(process.cwd(), 'src/components/tribes/TribeAttendanceTab.tsx'), 'utf8');
+  assert.match(tribeSrc, /data-excuse-affordance/,
+    'TribeAttendanceTab must render the ⋮ excused affordance (parity with AttendanceGridTab)');
+  const idx = tribeSrc.indexOf('data-excuse-affordance');
+  const slice = tribeSrc.slice(idx, idx + 800);
+  assert.match(slice, /role="button"/, 'the ⋮ must be role=button (focusable)');
+  assert.match(slice, /tabIndex=\{0\}/, 'the ⋮ must be in the tab order');
+  assert.match(slice, /onKeyDown/, 'the ⋮ must have a keyboard handler (Enter/Space)');
+  assert.match(slice, /openExcusedModal\(\)/, 'the ⋮ click/keydown must open the excused modal');
+});
+
+test('#529: TribeAttendanceTab help banner uses the shared helpExcuse* keys (not deprecated helpLongPress*)', () => {
+  const tribeSrc = readFileSync(resolve(process.cwd(), 'src/components/tribes/TribeAttendanceTab.tsx'), 'utf8');
+  assert.match(tribeSrc, /attendance\.helpExcuse'/, 'help banner should reference attendance.helpExcuse');
+  assert.ok(!/attendance\.helpLongPress/.test(tribeSrc),
+    'deprecated helpLongPress* keys (inline-fallback-only) must be removed in favor of the registered helpExcuse* family');
+});


### PR DESCRIPTION
**Part 2 of #529** (part 1 = #530, merged). Brings the tribe attendance grid to parity with the main grid. Frontend-only, needs deploy. **Closes #529.**

## Gap
`TribeAttendanceTab.tsx` had the full excused infra (modal, `mark_member_excused` writer, long-press) but **no visible affordance** — excused ("Falta justificada") was reachable only via the hidden 300ms long-press, the exact gap #519 fixed for `AttendanceGridTab`.

## Changes
- **Visible ⋮** (`data-excuse-affordance`) on every manageable cell: `role="button"` + `tabIndex={0}` + focus-visible ring. Opens the existing 3-option modal via **click AND Enter/Space**.
- Architecture note: TribeAttendanceTab uses **React per-cell inline handlers** (not document-level delegation like AttendanceGridTab), so the wiring is per-cell: an `openExcusedModal()` helper shared by `onClick`/`onKeyDown`, with `onPointerDown` `stopPropagation` so the ⋮ does **not** also start the wrapper's long-press timer. Wrapper span → `relative` to anchor the ⋮.
- **Help banner** converged from the deprecated, inline-fallback-only `helpLongPress*`/`helpLongPressDetail` keys onto the **registered** `helpExcuse*`/`helpExcuseDetail` family (shared with #530).
- **Modal Escape-to-close** `useEffect` + `autoFocus` on the first action — parity with #530 (the ⋮ is now the first keyboard path to open this modal too).

## Test
Extended `p519-visible-excused-affordance.test.mjs`: assert the TribeAttendanceTab ⋮ (role/tabIndex/onKeyDown/openExcusedModal) + the `helpExcuse*` convergence (and that `helpLongPress*` is gone).

## Verification
- `node --test p519-…` → **7/7 pass**.
- `npx astro build` → clean.

No backend/RPC change (`mark_member_excused`/`mark_member_present` already wired).