### PR TITLE
fix(605): ±1 display-rounding tolerance on M6 trail home==ranking test

### DIFF
--- a/tests/contracts/p277-419-m6-trail-cpmai-canonical.test.mjs
+++ b/tests/contracts/p277-419-m6-trail-cpmai-canonical.test.mjs
@@ -83,9 +83,12 @@ test('M6 behavioural: trail = the ranking cohort/total (home == ranking, modulo 
   const { data: ranking, error: e2 } = await sb.rpc('get_public_trail_ranking');
   assert.ifError(e2);
   const rankingAvg = ranking.reduce((s, r) => s + Number(r.pct), 0) / ranking.length;
-  // home is an integer ROUND of the same per-member partial-avg over the same cohort
-  assert.equal(Number(home), Math.round(rankingAvg),
-    `home trail (${home}) == ROUND(ranking avg ${rankingAvg.toFixed(2)})`);
+  // home is an integer ROUND of the same per-member partial-avg over the same cohort.
+  // Both round the SAME metric independently (home = ROUND of the SQL avg; rankingAvg = JS mean of the
+  // ranking's 2dp per-member pcts), so at a .5 boundary the two roundings can legitimately split by 1 —
+  // this is the "modulo display rounding" this test's own contract promises. A divergence of >1 is a real bug.
+  assert.ok(Math.abs(Number(home) - Math.round(rankingAvg)) <= 1,
+    `home trail (${home}) within ±1 of ROUND(ranking avg ${rankingAvg.toFixed(2)}) — display-rounding tolerance`);
 });
 
 test('M6 behavioural: cpmai goal count partitions by cert year (goal != wall)', { skip: dbGated ? false : skipMsg }, async () => {


### PR DESCRIPTION
Fixes the brittle behavioural test that flipped red (52 vs 51) on live-data drift — **not** a dependency/tool issue (verified: the RPCs are server-side; the only critical dependabot vuln is `vitest`, which this project doesn't use).

The test's own contract says *'modulo display rounding'* but asserted **exact** equality between two independently-rounded values (`home` = SQL `ROUND` of the avg; `rankingAvg` = JS mean of the ranking's 2dp per-member pcts). At a .5 boundary these split by 1. Relaxed to **±1** (the intended semantics); **>1 still fails** as a real bug.

Unblocks #604's clean merge (no `--admin` bypass needed). Closes #605.