### PR TITLE
fix(483): promote CCA terminal-status check into check_schema_invariants (B2)

### DIFF
--- a/supabase/migrations/20260805000119_483_followup_b2_cca_terminal_invariant.sql
+++ b/supabase/migrations/20260805000119_483_followup_b2_cca_terminal_invariant.sql
@@ -1,0 +1,459 @@
+-- #483 follow-up — promote the CCA terminal-status check into check_schema_invariants()
+--
+-- #483 (mig 117) fixed the WRITE path (sync_member_status_consistency B-trigger
+-- resets current_cycle_active=false on terminal member_status) + a one-time DML.
+-- The deferred follow-up (noted in mig 117 header + the #483 contract test) was to
+-- ALSO surface it as a check_schema_invariants() row for ongoing drift detection in
+-- the unified invariant report (guardian / /invariants / dashboards), not just the
+-- CI-time contract test.
+--
+-- This CREATE OR REPLACE reproduces the existing body byte-faithfully and appends
+-- ONE new RETURN QUERY block (B2_current_cycle_active_terminal_status) after the
+-- Z_webinar_status_domain block, mirroring B_is_active_status_mismatch (same VP +
+-- %_synthetic% exclusions, severity 'low' — data-quality, not authority).
+-- Live drift = 0 at migration time, so the new row reports green immediately.
+--
+-- Verified: file body minus the B2 block normalizes back to the prior live md5
+-- (0210799c2883802c06a9978e5cb8d588); post-apply live md5 == this file's body.
+-- No signature change (RETURNS TABLE shape unchanged) → CREATE OR REPLACE.
+--
+-- Rollback: CREATE OR REPLACE the prior body (drop the B2 block).
+
+CREATE OR REPLACE FUNCTION public.check_schema_invariants()
+ RETURNS TABLE(invariant_name text, description text, severity text, violation_count integer, sample_ids uuid[])
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL
+     AND current_setting('role', true) NOT IN ('service_role', 'postgres')
+     AND current_user NOT IN ('postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'Unauthorized: check_schema_invariants requires authentication';
+  END IF;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'alumni' AND operational_role IS DISTINCT FROM 'alumni'
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A1_alumni_role_consistency'::text,
+         'member_status=alumni must coerce operational_role=alumni (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'observer' AND operational_role NOT IN ('observer','guest','none')
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A2_observer_role_consistency'::text,
+         'member_status=observer must coerce operational_role IN (observer,guest,none) (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH computed AS (
+    SELECT m.id AS member_id,
+      CASE
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'co_gp')          THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'deputy_manager') THEN 'deputy_manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+        WHEN bool_or(
+          (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+          OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+              AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+          OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+              AND ae.role IN ('leader','co_leader','owner','coordinator'))
+        ) THEN 'researcher'
+        WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+        WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+        WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+        WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+        WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+        WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+        ELSE 'guest'
+      END AS expected_role
+    FROM public.members m
+    LEFT JOIN public.auth_engagements ae ON ae.person_id = m.person_id AND ae.is_authoritative = true
+    WHERE m.member_status='active' AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT c.member_id FROM computed c
+    JOIN public.members m ON m.id = c.member_id
+    WHERE m.operational_role IS DISTINCT FROM c.expected_role
+  )
+  SELECT 'A3_active_role_engagement_derivation'::text,
+         'active member operational_role must equal priority-ladder derivation from active engagements (cache trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE ((member_status='active' AND is_active=false) OR (member_status IN ('observer','alumni','inactive') AND is_active=true))
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B_is_active_status_mismatch'::text,
+         'members.is_active must match member_status mapping (active=true, terminal=false)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND designations IS NOT NULL AND array_length(designations,1)>0
+  )
+  SELECT 'C_designations_in_terminal_status'::text,
+         'members.designations must be empty when member_status is observer/alumni/inactive'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    JOIN public.persons p ON p.id = m.person_id
+    WHERE m.auth_id IS NOT NULL AND p.auth_id IS NOT NULL AND m.auth_id IS DISTINCT FROM p.auth_id
+  )
+  SELECT 'D_auth_id_mismatch_person_member'::text,
+         'persons.auth_id and members.auth_id must agree when both are set (ghost resolution sync)'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ae.engagement_id AS e_id FROM public.auth_engagements ae
+    JOIN public.members m ON m.person_id = ae.person_id
+    WHERE ae.status='active' AND m.member_status IN ('observer','alumni','inactive')
+      AND ae.kind NOT IN ('observer','alumni','external_signer','sponsor','chapter_board','partner_contact')
+  )
+  SELECT 'E_engagement_active_with_terminal_member'::text,
+         'engagement.status=active is inconsistent with member.member_status in (observer/alumni/inactive) unless kind matches'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(e_id ORDER BY e_id) FROM (SELECT e_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT i.id AS initiative_id FROM public.initiatives i
+    WHERE i.legacy_tribe_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.tribes t WHERE t.id = i.legacy_tribe_id)
+  )
+  SELECT 'F_initiative_legacy_tribe_orphan'::text,
+         'initiatives.legacy_tribe_id must point to an existing tribe (bridge integrity)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(initiative_id ORDER BY initiative_id) FROM (SELECT initiative_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    LEFT JOIN public.document_versions dv ON dv.id = gd.current_version_id
+    WHERE gd.current_version_id IS NOT NULL
+      AND (dv.id IS NULL OR dv.locked_at IS NULL)
+      AND NOT EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status IN ('review','approved','activated')
+          AND ac.closed_at IS NULL
+      )
+  )
+  SELECT 'J_current_version_published'::text,
+         'governance_documents.current_version_id must point to a document_versions row with locked_at IS NOT NULL — unless an open approval_chain (review/approved/activated, closed_at NULL) is in flight that will lock the version on close (Phase IP-1, chain-aware).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.operational_role='external_signer'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.auth_engagements ae
+        WHERE ae.person_id=m.person_id AND ae.kind='external_signer' AND ae.status='active' AND ae.is_authoritative=true
+      )
+  )
+  SELECT 'K_external_signer_integrity'::text,
+         'members.operational_role=external_signer must have an active auth_engagements row with kind=external_signer (Phase IP-1).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.member_status IN ('alumni','observer','inactive') AND m.anonymized_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM public.member_offboarding_records r WHERE r.member_id=m.id)
+  )
+  SELECT 'L_offboarding_record_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have a member_offboarding_records row (#91 G3 trigger).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH expected AS (
+    SELECT a.id AS application_id, a.research_score AS cached,
+      CASE
+        WHEN e.obj_avg IS NOT NULL AND e.int_avg IS NOT NULL THEN round(e.obj_avg + e.int_avg, 2)
+        WHEN e.obj_avg IS NOT NULL THEN round(e.obj_avg, 2)
+        ELSE NULL
+      END AS expected
+    FROM public.selection_applications a
+    CROSS JOIN LATERAL (
+      SELECT AVG(weighted_subtotal) FILTER (WHERE evaluation_type='objective' AND submitted_at IS NOT NULL) AS obj_avg,
+        AVG(weighted_subtotal) FILTER (WHERE evaluation_type='interview' AND submitted_at IS NOT NULL) AS int_avg
+      FROM public.selection_evaluations WHERE application_id=a.id
+    ) e
+  ),
+  drift AS (
+    SELECT application_id FROM expected
+    WHERE (cached IS NULL) IS DISTINCT FROM (expected IS NULL)
+       OR (cached IS NOT NULL AND expected IS NOT NULL AND ABS(cached - expected) > 0.01)
+  )
+  SELECT 'M_application_score_consistency'::text,
+         'selection_applications.research_score must equal compute_application_scores(application_id) derivation (sync trigger trg_recompute_application_scores).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive')
+      AND offboarded_at IS NULL AND anonymized_at IS NULL
+      AND name <> 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'N_terminal_status_offboarded_at_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have offboarded_at NOT NULL (ARM-9 G6 defense-in-depth complement to L).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ma.id AS artifact_id FROM public.meeting_artifacts ma
+    WHERE ma.event_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.id = ma.event_id)
+  )
+  SELECT 'O_meeting_artifact_event_orphan'::text,
+         'meeting_artifacts.event_id must point to an existing event when not NULL (FK defense).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(artifact_id ORDER BY artifact_id) FROM (SELECT artifact_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  SELECT 'P_tribe_initiative_bridge_complete'::text,
+         'tribes.is_active=true must have at least one initiative.legacy_tribe_id pointing to it (V3-V4 bridge; cron leader digest depends).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM public.tribes t
+          WHERE t.is_active = true
+            AND NOT EXISTS (SELECT 1 FROM public.initiatives i WHERE i.legacy_tribe_id = t.id)),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS engagement_id FROM public.engagements
+    WHERE status = 'expired' AND end_date > CURRENT_DATE
+  )
+  SELECT 'Q_expired_engagement_end_date'::text,
+         'engagements.status=expired requires end_date <= CURRENT_DATE (impossible to be expired in the future; VEP service_latest_end_date is source of truth).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT a.id AS application_id
+    FROM public.selection_applications a
+    WHERE a.status = 'approved'
+      AND a.email IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.members m WHERE lower(m.email) = lower(a.email)
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM public.member_emails me WHERE lower(me.email) = lower(a.email)
+      )
+  )
+  SELECT 'R_approved_application_has_member'::text,
+         'selection_applications.status=approved must have a matching members row by lower(email). Bypass of approve_selection_application() canonical RPC creates this drift (Issue #180).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT DISTINCT m.id AS member_id
+    FROM public.selection_applications a
+    JOIN public.members m ON lower(m.email) = lower(a.email)
+    WHERE a.status = 'approved' AND m.person_id IS NULL
+  )
+  SELECT 'S_approved_member_has_person_id'::text,
+         'members tied to an approved selection_applications row must have person_id NOT NULL (V4 graph anchor for engagements). Issue #180.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH primary_email_counts AS (
+    SELECT m.id AS member_id,
+           COUNT(me.id) FILTER (WHERE me.is_primary = true) AS primary_count
+    FROM public.members m
+    LEFT JOIN public.member_emails me ON me.member_id = m.id
+    WHERE m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT member_id FROM primary_email_counts
+    WHERE primary_count <> 1
+  )
+  SELECT 'T_member_has_exactly_one_primary_email'::text,
+         'Every member must have exactly one primary email in member_emails (Issue #205).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status = 'pending_proposer_consent'
+      AND EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status NOT IN ('withdrawn','superseded')
+      )
+  )
+  SELECT 'V_prime_pending_proposer_consent_no_open_chain'::text,
+         'status=pending_proposer_consent must not have non-cancelled approval_chains rows (#315 P0-Q7 + Amendment A2 — pending_proposer_consent precedes any chain).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status IN ('approved','active')
+      AND gd.current_ratified_chain_id IS NULL
+  )
+  SELECT 'V_status_chain_coherence'::text,
+         'governance_documents with status approved/active must have current_ratified_chain_id NOT NULL (#315 P0-Q6 + #367 Wave 1b first leaf). NO carve-out: 7 legacy pre-chain docs backfilled with PM-designated synthetic chains via migration 20260805000038 (acknowledge signoffs, metadata.legacy_migration=true, role=migration_attestation).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT cp.id AS product_id
+    FROM public.content_products cp
+    WHERE
+      CASE cp.source_kind
+        WHEN 'governance_document_version' THEN
+          NOT (cp.source_document_version_id IS NOT NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'board_item' THEN
+          NOT (cp.source_board_item_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'publication_idea' THEN
+          NOT (cp.source_publication_idea_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'external' THEN
+          NOT (cp.source_external_uri IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL)
+        WHEN 'none' THEN
+          NOT (cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        ELSE TRUE
+      END
+  )
+  SELECT 'W_content_product_source_integrity'::text,
+         'content_products row must satisfy chk_content_products_source_integrity CHECK semantics (exactly one source FK populated per source_kind; ADR-0099 §2.2 + §6 step 9). Defense-in-depth complement to the CHECK constraint; mirrors V/V''/T pattern.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(product_id ORDER BY product_id) FROM (SELECT product_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT p.id AS parecer_id
+    FROM public.blind_review_pareceres p
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.blind_review_assignments a
+      WHERE a.session_id = p.session_id
+        AND a.reviewer_member_id = p.reviewer_member_id
+        AND a.status = 'active'
+    )
+  )
+  SELECT 'X_blind_review_pareceres_session_product_match'::text,
+         'blind_review_pareceres.reviewer_member_id must have an active blind_review_assignments row in the same session (assignment-parecer integrity; ADR-0099 §2.7 + §7 step 11). Defense-in-depth complement to FK constraints; catches drift if assignment is withdrawn while parecer remains. #382 PR-B.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(parecer_id ORDER BY parecer_id) FROM (SELECT parecer_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH pe AS (
+    SELECT name AS k FROM public.partner_entities
+    WHERE entity_type = 'pmi_chapter' AND status = 'active' AND NOT COALESCE(is_international, false)
+  ),
+  ch AS (
+    SELECT 'PMI-' || code AS k FROM public.chapters WHERE status = 'active'
+  ),
+  drift AS (
+    SELECT k FROM pe WHERE k NOT IN (SELECT k FROM ch)
+    UNION ALL
+    SELECT k FROM ch WHERE k NOT IN (SELECT k FROM pe)
+  )
+  SELECT 'Y_chapter_pipeline_parity'::text,
+         'every active domestic pmi_chapter in partner_entities must have a matching active chapters row (by name = ''PMI-'' || chapters.code) and vice-versa — MEMBERSHIP parity (not just count), so it catches single-table inserts/archives even when row counts coincide. Drift = get_chapter_metrics()->>signed forks from the V4 chapters table (#481).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM drift),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS webinar_id FROM public.webinars
+    WHERE status IS NULL OR status NOT IN ('planned','confirmed','completed','cancelled')
+  )
+  SELECT 'Z_webinar_status_domain'::text,
+         'webinars.status must be within planned|confirmed|completed|cancelled (the realized=completed canonical definition depends on it; defense-in-depth complement to webinars_status_check — #479/#481).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(webinar_id ORDER BY webinar_id) FROM (SELECT webinar_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND current_cycle_active = true
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B2_current_cycle_active_terminal_status'::text,
+         'members in observer/alumni/inactive must have current_cycle_active=false (#483 sync_member_status_consistency B-trigger; CCA gates the get_gamification_leaderboard/get_public_leaderboard cohort).'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+END;
+$function$;

