### PR TITLE
docs(162): refresh stale MCP tool count 293→306 in consumer-facing docs

### DIFF
--- a/.claude/agents/platform-guardian.md
+++ b/.claude/agents/platform-guardian.md
@@ -56,7 +56,7 @@ Se qualquer invariante ≠ OK, **pare e reporte imediatamente**.
 
 ### 5. Drift docs vs código
 CLAUDE.md (p133+ Anthropic guidance) **NÃO pina counts mutáveis**. Pins canônicos vivem em `.claude/rules/*.md` e em `docs/adr/README.md`. Auditar:
-- **MCP tools**: `grep -c 'mcp.tool(' supabase/functions/nucleo-mcp/index.ts` vs `.claude/rules/mcp.md` (pin atual: "293 tools + 4 prompts + 3 resources" — p199-a v2.76.1)
+- **MCP tools**: `grep -c 'mcp.tool(' supabase/functions/nucleo-mcp/index.ts` (flat = /mcp + 3 /semantic) vs the live `/health` `/mcp.tools` count. `.claude/rules/mcp.md` intentionally does NOT pin a literal ("never recite from memory" — the count drifts every session). Re-query, don't trust a hardcoded number. (For reference only: ~306 /mcp as of 2026-06-06 S5 #188.)
 - **Edge functions**: `ls supabase/functions/ | wc -l` (lembre que `_shared` não é função). Sem pin em rules — referência canônica é git ls-tree
 - **Tests**: baseline em deploy/session audit (pin atual offline: "1449 pass, 0 fail, 46 skip"; DB-aware: "~1501 pass, 0 fail, 5 skip")
 - **ADRs**: `ls docs/adr/ADR-*.md | wc -l` vs `docs/adr/README.md` index (pin atual: 86 ADR files, ADR-0082 skip intentional documented in index)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ This file orients the AI assistant on the project so it can work effectively wit
 | Backend   | Supabase Edge Functions (~37 deployed) |
 | Auth      | Google + LinkedIn (OIDC) + Microsoft (Azure) |
 | Env access | `import { env } from 'cloudflare:workers'` (NOT `locals.runtime.env`) |
