### PR TITLE
feat(569): hand-rolled OpenTimestamps engine + stamp/upgrade EFs (Slice 0/2 + Slice 3 core)

### DIFF
--- a/docs/adr/ADR-0101-pi-exclusion-asset-registry-opentimestamps.md
+++ b/docs/adr/ADR-0101-pi-exclusion-asset-registry-opentimestamps.md
@@ -28,10 +28,10 @@ Architecture:
 **Eficácia = `confirmed`, não `pending`** (closes the QA gap on doc7 Cl.4.1): a freshly-created `.ots` is `pending` (not yet Bitcoin-anchored) and does not yet attest a date. `export_anexo_i` surfaces per-asset status + an `all_confirmed` flag so the Declaração's efficacy is reported honestly.
 
 ## Slices (1 PR each)
-- **0. Spike** — validate `opentimestamps` JS in a Deno EF (stamp → upgrade → verify a test digest). De-risks the approach before Slice 2.
+- **0. Spike — DONE** (2026-06-09): the `opentimestamps@0.4.9` lib is `likely_breaks` under Deno EF; decision = **HAND_ROLL** a zero-dep fetch+`.ots` engine (`_shared/ots.ts`), verified **byte-exact** vs 5 canonical vectors + a live stamp. See `docs/specs/SPEC_569_S0_OTS_DENO_SPIKE.md`.
 - **1. DB** — tables + RLS + member-facing RPCs + internal `_ots_*` pipeline RPCs (**this ADR**).
-- **2. EF stamp + verify.**
-- **3. pg_cron upgrade pass + health tool.**
+- **2. EF stamp — DONE** (2026-06-09): `ots-stamp` EF wires `ots.ts` to `_ots_claim_unstamped_assets`/`_ots_mark_stamped`; deployed + smoked in prod (full data path incl. the bytea-over-PostgREST seam verified byte-exact).
+- **3. pg_cron upgrade pass + health tool.** EF core `ots-upgrade` (list_pending → upgrade → block-height→UTC → mark_confirmed) is **deployed**; remaining = the pg_cron schedule migration + `get_ots_pipeline_health` tool.
 - **4. `export_anexo_i` + MCP tools; wire to doc7.**
 - **5. (opt.)** git pre-commit hook (repo script, out-of-platform).
 
@@ -59,6 +59,7 @@ Architecture:
 - Retention/elimination of `error`/`revoked` rows + `.ots` bytea (doc1 2.5.6) — with the Slice 3 cron.
 
 ## Open items (gate the later slices, not this migration)
-- OTS-lib-in-Deno feasibility (Slice 0 spike) before committing the EF.
-- `_ots_claim_unstamped_assets` row-locking (FOR UPDATE SKIP LOCKED) — Slice 2/3; until then the pipeline MUST be single-consumer.
+- ~~OTS-lib-in-Deno feasibility (Slice 0 spike)~~ **RESOLVED** → HAND_ROLL engine, verified (Slice 0/2 done).
+- `_ots_claim_unstamped_assets` row-locking (FOR UPDATE SKIP LOCKED) — Slice 3; until then the pipeline MUST be single-consumer (the `ots-stamp`/`ots-upgrade` EFs must not run concurrently — the Slice 3 cron schedules them non-overlapping).
+- Cron auth: the EFs gate on exact `SUPABASE_SERVICE_ROLE_KEY` string-match (repo convention); the pg_net cron call must use the EF's current injected key.
 - doc7 upload (workstream 2) before the Anexo I export is wired to a real governance_document.

