### PR TITLE
chore(611): Dependabot supersede-as-policy (Option A) — alerts-only + protocol doc

### DIFF
--- a/.claude/rules/bypass-protocol.md
+++ b/.claude/rules/bypass-protocol.md
@@ -69,9 +69,38 @@ gh pr list --state merged --search "merged:>$(date -d '7 days ago' +%Y-%m-%d)" -
 done
 ```
 
+## Dependabot PRs (política #611 — Option A, ratificada PM 2026-06-10)
+
+**Fato estrutural:** GitHub **não injeta repo secrets** em workflow runs disparados pelo
+Dependabot. O sentinel do `validate` (`SUPABASE_URL` + `SERVICE_ROLE_KEY` obrigatórios)
+falha portanto em **todo** PR do Dependabot, para sempre — não é flake, não é regressão,
+não debugar (descoberta 2026-06-10, PRs #598/#255; ver #611).
+
+**Política (Option A — supersede-as-policy):**
+
+1. **NUNCA mergear um PR do Dependabot** (nem com `--admin` — um Dependabot vermelho
+   não satisfaz nenhum critério de bypass legítimo acima: o red É causado pela natureza
+   do run, e mergear pularia TODOS os contract tests DB-aware).
+2. Cada onda de **security alerts** é resolvida por **PR local de higiene** (autoria
+   humana/assistida) onde o CI roda completo com secrets — padrão do PR #609.
+3. PRs do Dependabot existentes são **fechados como superseded** com referência a #611
+   (feito 2026-06-10 para #149–#153).
+4. `dependabot.yml` opera com `open-pull-requests-limit: 0` (alerts-only): o feed de
+   alertas continua dirigindo o trabalho, sem acumular PRs vermelhos imergeáveis.
+
+**Por que não carve-out no sentinel (Option B, rejeitada):** um skip condicionado a
+`github.actor == 'dependabot[bot]'` criaria um segundo significado de "CI verde" — o
+audit semanal de bypass raciocina sobre conclusões do `validate`, e um verde-sem-DB-gates
+contaminaria essa superfície, além de exigir guarda contra actor spoofing. Option C
+(`pull_request_target` com secrets) é o foot-gun canônico de Actions — auto-rejeitada.
+
+**Reconsiderar** apenas se a cadência de alertas crescer a ponto de o supersede local
+virar imposto semanal (histórico: ~1 onda/mês).
+
 ## Cross-ref
 
 - WATCH-207.D (P162 log #95): origin of bypass erosion concern
 - WATCH-209.C (P162 log #99): direct push counting addition
 - p209 close handoff: 16 bypass events documented + Option C decision
+- #611: Dependabot supersede-as-policy (seção acima, 2026-06-10)
 - CLAUDE.md: references this file in operational rules

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,15 @@
 # Dependabot — atualização de dependências
 # Ver: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# POLÍTICA #611 (Option A — supersede-as-policy, PM 2026-06-10):
+# GitHub NÃO injeta repo secrets em runs disparados pelo Dependabot, então o
+# sentinel do CI (`SUPABASE_URL` + `SERVICE_ROLE_KEY` obrigatórios no validate)
+# falha em TODO PR do Dependabot, para sempre. Em vez de carve-out no sentinel
+# (criaria um segundo significado de "CI verde" — ver .claude/rules/bypass-protocol.md
+# §Dependabot), version updates ficam DESLIGADOS (open-pull-requests-limit: 0):
+# o feed de SECURITY ALERTS continua ativo e cada onda de alertas é resolvida
+# por PR local de higiene (ex.: #609), onde o CI roda completo com secrets.
+# Nunca mergear/--admin um PR do Dependabot — supersede local é o caminho canônico.
 
 version: 2
 updates:
@@ -8,7 +18,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
## Decisão #611 — Option A (supersede-as-policy), ratificada PM 2026-06-10

**Fato estrutural:** GitHub não injeta repo secrets em runs disparados pelo Dependabot → o sentinel do `validate` falha em **todo** PR dele, para sempre (#598/#255 → superseded por #609 local).

**Mudanças:**
- `dependabot.yml`: `open-pull-requests-limit: 5 → 0` (alerts-only) — o feed de security alerts continua dirigindo PRs locais de higiene (padrão #609); para de acumular PRs vermelhos imergeáveis.
- `bypass-protocol.md`: nova seção **Dependabot PRs** — nunca mergear/`--admin` PR do Dependabot; supersede local é canônico; racional do descarte da Option B (carve-out no sentinel = segundo significado de "CI verde", contamina o audit semanal de bypass) e Option C (`pull_request_target` = foot-gun).

**Já executado:** zumbis #149–#153 fechados como superseded com referência a #611.

Closes #611
