### PR TITLE
fix(420): present-detection filter on attendance hours/impact metrics

### DIFF
--- a/supabase/migrations/20260805000122_p278_420_attendance_present_filter.sql
+++ b/supabase/migrations/20260805000122_p278_420_attendance_present_filter.sql
@@ -1,0 +1,184 @@
+-- Migration: #420 follow-up — present-detection filter on attendance hours/impact metrics
+-- Date: 2026-06-06 (session 6)
+--
+-- Context (#420, 2026-05-31 comment): the attendance table carries a `present` boolean
+-- (true: 1374 rows, false: 65 rows, no NULLs). Several consumers summed/counted attendance
+-- WITHOUT filtering present=true, so registered-but-absent rows inflated the numbers.
+-- Live antes (2026-06-06):
+--   get_public_impact_data.impact_hours          = 1655.99  -> present-only 1577.49 (-78.5h)
+--   get_public_impact_data.total_attendance_hours= 896.16   -> present-only 817.66  (-78.5h)
+-- This migration filters `a.present` in the two public/member hours metrics.
+--
+-- Body-faithful reproduction (Phase-C): the live `get_public_impact_data` body carried inline
+-- `-- #481` comments; apply_migration strips inline `--` comments inside $function$ (sediment #156),
+-- which would drift the body hash. They are removed here (the #481 rationale: chapters_summary is the
+-- 5 SIGNED chapters from partner_entities, member_count/sponsor from members filtered to those names —
+-- unchanged by this migration). No behavioural change beyond the present filter.
+--
+-- DEFERRED (NOT in this migration): get_admin_dashboard also has present-blind attendance logic —
+--   (a) the dropout 60-day alert subquery (1-line present filter, but buried in a 7KB body), and
+--   (b) the "detractors (3+ faltas consecutivas)" query, which is SEPARATELY BROKEN (its inner
+--       LEFT JOIN exposes a.member_id that the NOT EXISTS then negates against itself -> NULL
+--       member_ids -> the alert never fires). That needs a rewrite, not a present filter, and is
+--       tracked as a #420 follow-up. No regression: the detractor alert is already effectively dead.
+--
+-- Scope note (data-architect review): the canonical KPI-bar source `impact_hours_total` VIEW
+-- (mig 20260674400000) filters `present = true AND excused IS NOT TRUE` — stricter than this RPC's
+-- present-only `impact_hours`. The two surfaces are intentionally different scopes (public impact page
+-- = present participation hours; KPI bar = present-and-not-excused). Pre-existing divergence; this
+-- migration only moves the RPC from all-attendance to present-only, it does not unify the excused scope.
+--
+-- Rollback: re-apply the prior bodies (without the `AND a.present` / `WHERE a.present` predicates).
+
+CREATE OR REPLACE FUNCTION public.get_member_attendance_hours(p_member_id uuid, p_cycle_code text DEFAULT 'cycle_3'::text)
+ RETURNS TABLE(total_hours numeric, total_events integer, avg_hours_per_event numeric, current_streak integer)
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_cycle_start date;
+  v_streak int := 0;
+  v_rec record;
+  v_target_tribe int;
+BEGIN
+  SELECT id INTO v_caller_id
+  FROM public.members WHERE auth_id = auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  IF NOT (v_caller_id = p_member_id OR public.can_by_member(v_caller_id, 'view_pii')) THEN
+    RAISE EXCEPTION 'Unauthorized: can only view own attendance or requires view_pii permission';
+  END IF;
+
+  SELECT cycle_start INTO v_cycle_start
+  FROM public.cycles WHERE cycle_code = p_cycle_code;
+
+  IF v_cycle_start IS NULL THEN
+    RETURN QUERY SELECT 0::numeric, 0::int, 0::numeric, 0::int;
+    RETURN;
+  END IF;
+
+  SELECT tribe_id INTO v_target_tribe FROM public.members WHERE id = p_member_id;
+
+  FOR v_rec IN
+    SELECT e.id,
+           EXISTS(SELECT 1 FROM public.attendance a WHERE a.event_id = e.id AND a.member_id = p_member_id AND a.present) AS was_present
+    FROM public.events e
+    LEFT JOIN public.initiatives i ON i.id = e.initiative_id
+    WHERE e.date >= v_cycle_start
+      AND e.date <= current_date
+      AND (e.initiative_id IS NULL
+           OR i.legacy_tribe_id = v_target_tribe)
+    ORDER BY e.date DESC
+  LOOP
+    IF v_rec.was_present THEN
+      v_streak := v_streak + 1;
+    ELSE
+      EXIT;
+    END IF;
+  END LOOP;
+
+  RETURN QUERY
+  SELECT
+    COALESCE(SUM(e.duration_minutes / 60.0), 0)::numeric          AS total_hours,
+    COUNT(DISTINCT a.event_id)::int                                AS total_events,
+    CASE WHEN COUNT(DISTINCT a.event_id) > 0
+      THEN (COALESCE(SUM(e.duration_minutes / 60.0), 0) / COUNT(DISTINCT a.event_id))::numeric
+      ELSE 0::numeric
+    END                                                            AS avg_hours_per_event,
+    v_streak                                                       AS current_streak
+  FROM public.attendance a
+  JOIN public.events e ON e.id = a.event_id
+  WHERE a.member_id = p_member_id AND a.present;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_public_impact_data()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_result jsonb;
+  v_chapters jsonb := public.get_chapter_metrics();
+BEGIN
+  SELECT jsonb_build_object(
+    'chapters', (v_chapters->>'signed')::int,
+    'chapters_engaged', (v_chapters->>'engaged')::int,
+    'active_members', (SELECT COUNT(*) FROM members WHERE is_active = true AND current_cycle_active = true),
+    'tribes', (SELECT COUNT(*) FROM tribes),
+    'articles_published', (SELECT COUNT(*) FROM public_publications WHERE is_published = true),
+    'articles_approved', (
+      SELECT COUNT(*) FROM board_lifecycle_events WHERE action = 'curation_review' AND new_status = 'approved'
+    ),
+    'total_events', (SELECT COUNT(*) FROM events WHERE date >= '2026-03-01'),
+    'total_attendance_hours', (
+      SELECT COALESCE(SUM(e.duration_minutes / 60.0), 0)
+      FROM attendance a JOIN events e ON e.id = a.event_id
+      WHERE e.date >= '2026-03-01' AND a.present
+    ),
+    'impact_hours', (
+      SELECT COALESCE(SUM(e.duration_minutes / 60.0), 0)
+      FROM attendance a JOIN events e ON e.id = a.event_id
+      WHERE a.present
+    ),
+    'webinars', public.get_webinars_count(NULL, NULL, 'realized'),
+    'ia_pilots', (SELECT COUNT(*) FROM ia_pilots WHERE status IN ('active','completed')),
+    'partner_count', (SELECT COUNT(*) FROM partner_entities WHERE status = 'active'),
+    'courses_count', (SELECT COUNT(*) FROM courses),
+    'recent_publications', COALESCE((
+      SELECT jsonb_agg(sub ORDER BY sub.publication_date DESC NULLS LAST)
+      FROM (SELECT title, authors, external_platform AS platform, publication_date, external_url
+            FROM public_publications WHERE is_published = true
+            ORDER BY publication_date DESC NULLS LAST LIMIT 5) sub
+    ), '[]'::jsonb),
+    'tribes_summary', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'id', t.id, 'name', t.name, 'quadrant_name', t.quadrant_name,
+        'member_count', (SELECT COUNT(*) FROM members m WHERE m.tribe_id = t.id AND m.is_active),
+        'leader_name', (SELECT name FROM members WHERE id = t.leader_member_id)
+      ) ORDER BY t.id)
+      FROM tribes t
+    ), '[]'::jsonb),
+    'chapters_summary', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'chapter', pe.name,
+          'member_count', (SELECT COUNT(*) FROM members m WHERE m.chapter = pe.name AND m.is_active),
+          'sponsor', (SELECT ms.name FROM members ms WHERE ms.chapter = pe.name AND 'sponsor' = ANY(ms.designations) AND ms.is_active LIMIT 1)
+        )
+        ORDER BY (SELECT COUNT(*) FROM members m WHERE m.chapter = pe.name AND m.is_active) DESC, pe.name
+      )
+      FROM partner_entities pe
+      WHERE pe.entity_type = 'pmi_chapter' AND pe.status = 'active' AND NOT COALESCE(pe.is_international, false)
+    ), '[]'::jsonb),
+    'partners', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object('name', name, 'type', entity_type, 'status', status))
+      FROM partner_entities WHERE status = 'active'
+    ), '[]'::jsonb),
+    'recognitions', jsonb_build_array(
+      jsonb_build_object(
+        'title', 'Finalista — Prêmio "Carlos Novello" Voluntário do Ano',
+        'organization', 'PMI LATAM Excellence Awards 2025',
+        'recipient', 'Vitor Maia Rodovalho (GP)',
+        'date', '2026-02-26',
+        'category', 'Volunteer of the Year — LATAM Brasil',
+        'description', 'Nomeado pelo PMI Goiás pelo trabalho à frente do Núcleo de IA & GP'
+      )
+    ),
+    'timeline', jsonb_build_array(
+      jsonb_build_object('year', '2024', 'title', 'Fase Piloto', 'description', 'Concepção pelo PMI-GO. Patrocínio Ivan Lourenço. Experimentação e lições aprendidas.'),
+      jsonb_build_object('year', '2025.1', 'title', 'Oficialização', 'description', 'Parceria PMI-GO + PMI-CE. 7 artigos submetidos ao ProjectManagement.com. 1º Webinar.'),
+      jsonb_build_object('year', '2025.2', 'title', 'Amadurecimento', 'description', 'Manual de Governança R2. 13 pesquisadores selecionados. Expansão para PMI-DF, PMI-MG, PMI-RS.'),
+      jsonb_build_object('year', '2026', 'title', 'Escala', 'description', '44+ colaboradores, 8 tribos, 5 capítulos PMI. Plataforma digital própria. Processo seletivo estruturado.')
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;

--- a/tests/contracts/p420-bucket-a-metric-defects-regression-lock.test.mjs
+++ b/tests/contracts/p420-bucket-a-metric-defects-regression-lock.test.mjs
@@ -62,3 +62,25 @@ test('D12: get_events_with_attendance.attendee_count filters a.present = true', 
   assert.match(code, /a\.present = true\) AS attendee_count/,
     `${file}: attendee_count must count only present=true rows (not all attendance rows incl absent/excused)`);
 });
