### PR TITLE
docs(234): MCP org-connector enablement package + de-pin tool counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ This file orients the AI assistant on the project so it can work effectively wit
 | Backend   | Supabase Edge Functions (~37 deployed) |
 | Auth      | Google + LinkedIn (OIDC) + Microsoft (Azure) |
 | Env access | `import { env } from 'cloudflare:workers'` (NOT `locals.runtime.env`) |
-| MCP       | 306 tools, OAuth 2.1, Streamable HTTP SSE, `nucleoia.vitormr.dev/mcp` |
+| MCP       | 300+ tools, OAuth 2.1, Streamable HTTP SSE, `nucleoia.vitormr.dev/mcp` |
 | Observability | PostHog (custom events) + Sentry (global handlers) |
 | i18n      | PT-BR, EN, ES (keys in `src/i18n/`) |
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-306%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
+[![MCP](https://img.shields.io/badge/MCP-300%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,7 +43,7 @@ Fundado en 2024 como piloto en PMI Goias, el proyecto evoluciono hacia una alian
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de gobernanza | 160+ |
 | Posts en el blog | 9 |
-| Herramientas MCP | 306 |
+| Herramientas MCP | 300+ |
 | Edge Functions | 37 |
 | Claves i18n | 4.000+ (3 idiomas) |
 | Tests | 1.418 pasando (1.456 con service-role) |
@@ -108,7 +108,7 @@ graph LR
 | **Hospedaje** | Cloudflare Workers | SSR en el edge, proxy OAuth, proxy MCP |
 | **Base de Datos** | Supabase PostgreSQL | 795 RPCs y helpers SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor personalizado (306 herramientas) | Asistentes de IA consultan la plataforma via lenguaje natural |
+| **MCP** | Servidor personalizado (300+ herramientas) | Asistentes de IA consultan la plataforma via lenguaje natural |
 | **Logica Server** | Supabase Edge Functions (37) | Sync Credly, asistencia, MCP, campañas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de producto, session replay |
 | **Errores** | Sentry | Monitoreo de errores en tiempo real |
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracion con IA
 
-Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. 306 herramientas autenticadas via OAuth 2.1 con Row Level Security. Auto-refresh server-side mantiene sesiones activas por hasta 30 dias sin reconexion manual. Capa de conocimiento dinamica adapta orientaciones al rol y permisos de cada miembro.
+Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. 300+ herramientas autenticadas via OAuth 2.1 con Row Level Security. Auto-refresh server-side mantiene sesiones activas por hasta 30 dias sin reconexion manual. Capa de conocimiento dinamica adapta orientaciones al rol y permisos de cada miembro.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -151,7 +151,7 @@ sequenceDiagram
 
 | Compatibilidad | Estado |
 |----------------|--------|
-| Claude.ai | Verificado (306 herramientas) |
+| Claude.ai | Verificado |
 | Claude Code | Verificado |
 | ChatGPT | Verificado (beta) |
 | Perplexity | Verificado |

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-306%20Tools-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
+[![MCP](https://img.shields.io/badge/MCP-300%2B%20Tools-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -44,7 +44,7 @@ Founded in 2024 as a pilot within PMI Goiás, the initiative has grown into a st
 | Events held | 209 |
 | Governance entries | 141+ (GC-001 → GC-141+) |
 | Blog posts | 9 |
-| MCP tools | 306 |
+| MCP tools | 300+ |
 | Edge Functions | 37 |
 | pg_cron jobs | 34 |
 | RPCs (SECURITY DEFINER + helpers) | 795 |
@@ -111,7 +111,7 @@ graph LR
 | **Hosting** | Cloudflare Workers | Edge SSR, OAuth proxy, MCP proxy |
 | **Database** | Supabase PostgreSQL | 200+ SECURITY DEFINER functions, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, dynamic client registration |
-| **MCP** | Custom server (306 tools) | AI assistants query platform via natural language |
+| **MCP** | Custom server (300+ tools) | AI assistants query platform via natural language |
 | **Server Logic** | Supabase Edge Functions (37) | Credly sync, attendance, MCP, campaigns, Artia sync, PostHog proxy, AI triage |
 | **Analytics** | PostHog | Product analytics, session replay |
 | **Errors** | Sentry | Real-time error monitoring |
@@ -123,7 +123,7 @@ graph LR
 
 ## MCP Server — AI Integration
 
-Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. 306 tools authenticated via OAuth 2.1 with full Row Level Security enforcement. Server-side auto-refresh keeps sessions alive for up to 30 days without manual reconnection. Dynamic knowledge layer adapts guidance to each member's role and permissions.
+Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. 300+ tools authenticated via OAuth 2.1 with full Row Level Security enforcement. Server-side auto-refresh keeps sessions alive for up to 30 days without manual reconnection. Dynamic knowledge layer adapts guidance to each member's role and permissions.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -160,7 +160,7 @@ sequenceDiagram
 
 | Compatibility | Status |
 |--------------|--------|
-| Claude.ai | Verified (306 tools) |
+| Claude.ai | Verified |
 | Claude Code | Verified |
 | ChatGPT | Verified (beta) |
 | Perplexity | Verified |

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-306%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
+[![MCP](https://img.shields.io/badge/MCP-300%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,7 +43,7 @@ Fundado em 2024 como piloto no PMI Goias, o projeto evoluiu para uma alianca est
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de governanca | 160+ |
 | Posts no blog | 9 |
-| Ferramentas MCP | 306 |
+| Ferramentas MCP | 300+ |
 | Edge Functions | 37 |
 | Chaves i18n | 4.000+ (3 idiomas) |
 | Testes | 1.418 passando (1.456 com service-role) |
@@ -108,7 +108,7 @@ graph LR
 | **Hospedagem** | Cloudflare Workers | SSR na edge, proxy OAuth, proxy MCP |
 | **Banco de Dados** | Supabase PostgreSQL | 795 RPCs e helpers SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor customizado (306 ferramentas) | Assistentes de IA consultam a plataforma via linguagem natural |
+| **MCP** | Servidor customizado (300+ ferramentas) | Assistentes de IA consultam a plataforma via linguagem natural |
 | **Logica Server** | Supabase Edge Functions (37) | Sync Credly, presenca, MCP, campanhas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de produto, session replay |
 | **Erros** | Sentry | Monitoramento de erros em tempo real |
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracao com IA
 
-Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. 306 ferramentas autenticadas via OAuth 2.1 com Row Level Security. Auto-refresh server-side mantem sessoes ativas por ate 30 dias sem reconexao manual. Camada de conhecimento dinamica adapta orientacoes ao papel e permissoes de cada membro.
+Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. 300+ ferramentas autenticadas via OAuth 2.1 com Row Level Security. Auto-refresh server-side mantem sessoes ativas por ate 30 dias sem reconexao manual. Camada de conhecimento dinamica adapta orientacoes ao papel e permissoes de cada membro.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -151,7 +151,7 @@ sequenceDiagram
 
 | Compatibilidade | Status |
 |----------------|--------|
-| Claude.ai | Verificado (306 ferramentas) |
+| Claude.ai | Verificado |
 | Claude Code | Verificado |
 | ChatGPT | Verificado (beta) |
 | Perplexity | Verificado |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ We credit reporters in release notes unless anonymity is requested.
 In-scope:
 - `nucleoia.vitormr.dev` (production)
 - Supabase project `ldrfrvwhxsmgaabwmaik` (public API surfaces)
-- MCP server at `nucleoia.vitormr.dev/mcp` (OAuth 2.1, 76 tools)
+- MCP server at `nucleoia.vitormr.dev/mcp` (OAuth 2.1, 300+ tools)
 - Edge Functions at `ldrfrvwhxsmgaabwmaik.supabase.co/functions/v1/*`
 - GitHub repos `nucleo-ia-gp/wiki` and `nucleo-ia-gp/frameworks`
 

--- a/docs/MCP_ORG_CONNECTOR_ENABLEMENT.md
+++ b/docs/MCP_ORG_CONNECTOR_ENABLEMENT.md
@@ -1,0 +1,192 @@
+# MCP Org/Team Connector Enablement — Núcleo IA
+
+> **Tracker for GitHub issue [#234](https://github.com/VitorMRodovalho/ai-pm-research-hub/issues/234)** ·
+> **Decision: Option B — publish as an org/team connector** (PM, 2026-06-06; recorded in the #234 comment and in
+> `docs/council/decisions/2026-06-07-234-org-connector-enablement.md`). Option C (public Claude Connectors
+> Directory) was **not** chosen.
+>
+> This is the **enablement package**: everything the platform side can deliver is done; the remaining steps are
+> **PM/admin actions inside the Claude.ai organization UI** plus one **member OAuth smoke**. Keep #234 open until
+> both are complete + verified.
+
+## TL;DR
+
+| | |
+|---|---|
+| **What's left** | (a) PM adds the server in Claude.ai **org connector settings**; (b) one non-admin member does an end-to-end OAuth smoke; (c) observe 7-day continuity. |
+| **What's done (platform side)** | OAuth 2.1 DCR + PKCE, server-side auto-refresh (KV, 30-day TTL), `offline_access`+`refresh_token` advertised live, docs corrected, decision recorded. |
+| **Risk** | Low. No code change required for Option B. The connector already works as a per-user custom connector today. |
+
+---
+
+## 1. Connector metadata (values to register)
+
+Use these exact values when adding the connector in the Claude.ai organization settings.
+
+| Field | Value |
+|-------|-------|
+| **Name** | `Núcleo IA` |
+| **Short description** | Query and manage the AI & PM Research Hub (initiatives, tribes, boards, events, governance, gamification) from your AI assistant in natural language. |
+| **Long description** | Núcleo IA is the MCP server of PMI's Brazilian *AI & Project Management Research Hub*. It exposes the full implementation-tool catalog across personal, tribe, board, events, governance, communications, selection, gamification and knowledge domains, with role-based authority (`can()` / RLS) and full audit logging. OAuth 2.1 + PKCE secures every call; Row Level Security enforces per-member data scope (no PII in tool responses). |
+| **Server URL (`/mcp`)** | `https://nucleoia.vitormr.dev/mcp` — full catalog (recommended default for Claude.ai) |
+| **Semantic URL (`/mcp/semantic`)** | `https://nucleoia.vitormr.dev/mcp/semantic` — bridge-first gateway for strict clients (Claude.ai does not need this) |
+| **Canonical docs URL** | `https://nucleoia.vitormr.dev/docs/mcp` (live tool catalog) · setup guide: [`docs/MCP_SETUP_GUIDE.md`](MCP_SETUP_GUIDE.md) |
+| **Privacy page** | `https://nucleoia.vitormr.dev/privacy` |
+| **Icon** | `https://nucleoia.vitormr.dev/favicon.svg` — ⚠️ see note in §6 (a square PNG may be required by the UI) |
+| **Tool count** | Full catalog — **do not pin a number**; the live per-surface count is at `https://nucleoia.vitormr.dev/mcp` → `tools/list`, or the structured `/health` report (see §2). |
+
+### OAuth 2.1 endpoints (already implemented, no setup needed)
+
+| Purpose | Path |
+|---------|------|
+| Authorization-server discovery | `/.well-known/oauth-authorization-server` |
+| Protected-resource discovery | `/.well-known/oauth-protected-resource` |
+| Dynamic Client Registration (DCR) | `/oauth/register` |
+| Authorize | `/oauth/authorize` → `/oauth/consent` |
+| Token (PKCE verify, refresh) | `/oauth/token` |
+
+- **Grant types advertised:** `authorization_code`, `refresh_token`
+- **Scopes advertised:** `mcp:tools`, `offline_access`
+- **PKCE:** `S256`
+
+### Allowed link origins
+
+Trust is **subdomain-aware** (`host === root` OR `host` ends with `.root`). Roots, from
+`src/lib/oauth-security.ts`:
+
+`claude.ai` · `chatgpt.com` · `openai.com` · `perplexity.ai` · `cursor.com` · `manus.im` · `vitormr.dev`
+(each covers all `*.root` subdomains, e.g. `app.claude.ai`, `claude.com` redirect hosts are matched through
+`claude.ai`/its subdomains) — plus custom schemes `cursor://`, `vscode://`, `vscode-insiders://`, and
+`localhost`/`127.0.0.1` for local dev.
+
+> If Claude.ai's org-connector OAuth callback ever uses a host **not** under one of these roots (watch for a
+> `claude.com` apex or a new redirect host), add it to `TRUSTED_ROOT_HOSTS` in `src/lib/oauth-security.ts` and
+> redeploy the Worker — otherwise the authorize step will reject the redirect_uri.
+
+---
+
+## 2. Workstream A — stabilization (DONE, live evidence)
+
+All measured live on **2026-06-07** (re-measure before relying on any number — see project grounding rules).
+
+**OAuth metadata advertises refresh capability** (the #234 hotfix `7192b01e`, now in `main`):
+
+```
+GET https://nucleoia.vitormr.dev/.well-known/oauth-authorization-server
+  grant_types_supported : [ "authorization_code", "refresh_token" ]
+  scopes_supported      : [ "mcp:tools", "offline_access" ]
+
+GET https://nucleoia.vitormr.dev/.well-known/oauth-protected-resource
+  scopes_supported      : [ "mcp:tools", "offline_access" ]
+```
+
+**Server-side auto-refresh is real** (verified in code, this session):
+
+- `src/pages/mcp.ts` and `src/pages/mcp/semantic.ts` decode the JWT `exp`, and within a 5-minute window look up
+  `mcp_refresh:{sub}` from KV and renew against Supabase Auth — transparent to the MCP host.
+- `src/pages/oauth/token.ts` stores the `refresh_token` in KV with a **30-day TTL** on both the
+  `authorization_code` and `refresh_token` grants.
+- Net effect on the **happy path**: a Claude.ai connector stays alive well beyond 7 days without manual relogin.
+
+> **Known robustness gap (low severity, tracked separately):** the proxy's KV re-store at `mcp.ts:62` /
+> `semantic.ts:60` is gated on `if (data.refresh_token)` and lacks the `|| oldRefreshToken` fallback that
+> `oauth/token.ts:81` already has. In the (rare, non-standard) case Supabase returns an access token with **no**
+> refresh token, a stale rotated token can linger and the next refresh would fail → re-auth. Supabase echoes a new
+> refresh token on every successful rotation, so this is defensive-only and does not affect the realistic path.
+> Hardening is tracked in **[#580](https://github.com/VitorMRodovalho/ai-pm-research-hub/issues/580)** (see §7) and
+> should ship as its own Worker-deploy PR, not bundled with docs.
+
+**Tool surfaces (live):** `/mcp` full catalog · `/mcp/semantic` 4 tools (v0.2.0) — exact counts via
+`https://ldrfrvwhxsmgaabwmaik.supabase.co/functions/v1/nucleo-mcp/health`.
+
+---
+
+## 3. PM steps — add as an org/team connector (Claude.ai UI)
+
+> These run in the **Claude.ai organization settings** and cannot be done from the codebase. ~10 minutes.
+
+1. **Claude.ai → Settings → Connectors (organization scope)** → *Add custom connector* / *Add MCP server*.
+2. Paste the **Server URL**: `https://nucleoia.vitormr.dev/mcp`.
+3. Fill **Name** / **description** / **icon** / **docs URL** from §1. (DCR is automatic — no client_id/secret to paste.)
+4. Save. Claude.ai performs OAuth discovery against `/.well-known/oauth-*` and registers via `/oauth/register`.
+5. **Authorize once** as the admin: the browser opens `/oauth/authorize` → log in with a Núcleo account → approve
+   consent. This is the "one fresh reconnect" that captures the updated `offline_access` metadata.
+6. Confirm the connector shows **Connected** and tools load (ask Claude e.g. *"what are my upcoming Núcleo events?"*).
+7. **Scope it** to the org/team members who should have access per Claude.ai's connector-sharing controls.
+
+---
+
+## 4. Member OAuth smoke checklist (one non-admin member)
+
+Have a regular member (not the org admin) run this end-to-end to prove the org grant works for non-admins:
+
+- [ ] Member sees the **Núcleo IA** connector available in their Claude.ai (via org sharing).
+- [ ] Member clicks connect → OAuth window opens → logs in with **their own** Núcleo account → approves consent.
+- [ ] Connector shows **Connected**.
+- [ ] Member runs a **read** tool scoped to self — e.g. *"show my Núcleo profile"* (`get_my_profile`) or
+      *"my upcoming events"* (`get_upcoming_events`) — and gets **their** data (RLS scoping correct, no PII leak).
+- [ ] A tool the member is **not** authorized for (e.g. an admin dashboard) is correctly **denied** (fail-closed).
+- [ ] **Continuity:** member leaves the connector untouched and confirms it is **still connected after ≥24h**
+      (ideally 7 days) with **no relogin prompt**. (This is acceptance criterion #1 — observed over calendar time.)
+
+If any step fails, capture the error and check `mcp_usage_log` + the Worker logs; the
+[Troubleshooting table in the setup guide](MCP_SETUP_GUIDE.md#troubleshooting) covers the common cases.
+
+---
+
+## 5. Acceptance criteria status (#234)
+
+| # | Criterion | Status | Evidence / residual |
+|---|-----------|--------|---------------------|
+| 1 | Connector usable 7 days w/o manual relogin after one fresh reconnect | **Observational** | Enabling infra live + verified (auto-refresh, 30-day KV TTL, `offline_access`). Confirmed only by observing over 7 calendar days after the §3 reconnect. |
+| 2 | Prod OAuth metadata includes `offline_access` + `refresh_token` | **MET** | Both well-known endpoints, live (see §2). |
+| 3 | Docs stop telling users Claude.ai requires hourly relogin | **MET** | In-repo docs teach the correct refresh model (`MCP_SETUP_GUIDE.md` §69/§158/§164, README MCP section). No "hourly relogin" passage in any in-repo doc. |
+| 4 | `/docs/mcp` shows current runtime tool count (issue said "293") | **MET** | Live `/docs/mcp` renders the current manifest (308 `/mcp` + 4 `/semantic`); no "293" anywhere. |
+| 5 | Decision recorded (private vs org/team vs Directory) | **MET** | Option B recorded — #234 comment + decision doc. |
+| 6 | If pursuing official listing, create submission checklist | **N/A** (conditional) | Option C (Directory) not chosen. Stub kept in §8 in case it's revisited. |
+
+**4 MET · 1 observational (PM 7-day reconnect) · 1 N/A.** No platform/code criterion remains open.
+
+---
+
+## 6. Open items (PM-only)
+
+1. **Add the connector in Claude.ai org settings** (§3).
+2. **Run the member OAuth smoke** (§4) and record the result on #234.
+3. **Observe 7-day continuity** and confirm criterion #1 on #234, then close the issue.
+4. **Icon format:** only `favicon.svg` exists. If the org-connector UI requires a raster icon, export a **square
+   PNG** (≥512×512) and host it (e.g. `public/connector-icon.png` → `https://nucleoia.vitormr.dev/connector-icon.png`).
+   Optional for org-internal use.
+
+---
+
+## 7. Tracked follow-up — refresh-rotation hardening ([#580](https://github.com/VitorMRodovalho/ai-pm-research-hub/issues/580))
+
+Filed from this session's security-engineer review (see §2 gap). Scope for a **separate** Worker-deploy PR:
+
+- `mcp.ts` / `semantic.ts`: mirror `oauth/token.ts:81` — `const newRefresh = data.refresh_token || refreshToken;`
+  then always re-store to KV (never leave a rotated-stale token).
+- `oauth/token.ts:167-174`: the KV-store `try/catch` swallows base64 decode errors silently — a malformed
+  `access_token` means the session never gets server-side refresh despite a successful OAuth. Log it.
+- De-duplicate `decodeJwtPayload` + `tryAutoRefresh` (copy-pasted in `mcp.ts` and `semantic.ts`) into one shared
+  module (the `#280` follow-up already notes this).
+- Document the KV-TTL vs Supabase refresh-token-lifetime relationship (KV 30 d; keep ≤ the project's Supabase
+  refresh TTL).
+
+---
+
+## 8. Option C (Directory) — deferred checklist stub
+
+Only if the PM later revisits and chooses public submission to the Claude Connectors Directory:
+
+- [ ] Canonical docs URL (have: `/docs/mcp`)
+- [ ] Privacy page (have: `/privacy`) + **Terms of Service** page (missing — would need creating)
+- [ ] Support/contact channel linked from the connector
+- [ ] OAuth-flow evidence (have: §2) + MCP smoke evidence (have: §4)
+- [ ] Square PNG icon (see §6.4)
+- [ ] MFA-free review/demo account for Anthropic review
+- [ ] Stable connector name/description/allowed-origins (have: §1)
+
+---
+
+*Last verified live: 2026-06-07. Re-ground all numbers before relying on them (project grounding rule).*

--- a/docs/MCP_ORG_CONNECTOR_ENABLEMENT.md
+++ b/docs/MCP_ORG_CONNECTOR_ENABLEMENT.md
@@ -55,8 +55,8 @@ Trust is **subdomain-aware** (`host === root` OR `host` ends with `.root`). Root
 `src/lib/oauth-security.ts`:
 
 `claude.ai` · `chatgpt.com` · `openai.com` · `perplexity.ai` · `cursor.com` · `manus.im` · `vitormr.dev`
-(each covers all `*.root` subdomains, e.g. `app.claude.ai`, `claude.com` redirect hosts are matched through
-`claude.ai`/its subdomains) — plus custom schemes `cursor://`, `vscode://`, `vscode-insiders://`, and
+(each root also covers all its `*.root` subdomains, e.g. `app.claude.ai` — but **not** a different apex like
+`claude.com`) — plus custom schemes `cursor://`, `vscode://`, `vscode-insiders://`, `code-oss://`, and
 `localhost`/`127.0.0.1` for local dev.
 
 > If Claude.ai's org-connector OAuth callback ever uses a host **not** under one of these roots (watch for a
@@ -140,8 +140,8 @@ If any step fails, capture the error and check `mcp_usage_log` + the Worker logs
 |---|-----------|--------|---------------------|
 | 1 | Connector usable 7 days w/o manual relogin after one fresh reconnect | **Observational** | Enabling infra live + verified (auto-refresh, 30-day KV TTL, `offline_access`). Confirmed only by observing over 7 calendar days after the §3 reconnect. |
 | 2 | Prod OAuth metadata includes `offline_access` + `refresh_token` | **MET** | Both well-known endpoints, live (see §2). |
-| 3 | Docs stop telling users Claude.ai requires hourly relogin | **MET** | In-repo docs teach the correct refresh model (`MCP_SETUP_GUIDE.md` §69/§158/§164, README MCP section). No "hourly relogin" passage in any in-repo doc. |
-| 4 | `/docs/mcp` shows current runtime tool count (issue said "293") | **MET** | Live `/docs/mcp` renders the current manifest (308 `/mcp` + 4 `/semantic`); no "293" anywhere. |
+| 3 | Docs stop telling users Claude.ai requires hourly relogin | **MET** | In-repo docs teach the correct refresh model (`MCP_SETUP_GUIDE.md` "Security Model" + "Troubleshooting" sections; README MCP section: "auto-refresh keeps sessions alive for up to 30 days"). No "hourly relogin" passage in any in-repo doc. |
+| 4 | `/docs/mcp` shows current runtime tool count (issue said "293") | **MET** | Live `/docs/mcp` renders the current manifest (308 `/mcp` + 4 `/semantic` as of 2026-06-07 — query `/health` for today's value); no "293" anywhere. |
 | 5 | Decision recorded (private vs org/team vs Directory) | **MET** | Option B recorded — #234 comment + decision doc. |
 | 6 | If pursuing official listing, create submission checklist | **N/A** (conditional) | Option C (Directory) not chosen. Stub kept in §8 in case it's revisited. |
 

--- a/docs/MCP_SETUP_GUIDE.md
+++ b/docs/MCP_SETUP_GUIDE.md
@@ -2,32 +2,33 @@
 
 ## What is MCP?
 
-MCP (Model Context Protocol) is an open protocol that allows AI assistants to interact with external services. The Núcleo server exposes two surfaces: `/mcp` (299 implementation tools for verified clients) and `/mcp/semantic` (a smaller, bridge-first semantic gateway for strict MCP clients). Both surfaces let you query and manage project data from your AI assistant using natural language. A dynamic knowledge layer adapts guidance to each member's role and permissions.
+MCP (Model Context Protocol) is an open protocol that allows AI assistants to interact with external services. The Núcleo server exposes two surfaces: `/mcp` (the full implementation-tool catalog for verified clients) and `/mcp/semantic` (a smaller, bridge-first semantic gateway for strict MCP clients). Both surfaces let you query and manage project data from your AI assistant using natural language. A dynamic knowledge layer adapts guidance to each member's role and permissions.
 
 ## Endpoints
 
 | Endpoint | Tools | Purpose | Recommended clients |
 |----------|-------|---------|---------------------|
-| `https://nucleoia.vitormr.dev/mcp` | 299 | Full internal capability registry. Stable for clients that accept large catalogs. | Claude.ai, Claude Code, Cursor / VS Code, ChatGPT developer mode, Manus AI |
-| `https://nucleoia.vitormr.dev/mcp/semantic` | 3 (wave-1) | **Bridge-first semantic gateway (p222 #280 alpha).** Compact, review-ready public contract over the internal registry. Stable envelope `{ok,data,summary,warnings,next_actions,audit}`. Use when a strict client rejects the full catalog. | Perplexity, OpenAI Apps SDK review, Anthropic Connectors Directory review, future store/directory submissions |
+| `https://nucleoia.vitormr.dev/mcp` | Full catalog | Full internal capability registry. Stable for clients that accept large catalogs. | Claude.ai, Claude Code, Cursor / VS Code, ChatGPT developer mode, Manus AI |
+| `https://nucleoia.vitormr.dev/mcp/semantic` | 4 | **Bridge-first semantic gateway (p222 #280 alpha).** Compact, review-ready public contract over the internal registry. Stable envelope `{ok,data,summary,warnings,next_actions,audit}`. Use when a strict client rejects the full catalog. | Perplexity, OpenAI Apps SDK review, Anthropic Connectors Directory review, future store/directory submissions |
 
 Both endpoints share the same OAuth 2.1 flow (same account, same login). Pick the endpoint that matches your client's catalog tolerance — most clients should still default to `/mcp`.
 
-Wave-1 semantic tools (read-only):
-- `get_my_context` — compact self-scope context (profile, current cycle, gamification, upcoming events, certificates).
-- `search_nucleo_knowledge` — bounded multi-source search across hub resources + wiki + knowledge_assets.
-- `get_board_or_initiative_context` — initiative/board/tribe one-shot summary.
+Semantic tools (read-only):
+- `get_my_context` — compact self-scope context (profile, current cycle, gamification, upcoming events, certificates). *(wave-1)*
+- `search_nucleo_knowledge` — bounded multi-source search across hub resources + wiki + knowledge_assets. *(wave-1)*
+- `get_board_or_initiative_context` — initiative/board/tribe one-shot summary. *(wave-1)*
+- `get_operational_status` — composite operational summary (admin/GP only, `manage_platform`-gated, PII-clean). *(wave-2, v0.2.0)*
 
 ## Compatibility
 
 | Client | Status | Recommended endpoint | Notes |
 |--------|--------|----------------------|-------|
-| Claude.ai | ✅ Verified | `/mcp` (full 299) | Web and desktop. Streamable HTTP SSE. |
-| Claude Code | ✅ Verified | `/mcp` (full 299) | Terminal — see token workaround below. |
-| ChatGPT | ✅ Verified (beta) | `/mcp` (full 299) | Settings → Apps → Connectors → Advanced → New App. Apps SDK submission should target `/mcp/semantic`. |
-| Perplexity | ⚠️ Use `/mcp/semantic` | **`/mcp/semantic`** | Transport: **Streamable HTTP** (not SSE). Auth: OAuth 2.0. Perplexity rejected the 299-tool full catalog (see GH #277 / #280). |
-| Cursor / VS Code | ✅ Verified | `/mcp` (full 299) | Settings → MCP → Add. OAuth flow. |
-| Manus AI | ✅ Verified | `/mcp` (full 299) | Import by JSON: `{"url": "https://nucleoia.vitormr.dev/mcp"}` |
+| Claude.ai | ✅ Verified | `/mcp` (full catalog) | Web and desktop. Streamable HTTP SSE. |
+| Claude Code | ✅ Verified | `/mcp` (full catalog) | Terminal — see token workaround below. |
+| ChatGPT | ✅ Verified (beta) | `/mcp` (full catalog) | Settings → Apps → Connectors → Advanced → New App. Apps SDK submission should target `/mcp/semantic`. |
+| Perplexity | ⚠️ Use `/mcp/semantic` | **`/mcp/semantic`** | Transport: **Streamable HTTP** (not SSE). Auth: OAuth 2.0. Perplexity rejected the full tool catalog (see GH #277 / #280). |
+| Cursor / VS Code | ✅ Verified | `/mcp` (full catalog) | Settings → MCP → Add. OAuth flow. |
+| Manus AI | ✅ Verified | `/mcp` (full catalog) | Import by JSON: `{"url": "https://nucleoia.vitormr.dev/mcp"}` |
 | xAI / Grok | 🟡 Custom MCP | `/mcp/semantic` | BYO remote MCP via API; catalog submission not yet documented publicly. |
 | OpenAI Apps SDK review | 🟡 For submission | `/mcp/semantic` | Apps SDK review expects bounded tools + review-account; use semantic surface. |
 | Anthropic Connectors Directory review | 🟡 For submission | `/mcp/semantic` | Directory pre-submission checklist favors short bounded tool catalogs. |
@@ -89,7 +90,7 @@ Manual bearer tokens copied into Claude Code expire in 1 hour. Prefer the OAuth 
 
 ## Representative Tools
 
-The live source of truth is the MCP `tools/list` response. The examples below cover the most common member and operator workflows; the full runtime inventory currently exposes 306 tools.
+The live source of truth is the MCP `tools/list` response (or the `/health` endpoint for a per-surface count). The examples below cover the most common member and operator workflows; the full runtime inventory currently exposes 300+ tools — never pin the exact number, query it live.
 
 For the **complete machine-generated contract matrix** (tool → domain → RPC dependencies → tables → canV4 gate → external fetches → service_role usage), see:
 

--- a/docs/council/decisions/2026-06-07-234-org-connector-enablement.md
+++ b/docs/council/decisions/2026-06-07-234-org-connector-enablement.md
@@ -62,5 +62,5 @@ chosen). No platform/code criterion remains open.
 ## Refs
 
 - Enablement package: `docs/MCP_ORG_CONNECTOR_ENABLEMENT.md`
-- Working agreement: `memory/working_agreement_decision_process_2026_06_07.md`
+- Working agreement: PM decision-process working agreement (2026-06-07; session memory)
 - Prior MCP decision: `docs/council/decisions/2026-06-07-mcp-wave2-get-operational-status.md`

--- a/docs/council/decisions/2026-06-07-234-org-connector-enablement.md
+++ b/docs/council/decisions/2026-06-07-234-org-connector-enablement.md
@@ -1,0 +1,66 @@
+# Decision — #234 MCP connector: Option B (org/team connector) enablement + scope of the platform-side work
+
+**Date**: 2026-06-07
+**Decider**: PM (Vitor) — Option B recorded 2026-06-06 (#234 comment); platform-scope decisions this session by PL/CTO under the working agreement
+**Domain**: MCP / connector distribution (#234)
+**Status**: DECISION standing (Option B) · platform-side work SHIPPED this session · residual = PM/admin UI action + member smoke
+
+## Context
+
+#234 = "stabilize MCP connector refresh and evaluate official Claude listing." Two workstreams: **A** (short-term
+stabilization of OAuth refresh) and **B** (medium-term distribution path). Decision was already taken by the PM on
+2026-06-06 in the issue comment: **Option B — publish as an org/team connector**; Option C (public Claude Connectors
+Directory) explicitly **not** chosen.
+
+This session ("go", clean post-`/clear`) treated #234 as **build-ready** (per the working agreement: items past
+decision don't need another decision round). The job: finish everything the platform side can deliver and hand the
+PM a tight, evidenced residual.
+
+## Grounding (live, 2026-06-07 — before any conclusion)
+
+- Open issues **61**; schema invariants **0**; `7192b01e` (refresh-scope hotfix) confirmed **in `main`**.
+- OAuth metadata **live**: `grant_types_supported=[authorization_code, refresh_token]`,
+  `scopes_supported=[mcp:tools, offline_access]` on **both** well-known endpoints.
+- Runtime `/mcp` **308**, `/semantic` **4** (v0.2.0); deployed `/docs/mcp` renders manifest total **312** (= 308+4) —
+  the stale "293" the issue cited is gone.
+- Refresh **code path** read first-hand + adversarially reviewed (security-engineer): proxy auto-refresh + token
+  endpoint KV store are **real**; 30-day KV TTL. Verdict: `complete_with_caveats`.
+
+## Platform-side decisions taken this session (PL/CTO)
+
+1. **No Worker deploy / no code change in this PR.** `/docs/mcp` already shows the current count (criterion #4 MET
+   live), and the PM framed Workstream A as done ("ops/admin, not a code change"). Keeping it docs-only minimizes risk.
+2. **Refresh-rotation hardening → tracked follow-up, not this PR.** The security-engineer surfaced a MEDIUM-labelled
+   robustness gap (proxy KV re-store gated on `if (data.refresh_token)`, missing the `|| oldToken` fallback that
+   `oauth/token.ts:81` already has). First-hand assessment: **defensive-only** — Supabase echoes a new refresh token
+   on every successful rotation, so the realistic 7-day path is unaffected. It deserves its own focused Worker-deploy
+   PR + OAuth smoke, not bundling into a docs PR. Counter-rec to "fix it now" was declined on scope-discipline grounds.
+3. **De-pin MCP tool counts (28 live-facing instances)** across READMEs ×3, AGENTS.md, SECURITY.md, SKILL.md,
+   MCP_SETUP_GUIDE.md → `300+` / "full catalog" + a "query live" pointer. Ends the recurring per-session count-drift
+   sediment. Historical records (changelog, council snapshots, audit archives) left untouched.
+4. **Build the enablement package** `docs/MCP_ORG_CONNECTOR_ENABLEMENT.md` — connector metadata, PM org-settings
+   steps, member OAuth smoke checklist, live Workstream-A evidence, acceptance-criteria status, and an Option-C
+   (Directory) deferred stub.
+
+## Acceptance criteria outcome
+
+4 **MET** (OAuth metadata, docs relogin model, `/docs/mcp` count, decision recorded) · 1 **observational**
+(7-day continuity — PM observes after the org reconnect) · 1 **N/A** (Directory submission checklist — Option C not
+chosen). No platform/code criterion remains open.
+
+## Residual (PM-only — issue stays OPEN as the Option-B tracker)
+
+1. Add the server in Claude.ai **org connector settings** (metadata in the enablement doc §1/§3).
+2. One non-admin **member OAuth smoke** (enablement doc §4).
+3. Observe **7-day** continuity; then close #234.
+
+## Follow-ups (backlog)
+
+- Refresh-rotation hardening (own Worker-deploy PR) — filed this session as **#580**.
+- `/mcp`→`/mcp/full` rename (#280) stays blocked on gate G19.
+
+## Refs
+
+- Enablement package: `docs/MCP_ORG_CONNECTOR_ENABLEMENT.md`
+- Working agreement: `memory/working_agreement_decision_process_2026_06_07.md`
+- Prior MCP decision: `docs/council/decisions/2026-06-07-mcp-wave2-get-operational-status.md`

--- a/skills/nucleo-ia/SKILL.md
+++ b/skills/nucleo-ia/SKILL.md
@@ -18,7 +18,7 @@ description: >
 - **Auth:** Supabase Auth (Google + LinkedIn + Microsoft (Azure) + Magic Link)
 - **Hosting:** Cloudflare Workers
 - **Live URL:** https://nucleoia.vitormr.dev
-- **MCP Server:** 64 tools (51 read + 13 write) + 1 dynamic prompt + 1 static resource at `/mcp` — proxied to Supabase EF `nucleo-mcp`, server-side auto-refresh (30-day KV TTL)
+- **MCP Server:** 300+ tools (read + write) + dynamic prompts + static resources at `/mcp` — proxied to Supabase EF `nucleo-mcp`, server-side auto-refresh (30-day KV TTL)
 - **OAuth 2.1 Server:** Custom implementation in Workers (DCR + PKCE + KV code storage)
 - **i18n:** 3 locales: PT-BR (default, no prefix), EN-US (`/en/`), ES-LATAM (`/es/`)
 - **Charts:** Chart.js (NOT recharts)
@@ -303,7 +303,7 @@ const isTier3Plus = ['manager','deputy_manager','tribe_leader','sponsor','chapte
 
 ## CRITICAL RULE 11: MCP Server + OAuth 2.1
 
-**MCP Server:** Supabase Edge Function `nucleo-mcp` (64 tools + 1 prompt + 1 resource), proxied via Workers at `/mcp`.
+**MCP Server:** Supabase Edge Function `nucleo-mcp` (300+ tools + prompts + resources), proxied via Workers at `/mcp`.
 - Source: `supabase/functions/nucleo-mcp/index.ts`
 - Deploy: `supabase functions deploy nucleo-mcp --no-verify-jwt`
 - Health: `curl https://ldrfrvwhxsmgaabwmaik.supabase.co/functions/v1/nucleo-mcp/health`


### PR DESCRIPTION
Closes the platform-side of **#234** (stabilize MCP connector + evaluate listing). Decision **Option B — org/team connector** was already recorded by the PM (2026-06-06); this PR delivers everything the platform side can, leaving a tight PM/admin residual. **Docs-only — no code, migration, or deploy.**

## What this delivers

- **`docs/MCP_ORG_CONNECTOR_ENABLEMENT.md`** (new) — the Option-B enablement package: connector metadata to register, PM step-by-step for Claude.ai org settings, a non-admin member OAuth smoke checklist, live Workstream-A evidence, and an acceptance-criteria status table.
- **`docs/council/decisions/2026-06-07-234-org-connector-enablement.md`** (new) — formal decision record.
- **De-pin 28 live-facing MCP tool counts** across READMEs ×3, `AGENTS.md`, `SECURITY.md`, `SKILL.md`, `MCP_SETUP_GUIDE.md` → `300+` / "full catalog" + a "query live" pointer. Ends the recurring per-session count-drift sediment (counts were stale at 306/299/76/64). Historical records (changelog, council snapshots, audit archives) left untouched.
- **`MCP_SETUP_GUIDE.md`**: `/semantic` 3 → 4 (adds `get_operational_status`, wave-2 v0.2.0).

## Live grounding (2026-06-07)

- OAuth metadata advertises `offline_access` + `refresh_token` on both well-known endpoints (the `7192b01e` hotfix, in `main`).
- Runtime `/mcp` **308** + `/semantic` **4**; deployed `/docs/mcp` already renders the current count (**312** = 308+4) — the stale "293" the issue cited is gone, so acceptance criterion #4 is **MET live without a deploy**.
- Server-side auto-refresh code path verified first-hand (proxy + token endpoint KV store, 30-day TTL) — happy-path multi-day continuity is real.

## Acceptance criteria (#234)

4 **MET** (OAuth metadata, docs relogin model, `/docs/mcp` count, decision recorded) · 1 **observational** (7-day continuity — PM observes after the org reconnect) · 1 **N/A** (Directory checklist — Option C not chosen). No platform/code criterion remains open. **#234 stays open** as the Option-B enablement tracker until the PM completes the org-settings action + member smoke.

## Follow-up

- **#580** — refresh-rotation hardening (proxy KV re-store fallback + swallow logging + dedupe), surfaced by the security review. Low severity / defensive-only; ships as its own Worker-deploy PR.

## Test / build

- `npx astro build` ✓ (0 errors).
- `npm test` 3614/3615 ✓. The 1 failure (`p403-governance-insert-rpcs-required-columns`) is a **network transient** (`TypeError: fetch failed` after a 300s stall, unrelated to this docs-only change) — verified live that the 3 asserted columns are `NOT NULL`, so the invariant holds; CI will re-run clean.