-| MCP       | 293 tools, OAuth 2.1, Streamable HTTP SSE, `nucleoia.vitormr.dev/mcp` |
+| MCP       | 306 tools, OAuth 2.1, Streamable HTTP SSE, `nucleoia.vitormr.dev/mcp` |
 | Observability | PostHog (custom events) + Sentry (global handlers) |
 | i18n      | PT-BR, EN, ES (keys in `src/i18n/`) |
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-293%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
+[![MCP](https://img.shields.io/badge/MCP-306%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,7 +43,7 @@ Fundado en 2024 como piloto en PMI Goias, el proyecto evoluciono hacia una alian
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de gobernanza | 160+ |
 | Posts en el blog | 9 |
-| Herramientas MCP | 293 |
+| Herramientas MCP | 306 |
 | Edge Functions | 37 |
 | Claves i18n | 4.000+ (3 idiomas) |
 | Tests | 1.418 pasando (1.456 con service-role) |
@@ -108,7 +108,7 @@ graph LR
 | **Hospedaje** | Cloudflare Workers | SSR en el edge, proxy OAuth, proxy MCP |
 | **Base de Datos** | Supabase PostgreSQL | 795 RPCs y helpers SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor personalizado (293 herramientas) | Asistentes de IA consultan la plataforma via lenguaje natural |
+| **MCP** | Servidor personalizado (306 herramientas) | Asistentes de IA consultan la plataforma via lenguaje natural |
 | **Logica Server** | Supabase Edge Functions (37) | Sync Credly, asistencia, MCP, campañas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de producto, session replay |
 | **Errores** | Sentry | Monitoreo de errores en tiempo real |
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracion con IA
 
-Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. 293 herramientas autenticadas via OAuth 2.1 con Row Level Security. Auto-refresh server-side mantiene sesiones activas por hasta 30 dias sin reconexion manual. Capa de conocimiento dinamica adapta orientaciones al rol y permisos de cada miembro.
+Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. 306 herramientas autenticadas via OAuth 2.1 con Row Level Security. Auto-refresh server-side mantiene sesiones activas por hasta 30 dias sin reconexion manual. Capa de conocimiento dinamica adapta orientaciones al rol y permisos de cada miembro.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -151,7 +151,7 @@ sequenceDiagram
 
 | Compatibilidad | Estado |
 |----------------|--------|
-| Claude.ai | Verificado (293 herramientas) |
+| Claude.ai | Verificado (306 herramientas) |
 | Claude Code | Verificado |
 | ChatGPT | Verificado (beta) |
 | Perplexity | Verificado |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-293%20Tools-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
+[![MCP](https://img.shields.io/badge/MCP-306%20Tools-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -44,7 +44,7 @@ Founded in 2024 as a pilot within PMI Goiás, the initiative has grown into a st
 | Events held | 209 |
 | Governance entries | 141+ (GC-001 → GC-141+) |
 | Blog posts | 9 |
-| MCP tools | 293 |
+| MCP tools | 306 |
 | Edge Functions | 37 |
 | pg_cron jobs | 34 |
 | RPCs (SECURITY DEFINER + helpers) | 795 |
@@ -111,7 +111,7 @@ graph LR
 | **Hosting** | Cloudflare Workers | Edge SSR, OAuth proxy, MCP proxy |
 | **Database** | Supabase PostgreSQL | 200+ SECURITY DEFINER functions, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, dynamic client registration |
-| **MCP** | Custom server (293 tools) | AI assistants query platform via natural language |
+| **MCP** | Custom server (306 tools) | AI assistants query platform via natural language |
 | **Server Logic** | Supabase Edge Functions (37) | Credly sync, attendance, MCP, campaigns, Artia sync, PostHog proxy, AI triage |
 | **Analytics** | PostHog | Product analytics, session replay |
 | **Errors** | Sentry | Real-time error monitoring |
@@ -123,7 +123,7 @@ graph LR
 
 ## MCP Server — AI Integration
 
-Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. 293 tools authenticated via OAuth 2.1 with full Row Level Security enforcement. Server-side auto-refresh keeps sessions alive for up to 30 days without manual reconnection. Dynamic knowledge layer adapts guidance to each member's role and permissions.
+Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. 306 tools authenticated via OAuth 2.1 with full Row Level Security enforcement. Server-side auto-refresh keeps sessions alive for up to 30 days without manual reconnection. Dynamic knowledge layer adapts guidance to each member's role and permissions.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -160,7 +160,7 @@ sequenceDiagram
 
 | Compatibility | Status |
 |--------------|--------|
-| Claude.ai | Verified (293 tools) |
+| Claude.ai | Verified (306 tools) |
 | Claude Code | Verified |
 | ChatGPT | Verified (beta) |
 | Perplexity | Verified |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-293%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
+[![MCP](https://img.shields.io/badge/MCP-306%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,7 +43,7 @@ Fundado em 2024 como piloto no PMI Goias, o projeto evoluiu para uma alianca est
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de governanca | 160+ |
 | Posts no blog | 9 |
-| Ferramentas MCP | 293 |
+| Ferramentas MCP | 306 |
 | Edge Functions | 37 |
 | Chaves i18n | 4.000+ (3 idiomas) |
 | Testes | 1.418 passando (1.456 com service-role) |
@@ -108,7 +108,7 @@ graph LR
 | **Hospedagem** | Cloudflare Workers | SSR na edge, proxy OAuth, proxy MCP |
 | **Banco de Dados** | Supabase PostgreSQL | 795 RPCs e helpers SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor customizado (293 ferramentas) | Assistentes de IA consultam a plataforma via linguagem natural |
+| **MCP** | Servidor customizado (306 ferramentas) | Assistentes de IA consultam a plataforma via linguagem natural |
 | **Logica Server** | Supabase Edge Functions (37) | Sync Credly, presenca, MCP, campanhas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de produto, session replay |
 | **Erros** | Sentry | Monitoramento de erros em tempo real |
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracao com IA
 
-Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. 293 ferramentas autenticadas via OAuth 2.1 com Row Level Security. Auto-refresh server-side mantem sessoes ativas por ate 30 dias sem reconexao manual. Camada de conhecimento dinamica adapta orientacoes ao papel e permissoes de cada membro.
+Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. 306 ferramentas autenticadas via OAuth 2.1 com Row Level Security. Auto-refresh server-side mantem sessoes ativas por ate 30 dias sem reconexao manual. Camada de conhecimento dinamica adapta orientacoes ao papel e permissoes de cada membro.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -151,7 +151,7 @@ sequenceDiagram
 
 | Compatibilidade | Status |
 |----------------|--------|
-| Claude.ai | Verificado (293 ferramentas) |
+| Claude.ai | Verificado (306 ferramentas) |
 | Claude Code | Verificado |
 | ChatGPT | Verificado (beta) |
 | Perplexity | Verificado |

--- a/docs/MCP_SETUP_GUIDE.md
+++ b/docs/MCP_SETUP_GUIDE.md
@@ -89,7 +89,7 @@ Manual bearer tokens copied into Claude Code expire in 1 hour. Prefer the OAuth 
 
 ## Representative Tools
 
-The live source of truth is the MCP `tools/list` response. The examples below cover the most common member and operator workflows; the full runtime inventory currently exposes 293 tools.
+The live source of truth is the MCP `tools/list` response. The examples below cover the most common member and operator workflows; the full runtime inventory currently exposes 306 tools.
 
 For the **complete machine-generated contract matrix** (tool → domain → RPC dependencies → tables → canV4 gate → external fetches → service_role usage), see:
 


### PR DESCRIPTION
## #162 — refresh MCP tool reference

Closes #162. The contract matrix + manifest + parser script already cover all runtime tools (regenerated to **309** = 306 `/mcp` + 3 `/semantic` in PR #551); the only remaining DoD gap (criterion 4 — *tools/list, /health, README/guide agree*) was the stale hardcoded **293** in consumer/agent-facing docs.

### Changes (doc-only, no code/schema)
- `README.md` / `README.pt-BR.md` / `README.es.md` — badge + tables + prose `293 → 306`
- `AGENTS.md`, `docs/MCP_SETUP_GUIDE.md` — `293 tools → 306 tools`
- `.claude/agents/platform-guardian.md` — **de-hardcoded** the drift-check pin to point at live `/health` (the count drifts every session; `.claude/rules/mcp.md` intentionally stays unpinned)

Live source of truth (verified 2026-06-06): `/mcp` `tools/list` = **306**, `/health` = 306.

🤖 triaged via the council multi-agent workflow