+
+// ── #420 follow-up (2026-05-31 comment): 3 present-blind consumers (mig 20260805000122) ──
+// get_public_impact_data + get_member_attendance_hours summed/counted attendance without filtering
+// present=true (registered-but-absent rows inflated hours by 78.5h: impact 1656→1577.5, total 896→817.7).
+// (get_admin_dashboard's dropout/detractor present-blindness is deferred — its detractor query is
+//  separately broken/dead, needs a rewrite not a present filter.)
+
+test('#420 follow-up: get_member_attendance_hours filters a.present (streak EXISTS + hours aggregate)', () => {
+  const { file, code } = latestDeclarerCode('get_member_attendance_hours');
+  assert.match(code, /EXISTS\(SELECT 1 FROM public\.attendance a WHERE a\.event_id = e\.id AND a\.member_id = p_member_id AND a\.present\)/,
+    `${file}: streak presence-EXISTS must require a.present (not bare attendance-row existence)`);
+  assert.match(code, /WHERE a\.member_id = p_member_id AND a\.present/,
+    `${file}: total_hours/total_events aggregate must filter a.present (absent rows earn no hours/credit)`);
+});
+
+test('#420 follow-up: get_public_impact_data hours metrics filter a.present', () => {
+  const { file, code } = latestDeclarerCode('get_public_impact_data');
+  assert.match(code, /WHERE e\.date >= '2026-03-01' AND a\.present/,
+    `${file}: total_attendance_hours must filter a.present`);
+  assert.match(code, /FROM attendance a JOIN events e ON e\.id = a\.event_id\s+WHERE a\.present/,
+    `${file}: impact_hours must filter a.present`);
+});


