### PR TITLE
fix(221): EF-level voice-biometric consent re-check + EF contract entry (WIP rescue)

### DIFF
--- a/supabase/functions/analyze-application-video/index.ts
+++ b/supabase/functions/analyze-application-video/index.ts
@@ -219,11 +219,14 @@ async function processVideosBackground(
   try {
     const { data: app, error: appErr } = await sb
       .from("selection_applications")
-      .select("id, applicant_name, cycle_id, organization_id, consent_ai_analysis_at, consent_ai_analysis_revoked_at")
+      .select("id, applicant_name, cycle_id, organization_id, consent_ai_analysis_at, consent_ai_analysis_revoked_at, consent_voice_biometric_at, consent_voice_biometric_revoked_at")
       .eq("id", application_id).single();
     if (appErr || !app) { console.error("app_not_found:", appErr?.message); return; }
     if (!app.consent_ai_analysis_at || app.consent_ai_analysis_revoked_at) {
       console.log("consent_pending_or_revoked, skipping:", application_id); return;
+    }
+    if (!app.consent_voice_biometric_at || app.consent_voice_biometric_revoked_at) {
+      console.log("voice_biometric_consent_pending_or_revoked, skipping:", application_id); return;
     }
 
     const videoQuery = sb.from("pmi_video_screenings")

--- a/supabase/migrations/20260801000000_p207_issue_221_whisper_art11_drop_trigger.sql
+++ b/supabase/migrations/20260801000000_p207_issue_221_whisper_art11_drop_trigger.sql
@@ -1,0 +1,36 @@
+-- P207 issue #221 — Whisper Art. 11 RETROATIVO Phase 1 of 3
+-- DROP TRIGGER trg_video_ai_analysis_on_upload
+--
+-- Tier 3 strategic council (5/5 GO-WITH-AMENDMENTS, 2026-05-20 p207) ordered
+-- this trigger DROPPED unconditionally as P0 LGPD remediation. The trigger
+-- dispatches `analyze_application_video_async` on `pmi_video_screenings`
+-- INSERT/UPDATE, which calls OpenAI Whisper to transcribe candidate video
+-- audio (voice biometric, LGPD Art. 11 §I = sensitive data).
+--
+-- Current `consent_ai_analysis_at` gate covers generic "AI analysis" intent
+-- but NOT explicit Art. 11 voice biometric consent (Art. 11 §II hypotheses
+-- are taxative; only consentimento explícito + destacado per Art. 8 applies).
+--
+-- Empirical state (live query 2026-05-20):
+--   pmi_video_screenings.transcribed=0; has_transcription_text=1; in_flight=5
+--   distinct_applications=18; ai_processing_log video_screening rows=3 (1c/2f)
+--
+-- The intent to process without Art. 11 consent IS the violation, independent
+-- of OpenAI 429 quota having intervened. DROP the trigger first; rebuilds
+-- come after Angeline's Art. 48 written determination + Termo de Speaker
+-- ratification (sequence per accountability §2.1 A1).
+--
+-- Rollback: re-CREATE the trigger via Phase 3 migration once consent gate is
+-- in place. Until then, manual `analyze_application_video(p_application_id)`
+-- MCP tool calls continue to be blocked at Phase 3 (helper gate update).
+--
+-- Refs: issue #221 · ADR-0094 (Draft) · #212 Tier 3 synthesis
+--   docs/council/2026-05-20-p207-tier3-strategic-review-212.md
+
+DROP TRIGGER IF EXISTS trg_video_ai_analysis_on_upload ON public.pmi_video_screenings;
+
+-- Audit comment on the now-orphaned helper function until Phase 3 updates body
+COMMENT ON FUNCTION public._trg_video_ai_analysis_on_upload() IS
+  'p207 issue #221 (2026-05-20): trigger BODY preserved but trigger DROPPED for LGPD Art. 11 RETROACTIVE remediation. Function no longer fires automatically. Will be re-attached at Phase 3 (consent_voice_biometric_at gate) after Angeline Art. 48 determination.';
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260801000001_p207_issue_221_capture_voice_biometric_consent_columns.sql
+++ b/supabase/migrations/20260801000001_p207_issue_221_capture_voice_biometric_consent_columns.sql
@@ -1,0 +1,52 @@
+-- P207 issue #221 — Whisper Art. 11 RETROATIVO Phase 2 of 3
+-- Capture voice biometric consent columns + add evidence column
+--
+-- DRIFT CAPTURE: `consent_voice_biometric_at` + `consent_voice_biometric_revoked_at`
+-- already exist on public.selection_applications but NO MIGRATION FILE captures
+-- their DDL (grep `voice_biometric` in supabase/migrations/ returned empty).
+-- This violates GC-097 (DDL must go through apply_migration, never execute_sql).
+-- Phase 2 captures the drift idempotently via ADD COLUMN IF NOT EXISTS.
+--
+-- NEW: `consent_voice_biometric_evidence` text column added so audit chain
+-- can capture HOW consent was attested (e.g., URL to signed termo PDF, email
+-- thread ID with Angeline's notification template, or video-recorded verbal
+-- consent reference).
+--
+-- Pattern mirrors p197d_a `consent_ai_analysis_at` + `consent_ai_analysis_evidence`
+-- already in place for generic AI analysis consent. Voice biometric needs ITS OWN
+-- column tracked separately (Art. 11 §I requires explicit + destacado consent;
+-- cannot be inferred from broader AI consent per Phase 2 legal-counsel).
+--
+-- After this migration:
+--   - 3 columns on selection_applications:
+--     consent_voice_biometric_at         timestamptz (when consent captured)
+--     consent_voice_biometric_revoked_at timestamptz (Art. 9 §V revogabilidade)
+--     consent_voice_biometric_evidence   text        (URL/ID/notes audit trail)
+--   - Helper `analyze_application_video_async` will gate on these in Phase 3
+--
+-- LGPD Art. 8 §6: consent specificity for sensitive data must be per-finalidade.
+-- LGPD Art. 9 §V: data subject can revoke consent at any time. Revoked_at column
+-- maintains revocation timestamp for Art. 18 deletion audit chain.
+--
+-- Rollback: ALTER TABLE public.selection_applications DROP COLUMN IF EXISTS
+--   consent_voice_biometric_evidence; (the AT + revoked_at columns predate this
+--   migration via drift and should not be dropped on rollback).
+--
+-- Refs: issue #221 · #212 ADR-0094 G1.6 (consent log architecture)
+--   docs/council/2026-05-20-p207-tier3-strategic-review-212.md §1.5
+
+ALTER TABLE public.selection_applications
+  ADD COLUMN IF NOT EXISTS consent_voice_biometric_at        timestamptz,
+  ADD COLUMN IF NOT EXISTS consent_voice_biometric_revoked_at timestamptz,
+  ADD COLUMN IF NOT EXISTS consent_voice_biometric_evidence  text;
+
+COMMENT ON COLUMN public.selection_applications.consent_voice_biometric_at IS
+  'p207 #221 (2026-05-20, drift-captured from earlier execute_sql): timestamp when candidate gave explicit Art. 11 §I consent to process voice biometric (Whisper transcription + downstream multimodal analysis). NULL = no consent = analyze_application_video pipeline MUST refuse to dispatch.';
+
+COMMENT ON COLUMN public.selection_applications.consent_voice_biometric_revoked_at IS
+  'p207 #221 (2026-05-20, drift-captured): timestamp when candidate revoked Art. 11 consent (LGPD Art. 9 §V). When non-NULL, pipeline must refuse new analyses AND audit-chain must trigger deletion per Art. 18 §IV.';
+
+COMMENT ON COLUMN public.selection_applications.consent_voice_biometric_evidence IS
+  'p207 #221 (2026-05-20): audit trail of how consent was captured — URL to signed termo PDF in Drive, email thread ID with Angeline notification, or video-recorded verbal-consent reference. REQUIRED for ANPD audit defense (Art. 37 record-keeping).';
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260801000002_p207_issue_221_helper_gate_voice_biometric_consent.sql
+++ b/supabase/migrations/20260801000002_p207_issue_221_helper_gate_voice_biometric_consent.sql
@@ -1,0 +1,126 @@
+-- P207 issue #221 — Whisper Art. 11 RETROATIVO Phase 3 of 3
+-- Update `analyze_application_video_async` to gate on consent_voice_biometric_at
+--
+-- BODY pulled from pg_get_functiondef pre-update (sediment
+-- [[feedback-create-or-replace-full-body-fetch]]). Single new gate added
+-- after existing consent_ai_analysis_at check. Returns same skipped envelope
+-- shape so MCP tool callers see graceful skip, not exception.
+--
+-- This migration keeps the public entrypoint `analyze_application_video(uuid,text,bool)`
+-- unchanged — it still delegates to async helper. New gate fires for BOTH the
+-- (now-dropped) trigger path AND the MCP tool path. Trigger remains DROPPED
+-- from Phase 1 until Angeline's Art. 48 determination clears consent flow.
+--
+-- After this migration:
+--   - Phase 1 trigger DROP keeps automatic dispatch dead
+--   - Phase 3 helper gate keeps manual MCP tool call dead
+--   - Re-enabling requires per-candidate consent_voice_biometric_at NOT NULL
+--   - Future re-attachment of trg_video_ai_analysis_on_upload (Phase 4, separate
+--     migration after Angeline cycle complete) restores automatic path with gate
+--
+-- LGPD legal basis for the gate:
+--   - Art. 11 §I (biometria de voz = dado sensível)
+--   - Art. 11 §II (hipóteses taxativas — só consentimento explícito Art. 8 cabe)
+--   - Art. 8 §6 (especificidade da finalidade — consentimento AI genérico ≠ Art. 11)
+--   - Art. 9 §V (revogabilidade — revoked_at column gate also applies)
+--
+-- Rollback: re-CREATE OR REPLACE FUNCTION with the pre-Phase-3 body (preserved
+-- in p197d migration file 20260519041719). NOT RECOMMENDED — restores violation.
+--
+-- Refs: issue #221 · ADR-0094 (Draft, gated on this Phase 3 being live)
+
+CREATE OR REPLACE FUNCTION public.analyze_application_video_async(
+  p_application_id uuid,
+  p_pillar text DEFAULT NULL::text,
+  p_force boolean DEFAULT false
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_app record;
+  v_url text := 'https://ldrfrvwhxsmgaabwmaik.supabase.co/functions/v1/analyze-application-video';
+  v_key text;
+  v_dispatch_id bigint;
+  v_existing_pending int;
+BEGIN
+  SELECT id, cycle_id,
+         consent_ai_analysis_at, consent_ai_analysis_revoked_at,
+         consent_voice_biometric_at, consent_voice_biometric_revoked_at
+    INTO v_app FROM public.selection_applications WHERE id = p_application_id;
+  IF v_app.id IS NULL THEN
+    RETURN jsonb_build_object('error', 'application_not_found');
+  END IF;
+
+  -- LGPD generic AI consent gate (predates this migration; preserved)
+  IF v_app.consent_ai_analysis_at IS NULL OR v_app.consent_ai_analysis_revoked_at IS NOT NULL THEN
+    RETURN jsonb_build_object('skipped', true, 'reason', 'consent_pending_or_revoked');
+  END IF;
+
+  -- p207 #221: LGPD Art. 11 §I biometric voice consent gate (NEW)
+  -- Trigger trg_video_ai_analysis_on_upload was DROPPED at Phase 1 of this
+  -- remediation. This gate ALSO refuses manual MCP tool calls until candidate
+  -- has explicit Art. 11 consent + non-revoked status. Returns graceful skip
+  -- envelope so MCP/UI callers see structured response, not exception.
+  IF v_app.consent_voice_biometric_at IS NULL OR v_app.consent_voice_biometric_revoked_at IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'skipped', true,
+      'reason', 'voice_biometric_consent_required',
+      'detail', 'LGPD Art. 11 §I — voice biometric is sensitive data requiring explicit consent destacado per Art. 8. Pipeline blocked until consent_voice_biometric_at is captured per Termo de Speaker.',
+      'issue', 221
+    );
+  END IF;
+
+  -- Idempotency: skip if pending suggestion already exists (unless force)
+  IF NOT p_force THEN
+    SELECT COUNT(*) INTO v_existing_pending FROM public.selection_evaluation_ai_suggestions
+    WHERE application_id = p_application_id
+      AND evaluation_type = 'video'
+      AND used_in_evaluation_id IS NULL
+      AND superseded_by IS NULL
+      AND (p_pillar IS NULL OR suggested_scores ? p_pillar);
+    IF v_existing_pending > 0 THEN
+      RETURN jsonb_build_object('skipped', true, 'reason', 'pending_suggestion_exists',
+        'existing_count', v_existing_pending,
+        'hint', 'pass force=true to regenerate');
+    END IF;
+  END IF;
+
+  -- Read service_role_key from vault
+  SELECT decrypted_secret INTO v_key
+  FROM vault.decrypted_secrets WHERE name = 'service_role_key' LIMIT 1;
+  IF v_key IS NULL THEN
+    RAISE EXCEPTION 'service_role_key not in vault (analyze_application_video_async)';
+  END IF;
+
+  -- Async dispatch via pg_net (EF returns 200 quickly; analysis is async inside)
+  SELECT net.http_post(
+    url := v_url,
+    body := jsonb_build_object(
+      'application_id', p_application_id,
+      'pillar', p_pillar,
+      'force', p_force,
+      'triggered_by', 'rpc'
+    ),
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'Authorization', 'Bearer ' || v_key
+    )
+  ) INTO v_dispatch_id;
+
+  RETURN jsonb_build_object(
+    'dispatched', true,
+    'application_id', p_application_id,
+    'pillar', COALESCE(p_pillar, 'all'),
+    'force', p_force,
+    'dispatch_id', v_dispatch_id
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.analyze_application_video_async(uuid, text, boolean) IS
+  'p207 #221 (2026-05-20): internal dispatch RPC for video AI analysis. Called by MCP tool analyze_application_video (trigger trg_video_ai_analysis_on_upload DROPPED at Phase 1 of this remediation). Idempotent (skips if pending suggestion exists unless force=true). Two LGPD gates: (1) consent_ai_analysis_at (predates p207); (2) consent_voice_biometric_at (NEW — Art. 11 §I). Async via pg_net.';
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/edge-functions/ef-contracts.test.mjs
+++ b/tests/edge-functions/ef-contracts.test.mjs
@@ -99,6 +99,11 @@ const EF_CONTRACTS = [
     imports: [],
     deprecated: true,
   },
+  {
+    name: 'analyze-application-video',
+    tables: ['selection_applications', 'pmi_video_screenings', 'ai_processing_log', 'selection_evaluation_ai_suggestions'],
+    imports: [],
+  },
 ];
 
 for (const ef of EF_CONTRACTS) {


### PR DESCRIPTION
## What this is

WIP rescued from the `ai-pm-issue-221` worktree during the 2026-06-10 worktree cleanup (tip commit `4cbe322b`, authored 2026-06-09). Opened as **draft** for PM decision.

## Content (small, coherent: +9/−1 across 2 files)

1. **`supabase/functions/analyze-application-video/index.ts`** — adds the `consent_voice_biometric_at` / `consent_voice_biometric_revoked_at` re-check in `processVideosBackground` (graceful skip, mirrors the existing `consent_ai_analysis_at` re-check). This is the **EF-level defense-in-depth** that the merged #222 migration (`analyze_application_video_async` gate, LGPD Art. 11 §I/§II) describes — main currently re-verifies only `consent_ai_analysis_at` at dispatch-time, so a consent state change between RPC gate and background processing is not caught for voice biometrics.
2. **`tests/edge-functions/ef-contracts.test.mjs`** — adds the missing `analyze-application-video` EF contract entry (4 tables declared).

## Validation (local, 2026-06-10)

- Merges clean vs current main (`git merge-tree --write-tree`: 0 conflicts)
- EF contract suite on the **merged tree**: **112/112 pass**

## Governance note (PM should weigh)

`docs/audit/2026-05-23_p237_orphan_branches_equivalence.md` ratified "delete agent/issue-221, do not cherry-pick" — but that decision analyzed the branch **as of 2026-05-23** (only `a48ebc90`, patch-equivalent to the #222 squash). This WIP commit post-dates the decision and contains content **not** in main (verified by adversarial triage agents: main's EF has no voice-biometric re-check; EF contract list has no analyze-application-video entry). If the PM judges the EF-level re-check redundant with the RPC gate, close this PR unmerged and delete the branch — the triage record preserves the content description.

Refs #221 (closed — this completes its defense-in-depth tail; does not reopen scope)
