### PR TITLE
fix(618): backup workflow — PG17 client via PGDG + pipefail on the dump pipe

### DIFF
--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -14,13 +14,23 @@ jobs:
     steps:
       - name: Install PostgreSQL client
         run: |
+          # #618: the server is Postgres 17 (Supabase platform upgrade) and pg_dump's major
+          # version must be >= the server's — pg_dump 16 aborts with "server version mismatch".
+          # Ubuntu 24.04 runners top out at postgresql-client-16 in the default apt, so add
+          # the official PGDG repo for client 17.
+          sudo install -d /usr/share/postgresql-common/pgdg
+          sudo curl -sS -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc
+          sudo sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
           sudo apt-get update -qq
-          sudo apt-get install -y -qq postgresql-client-16
+          sudo apt-get install -y -qq postgresql-client-17
 
       - name: Create backup
         env:
           DATABASE_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
+          # #618: without pipefail a pg_dump failure is masked by gzip's exit 0 — only the
+          # downstream size check caught it, with a misleading "too small" message. Fail loud.
+          set -o pipefail
           TIMESTAMP=$(date +%Y%m%d_%H%M%S)
           FILENAME="backup_${TIMESTAMP}.sql.gz"
 


### PR DESCRIPTION
## Duas pernas do #618 (descobertas na verificação da rotação de senha)

A credencial rotacionada + URI session-pooler **conectam** — a falha seguinte na fila era o dump em si:

1. **`pg_dump: server version mismatch`** — servidor é **Postgres 17** (upgrade da plataforma Supabase); o apt do Ubuntu 24.04 só tem client 16 → instalar o 17 via repo oficial PGDG.
2. **`set -o pipefail`** no passo do dump — a falha do pg_dump era mascarada pelo exit 0 do gzip; só o size-check de 1KB pegava, com mensagem enganosa.

## Feito fora do repo (esta sessão)

- **Senha do banco ROTACIONADA** via Management API (a antiga vazou fragmento em log de CI — #618)
- Secret `SUPABASE_DB_URL` re-salvo: senha **só-alfanumérica** (classe do bug de percent-encoding morta na raiz) + host **session pooler** (runners GH não têm IPv6 p/ o `db.*` direto)
- Validação: psql via pooler conecta com a nova senha · plataforma 200 (caminho de API keys, inalterado) · CLI `migration list` OK

Smoke pós-merge: `workflow_dispatch` → backup verde + artefato com tamanho real.

Refs #618