--- a/tests/contracts/p266-382-w4f-blind-review-primitives.test.mjs
+++ b/tests/contracts/p266-382-w4f-blind-review-primitives.test.mjs
@@ -472,11 +472,11 @@ describe('p266 #382 W4f Primitives — blind-review primitives (ADR-0099 §7)', 
       assert.equal(parecerCount, 0);
     });
 
-    it('check_schema_invariants() reports 25 invariants with X violation_count=0', { skip: !sb }, async () => {
+    it('check_schema_invariants() reports 26 invariants with X violation_count=0', { skip: !sb }, async () => {
       const { data, error } = await sb.rpc('check_schema_invariants');
       assert.equal(error, null);
-      // 23 at p266 (X-add); #481 (mig 094) added Y_chapter_pipeline_parity + Z_webinar_status_domain → 25.
-      assert.equal(data.length, 25);
+      // 23 at p266 (X-add); #481 (mig 094) added Y_chapter_pipeline_parity + Z_webinar_status_domain → 25; #483 (mig 119) added B2_current_cycle_active_terminal_status → 26.
+      assert.equal(data.length, 26);
       const x = data.find(r => r.invariant_name === 'X_blind_review_pareceres_session_product_match');
       assert.ok(x, 'X invariant present');
       assert.equal(x.violation_count, 0);

--- a/tests/contracts/p277-triage-link-and-invariant-r.test.mjs
+++ b/tests/contracts/p277-triage-link-and-invariant-r.test.mjs
@@ -73,13 +73,13 @@ test('R extension: sanity DO asserts R=0 post-apply', () => {
 });
 
 // ── DB-gated ───────────────────────────────────────────────────────────────────
-test('DB: check_schema_invariants reports R=0 and 25 invariants, 0 total violations', { skip: dbGated ? false : skipMsg }, async () => {
+test('DB: check_schema_invariants reports R=0 and 26 invariants, 0 total violations', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
   const { data, error } = await sb.rpc('check_schema_invariants');
   assert.ok(!error, error?.message);
   assert.ok(Array.isArray(data), 'returns rows');
-  // 23 through p277; #481 (mig 094) added Y_chapter_pipeline_parity + Z_webinar_status_domain → 25.
-  assert.strictEqual(data.length, 25, `expected 25 invariants, got ${data.length}`);
+  // 23 through p277; #481 (mig 094) added Y_chapter_pipeline_parity + Z_webinar_status_domain → 25; #483 (mig 119) added B2_current_cycle_active_terminal_status → 26.
+  assert.strictEqual(data.length, 26, `expected 26 invariants, got ${data.length}`);
   const r = data.find(x => x.invariant_name === 'R_approved_application_has_member');
   assert.ok(r, 'R present');
   assert.strictEqual(r.violation_count, 0, 'R must have 0 violations (alternate-email match honored)');

--- a/tests/contracts/schema-invariants.test.mjs
+++ b/tests/contracts/schema-invariants.test.mjs
@@ -50,7 +50,7 @@ test('ADR-0012 B10: schema invariants report', { skip: !canRun && skipMsg }, asy
   const rows = await callInvariantRpc();
 
   assert.ok(Array.isArray(rows), 'RPC must return an array');
-  assert.ok(rows.length >= 25, `Expected 25+ invariants, got ${rows.length}`);
+  assert.ok(rows.length >= 26, `Expected 26+ invariants, got ${rows.length}`);
 
   const byName = Object.fromEntries(rows.map(r => [r.invariant_name, r]));
   const expected = [
@@ -58,6 +58,7 @@ test('ADR-0012 B10: schema invariants report', { skip: !canRun && skipMsg }, asy
     'A2_observer_role_consistency',
     'A3_active_role_engagement_derivation',
     'B_is_active_status_mismatch',
+    'B2_current_cycle_active_terminal_status',
     'C_designations_in_terminal_status',
     'D_auth_id_mismatch_person_member',
     'E_engagement_active_with_terminal_member',


### PR DESCRIPTION
Closes the #483 deferred follow-up (the invariant noted in mig 117 header + the #483 contract test).

## What
#483 fixed the **write** path (the `sync_member_status_consistency` B-trigger resets `current_cycle_active=false` on terminal `member_status`). This adds the matching **ongoing-drift detection**: a 26th invariant `B2_current_cycle_active_terminal_status` in `check_schema_invariants()` — members in observer/alumni/inactive must have `current_cycle_active=false`. Mirrors `B_is_active_status_mismatch` (same VP + `%_synthetic%` exclusions, severity `low`). CCA gates the leaderboard cohort, so drift is data-quality-visible.

## How (mig `20260805000119`)
`CREATE OR REPLACE` of the full `check_schema_invariants` body + one new `RETURN QUERY` block appended after `Z_webinar_status_domain`.

## Byte-faithful reproduction proof
- The B2-**stripped** file body normalizes back to the **prior** live md5 `0210799c…` → I altered nothing in the existing 25 invariants, only appended B2.
- Post-apply live md5 == the migration file body (`91ac3d25…`) → Phase-C safe (file==live).
- Live: **26 invariants, 0 violations, B2=0**.

## Tests
- `schema-invariants` **28/28** (`expected[]` += B2, `rows.length >= 26`)
- `rpc-migration-coverage` (Phase-C) **22/22**
- `astro build` exit 0
- No `package.json` change (schema-invariants.test.mjs already whitelisted).

No PM fork — purely additive follow-up, severity/naming/exclusions dictated by the existing sibling pattern.