### PR TITLE
fix(161): migrate sensitive UI gates from global hasPermission to V4 canFor

### DIFF
--- a/docs/audit/P161_UI_GATES_CANFOR_AUDIT.md
+++ b/docs/audit/P161_UI_GATES_CANFOR_AUDIT.md
@@ -1,0 +1,123 @@
+# P161 — Sensitive UI Gates Audit (V3 `hasPermission` → V4 `canFor`)
+
+**Issue:** #161 — *permissions: audit sensitive UI gates against V4 canFor*
+**Date:** 2026-06-06
+**Trigger:** p201 root cause — Roberto & Sarah held `curate_content=true` via **engagement**, but the UI gated on
+a global `hasPermission(...)` keyed on the cached `operational_role`, which didn't reflect it → they were wrongly
+**blocked**. Same class can leak the other way (a tribe-X leader sees tribe-Y controls via a global gate).
+
+## The two functions
+
+| | `hasPermission(member, perm)` (`src/lib/permissions.ts:563`) | `canFor(action, scope?)` (`:418`) |
+|---|---|---|
+| Source | `member.operational_role` (ONE cached tier) + `member.designations` | engagement-derived `org_actions` / `initiative_actions` / `tribe_actions` |
+| Scope awareness | **None** — global/tier only | initiative- or tribe-scoped |
+| Simulation | Yes (`_simulation` branch) | No (reads real caps) |
+
+`canFor` for `.astro` inline scripts is reached via the `window.__nucleoCanFor` bridge defined in
+`Nav.astro:1056`; React islands import `canFor` directly. The reference migration pattern is
+`CardDetail.tsx:103-104` (initiative-first, tribe fallback).
+
+## Classification rubric (3 classes + orphan)
+
+- **A — KEEP**: gate decides a global/org-tier affordance (page entry to an admin surface, "is staff-tier",
+  self-service "can this person submit at all"). No specific tribe/initiative resource is gated. `hasPermission`
+  (or `canForAdminEntry`) is the correct axis.
+- **B — MIGRATE**: gate controls an action on a SPECIFIC tribe/initiative that is in scope at the callsite, but
+  uses the global `hasPermission`. Scope-leak / under-grant bug. Migrated to `canFor(action, {type, id})`.
+- **C — DOCUMENT (intentional local-tier)**: tier-level affordance (view-tier selector, display/UX hint, or
+  self-service filtered to the viewer's own id) where the underlying **data RPC enforces the real gate
+  server-side**. Kept as `hasPermission`.
+- **ORPHAN**: gates in `TribeKanbanIsland.tsx` — a confirmed 0-mount orphan (imported by `tribe/[id].astro` but
+  never JSX-rendered; the live board is `BoardEngine`). MOOT — to be **deleted** separately (its 3
+  ui-stabilization test reads must be re-pointed first), not migrated.
+
+## Result
+
+| Class | Count |
+|---|---|
+| A — keep (global-tier, correct) | 37 |
+| **B — migrated to `canFor`** | **8** |
+| C — documented local-tier | 9 |
+| Orphan (TribeKanbanIsland — delete separately) | 11 |
+| **Total `hasPermission(` callsites audited** | **65** |
+
+## Class B — migrated (this PR)
+
+Each MCP/UI gate now **mirrors the underlying RPC's own server gate** (verified live from `pg_proc`):
+
+| Callsite | Gated resource | RPC server gate (verified) | New UI gate |
+|---|---|---|---|
+| `tribe/[id].astro:983` (canSeeContacts) | member-contact PII display | `get_*_member_contacts` → **`view_pii`** (init) / `view_pii` OR tribe `write` | `canSeeTribeContacts()` helper |
+| `tribe/[id].astro:~1622` (fetch contacts) | PII RPC fetch | idem | `canSeeTribeContacts()` |
+| `tribe/[id].astro:~1818` (fetch contacts) | PII RPC fetch | idem | `canSeeTribeContacts()` |
+| `tribe/[id].astro:~1456` (broadcast tab) | leader broadcast affordance | leader/write | `isLeaderOfThisTribeV4()` → `write_board` |
+| `tribe/[id].astro:~1887` (canEdit) | minutes/board edit | `write_board` | `isLeaderOfThisTribeV4()` |
+| `workspace.astro:425` (isLeader) | own-tribe dashboard link/badge | `write_board` | `__nucleoCanFor('write_board', {tribe})` |
+| `meetings/MeetingsPage.tsx:236` (canCurateChampions) | champions-da-noite picker | `set_event_champions` → **`manage_event` OR `award_champion`** (org-level `can_by_member`) | **scopeless** `canFor` (org mirror) — see note |
+| `ui/PresentationLayer.astro:109` (canShowToggle) | tribe presentation toggle | `write_board` | scoped `canFor` on CTX init/tribe |
+
+**Corrections caught during audit/review (UI gate must mirror the real RPC gate, not a plausible substitute):**
+- The contact gates (983/1622/1818) gate **`view_pii`** server-side, not `write_board`
+  (`get_initiative_member_contacts` → `can(view_pii, initiative)`; `get_tribe_member_contacts` → `view_pii` OR
+  tribe `write`).
+- `set_event_champions` gates on **org-level** `can_by_member('manage_event') OR can_by_member('award_champion')`
+  (`can(…, NULL, NULL)`), so the champions gate is a **scopeless** `canFor('manage_event') || canFor('award_champion')`
+  — NOT scoped to the event. Scoping it to the event's tribe/initiative was both an over-restriction (the RPC is
+  org-wide) and a regression on *geral* meetings (no tribe/initiative → permanently false; also
+  `get_meeting_detail` doesn't return `initiative_id`). Caught by the adversarial review.
+
+### Simulation overlay (DoD: "no regression in simulation mode")
+
+`canFor` reads **real** capabilities (superadmin bypass), so it cannot preview a lower tier. Mirroring the
+established pattern (`AdminNav.astro:122-126` uses `!isSimulating ? canFor : hasPermission(effectiveMember)`;
+`useBoardPermissions.ts:113-119` overlays `getSimulation()` onto an effective role/tribe), every migrated gate
+branches:
+
+```
+const sim = getSimulation();
+if (sim.active) return hasPermission(member, 'board.edit_tribe_items') && getEffectiveTribeId(member) === ID; // V3 preview
+… canFor(...) …                                                                                                 // V4 real
+```
+
+This also **fixes** a pre-existing simulation bug: the old gates compared the **real** `member.tribe_id` even
+while simulating; the overlay now uses `getEffectiveTribeId` (the simulated tribe).
+
+## Class C — intentional local-tier (kept; data gated server-side)
+
+| Callsite | Permission | Why local-tier is correct |
+|---|---|---|
+| `workspace.astro:596` | `content.submit_publication` | "My Publications" self-service; data filtered to the viewer's own `member.id`. |
+| `workspace.astro:807` | `event.create` | Un-hides the AttendanceForm island; the island filters to `member.tribe_id` server-side. |
+| `workspace/AttendanceDashboard.tsx:77` | `event.create` | `isLeader` view-tier selector; rows come from a tribe-filtered RPC. |
+| `workspace/AttendanceForm.tsx:63` | `event.create` | `isLeader` filtering of an already tribe-scoped form. |
+| `workspace/DropoutRiskBanner.tsx:43` | `event.create` | `isLeader` reveals the banner; `get_dropout_risk_members` filters to the caller's tribe. |
+| `admin/gamification.astro:706` | `champion.award` | Deliberate surface-visibility gate (audit GI-2/#424); the award RPC re-gates. |
+| `admin/gamification.astro:728` | `champion.award_general` | Pure UX hint dropping the 'general' `<option>`. |
+| `help/HelpFloatingButton.tsx:360` | `board.create_item` | Pure display hint: show the "leaders" FAQ section. |
+| `help/HelpFloatingButton.tsx:361` | `admin.access` | Pure display hint: show the "admin" FAQ section. |
+
+These rely on the data RPC as the real enforcer; the `hasPermission` gate is a tier-level UI affordance only.
+
+## Class A — kept (global-tier, correct)
+
+37 callsites: admin page-entry gates (`admin/*.astro` — `admin.access`/`admin.portfolio`/`admin.analytics`/…),
+the admin-nav link map (`AdminNav.astro:126`), self-service global gates (`publications.astro:515`,
+`gamification.astro:1446`), workspace org-tier gates (`workspace.astro:502` GP alerts), and the
+`isGP` (`admin.access`) axis in the attendance components (distinct from the `isLeader` Class-C flag). All gate a
+global/org-tier affordance with no specific tribe/initiative in scope — `hasPermission` is the right axis.
+
+## Follow-up (not in this PR)
+
+- **Delete the `TribeKanbanIsland.tsx` orphan** (11 MOOT gates). Blocked on re-pointing 3 `ui-stabilization`
+  test reads to `BoardEngine` first (see [[handoff-2026-06-05-curatorship-cluster-swept]]).
+
+## Persona smoke (DoD)
+
+| Persona | Expectation | Mechanism |
+|---|---|---|
+| Roberto / Sarah (curator via engagement) | sees curation + own-tribe contacts despite stale `operational_role` | `canFor('view_pii'/'curate_content', scope)` reads engagement caps ✓ |
+| Tribe leader (engagement) of tribe X | edit/contacts on tribe X only, not tribe Y | scoped `canFor` — no cross-tribe leak ✓ |
+| Marcos / Herlon / member | masked contacts, no edit | gate returns false; server RPC returns `{}` ✓ |
+| chapter_liaison | admin entries via `canForAdminEntry`; no tribe-scoped edit | Class-A gates unchanged ✓ |
+| superadmin simulating tier T | previews tier T's affordances | simulation overlay (V3 path on effective tribe) ✓ |

--- a/src/components/meetings/MeetingsPage.tsx
+++ b/src/components/meetings/MeetingsPage.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { marked } from 'marked';
-import { hasPermission } from '../../lib/permissions';
+import { canFor, getSimulation, hasPermission } from '../../lib/permissions';
 
 interface Meeting {
   id: string;
@@ -231,10 +231,19 @@ export default function MeetingsPage({ lang = 'pt-BR' }: Props) {
     return () => window.removeEventListener('nav:member', onMember as EventListener);
   }, []);
 
-  // p277 F2: leaders (manage_event) or initiative-scoped grantors (champion.award) can tag the
-  // "champions da noite" on a meeting → feeds set_event_champions → the award modal (F3 override).
-  const canCurateChampions = !!member && (hasPermission(member, 'manage_event') || hasPermission(member, 'champion.award'));
-  const closeDetail = () => { closeDetail(); setSelectedEventId(null); };
+  // p277 F2 / #161: tagging the "champions da noite" feeds set_event_champions, which gates on
+  // can_by_member('manage_event') OR can_by_member('award_champion') — i.e. ORG-level authority
+  // (can(..., NULL, NULL)), NOT scoped to the event. Mirror with scopeless canFor (org_actions check).
+  // This fixes the V3 over-grant (global hasPermission showed the picker to tribe-scoped holders the
+  // server rejects) AND geral meetings (no tribe/initiative) where a manager must still curate.
+  // Simulation overlay: preview the simulated V3 tier (canFor reads real caps, bypassing simulation).
+  const _simMtg = getSimulation();
+  const canCurateChampions = _simMtg.active
+    ? Boolean(member && (hasPermission(member, 'manage_event') || hasPermission(member, 'champion.award')))
+    : Boolean(member && (canFor('manage_event') || canFor('award_champion')));
+  // #161 drive-by: was `closeDetail()` calling itself (infinite recursion → stack overflow on the ×
+  // button + overlay click, and it never cleared selectedMeeting so the modal couldn't close).
+  const closeDetail = () => { setSelectedMeeting(null); setSelectedEventId(null); };
 
   const loadMeetings = useCallback(async () => {
     const sb = getSb();

--- a/src/components/ui/PresentationLayer.astro
+++ b/src/components/ui/PresentationLayer.astro
@@ -92,7 +92,7 @@ const PRES_I18N = {
   window.__PRES_CTX = { context: context || 'home', tribeId: tribeId || null, initiativeId: initiativeId || null, i18n: PRES_I18N || {} };
 </script>
 <script>
-  import { hasPermission } from '../../lib/permissions';
+  import { hasPermission, canFor, getSimulation, getEffectiveTribeId } from '../../lib/permissions';
   const CTX = (window as any).__PRES_CTX || { context: 'home', tribeId: null, i18n: {} };
   const PI = CTX.i18n;
   let presActive = false;
@@ -106,8 +106,17 @@ const PRES_I18N = {
 
     if (CTX.context === 'tribe') {
       if (isAdmin) return true;
-      return hasPermission(member, 'board.edit_tribe_items')
-        && member.tribe_id === CTX.tribeId;
+      // #161: V4 scoped write_board on the presented tribe/initiative (was global
+      // board.edit_tribe_items && hand-rolled member.tribe_id===CTX.tribeId equality).
+      // Simulation overlay: preview the simulated V3 tier + effective tribe (canFor reads real caps).
+      const sim = getSimulation();
+      if (sim.active) {
+        return hasPermission(member, 'board.edit_tribe_items') && getEffectiveTribeId(member) === CTX.tribeId;
+      }
+      return Boolean(
+        (CTX.initiativeId && canFor('write_board', { type: 'initiative', id: CTX.initiativeId }))
+        || (CTX.tribeId != null && canFor('write_board', { type: 'tribe', id: CTX.tribeId }))
+      );
     }
     return false;
   }

--- a/src/pages/tribe/[id].astro
+++ b/src/pages/tribe/[id].astro
@@ -310,7 +310,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
   import { getCurrentCycle, loadCycles } from '../../lib/cycles';
   import { canExploreTribes, canManageTribeLifecycle, canSeeInactiveTribes } from '../../lib/tribes/access';
   import { buildTribeLabel } from '../../lib/tribes/catalog';
-  import { hasPermission } from '../../lib/permissions';
+  import { hasPermission, getSimulation, getEffectiveTribeId } from '../../lib/permissions';
   import { getTribePermissions } from '../../lib/tribePermissions';
   import { marked } from 'marked';
 
@@ -426,6 +426,44 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
 
   let sb: any = null;
   let currentMember: any = null;
+
+  // #161 (2026-06-06): V4 scoped gate for member-contact PII visibility. Mirrors the server RPCs
+  // get_initiative_member_contacts (can view_pii on the initiative) + get_tribe_member_contacts
+  // (org-wide view_pii OR tribe-scoped write). Replaces the V3 global
+  // hasPermission('board.edit_tribe_items') && tribe_id===TRIBE_ID gate that under-granted
+  // engagement-derived leaders of THIS tribe whose operational_role cache lost the permission (p201 class).
+  function canSeeTribeContacts(): boolean {
+    if (!currentMember) return false;
+    if (isHighManagement(currentMember)) return true;
+    // Admin simulation overlay: canFor reads REAL caps (superadmin bypass), so it can't preview a
+    // lower tier. While simulating, decide on the simulated V3 tier + effective (simulated) tribe.
+    const sim = getSimulation();
+    if (sim.active) {
+      return hasPermission(currentMember, 'board.edit_tribe_items') && getEffectiveTribeId(currentMember) === TRIBE_ID;
+    }
+    const cf = (window as any).__nucleoCanFor;
+    if (typeof cf !== 'function') return false;
+    if (INITIATIVE_ID && cf('view_pii', { type: 'initiative', id: INITIATIVE_ID }) === true) return true;
+    if (cf('view_pii', { type: 'tribe', id: TRIBE_ID }) === true) return true;
+    return cf('write', { type: 'tribe', id: TRIBE_ID }) === true;
+  }
+
+  // #161 (2026-06-06): V4 scoped gate for tribe board/edit authority (broadcast tab, minutes/board
+  // edit). Mirrors write_board on the page's initiative (tribe fallback). Replaces the V3 global
+  // hasPermission('board.edit_tribe_items') && tribe_id===TRIBE_ID under-grant pattern.
+  function isLeaderOfThisTribeV4(): boolean {
+    if (!currentMember) return false;
+    // Admin simulation overlay (see canSeeTribeContacts): preview the simulated V3 tier + tribe.
+    const sim = getSimulation();
+    if (sim.active) {
+      return hasPermission(currentMember, 'board.edit_tribe_items') && getEffectiveTribeId(currentMember) === TRIBE_ID;
+    }
+    const cf = (window as any).__nucleoCanFor;
+    if (typeof cf !== 'function') return false;
+    if (INITIATIVE_ID && cf('write_board', { type: 'initiative', id: INITIATIVE_ID }) === true) return true;
+    return cf('write_board', { type: 'tribe', id: TRIBE_ID }) === true;
+  }
+
   let membersMap: Map<string, any> = new Map();
   let _canonicalMemberCount: number | null = null; // M4-D (#419): canonical roster member_count — single source for the header badge
   let canEdit = false;
@@ -980,7 +1018,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
 
     const contact = contactData[m.id];
     const hasContact = contact && (contact.email || contact.phone);
-    const canSeeContacts = currentMember && (isHighManagement(currentMember) || (hasPermission(currentMember, 'board.edit_tribe_items') && currentMember.tribe_id === TRIBE_ID));
+    const canSeeContacts = canSeeTribeContacts(); // #161: V4 scoped view_pii (was global board.edit_tribe_items)
 
     let contactHtml = '';
     if (canSeeContacts && hasContact) {
@@ -1453,8 +1491,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
 
   function checkBroadcastAccess() {
     if (!currentMember) return;
-    const isLeaderOfThisTribe = hasPermission(currentMember, 'board.edit_tribe_items')
-      && currentMember.tribe_id === TRIBE_ID;
+    const isLeaderOfThisTribe = isLeaderOfThisTribeV4(); // #161: V4 scoped write_board (was global board.edit_tribe_items)
     if (isLeaderOfThisTribe || isHighManagement(currentMember)) {
       showBroadcastTab();
       renderBroadcastPanel();
@@ -1613,10 +1650,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
       checkEditPermission();
       checkBroadcastAccess();
       renderAccessNote();
-      if (currentMember && !Object.keys(contactData).length
-          && (isHighManagement(currentMember)
-              || (hasPermission(currentMember, 'board.edit_tribe_items')
-                  && currentMember.tribe_id === TRIBE_ID))) {
+      if (!Object.keys(contactData).length && canSeeTribeContacts()) { // #161: V4 scoped view_pii
         try {
           const { data: cd } = INITIATIVE_ID
               ? await sb.rpc('get_initiative_member_contacts', { p_initiative_id: INITIATIVE_ID })
@@ -1811,7 +1845,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
       allMembers.forEach((m: any) => membersMap.set(m.id, m));
 
       // Load contact data for leaders/admins (LGPD-gated RPC)
-      if (currentMember && (isHighManagement(currentMember) || (hasPermission(currentMember, 'board.edit_tribe_items') && currentMember.tribe_id === TRIBE_ID))) {
+      if (canSeeTribeContacts()) { // #161: V4 scoped view_pii (was global board.edit_tribe_items)
         try {
           const { data: cd } = INITIATIVE_ID
               ? await sb.rpc('get_initiative_member_contacts', { p_initiative_id: INITIATIVE_ID })
@@ -1884,7 +1918,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
         || desigs.includes('comms_member')
       );
     canEdit = isHighManagement(currentMember) ||
-      (hasPermission(currentMember, 'board.edit_tribe_items') && currentMember.tribe_id === TRIBE_ID) ||
+      isLeaderOfThisTribeV4() || // #161: V4 scoped write_board (was global board.edit_tribe_items)
       canOperateComms;
   }
 

--- a/src/pages/workspace.astro
+++ b/src/pages/workspace.astro
@@ -233,7 +233,7 @@ const WK = {
   <script id="wk-i18n" type="application/json" set:html={JSON.stringify(WK)}></script>
   <script is:inline define:vars={{ langPrefix }}>window.__LANG_PREFIX = langPrefix;</script>
   <script>
-    import { hasPermission } from '../lib/permissions';
+    import { hasPermission, getSimulation } from '../lib/permissions';
     // p123 i18n nav: prefix preserves /en /es when navigating between sections
     const LP: string = (typeof window !== 'undefined' && (window as any).__LANG_PREFIX) || '';
     // ── Workspace Cockpit — client-side orchestration ──
@@ -422,7 +422,13 @@ const WK = {
         const tribeName = myTribeBoard.board_name?.replace(/^Board\s*/i, '') || `${i18n.tribePrefix} ${member.tribe_id}`;
 
         const tribeColor = getTribeColor(member.tribe_id);
-        const isLeader = hasPermission(member, 'board.edit_tribe_items');
+        // #161: V4 scoped write_board on the viewer's own tribe (was global board.edit_tribe_items —
+        // under-granted engagement-derived leaders whose operational_role cache lost the permission).
+        // Simulation overlay: preview the simulated V3 tier (canFor reads real caps).
+        const _simWk = getSimulation();
+        const isLeader = _simWk.active
+          ? hasPermission(member, 'board.edit_tribe_items')
+          : (window as any).__nucleoCanFor?.('write_board', { type: 'tribe', id: member.tribe_id }) === true;
 
         if ($tribeCard) $tribeCard.innerHTML = `
           <a href="/tribe/${member.tribe_id}?tab=board" class="block no-underline group">

--- a/tests/contracts/p277-champions-da-noite-capture.test.mjs
+++ b/tests/contracts/p277-champions-da-noite-capture.test.mjs
@@ -54,9 +54,17 @@ test('p277 F2: get_event_champion_suggestions gains p_force_derive (skips overri
 });
 
 // ── frontend ─────────────────────────────────────────────────────────────────
-test('p277 F2 FE: MeetingsPage gates the picker on manage_event / champion.award', () => {
-  assert.match(page, /import \{ hasPermission \} from '\.\.\/\.\.\/lib\/permissions'/);
-  assert.match(page, /canCurateChampions =[\s\S]*?hasPermission\(member, 'manage_event'\)[\s\S]*?hasPermission\(member, 'champion\.award'\)/i);
+test('p277 F2 FE + #161: MeetingsPage gates the picker on manage_event / award_champion (V4 canFor, org-level mirror)', () => {
+  // #161: migrated from global hasPermission to canFor mirroring set_event_champions, which gates on
+  // can_by_member(manage_event) OR can_by_member(award_champion) = ORG-level (can(...,NULL,NULL)).
+  // The mirror is scopeless canFor (org_actions check), with a V3 hasPermission simulation overlay.
+  assert.match(page, /import \{ canFor, getSimulation, hasPermission \} from '\.\.\/\.\.\/lib\/permissions'/);
+  // V4 real path: scopeless (org-level) canFor on manage_event OR award_champion (matches the RPC's org gate).
+  assert.match(page, /canCurateChampions =[\s\S]*?canFor\('manage_event'\)[\s\S]*?canFor\('award_champion'\)/i,
+    'real path gates on org-level canFor(manage_event) OR canFor(award_champion)');
+  // Simulation overlay: preserves the V3 hasPermission(manage_event|champion.award) preview path.
+  assert.match(page, /_simMtg\.active[\s\S]*?hasPermission\(member, 'manage_event'\)[\s\S]*?hasPermission\(member, 'champion\.award'\)/i,
+    'simulation overlay keeps the V3 tier preview (no regression in simulation mode)');
   assert.match(page, /\{canCurateChampions && selectedEventId && \(\s*<ChampionPicker/i, 'picker only rendered when permitted + an event is open');
 });
 


### PR DESCRIPTION
## #161 — audit sensitive UI gates against V4 `canFor`

Closes #161. Last Wave-1 blocker. Audits **all 65** `hasPermission()` UI gates and migrates the **8** scope-leak / under-grant gates to engagement-derived `canFor`, fixing the **p201 class** (leaders authorized via engagement were wrongly blocked because the gate keyed on the stale `operational_role` cache). Full inventory: `docs/audit/P161_UI_GATES_CANFOR_AUDIT.md`.

### Classification (DoD a)
| Class | Count | Action |
|---|---|---|
| A — global-tier (correct) | 37 | keep |
| **B — scope-leak / under-grant** | **8** | **migrate → `canFor`** |
| C — intentional local-tier (data server-gated) | 9 | document |
| Orphan (`TribeKanbanIsland`, 0-mount) | 11 | delete separately |

### Migrated (DoD b) — each mirrors its RPC's own server gate (verified from `pg_proc`)
- **`tribe/[id].astro`** — 3 member-contact **PII** gates → **`view_pii`** (the `get_*_member_contacts` RPCs gate `view_pii`, *not* `write_board` — the adversarial review caught the classifier's uniform `write_board` proposal); 2 edit gates (broadcast tab, `canEdit`) → `write_board`. Extracted `canSeeTribeContacts()` + `isLeaderOfThisTribeV4()`.
- **`workspace.astro`** — own-tribe dashboard link → `write_board`.
- **`MeetingsPage.tsx`** — champions picker → **scopeless** `canFor('manage_event') || canFor('award_champion')`, mirroring `set_event_champions`' **org-level** `can_by_member` gate.
- **`PresentationLayer.astro`** — tribe presentation toggle → `write_board`.

### Simulation overlay (DoD d — no regression in simulation mode)
`canFor` reads **real** caps (superadmin bypass), so it can't preview a lower tier. Every migrated gate branches `sim.active ? <V3 hasPermission on effective tribe> : <V4 canFor>` — mirroring `AdminNav.astro:122-126` and `useBoardPermissions.ts:113-119`. This also **fixes** a latent bug where the old gates compared the *real* `member.tribe_id` even while simulating.

### Council review (adversarial, 3 lenses)
- **security-engineer:** ship-with-nits — no PII leak, no privilege escalation; gates are equal-to-or-stricter-than the server enforcer; simulation overlay fail-closed.
- **senior-software-engineer:** **block** → **fixed**: champions gate was over-scoped to `champEvent.initiative_id`/`tribe_id`, but `get_meeting_detail` has no `initiative_id` and *geral* meetings (no tribe) regressed to always-false. Re-mirrored to the RPC's **org-level** gate (scopeless `canFor`).
- **code-reviewer:** ship-with-nits — pattern-consistent; audit doc accurate; the 9 Class-C keeps defensible.

### Drive-by
Fixed a reachable `closeDetail()` **infinite-recursion crash** in `MeetingsPage` (× button / overlay click stack-overflowed and never cleared `selectedMeeting`) — surfaced by the security lens.

### Verification
`astro build` ✅ · full offline suite **3500 / 3268 pass / 0 fail / 232 skipped** · `p277-champions` test updated to the org-level mirror + simulation overlay.

### Persona smoke
Roberto/Sarah (engagement curator) → sees own-tribe contacts despite stale role cache · tribe-X leader → tribe X only, no Y leak · member → masked + server returns `{}` · chapter_liaison → admin entries unchanged · superadmin simulating tier T → previews T (overlay).

### Follow-up (not here)
Delete the `TribeKanbanIsland.tsx` orphan (11 MOOT gates) — blocked on re-pointing 3 `ui-stabilization` test reads to `BoardEngine` first.

🤖 reviewed via the council multi-agent workflow