### PR DESCRIPTION
## #420 follow-up — present-blind attendance consumers

Part of #420. The original Bucket-A defects (D14/D6/D12/D10) were already fixed by #419 M3; a 2026-05-31 comment surfaced **3 still-present-blind consumers**. This PR fixes the **2 metric functions** (the source of the public hours disparity); `get_admin_dashboard` is deferred (see below).

### The bug
`attendance.present` is boolean (true: 1374, false: 65, no NULLs). Two functions summed/counted attendance **without filtering `present`**, so registered-but-absent rows inflated the numbers by **78.5h**.

| Metric | Before | After (present-only) |
|---|---|---|
| `get_public_impact_data.impact_hours` | 1655.99 | **1577.49** |
| `get_public_impact_data.total_attendance_hours` | 896.16 | **817.66** |

(antes→depois both verified live against the DB.)

### Changes (mig `20260805000122`)
- **`get_member_attendance_hours`** — streak `EXISTS(...)` + the hours/events aggregate now require `a.present` (no hours/streak credit for absences).
- **`get_public_impact_data`** — `total_attendance_hours` + `impact_hours` filter `a.present`.

Body-faithful `CREATE OR REPLACE` — **Phase-C verified** (the migration file's parsed `bodyHash` == live `md5(regexp_replace(prosrc,'\s+',' '))` for both functions). Inline `-- #481` comments stripped (apply_migration strips them → would drift the hash), rationale moved to the migration header. Signatures + VOLATILE/STABLE + SECURITY DEFINER + search_path all preserved.

### Deferred (Part of #420 — `get_admin_dashboard`)
- **dropout 60-day alert** — adding `present` here is a **grey-zone** semantic change (a no-show who registered could itself be a dropout signal), not a clean filter.
- **"detractors 3+ faltas" query** — separately **broken/dead**: its inner `LEFT JOIN attendance a` exposes `a.member_id`, which the `NOT EXISTS` then negates against itself (`ax.member_id = NULL`) → no rows ever → the alert never fires. Needs a **rewrite**, not a present filter. (No regression: already dead.)

### Verification
`astro build` ✅ · `p420` regression-lock test extended (**5/0**) · `rpc-migration-coverage` offline 8/0 (DB-gated Phase-C runs in CI) · migration registered (`supabase migration repair`) + shadow row cleaned + `NOTIFY pgrst`.

### Council
**data-architect: SHIP** — semantics correct (consumers are "hours I earned" / "active participation", absences shouldn't count), no other present-blind aggregation inside the 2 functions, faithful reproduction, sound deferral. One non-blocking nit folded (header note on the `impact_hours_total` VIEW's stricter `present AND excused` scope — intentional public-page vs KPI-bar divergence, pre-existing).

🤖 reviewed via the council (data-architect)