### PR TITLE
fix(185): gate the ungated list_curation_board reader (Item 2)

### DIFF
--- a/supabase/migrations/20260805000112_185_gate_list_curation_board.sql
+++ b/supabase/migrations/20260805000112_185_gate_list_curation_board.sql
@@ -16,13 +16,14 @@
 --   close this leak. #185 Item-1 (tighten to curators-only) closed as by-design.
 --
 -- SCOPE LOCK: gate-only. The RETURN QUERY body (hub_resources projection,
---   p_status filter, ORDER BY, suggest_tags) is reproduced byte-equivalent;
---   only the auth gate is prepended. Signature unchanged (body-only CoR).
+--   p_status filter, ORDER BY, suggest_tags) is reproduced byte-equivalent
+--   from the CURRENT live body (the ADR-0012 artifacts UNION arm was already
+--   retired); only the auth gate is prepended. Signature unchanged (body-only CoR).
 --
 -- INVARIANTS: check_schema_invariants() unaffected (no invariant touches this fn).
 --
--- ROLLBACK: CREATE OR REPLACE list_curation_board from its prior capture
---   (mig 20260311020000 family — ungated body) to remove the gate.
+-- ROLLBACK: CREATE OR REPLACE list_curation_board from its latest pre-gate
+--   capture (20260679000000_p174_qb_drift_correction_5plus_touch.sql) to remove the gate.
 --
 -- CROSS-REF: #185, #245, 20260805000098 (sibling gates), ADR-0007 (can() authority).
 -- =====================================================================

--- a/supabase/migrations/20260805000112_185_gate_list_curation_board.sql
+++ b/supabase/migrations/20260805000112_185_gate_list_curation_board.sql
@@ -1,0 +1,67 @@
+-- =====================================================================
+-- #185 (Item 2) — gate the ungated list_curation_board reader
+-- =====================================================================
+-- WHAT: add the standard V4 curation gate to list_curation_board(). It was
+--   the ONLY curation SECURITY DEFINER reader with no auth gate — it ran
+--   `RETURN QUERY SELECT ... FROM hub_resources` straight, returning all 330
+--   hub_resources rows (incl. 83 unpublished) to ANY authenticated member,
+--   bypassing the V4 contract that every sibling curation RPC enforces.
+--   Wired live as the legacy fallback at CuratorshipBoardIsland.tsx (the same
+--   super-kanban view get_curation_dashboard serves), so it gets the SAME gate:
+--   curate_content OR write_board.
+--
+-- WHY: #245 fixed the 3 active-queue readers (mig 20260805000098) but left
+--   list_curation_board as a deferred Item-2. PM decision 2026-06-05: keep the
+--   broad curate_content OR write_board queue gate (no member loses access) and
+--   close this leak. #185 Item-1 (tighten to curators-only) closed as by-design.
+--
+-- SCOPE LOCK: gate-only. The RETURN QUERY body (hub_resources projection,
+--   p_status filter, ORDER BY, suggest_tags) is reproduced byte-equivalent;
+--   only the auth gate is prepended. Signature unchanged (body-only CoR).
+--
+-- INVARIANTS: check_schema_invariants() unaffected (no invariant touches this fn).
+--
+-- ROLLBACK: CREATE OR REPLACE list_curation_board from its prior capture
+--   (mig 20260311020000 family — ungated body) to remove the gate.
+--
+-- CROSS-REF: #185, #245, 20260805000098 (sibling gates), ADR-0007 (can() authority).
+-- =====================================================================
+
+CREATE OR REPLACE FUNCTION public.list_curation_board(p_status text DEFAULT NULL::text)
+ RETURNS SETOF json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+BEGIN
+  SELECT id INTO v_member_id FROM public.members WHERE auth_id = auth.uid() LIMIT 1;
+  IF v_member_id IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+  IF NOT (public.can_by_member(v_member_id, 'curate_content')
+          OR public.can_by_member(v_member_id, 'write_board')) THEN
+    RAISE EXCEPTION 'Curatorship access required';
+  END IF;
+
+  RETURN QUERY
+  SELECT row_to_json(r) FROM (
+    SELECT hr.id, hr.title, hr.asset_type AS type, hr.url, hr.description,
+      CASE WHEN hr.is_active THEN 'approved' ELSE 'pending' END AS status,
+      i.legacy_tribe_id AS tribe_id, i.title AS tribe_name, m.name AS author_name,
+      hr.tags, hr.created_at AS submitted_at,
+      NULL::TIMESTAMPTZ AS reviewed_at, NULL::TEXT AS review_notes,
+      'hub_resources'::TEXT AS _table,
+      COALESCE(hr.source, 'manual') AS source,
+      public.suggest_tags(hr.title, hr.asset_type, hr.cycle_code) AS suggested_tags
+    FROM hub_resources hr
+    LEFT JOIN initiatives i ON i.id = hr.initiative_id
+    LEFT JOIN members m ON m.id = hr.author_id
+    WHERE (p_status IS NULL
+           OR (p_status = 'approved' AND hr.is_active = true)
+           OR (p_status = 'pending' AND hr.is_active = false))
+    ORDER BY hr.created_at DESC NULLS LAST
+  ) r;
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/p245-curation-view-gates-curate-content.test.mjs
+++ b/tests/contracts/p245-curation-view-gates-curate-content.test.mjs
@@ -25,6 +25,9 @@ import { createClient } from '@supabase/supabase-js';
 const ROOT = process.cwd();
 const MIG = resolve(ROOT, 'supabase/migrations/20260805000098_245_curation_view_gates_curate_content.sql');
 const migRaw = existsSync(MIG) ? readFileSync(MIG, 'utf8') : '';