--- a/docs/specs/SPEC_569_S0_OTS_DENO_SPIKE.md
+++ b/docs/specs/SPEC_569_S0_OTS_DENO_SPIKE.md
@@ -1,0 +1,109 @@
+# SPEC #569 Slice 0 — OpenTimestamps-in-Deno feasibility spike
+
+- **Issue:** #569 (OpenTimestamps / carimbo de tempo, Parecer 01/2026 rec k)
+- **ADR:** ADR-0101 (digest-only asset registry) — closes its open item *"OTS-lib-in-Deno feasibility (Slice 0 spike)"*
+- **Date:** 2026-06-09
+- **Method:** source-grounded research (workflow `wf_dda4ebd6-078` — 4 research arms + 1 adversarial verifier, all WebFetch/WebSearch grounded against unpkg/GitHub raw/Deno docs/Supabase docs), then the chosen engine was **built + verified under Node 24** (the sandbox blocks Deno/`npm install`, but Node 24 type-strips the zero-dep TS directly and has `fetch`/`getRandomValues`/`AbortSignal.timeout`).
+- **Status:** **DONE.** Decision = **HAND_ROLL** (PM, 2026-06-09). Engine `supabase/functions/_shared/ots.ts` built and **verified byte-exact** against 5 canonical `.ots` vectors + a live multi-calendar stamp. The lib-viability probe became unnecessary (we proved the hand-roll directly).
+
+## Outcome (2026-06-09) — VERIFIED
+
+PM chose **HAND_ROLL** (zero-dep). The engine is implemented at `supabase/functions/_shared/ots.ts` (`stamp` / `upgrade` / `describe`, pure Deno-std + `node:crypto` SHA-256 + native `fetch`; no npm). Verification (Node 24, `--experimental-strip-types`; tests at `_shared/ots_test.ts` for Deno CI + `/tmp/ots-node-test.ts` for the Node run):
+- **Byte-exact round-trip (parse → re-serialize == canonical bytes) of 5 reference vectors** from `opentimestamps/javascript-opentimestamps/examples`: `incomplete` (175B pending), `two-calendars` (265B multi-op fork), `merkle2` (335B), `known-and-unknown-notary` (265B — UnknownAttestation preserved + cross-class attestation sort), `hello-world` (688B full Bitcoin-merkle attestation, block 358391). **10/10 pass.** This proves the serializer matches the consensus-critical wire format across every important shape.
+- **Live stamp** against the public calendars: reached alice+bob+catallaxy, produced a 543B pending `.ots`, which **round-trips** and `describe`s as 3 pendings / 0 bitcoin; immediate `upgrade` is correctly a no-op (not yet anchored). Proof written to `/tmp/live.ots`.
+- **Remaining gate (PM / time):** canonical `ots verify` accepting a stamped proof — needs Bitcoin anchoring (~hours) and the python `ots` client or opentimestamps.org drag-drop. This is the final independent acceptance gate.
+
+**Still to build (Slice 2/3 proper):** the EF(s) that wire `ots.ts` to the `_ots_*` RPCs (`_ots_claim_unstamped_assets` → `stamp` → `_ots_mark_stamped`; cron `_ots_list_pending` → `upgrade` → `_ots_mark_confirmed`), the **bytea-over-PostgREST** encoding (pass the proof as `\x<hex>`; confirm at the deploy smoke), the block-height→UTC lookup for `attested_at`, and the health tool. EF deploy is PM-gated.
+
+## Spike question
+Can a Supabase Edge Function (Deno 2.1 line) produce/upgrade OpenTimestamps `.ots` proofs over a SHA-256 digest using `npm:opentimestamps@0.4.9`, or do we hand-roll a zero-dependency fetch-based client? This de-risks Slice 2 (stamp/verify EF) before any EF code is committed.
+
+## Verdict
+
+**Library `opentimestamps@0.4.9` under Deno EF = `likely_breaks` (medium confidence).** Two stacked, runtime-only failure modes that no doc-reading can settle:
+
+1. **Entrypoint resolution (newly found in the adversarial pass).** `package.json` declares `"main": "open-timestamps.js"`, but **there is no `open-timestamps.js` at the package root** — the file that attaches the sub-modules (`OTS.DetachedTimestampFile`, `.Ops`, `.Context`, `.Timestamp`, `.Calendar`) onto the export is `index.js`. The lib works only if Deno's npm CJS resolver honours Node's `LOAD_AS_DIRECTORY → LOAD_INDEX` fallback for a missing named `main` (likely, **not docs-guaranteed**). If Deno instead lands on `src/open-timestamps.js` (which exports only the 11 public *functions* and none of the classes), `OTS.DetachedTimestampFile` is `undefined` → `TypeError` on the first line.
+2. **`request`/`request-promise` transport.** This deprecated (since 2020) node:http-based stack is the **sole** calendar client in `src/calendar.js` (`POST /digest`, `GET /timestamp/<hex>`). Deno node-compat marks `node:http/https/net/tls` "partially supported"; `denoland/deno#27757` corrupts npm:request response decoding on Deno **2.1.5+** (Supabase EF is on **2.1.4**, one minor below — not biting *yet*, but fragile and a future EF Deno bump activates it). Also `this.timeout` is never initialised → stamp() has **no per-call timeout** → a hung calendar can approach the 150s wall/idle limit → 504.
+3. **Lower-tier (real):** `Buffer` is **not** a Deno default global, but the lib uses bare `Buffer.from` / `stream instanceof Buffer` → must `globalThis.Buffer = (await import('node:buffer')).Buffer` **before** importing the lib.
+
+**Crucially, even the "use the lib" path bypasses its transport** (both research arms converge on: do the calendar HTTP with native `fetch`, use the lib only for `fromHash` + `serializeToBytes` + `Context.StreamDeserialization`). So the lib's only safe contribution is **`.ots` serialization** — while still dragging `bitcore-lib@8.14.4` + `request` + `request-promise` + `moment-timezone` (large tz DB) into a 20 MB-capped EF bundle and gambling on the entrypoint resolution + Buffer shim.
+
+**Hand-rolled zero-dependency fetch client = realistic and cleaner.** The wire protocol is trivial; the `.ots` format is well-specified; SHA-256 is native (`crypto.subtle`). MVP ~150–250 LoC (one calendar response per `.ots`, no merge — a legitimate, `ots verify`-acceptable proof); full multi-calendar merge ~400–600 LoC. It removes **every** Deno unknown (entrypoint, request stack, Buffer global, bitcore-lib bloat).
+
+**EF constraints (all green, measured):** outbound HTTPS to the calendars works (443 open, no egress allowlist; only ports 25/587 blocked); `npm:` supported; Deno 2.1 line (2.5 upgrade closed not-planned Oct-2025); wall-clock 150s free / 400s paid; CPU 2s (excludes I/O); memory 256 MB; bundle 20 MB. A stamp = 3–4 fast network calls → fits comfortably. Set explicit per-calendar `AbortSignal.timeout` and fire in parallel.
+
+## Recommendation (PL/CTO)
+
+**Primary: HAND_ROLL the fetch-based stamp/upgrade + a minimal `.ots` serializer; do NOT ship `opentimestamps@0.4.9`.** Use the canonical `ots` CLI (or the lib in a local Deno scratch, if the probe shows it loads) **as a correctness oracle during development only.** Rationale:
+- The lib's only safe contribution (serialization) is the *one* part the hand-roll must write anyway; everything else (its transport) is bypassed regardless.
+- Removes all Deno-compat unknowns + every deprecated/heavy dep from legal-evidence infra (dependency hygiene matters more here — a `.ots` that `ots verify` rejects defeats rec k's probative purpose).
+- Full control + unit-testable byte-fidelity against known-good vectors.
+
+**Mandatory correctness gate for the hand-roll:** round-trip known-good `.ots` vectors (parse → re-serialize → byte-identical) **and** prove a freshly-stamped proof is accepted by the canonical `ots verify` (or opentimestamps.org drag-drop). A self-rolled cryptographic-proof serializer is not trusted until an independent verifier accepts its output.
+
+**Alternative (if PM prefers): USE_LIB_WITH_SHIMS** — `globalThis.Buffer` shim + import + native-`fetch` calendar transport (lib only for `fromHash`/serialize). Cheaper to write *if* the probe passes, but carries the bundle/dep/entrypoint risk.
+
+## Decisive empirical probe (settles both top failure modes, ~30s, offline, no deploy)
+
+Run locally with a Deno on the **2.1.x** line (to match the EF). *Kept for reference only — the HAND_ROLL decision made this unnecessary; the engine was verified directly (see Outcome above).*
+
+```ts
+// otsprobe.ts  —  deno run -A otsprobe.ts
+import { Buffer } from "node:buffer";
+(globalThis as any).Buffer = Buffer;                 // required: lib uses bare Buffer
+import OTS from "npm:opentimestamps@0.4.9";
+
+// PROBE 1 — entrypoint/import shape (the newly-found killer):
+const keys = Object.keys(OTS as any);
+const hasClasses = !!(OTS as any).DetachedTimestampFile && !!(OTS as any).Ops && !!(OTS as any).Context;
+console.log("KEYS:", keys.join(","));
+console.log("PROBE1 import-shape:", hasClasses ? "PASS (resolved index.js)" : "FAIL (resolved bare main; classes missing)");
+
+// PROBE 2 — module graph (incl. require('request-promise')) loads + build+serialize works offline:
+try {
+  const { DetachedTimestampFile, Ops } = OTS as any;
+  const fdHash = new Uint8Array(32).fill(7);          // fake 32-byte sha256 digest
+  const det = DetachedTimestampFile.fromHash(new Ops.OpSHA256(), fdHash);
+  const bytes = det.serializeToBytes();               // pure, no network
+  console.log("PROBE2 build+serialize:", bytes?.length, "bytes -> PASS");
+} catch (e) {
+  console.log("PROBE2 build+serialize: FAIL ->", (e as Error).message);
+}
+```
+
+- **PASS** (lib viable as oracle / as Alternative): `KEYS` includes `DetachedTimestampFile,Ops,Context,Timestamp,Calendar`; PROBE1 PASS; PROBE2 prints a byte length + PASS.
+- **PROBE1 FAIL** → import the subpath explicitly: `import OTS from "npm:opentimestamps@0.4.9/index.js"` and re-run.
+- **PROBE2 FAIL** (`Buffer is not defined` / request-promise load error) → lib graph doesn't load under Deno node-compat → go straight to HAND_ROLL.
+- Only if both pass: a 10-line throwaway EF doing `await OTS.stamp(det,{calendars:["https://alice.btc.calendar.opentimestamps.org"],m:1})` on the **deployed** runtime (local CLI Deno ≠ prod, per supabase/cli#504) settles whether `request` survives Deno 2.1.4 over the network.
+
+## Slice 2 design (stamp EF) — engine-agnostic
+
+Pipeline (single-consumer until `FOR UPDATE SKIP LOCKED` lands — ADR-0101 open item):
+1. `service_role` calls `_ots_claim_unstamped_assets(limit)` → `[{id, sha256}]`.
+2. Per asset: `fileDigest = hexToBytes(sha256)` (32 B). Build the OTS commitment exactly as the protocol requires: **`nonce = crypto.getRandomValues(new Uint8Array(16))`; `S = SHA256(fileDigest ‖ nonce)`** (the lib does `OpAppend(nonce)` then `OpSHA256`). Submit **`S`** (raw bytes) — never the bare file digest.
+3. For each calendar (alice/bob/finney + catallaxy): `fetch(POST {cal}/digest, { body: S, headers: { Accept: "application/vnd.opentimestamps.v1" }, signal: AbortSignal.timeout(20_000) })`. 200 → `arrayBuffer()` is a bare serialized `Timestamp` (msg == S, no `.ots` magic). Tolerate partial calendar failures; require `m` ≥ 1–2 successes. Fire in parallel.
+4. Build the full `.ots`: header magic (31 B) + `0x01` + fileHashOp tag `0x08` + fileDigest + the timestamp tree (`fileDigest --OpAppend(nonce)--> --OpSHA256--> S`, with each calendar's returned subtree under `S`). **MVP shortcut:** store **one calendar response per `.ots`** (no merge) — independently upgradeable/verifiable; merge is robustness, not correctness.
+5. `_ots_mark_stamped(asset_id, ots_proof::bytea)` → flips to `pending`. **bytea-over-PostgREST edge:** supabase-js sends a JSON string; pass the proof as a `\\x<hex>` escaped string (Postgres `bytea` hex input) so it round-trips byte-exact. Validate by reading back via `_ots_list_pending` (which `encode(...,'base64')`s it) and comparing.
+6. On hard failure: `_ots_mark_error(asset_id, error)` (status → `error` on the 5th attempt).
+
+## Slice 3 design (upgrade cron) + the `attested_at` gap
+
+1. `pg_cron` → `pg_net` → EF `upgrade`; EF calls `_ots_list_pending(limit)` → `[{id, sha256, ots_proof_b64}]`.
+2. Per asset: decode base64 → parse `.ots` → for each `PendingAttestation`, `GET {cal}/timestamp/<hex(commitment)>` (commitment = the msg at the pending node). **200** → bare `Timestamp` ending in a `BitcoinBlockHeaderAttestation(blockHeight)`; merge into the tree, re-serialize. **404** → still pending (Bitcoin not yet mined, ~min–hours) → leave, retry next cron.
+3. ⚠️ **`attested_at` is NOT in the proof.** `BitcoinBlockHeaderAttestation` commits only the **block height** (the merkle root in block N) — *not* a UTC. `_ots_mark_confirmed(id, proof, bitcoin_block, attested_at)` requires both. Getting the UTC needs a block-height→time source. The lib's `verify()` does this via bitcore-lib + esplora (**heavy — keep out of the EF**). **Use a lightweight HTTP lookup instead:** `blockstream.info/api/block-height/{N}` → block hash → `/block/{hash}` → `.timestamp` (or a maintained block-time table). This keeps bitcore-lib entirely out of the bundle. Treat the explorer as untrusted-but-non-probative (the *proof* is the Bitcoin attestation; the UTC is a convenience field for display/ordering — document that the attestation, not our stored UTC, is the legal anchor).
+4. `_ots_mark_confirmed(id, upgradedProof, blockHeight, attestedUtc)` (CHECK PI1: confirmed ⇒ block+attested).
+5. Health tool in the `get_lgpd_cron_health` mould (Slice 3).
+
+## `.ots` wire format (hand-roll reference — verified vs python/js-opentimestamps source)
+- **HEADER_MAGIC** (31 bytes, raw): `00 4f 70 65 6e 54 69 6d 65 73 74 61 6d 70 73 00 00 50 72 6f 6f 66 00 bf 89 e2 e8 84 e8 92 94` = `"\x00OpenTimestamps\x00\x00Proof\x00"` + `bf89e2e884e89294`.
+- **MAJOR_VERSION** `0x01` (varuint). **fileHashOp** = 1 tag byte: SHA256 `0x08` (32 B digest), SHA1 `0x02`, RIPEMD160 `0x03`, KECCAK256 `0x67`. Then the **fileDigest** bytes raw.
+- **Timestamp** = recursive `msg + ops-map + attestations-set`. On the wire: read a tag; `0xff` = fork (read next as real tag); `0x00` = an attestation follows; else it's an op (`f0` append [+varbytes arg], `f1` prepend [+varbytes], `f2` reverse, `f3` hexlify, `02/03/08/67` crypt [no arg]) then recurse. Linear chains write the op tag directly (no `0xff`); multiple branches fork with `0xff`, last edge no `0xff`.
+- **Attestation** (after `0x00`): 8-byte TAG + `varbytes(payload)`. `PendingAttestation` TAG `83dfe30d2ef90c8e`, payload = `varbytes(uri_utf8)`. `BitcoinBlockHeaderAttestation` TAG `0588960d73d71901`, payload = `varuint(blockHeight)`. Unknown tags preserved as raw varbytes.
+- **varuint** = LEB128 (low 7 bits + `0x80` continuation). **varbytes** = `varuint(len) + bytes`. Calendar responses cap at 10000 bytes; submit digest cap 64 bytes.
+
+## Open decisions (PM)
+1. **Slice 2 engine:** HAND_ROLL (rec) vs USE_LIB_WITH_SHIMS.
+2. **Execution:** this session's sandbox blocks local `npm install` / Deno install → building+**verifying** Slice 2 needs either the PM running the probe (+ later EF deploy) via `!`, or a local-toolchain permission, or me drafting code the PM runs/deploys.
+
+## Sources
+Workflow `wf_dda4ebd6-078` arms cite: unpkg/GitHub-raw `opentimestamps@0.4.9` + `python-opentimestamps` source; Deno node-compat docs; Supabase EF limits/changelog; `denoland/deno#27757`, `supabase/cli#504`, `bitpay/bitcore#1454`. Full structured output archived with the run.

--- a/supabase/functions/_shared/ots.ts
+++ b/supabase/functions/_shared/ots.ts
@@ -1,0 +1,459 @@
+// _shared/ots.ts — zero-dependency OpenTimestamps client for Deno / Supabase Edge Functions.
+//
+// #569 Slice 2/3 (ADR-0101). Produces + upgrades `.ots` DetachedTimestampFile proofs over a
+// SHA-256 digest. NO npm deps: SHA-256 via node:crypto (Deno-fully-supported built-in), calendar
+// HTTP via native fetch. Mirrors the consensus-critical wire format of python-opentimestamps
+// (core/serialize.py, timestamp.py, op.py, notary.py) byte-for-byte — see SPEC_569_S0_OTS_DENO_SPIKE.md.
+//
+// The work never leaves the Núcleo: only the digest is submitted to public calendars (digest-only, ADR-0101).
+
+import { createHash } from "node:crypto";
+
+export const DEFAULT_CALENDARS = [
+  "https://alice.btc.calendar.opentimestamps.org",
+  "https://bob.btc.calendar.opentimestamps.org",
+  "https://finney.btc.calendar.opentimestamps.org",
+  "https://btc.calendar.catallaxy.com",
+];
+
+// DetachedTimestampFile.HEADER_MAGIC (31 bytes) — "\x00OpenTimestamps\x00\x00Proof\x00" + bf89e2e884e89294
+const HEADER_MAGIC = new Uint8Array([
+  0x00, 0x4f, 0x70, 0x65, 0x6e, 0x54, 0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x73,
+  0x00, 0x00, 0x50, 0x72, 0x6f, 0x6f, 0x66, 0x00, 0xbf, 0x89, 0xe2, 0xe8, 0x84, 0xe8, 0x92, 0x94,
+]);
+const MAJOR_VERSION = 1;
+
+// op tags (op.py)
+const OP_APPEND = 0xf0, OP_PREPEND = 0xf1, OP_REVERSE = 0xf2, OP_HEXLIFY = 0xf3;
+const OP_SHA1 = 0x02, OP_RIPEMD160 = 0x03, OP_SHA256 = 0x08, OP_KECCAK256 = 0x67;
+const MAX_RESULT_LENGTH = 4096;
+const CALENDAR_MAX_RESPONSE = 10000; // calendar.js ExceededSizeError threshold
+
+// attestation tags (notary.py) — 8 bytes each
+const TAG_PENDING = hexToBytes("83dfe30d2ef90c8e");
+const TAG_BITCOIN = hexToBytes("0588960d73d71901");
+const TAG_LITECOIN = hexToBytes("06869a0d73d71b45");
+const ATT_MAX_PAYLOAD = 8192;
+const URI_MAX = 1000;
+
+// ============================================================================
+// byte helpers
+// ============================================================================
+export function hexToBytes(hex: string): Uint8Array {
+  if (hex.length % 2 !== 0) throw new Error("odd-length hex");
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) out[i] = parseInt(hex.substr(i * 2, 2), 16);
+  return out;
+}
+export function bytesToHex(b: Uint8Array): string {
+  let s = "";
+  for (let i = 0; i < b.length; i++) s += b[i].toString(16).padStart(2, "0");
+  return s;
+}
+function concat(...parts: Uint8Array[]): Uint8Array {
+  let n = 0;
+  for (const p of parts) n += p.length;
+  const out = new Uint8Array(n);
+  let off = 0;
+  for (const p of parts) { out.set(p, off); off += p.length; }
+  return out;
+}
+function eqBytes(a: Uint8Array, b: Uint8Array): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+function cmpBytes(a: Uint8Array, b: Uint8Array): number {
+  const n = Math.min(a.length, b.length);
+  for (let i = 0; i < n; i++) { if (a[i] !== b[i]) return a[i] - b[i]; }
+  return a.length - b.length;
+}
+function sha256(msg: Uint8Array): Uint8Array {
+  return new Uint8Array(createHash("sha256").update(msg).digest());
+}
+
+// ============================================================================
+// Writer / Reader (serialize.py: LEB128 varuint, varbytes = varuint(len)+bytes)
+// ============================================================================
+class Writer {
+  private chunks: number[] = [];
+  writeByte(b: number) { this.chunks.push(b & 0xff); }
+  writeBytes(b: Uint8Array) { for (let i = 0; i < b.length; i++) this.chunks.push(b[i]); }
+  writeVaruint(value: number) {
+    if (value === 0) { this.chunks.push(0x00); return; }
+    while (value !== 0) {
+      let b = value & 0x7f;
+      if (value > 0x7f) b |= 0x80;
+      this.chunks.push(b);
+      if (value <= 0x7f) break;
+      value = Math.floor(value / 128);
+    }
+  }
+  writeVarbytes(b: Uint8Array) { this.writeVaruint(b.length); this.writeBytes(b); }
+  getBytes(): Uint8Array { return new Uint8Array(this.chunks); }
+}
+
+class Reader {
+  pos = 0;
+  private buf: Uint8Array;
+  constructor(buf: Uint8Array) { this.buf = buf; }
+  private need(n: number) { if (this.pos + n > this.buf.length) throw new Error("TruncationError"); }
+  readByte(): number { this.need(1); return this.buf[this.pos++]; }
+  readBytes(n: number): Uint8Array { this.need(n); const r = this.buf.slice(this.pos, this.pos + n); this.pos += n; return r; }
+  readVaruint(): number {
+    let value = 0, shift = 0;
+    for (;;) {
+      const b = this.readByte();
+      value += (b & 0x7f) * Math.pow(2, shift);
+      if (!(b & 0x80)) break;
+      shift += 7;
+    }
+    return value;
+  }
+  readVarbytes(maxLen: number, minLen = 0): Uint8Array {
+    const l = this.readVaruint();
+    if (l > maxLen) throw new Error(`varbytes max length exceeded: ${l} > ${maxLen}`);
+    if (l < minLen) throw new Error(`varbytes min length not met: ${l} < ${minLen}`);
+    return this.readBytes(l);
+  }
+  assertMagic(magic: Uint8Array) {
+    const got = this.readBytes(magic.length);
+    if (!eqBytes(got, magic)) throw new Error("BadMagicError");
+  }
+  assertEof() { if (this.pos !== this.buf.length) throw new Error("TrailingGarbageError"); }
+  eof(): boolean { return this.pos >= this.buf.length; }
+}
+
+// ============================================================================
+// Op (op.py)
+// ============================================================================
+type Op =
+  | { tag: number; arg: Uint8Array } // binary: append/prepend
+  | { tag: number };                  // unary: sha256/sha1/ripemd160/keccak256/reverse/hexlify
+
+function isBinary(tag: number) { return tag === OP_APPEND || tag === OP_PREPEND; }
+
+function opApply(op: Op, msg: Uint8Array): Uint8Array {
+  switch (op.tag) {
+    case OP_APPEND: return concat(msg, (op as any).arg);
+    case OP_PREPEND: return concat((op as any).arg, msg);
+    case OP_SHA256: return sha256(msg);
+    case OP_REVERSE: { const r = msg.slice(); r.reverse(); return r; }
+    case OP_HEXLIFY: return new TextEncoder().encode(bytesToHex(msg));
+    // sha1/ripemd160/keccak256 are not produced by Bitcoin OTS paths; supported on read only if needed.
+    case OP_SHA1: return new Uint8Array(createHash("sha1").update(msg).digest());
+    case OP_RIPEMD160: return new Uint8Array(createHash("ripemd160").update(msg).digest());
+    default: throw new Error(`opApply: unsupported op tag 0x${op.tag.toString(16)}`);
+  }
+}
+
+function opSerialize(w: Writer, op: Op) {
+  w.writeByte(op.tag);
+  if (isBinary(op.tag)) w.writeVarbytes((op as any).arg);
+}
+
+function opDeserialize(r: Reader, tag: number): Op {
+  switch (tag) {
+    case OP_APPEND: case OP_PREPEND:
+      return { tag, arg: r.readVarbytes(MAX_RESULT_LENGTH, 1) };
+    case OP_SHA1: case OP_RIPEMD160: case OP_SHA256: case OP_KECCAK256:
+    case OP_REVERSE: case OP_HEXLIFY:
+      return { tag };
+    default:
+      throw new Error(`Unknown operation tag 0x${tag.toString(16)}`);
+  }
+}
+
+// Op ordering (Op.__lt__): by TAG byte, then by tuple(self) = (arg,) for binary, () for unary.
+function opCompare(a: Op, b: Op): number {
+  if (a.tag !== b.tag) return a.tag - b.tag;
+  const aa = (a as any).arg as Uint8Array | undefined;
+  const bb = (b as any).arg as Uint8Array | undefined;
+  if (aa && bb) return cmpBytes(aa, bb);
+  return 0;
+}
+function opEqual(a: Op, b: Op): boolean { return opCompare(a, b) === 0; }
+
+// ============================================================================
+// Attestation (notary.py)
+// ============================================================================
+type Attestation =
+  | { kind: "pending"; uri: string }
+  | { kind: "bitcoin"; height: number }
+  | { kind: "litecoin"; height: number }
+  | { kind: "unknown"; tag: Uint8Array; payload: Uint8Array };
+
+function attTag(a: Attestation): Uint8Array {
+  switch (a.kind) {
+    case "pending": return TAG_PENDING;
+    case "bitcoin": return TAG_BITCOIN;
+    case "litecoin": return TAG_LITECOIN;
+    case "unknown": return a.tag;
+  }
+}
+
+function attSerialize(w: Writer, a: Attestation) {
+  w.writeBytes(attTag(a));
+  const pw = new Writer();
+  switch (a.kind) {
+    case "pending": pw.writeVarbytes(new TextEncoder().encode(a.uri)); break;
+    case "bitcoin": case "litecoin": pw.writeVaruint(a.height); break;
+    case "unknown": pw.writeBytes(a.payload); break;
+  }
+  w.writeVarbytes(pw.getBytes());
+}
+
+function attDeserialize(r: Reader): Attestation {
+  const tag = r.readBytes(8);
+  const payload = r.readVarbytes(ATT_MAX_PAYLOAD);
+  const pr = new Reader(payload);
+  if (eqBytes(tag, TAG_PENDING)) {
+    const uri = new TextDecoder().decode(pr.readVarbytes(URI_MAX));
+    pr.assertEof();
+    return { kind: "pending", uri };
+  } else if (eqBytes(tag, TAG_BITCOIN)) {
+    const height = pr.readVaruint(); pr.assertEof();
+    return { kind: "bitcoin", height };
+  } else if (eqBytes(tag, TAG_LITECOIN)) {
+    const height = pr.readVaruint(); pr.assertEof();
+    return { kind: "litecoin", height };
+  }
+  return { kind: "unknown", tag, payload };
+}
+
+// TimeAttestation.__lt__: cross-class by TAG; same-class by uri (pending) / height (bitcoin/litecoin) / (tag,payload) (unknown).
+function attCompare(a: Attestation, b: Attestation): number {
+  const t = cmpBytes(attTag(a), attTag(b));
+  if (t !== 0) return t;
+  if (a.kind === "pending" && b.kind === "pending") return a.uri < b.uri ? -1 : a.uri > b.uri ? 1 : 0;
+  if ((a.kind === "bitcoin" || a.kind === "litecoin") && (b.kind === "bitcoin" || b.kind === "litecoin")) return a.height - b.height;
+  if (a.kind === "unknown" && b.kind === "unknown") return cmpBytes(a.payload, b.payload);
+  return 0;
+}
+function attEqual(a: Attestation, b: Attestation): boolean { return attCompare(a, b) === 0; }
+
+// ============================================================================
+// Timestamp (timestamp.py)
+// ============================================================================
+class Timestamp {
+  msg: Uint8Array;
+  attestations: Attestation[] = [];
+  ops: { op: Op; child: Timestamp }[] = [];
+  constructor(msg: Uint8Array) { this.msg = msg; }
+
+  // Timestamp.serialize — replicates the 0xff/0x00 fork layout exactly (timestamp.py:101-128).
+  serialize(w: Writer) {
+    if (this.attestations.length === 0 && this.ops.length === 0) throw new Error("empty timestamp");
+    const atts = [...this.attestations].sort(attCompare);
+    if (atts.length > 1) {
+      for (let i = 0; i < atts.length - 1; i++) { w.writeBytes(new Uint8Array([0xff, 0x00])); attSerialize(w, atts[i]); }
+    }
+    if (this.ops.length === 0) {
+      w.writeByte(0x00); attSerialize(w, atts[atts.length - 1]);
+    } else {
+      if (atts.length > 0) { w.writeBytes(new Uint8Array([0xff, 0x00])); attSerialize(w, atts[atts.length - 1]); }
+      const ops = [...this.ops].sort((x, y) => opCompare(x.op, y.op));
+      for (let i = 0; i < ops.length - 1; i++) { w.writeByte(0xff); opSerialize(w, ops[i].op); ops[i].child.serialize(w); }
+      const last = ops[ops.length - 1];
+      opSerialize(w, last.op); last.child.serialize(w);
+    }
+  }
+
+  static deserialize(r: Reader, initialMsg: Uint8Array, recursion = 256): Timestamp {
+    if (recursion <= 0) throw new Error("RecursionLimitError");
+    const self = new Timestamp(initialMsg);
+    const handle = (tag: number) => {
+      if (tag === 0x00) {
+        self.attestations.push(attDeserialize(r));
+      } else {
+        const op = opDeserialize(r, tag);
+        const result = opApply(op, initialMsg);
+        const child = Timestamp.deserialize(r, result, recursion - 1);
+        self.ops.push({ op, child });
+      }
+    };
+    let tag = r.readByte();
+    while (tag === 0xff) { handle(r.readByte()); tag = r.readByte(); }
+    handle(tag);
+    return self;
+  }
+
+  // Timestamp.merge — same msg required; union attestations; merge ops recursively (timestamp.py:84-99).
+  merge(other: Timestamp) {
+    if (!eqBytes(this.msg, other.msg)) throw new Error("merge: different messages");
+    for (const oa of other.attestations) {
+      if (!this.attestations.some((a) => attEqual(a, oa))) this.attestations.push(oa);
+    }
+    for (const oe of other.ops) {
+      const mine = this.ops.find((e) => opEqual(e.op, oe.op));
+      if (mine) mine.child.merge(oe.child);
+      else this.ops.push({ op: oe.op, child: oe.child });
+    }
+  }
+
+  // walk every (nodeMsg, attestation)
+  *allAttestations(): Generator<{ msg: Uint8Array; att: Attestation }> {
+    for (const a of this.attestations) yield { msg: this.msg, att: a };
+    for (const e of this.ops) yield* e.child.allAttestations();
+  }
+
+  // find the node with the given msg (first match, DFS)
+  findNode(msg: Uint8Array): Timestamp | null {
+    if (eqBytes(this.msg, msg)) return this;
+    for (const e of this.ops) { const n = e.child.findNode(msg); if (n) return n; }
+    return null;
+  }
+}
+
+// ============================================================================
+// DetachedTimestampFile (.ots)
+// ============================================================================
+export interface DetachedTimestamp { fileHashOpTag: number; timestamp: Timestamp; }
+
+function serializeDetached(fileHashOpTag: number, timestamp: Timestamp): Uint8Array {
+  const w = new Writer();
+  w.writeBytes(HEADER_MAGIC);
+  w.writeByte(MAJOR_VERSION);
+  w.writeByte(fileHashOpTag);          // CryptOp.serialize = 1 tag byte
+  w.writeBytes(timestamp.msg);          // the file digest
+  timestamp.serialize(w);
+  return w.getBytes();
+}
+
+function deserializeDetached(bytes: Uint8Array): DetachedTimestamp {
+  const r = new Reader(bytes);
+  r.assertMagic(HEADER_MAGIC);
+  const major = r.readByte();
+  if (major !== MAJOR_VERSION) throw new Error(`Unsupported major version ${major}`);
+  const fileHashOpTag = r.readByte();
+  const digestLen = fileHashOpTag === OP_SHA256 ? 32 : fileHashOpTag === OP_SHA1 || fileHashOpTag === OP_RIPEMD160 ? 20 : fileHashOpTag === OP_KECCAK256 ? 32 : -1;
+  if (digestLen < 0) throw new Error(`unexpected file_hash_op tag 0x${fileHashOpTag.toString(16)}`);
+  const fileDigest = r.readBytes(digestLen);
+  const timestamp = Timestamp.deserialize(r, fileDigest);
+  r.assertEof();
+  return { fileHashOpTag, timestamp };
+}
+
+// ============================================================================
+// Public API: stamp + upgrade
+// ============================================================================
+
+export interface StampResult { otsBytes: Uint8Array; calendarsOk: string[]; submittedDigest: string; }
+
+/**
+ * Stamp a 32-byte SHA-256 file digest: nonce-append + SHA-256 → submit to calendars → build the .ots.
+ * Returns the serialized `.ots` (pending, not yet Bitcoin-anchored) + which calendars responded.
+ */
+export async function stamp(
+  fileDigest: Uint8Array,
+  opts: { calendars?: string[]; m?: number; timeoutMs?: number } = {},
+): Promise<StampResult> {
+  if (fileDigest.length !== 32) throw new Error("stamp: expected a 32-byte SHA-256 digest");
+  const calendars = opts.calendars ?? DEFAULT_CALENDARS;
+  const m = opts.m ?? Math.min(2, calendars.length);
+  const timeoutMs = opts.timeoutMs ?? 20000;
+
+  // tree: fileDigest --OpAppend(nonce16)--> (fileDigest‖nonce) --OpSHA256--> S
+  const nonce = crypto.getRandomValues(new Uint8Array(16));
+  const appended = concat(fileDigest, nonce);
+  const S = sha256(appended);
+
+  const root = new Timestamp(fileDigest);
+  const t1 = new Timestamp(appended);
+  root.ops.push({ op: { tag: OP_APPEND, arg: nonce }, child: t1 });
+  const tS = new Timestamp(S);
+  t1.ops.push({ op: { tag: OP_SHA256 }, child: tS });
+
+  const calendarsOk: string[] = [];
+  await Promise.all(calendars.map(async (cal) => {
+    try {
+      const resp = await fetch(`${cal.replace(/\/$/, "")}/digest`, {
+        method: "POST",
+        headers: { "Accept": "application/vnd.opentimestamps.v1", "Content-Type": "application/x-www-form-urlencoded" },
+        body: S,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      const buf = new Uint8Array(await resp.arrayBuffer());
+      if (buf.length > CALENDAR_MAX_RESPONSE) throw new Error("calendar response too large");
+      const calTs = Timestamp.deserialize(new Reader(buf), S); // rooted at S
+      tS.merge(calTs);
+      calendarsOk.push(cal);
+    } catch (_e) { /* tolerate per-calendar failure; require m successes below */ }
+  }));
+
+  if (calendarsOk.length < m) throw new Error(`stamp: only ${calendarsOk.length}/${m} calendars responded`);
+  return { otsBytes: serializeDetached(OP_SHA256, root), calendarsOk, submittedDigest: bytesToHex(S) };
+}
+
+export interface UpgradeResult {
+  otsBytes: Uint8Array;
+  changed: boolean;
+  confirmed: boolean;
+  bitcoinBlockHeight: number | null; // attested UTC requires a block-height→time lookup (Slice 3 cron)
+}
+
+/**
+ * Upgrade a pending `.ots`: for each PendingAttestation, GET the calendar's /timestamp/<commitment>.
+ * 200 → merge the Bitcoin attestation; 404 → still pending. Returns the (possibly) upgraded `.ots`.
+ */
+export async function upgrade(
+  otsBytes: Uint8Array,
+  opts: { timeoutMs?: number; calendarAllowlist?: string[] } = {},
+): Promise<UpgradeResult> {
+  const timeoutMs = opts.timeoutMs ?? 20000;
+  const allow = opts.calendarAllowlist ?? DEFAULT_CALENDARS;
+  const { fileHashOpTag, timestamp } = deserializeDetached(otsBytes);
+
+  // collect pending (nodeMsg, uri) before mutating
+  const pendings: { msg: Uint8Array; uri: string }[] = [];
+  for (const { msg, att } of timestamp.allAttestations()) {
+    if (att.kind === "pending") pendings.push({ msg, uri: att.uri });
+  }
+
+  let changed = false;
+  for (const p of pendings) {
+    const base = p.uri.replace(/\/$/, "");
+    // only follow calendars we trust (the pending URI is attacker-influenceable in general; here it is our own submit set)
+    if (!allow.some((c) => base === c.replace(/\/$/, ""))) continue;
+    try {
+      const resp = await fetch(`${base}/timestamp/${bytesToHex(p.msg)}`, {
+        headers: { "Accept": "application/vnd.opentimestamps.v1" },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      if (resp.status === 404) continue; // not yet anchored
+      if (!resp.ok) continue;
+      const buf = new Uint8Array(await resp.arrayBuffer());
+      if (buf.length > CALENDAR_MAX_RESPONSE) continue;
+      const upg = Timestamp.deserialize(new Reader(buf), p.msg); // rooted at the commitment
+      const node = timestamp.findNode(p.msg);
+      if (node) { node.merge(upg); changed = true; }
+    } catch (_e) { /* leave pending; retry next pass */ }
+  }
+
+  let height: number | null = null;
+  for (const { att } of timestamp.allAttestations()) {
+    if (att.kind === "bitcoin") height = height === null ? att.height : Math.min(height, att.height);
+  }
+
+  return {
+    otsBytes: changed ? serializeDetached(fileHashOpTag, timestamp) : otsBytes,
+    changed,
+    confirmed: height !== null,
+    bitcoinBlockHeight: height,
+  };
+}
+
+// info-ish: list attestations in a stored proof (for health/debug, no network)
+export function describe(otsBytes: Uint8Array): { fileDigest: string; pending: string[]; bitcoinHeights: number[] } {
+  const { timestamp } = deserializeDetached(otsBytes);
+  const pending: string[] = [];
+  const bitcoinHeights: number[] = [];
+  for (const { att } of timestamp.allAttestations()) {
+    if (att.kind === "pending") pending.push(att.uri);
+    else if (att.kind === "bitcoin") bitcoinHeights.push(att.height);
+  }
+  return { fileDigest: bytesToHex(timestamp.msg), pending, bitcoinHeights };
+}
+
+export const _internal = { Writer, Reader, Timestamp, serializeDetached, deserializeDetached, sha256, HEADER_MAGIC };

--- a/supabase/functions/_shared/ots_test.ts
+++ b/supabase/functions/_shared/ots_test.ts
@@ -1,0 +1,100 @@
+// ots_test.ts — #569 Slice 2/3 correctness gate. Run: deno test -A supabase/functions/_shared/ots_test.ts
+//
+// The decisive check is BYTE-EXACT round-trip (parse -> re-serialize == canonical bytes) of real `.ots`
+// vectors from opentimestamps/javascript-opentimestamps/examples. If these pass, the serializer matches
+// the consensus-critical wire format across pending / multi-calendar-fork / Bitcoin-merkle / unknown-attestation.
+// The live stamp test (OTS_LIVE=1) additionally proves a freshly-produced proof round-trips; the FINAL legal
+// gate (a canonical `ots verify` accepting our proof) is run by the PM.
+
+import { assert, assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+import { _internal, bytesToHex, hexToBytes, describe, stamp, upgrade } from "./ots.ts";
+
+// --- canonical vectors (javascript-opentimestamps/examples/*.ots) ---
+const VECTORS: Record<string, string> = {
+  // single pending calendar (alice)
+  incomplete:
+    "004f70656e54696d657374616d7073000050726f6f6600bf89e2e884e89294010805c4f616a8e5310d19d938cfd769864d7f4ccdc2ca8b479b10af83564b097af9f0010e754bf93806a7ebaa680ef7bd0114bf408f010b573e8850cfd9e63d1f043fbb6fc250e08f10457cfa5c4f0086fb1ac8d4e4eb0e70083dfe30d2ef90c8e2e2d68747470733a2f2f616c6963652e6274632e63616c656e6461722e6f70656e74696d657374616d70732e6f7267",
+  // fork into two calendars (alice + bob) — exercises multi-op fork + op sort
+  twoCalendars:
+    "004f70656e54696d657374616d7073000050726f6f6600bf89e2e884e892940108efaa174f68e59705757460f4f7d204bd2b535cfd194d9d945418732129404ddbf010839037eef449dec6dac322ca97347c4508fff0106b4023b6edd3a0eeeb09e5d718723b9e08f10457d46515f008eadd66b1688d55740083dfe30d2ef90c8e2e2d68747470733a2f2f616c6963652e6274632e63616c656e6461722e6f70656e74696d657374616d70732e6f7267f010a3ad701ef9f10535a84968b5a99d858008f10457d46516f008647b90ea1b270a970083dfe30d2ef90c8e2c2b68747470733a2f2f626f622e6274632e63616c656e6461722e6f70656e74696d657374616d70732e6f7267",
+  // full Bitcoin attestation via a tx merkle path — exercises the long op chain + BitcoinBlockHeaderAttestation
+  helloWorld:
+    "004f70656e54696d657374616d7073000050726f6f6600bf89e2e884e89294010803ba204e50d126e4674c005e04d82e84c21366780af1f43bd54a37816b6ab34003f1c8010100000001e482f9d32ecc3ba657b69d898010857b54457a90497982ff56f97c4ec58e6f98010000006b483045022100b253add1d1cf90844338a475a04ff13fc9e7bd242b07762dea07f5608b2de367022000b268ca9c3342b3769cdd062891317cdcef87aac310b6855e9d93898ebbe8ec0121020d8e4d107d2b339b0050efdd4b4a09245aa056048f125396374ea6a2ab0709c6ffffffff026533e605000000001976a9140bf057d40fbba6744862515f5b55a2310de5772f88aca0860100000000001976a914f00688ac000000000808f120a987f716c533913c314c78e35d35884cac943fa42cac49d2b2c69f4003f85f880808f120dec55b3487e1e3f722a49b55a7783215862785f4a3acb392846019f71dc64a9d0808f120b2ca18f485e080478e025dab3d464b416c0e1ecb6629c9aefce8c8214d0424320808f02011b0e90661196ff4b0813c3eda141bab5e91604837bdf7a0c9df37db0e3a11980808f020c34bc1a4a1093ffd148c016b1e664742914e939efabe4d3d356515914b26d9e20808f020c3e6e7c38c69f6af24c2be34ebac48257ede61ec0a21b9535e4443277be306460808f1200798bf8606e00024e5d5d54bf0c960f629dfb9dad69157455b6f2652c0e8de810808f0203f9ada6d60baa244006bb0aad51448ad2fafb9d4b6487a0999cff26b91f0f5360808f120c703019e959a8dd3faef7489bb328ba485574758e7091f01464eb65872c975c80808f020cbfefff513ff84b915e3fed6f9d799676630f8364ea2a6c7557fad94a5b5d7880808f1200be23709859913babd4460bbddf8ed213e7c8773a4b1face30f8acfdf093b7050808000588960d73d7190103f7ef15",
+  // known (bob pending) + an UnknownAttestation (tag 0001020304050607) — exercises preservation + cross-class sort
+  knownUnknown:
+    "004f70656e54696d657374616d7073000050726f6f6600bf89e2e884e892940108d288b2ee212b01e3e5f6d333df3a4d53f292cc3f07b09013c0b40c8e7dcb9c03f01046d842bd5d8377e0f42041bec9bda66708fff010332c572f9c4b8d5db9d99758d48fff3408f10457e89f38f00873c6dc4d0cbc29f00083dfe30d2ef90c8e2c2b68747470733a2f2f626f622e6274632e63616c656e6461722e6f70656e74696d657374616d70732e6f7267f010e7ad29076f188033d20767602ca3a8e008f10457e89f37f00862df56371ae23d8d0001020304050607082e78787878787878787878787878787878787878787878787878787878787878787878787878787878787878787878",
+  // two calendars under a deeper merkle path
+  merkle2:
+    "004f70656e54696d657374616d7073000050726f6f6600bf89e2e884e8929401088bd5a5f07b4451c29756df5eb51d194fb5b20c7e89812d877bbad30d871c582ff010b63d8f213d047298b8ab4595acd8e5d008f120ae59d2c0d2f5efa97df8f3cca7e85845880c102237f1a6a1b0b4c6a5ab77f49408f020026356e7972f023930ec84c213adedc4050460973935bbd2f4df3d7bd5dec55f08fff0102e12050afd7a10ea4f591ed717d35de608f10457d982dff008b1f26e2e555904770083dfe30d2ef90c8e2e2d68747470733a2f2f616c6963652e6274632e63616c656e6461722e6f70656e74696d657374616d70732e6f7267f0104aaade9c2ffb853ccff9c07681d019fd08f10457d982e0f0086644ef713071762a0083dfe30d2ef90c8e2c2b68747470733a2f2f626f622e6274632e63616c656e6461722e6f70656e74696d657374616d70732e6f7267",
+};
+
+Deno.test("sha256 NIST vector (abc)", () => {
+  const h = _internal.sha256(new TextEncoder().encode("abc"));
+  assertEquals(bytesToHex(h), "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+});
+
+Deno.test("varuint round-trip (LEB128)", () => {
+  for (const v of [0, 1, 127, 128, 255, 256, 16383, 16384, 65535, 1234567]) {
+    const w = new _internal.Writer();
+    w.writeVaruint(v);
+    const r = new _internal.Reader(w.getBytes());
+    assertEquals(r.readVaruint(), v, `varuint ${v}`);
+    assert(r.eof(), `varuint ${v} consumed exactly`);
+  }
+});
+
+Deno.test("varbytes round-trip", () => {
+  const payload = hexToBytes("deadbeef0001ff");
+  const w = new _internal.Writer();
+  w.writeVarbytes(payload);
+  const r = new _internal.Reader(w.getBytes());
+  assertEquals(bytesToHex(r.readVarbytes(100)), "deadbeef0001ff");
+});
+
+// THE decisive correctness gate: byte-exact round-trip of canonical vectors.
+for (const [name, hex] of Object.entries(VECTORS)) {
+  Deno.test(`round-trip byte-exact: ${name}`, () => {
+    const bytes = hexToBytes(hex);
+    const { fileHashOpTag, timestamp } = _internal.deserializeDetached(bytes);
+    const out = _internal.serializeDetached(fileHashOpTag, timestamp);
+    assertEquals(bytesToHex(out), hex, `${name} did not round-trip byte-exact`);
+  });
+}
+
+Deno.test("describe: incomplete has one alice pending, no bitcoin", () => {
+  const d = describe(hexToBytes(VECTORS.incomplete));
+  assertEquals(d.pending, ["https://alice.btc.calendar.opentimestamps.org"]);
+  assertEquals(d.bitcoinHeights, []);
+});
+
+Deno.test("describe: helloWorld is Bitcoin-confirmed", () => {
+  const d = describe(hexToBytes(VECTORS.helloWorld));
+  assertEquals(d.pending, []);
+  assert(d.bitcoinHeights.length === 1 && d.bitcoinHeights[0] > 0, "expected one bitcoin attestation");
+});
+
+Deno.test("describe: knownUnknown keeps bob pending alongside the unknown attestation", () => {
+  const d = describe(hexToBytes(VECTORS.knownUnknown));
+  assertEquals(d.pending, ["https://bob.btc.calendar.opentimestamps.org"]);
+});
+
+// --- live (network) — opt-in: OTS_LIVE=1 deno test -A ---
+Deno.test({
+  name: "LIVE: stamp a digest -> pending .ots round-trips + >=1 calendar",
+  ignore: Deno.env.get("OTS_LIVE") !== "1",
+  fn: async () => {
+    const digest = _internal.sha256(new TextEncoder().encode("nucleo-ia-ots-spike-2026-06-09"));
+    const res = await stamp(digest, { m: 1, timeoutMs: 25000 });
+    assert(res.calendarsOk.length >= 1, "at least one calendar should respond");
+    // round-trip our freshly produced proof
+    const { fileHashOpTag, timestamp } = _internal.deserializeDetached(res.otsBytes);
+    const out = _internal.serializeDetached(fileHashOpTag, timestamp);
+    assertEquals(bytesToHex(out), bytesToHex(res.otsBytes), "live proof must round-trip");
+    const d = describe(res.otsBytes);
+    assert(d.pending.length >= 1, "fresh proof is pending");
+    assertEquals(d.bitcoinHeights, [], "fresh proof not yet Bitcoin-anchored");
+    // upgrade immediately should be a no-op (not yet mined) but must not corrupt the proof
+    const up = await upgrade(res.otsBytes, { timeoutMs: 25000 });
+    assert(!up.confirmed, "fresh proof should still be pending right after stamp");
+  },
+});

--- a/supabase/functions/ots-stamp/index.ts
+++ b/supabase/functions/ots-stamp/index.ts
@@ -1,0 +1,85 @@
+// ots-stamp — #569 Slice 2 (ADR-0101). Internal OTS stamping pipeline (service-role only).
+//
+// Claims a batch of `unstamped` PI-exclusion assets, submits each digest to the OpenTimestamps
+// calendars via the zero-dep engine (`../_shared/ots.ts`), and persists the `pending` `.ots` proof.
+// Digest-only: only the SHA-256 leaves the Núcleo. Single-consumer until `_ots_claim_unstamped_assets`
+// gains FOR UPDATE SKIP LOCKED (ADR-0101 open item) — do NOT run two invocations concurrently.
+//
+// Invoke (later) from pg_cron -> pg_net with the service-role key as Bearer. Deploy with --no-verify-jwt.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+import { stamp, hexToBytes, bytesToHex, describe } from "../_shared/ots.ts";
+
+// Keep the batch small: each asset = up to 4 sequential-ish calendar round-trips; stay well under the
+// 150s wall-clock. Tunable by the caller (pg_cron job) via the request body.
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+}
+
+function extractError(err: unknown): string {
+  if (err && typeof err === "object") {
+    const e = err as Record<string, unknown>;
+    if (typeof e.message === "string" && e.message) return e.message;
+    try { return JSON.stringify(err); } catch { /* fallthrough */ }
+  }
+  return String(err || "Unknown error");
+}
+
+// bytea over PostgREST: a JSON string in Postgres `\x<hex>` input format casts to bytea byte-exact.
+function toByteaHex(b: Uint8Array): string { return "\\x" + bytesToHex(b); }
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+  // service-role only: this drives the internal `_ots_*` RPCs (REVOKEd from anon/authenticated).
+  const token = (req.headers.get("Authorization") ?? "").replace(/^Bearer\s+/i, "");
+  if (!token) return jsonResponse({ success: false, error: "Unauthorized" }, 401);
+  if (token !== serviceRoleKey) return jsonResponse({ success: false, error: "Forbidden: service-role only" }, 403);
+
+  let limit = DEFAULT_LIMIT;
+  try {
+    const body = req.method === "POST" ? await req.json().catch(() => ({})) : {};
+    if (typeof body?.limit === "number" && body.limit > 0) limit = Math.min(Math.floor(body.limit), MAX_LIMIT);
+  } catch { /* default limit */ }
+
+  const sb = createClient(supabaseUrl, serviceRoleKey);
+
+  try {
+    const { data: claimed, error: claimErr } = await sb.rpc("_ots_claim_unstamped_assets", { p_limit: limit });
+    if (claimErr) throw claimErr;
+    const assets = (claimed ?? []) as { id: string; sha256: string }[];
+    if (assets.length === 0) return jsonResponse({ success: true, claimed: 0, stamped: 0, failed: 0, results: [] });
+
+    let stamped = 0, failed = 0;
+    const results: Record<string, unknown>[] = [];
+
+    // sequential per asset (single-consumer + deterministic wall-clock); calendars fan out inside stamp()
+    for (const a of assets) {
+      try {
+        if (!/^[0-9a-f]{64}$/.test(a.sha256)) throw new Error("asset sha256 is not 64 lowercase hex");
+        const res = await stamp(hexToBytes(a.sha256), { m: 1, timeoutMs: 20000 });
+        const { error: markErr } = await sb.rpc("_ots_mark_stamped", { p_asset_id: a.id, p_ots_proof: toByteaHex(res.otsBytes) });
+        if (markErr) throw markErr;
+        stamped++;
+        results.push({ id: a.id, status: "pending", calendars: res.calendarsOk.length, bytes: res.otsBytes.length, pending: describe(res.otsBytes).pending });
+      } catch (e) {
+        failed++;
+        const msg = extractError(e);
+        // best-effort error mark (status flips to 'error' on the 5th attempt); never throws the whole batch
+        await sb.rpc("_ots_mark_error", { p_asset_id: a.id, p_error: msg.slice(0, 500) }).catch(() => {});
+        results.push({ id: a.id, status: "error", error: msg });
+      }
+    }
+
+    return jsonResponse({ success: true, claimed: assets.length, stamped, failed, results });
+  } catch (error) {
+    return jsonResponse({ success: false, error: extractError(error) }, 500);
+  }
+});

--- a/supabase/functions/ots-upgrade/index.ts
+++ b/supabase/functions/ots-upgrade/index.ts
@@ -1,0 +1,119 @@
+// ots-upgrade — #569 Slice 3 (ADR-0101). Internal OTS upgrade pass (service-role only).
+//
+// For each `pending` asset, asks the calendars to upgrade the proof; once Bitcoin-anchored, resolves the
+// block height -> UTC (the OTS attestation carries only the height) and marks the asset `confirmed`.
+// Eficácia probatória = `confirmed`, not `pending`. Single-consumer (ADR-0101). Deploy --no-verify-jwt;
+// invoke from pg_cron -> pg_net with the service-role key as Bearer (Slice 3 cron migration is separate).
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { corsHeaders } from "../_shared/cors.ts";
+import { upgrade, bytesToHex } from "../_shared/ots.ts";
+
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+function jsonResponse(body: Record<string, unknown>, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+}
+function extractError(err: unknown): string {
+  if (err && typeof err === "object") {
+    const e = err as Record<string, unknown>;
+    if (typeof e.message === "string" && e.message) return e.message;
+    try { return JSON.stringify(err); } catch { /* fallthrough */ }
+  }
+  return String(err || "Unknown error");
+}
+function toByteaHex(b: Uint8Array): string { return "\\x" + bytesToHex(b); }
+function b64ToBytes(b64: string): Uint8Array { return Uint8Array.from(atob(b64), (c) => c.charCodeAt(0)); }
+
+// Bitcoin block height -> attested UTC. The proof is the legal anchor; this UTC is a convenience field
+// derived from a public explorer (blockstream, mempool fallback). Untrusted-but-non-probative.
+async function blockTimeUtc(height: number, timeoutMs = 15000): Promise<string> {
+  const sources = [
+    { h: (n: number) => `https://blockstream.info/api/block-height/${n}`, b: (hash: string) => `https://blockstream.info/api/block/${hash}` },
+    { h: (n: number) => `https://mempool.space/api/block-height/${n}`, b: (hash: string) => `https://mempool.space/api/block/${hash}` },
+  ];
+  let lastErr: unknown;
+  for (const s of sources) {
+    try {
+      const hr = await fetch(s.h(height), { signal: AbortSignal.timeout(timeoutMs) });
+      if (!hr.ok) throw new Error(`block-height ${hr.status}`);
+      const hash = (await hr.text()).trim();
+      if (!/^[0-9a-f]{64}$/.test(hash)) throw new Error("bad block hash");
+      const br = await fetch(s.b(hash), { signal: AbortSignal.timeout(timeoutMs) });
+      if (!br.ok) throw new Error(`block ${br.status}`);
+      const blk = await br.json();
+      if (typeof blk?.timestamp !== "number") throw new Error("block has no timestamp");
+      return new Date(blk.timestamp * 1000).toISOString();
+    } catch (e) { lastErr = e; }
+  }
+  throw new Error(`block-time lookup failed for height ${height}: ${extractError(lastErr)}`);
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+
+  const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
+  const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+
+  const token = (req.headers.get("Authorization") ?? "").replace(/^Bearer\s+/i, "");
+  if (!token) return jsonResponse({ success: false, error: "Unauthorized" }, 401);
+  if (token !== serviceRoleKey) return jsonResponse({ success: false, error: "Forbidden: service-role only" }, 403);
+
+  let limit = DEFAULT_LIMIT;
+  try {
+    const body = req.method === "POST" ? await req.json().catch(() => ({})) : {};
+    if (typeof body?.limit === "number" && body.limit > 0) limit = Math.min(Math.floor(body.limit), MAX_LIMIT);
+  } catch { /* default */ }
+
+  const sb = createClient(supabaseUrl, serviceRoleKey);
+
+  try {
+    const { data: pendingRows, error: listErr } = await sb.rpc("_ots_list_pending", { p_limit: limit });
+    if (listErr) throw listErr;
+    const rows = (pendingRows ?? []) as { id: string; sha256: string; ots_proof_b64: string }[];
+    if (rows.length === 0) return jsonResponse({ success: true, checked: 0, confirmed: 0, still_pending: 0, errors: 0, results: [] });
+
+    let confirmed = 0, stillPending = 0, errors = 0;
+    const results: Record<string, unknown>[] = [];
+
+    for (const row of rows) {
+      try {
+        const proof = b64ToBytes(row.ots_proof_b64);
+        const up = await upgrade(proof, { timeoutMs: 20000 });
+        if (up.confirmed && up.bitcoinBlockHeight !== null) {
+          let attestedAt: string;
+          try {
+            attestedAt = await blockTimeUtc(up.bitcoinBlockHeight);
+          } catch (e) {
+            // anchored but explorer unavailable -> leave pending, retry next pass (don't mark error)
+            stillPending++;
+            results.push({ id: row.id, status: "pending", note: "anchored; block-time lookup deferred", detail: extractError(e) });
+            continue;
+          }
+          const { error: confErr } = await sb.rpc("_ots_mark_confirmed", {
+            p_asset_id: row.id,
+            p_ots_proof: toByteaHex(up.otsBytes),
+            p_bitcoin_block: up.bitcoinBlockHeight,
+            p_attested_at: attestedAt,
+          });
+          if (confErr) throw confErr;
+          confirmed++;
+          results.push({ id: row.id, status: "confirmed", block: up.bitcoinBlockHeight, attested_at: attestedAt });
+        } else {
+          stillPending++;
+          results.push({ id: row.id, status: "pending", changed: up.changed });
+        }
+      } catch (e) {
+        errors++;
+        const msg = extractError(e);
+        await sb.rpc("_ots_mark_error", { p_asset_id: row.id, p_error: msg.slice(0, 500) }).catch(() => {});
+        results.push({ id: row.id, status: "error", error: msg });
+      }
+    }
+
+    return jsonResponse({ success: true, checked: rows.length, confirmed, still_pending: stillPending, errors, results });
+  } catch (error) {
+    return jsonResponse({ success: false, error: extractError(error) }, 500);
+  }
+});


### PR DESCRIPTION
## #569 Slice 0/2 (+ Slice 3 core) — hand-rolled OpenTimestamps engine

Closes the Slice 0 spike and ships the stamp/upgrade engine for the PI-exclusion asset registry (Parecer 01/2026 rec **k**; ADR-0101).

### Spike outcome (Slice 0)
`opentimestamps@0.4.9` is **likely_breaks** under the Deno EF runtime: a dangling `main` entry that only resolves via Node's `index.js` fallback; the sole calendar transport is the deprecated `request`/`request-promise` on Deno's partially-supported `node:http`; `Buffer` is not a Deno global. And even the lib path bypasses its transport with native `fetch`, leaving the lib's only contribution as `.ots` serialization. **Decision: HAND_ROLL** a zero-dep engine. Full report: `docs/specs/SPEC_569_S0_OTS_DENO_SPIKE.md`.

### What's here
- **`_shared/ots.ts`** — zero-dep OTS client (`stamp`/`upgrade`/`describe`). SHA-256 via `node:crypto`, calendars via native `fetch`. Mirrors the consensus-critical python-opentimestamps wire format byte-for-byte.
- **`_shared/ots_test.ts`** — Deno round-trip + live gate.
- **`ots-stamp`** (Slice 2) — `_ots_claim_unstamped_assets` → `stamp` → `_ots_mark_stamped`; service-role only.
- **`ots-upgrade`** (Slice 3 core) — `_ots_list_pending` → `upgrade` → block-height→UTC (blockstream/mempool) → `_ots_mark_confirmed`.
- ADR-0101 slice/open-item updates.

### Verification
- **Byte-exact round-trip** of 5 canonical vectors (pending / 2-calendar fork / merkle / unknown-attestation / full Bitcoin attestation) — **10/10** (Node 24, `--experimental-strip-types`).
- **Live stamp** against alice/bob/catallaxy → valid 543B pending `.ots` that round-trips.
- **Prod smoke** (deployed EFs): test asset → stamp → **bytea-over-PostgREST seam verified byte-exact** (578B stored, base64 read-back parses identical) → asset `pending` → test data cleaned up (tables 0/0).
- `npx astro build` ✓ · `npm test` **0 fail** (3652 pass, 252 db-skipped) ✓.

### Notes
- EFs **already deployed** (ots-stamp 70.65kB, ots-upgrade 71.51kB) — this PR brings the source into git. **No migration / RPC / schema change.**
- Pipeline is **single-consumer** until `_ots_claim_unstamped_assets` gets `FOR UPDATE SKIP LOCKED` (ADR open item); the Slice 3 cron must schedule the two EFs non-overlapping.
- EFs gate on exact `SUPABASE_SERVICE_ROLE_KEY` match (repo convention) — the pg_net cron call must use the EF's current injected key.

### Remaining
- **Slice 3:** pg_cron schedule + `get_ots_pipeline_health` tool.
- **Slice 4:** `export_anexo_i` MCP tool + wire to doc7 + `export_my_data` Art.18.

Refs #569.