+// #185 Item-2: list_curation_board (the 4th, previously-ungated curation reader) gated 2026-06-05.
+const MIG185 = resolve(ROOT, 'supabase/migrations/20260805000112_185_gate_list_curation_board.sql');
+const mig185Raw = existsSync(MIG185) ? readFileSync(MIG185, 'utf8') : '';
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -73,7 +76,34 @@ test('#245 static: no view RPC narrows to a curate_content-ONLY gate (symmetric 
     'no curation view RPC may gate on curate_content alone (must keep the write_board/write OR-arm)');
 });
 
+test('#185 Item-2 static: migration 112 exists and gates list_curation_board', () => {
+  assert.ok(existsSync(MIG185), 'migration 20260805000112 exists');
+  assert.match(mig185Raw,
+    /CREATE OR REPLACE FUNCTION public\.list_curation_board[\s\S]*?can_by_member\(v_member_id, 'curate_content'\)[\s\S]{0,80}OR[\s\S]{0,80}can_by_member\(v_member_id, 'write_board'\)/,
+    'list_curation_board gate is additive (curate_content OR write_board)');
+  assert.match(mig185Raw, /RAISE EXCEPTION 'Not authenticated'/,
+    'list_curation_board raises when caller is not a member');
+});
+
+test('#185 Item-2 static: list_curation_board does not narrow to a single-capability gate', () => {
+  assert.doesNotMatch(mig185Raw, /IF NOT public\.can_by_member\(v_member_id, 'curate_content'\) THEN/,
+    'list_curation_board must keep the write_board OR-arm (no curate_content-only narrowing)');
+  assert.doesNotMatch(mig185Raw, /IF NOT public\.can_by_member\(v_member_id, 'write_board'\) THEN/,
+    'list_curation_board must keep the curate_content OR-arm (no write_board-only gate)');
+});
+
 // ── BEHAVIOURAL (DB-gated) ────────────────────────────────────────────────────────
+test('#185 Item-2 behavioural: list_curation_board denies an unauthenticated caller (leak closed)',
+  { skip: dbGated ? false : skipMsg }, async () => {
+    const sb = client();
+    // Service-role => auth.uid() is NULL => v_member_id IS NULL => 'Not authenticated' fires.
+    // Pre-fix this RPC had NO gate and returned all hub_resources rows to any caller.
+    const { error } = await sb.rpc('list_curation_board');
+    assert.ok(error, 'list_curation_board must now gate (was ungated)');
+    assert.match(String(error.message || ''), /Not authenticated|Curatorship access required/,
+      `expected the curation gate to fire, got: ${JSON.stringify(error)}`);
+  });
+
 test('#245 behavioural: the unblocked population exists (curate_content=true, write_board=false)',
   { skip: dbGated ? false : skipMsg }, async () => {
     const sb = client();


### PR DESCRIPTION
Closes #185

## What
`list_curation_board()` was the **only** curation `SECURITY DEFINER` reader with **no auth gate** — it ran `RETURN QUERY SELECT ... FROM hub_resources` straight, returning all **330** `hub_resources` rows (incl. 83 unpublished, `is_active=false`) to **any authenticated member**, bypassing the V4 contract every sibling curation RPC enforces. Wired live as the legacy fallback in `CuratorshipBoardIsland.tsx` (the same super-kanban `get_curation_dashboard` serves).

This prepends the standard gate (`Not authenticated` + `curate_content OR write_board`), mirroring `get_curation_dashboard`'s gate so the fallback admits exactly the population the primary view does.

## PM decision (2026-06-05)
Keep the broad `curate_content OR write_board` queue gate (no member loses access); **#185 Item-1** (tighten to curators-only) closed as **by-design**. This PR ships **Item 2** (close the leak) only — the remaining valid sub-scope of #185 (the original "curators denied" symptom was already fixed by p245).

## Evidence
- migration `20260805000112` — body-only `CREATE OR REPLACE`, RETURN QUERY projection byte-equivalent; zero inline body comments (Phase-C safe); live `has_gate=true`, `has_inline_comment=false`
- p245 test extended: 2 static (additive gate + no single-capability narrowing) + 1 DB-gated (service-role now denied) — **13/13 pass with DB creds**
- `npx astro build` ✓ 0 errors

## Lane
Backend-only (DB migration + test extension on the already-whitelisted p245 file). No frontend, no deploy. The island's `try/catch` already handles RPC errors, so a now-denied non-curator simply gets the empty fallback instead of leaked rows.