### PR TITLE
fix(618): call the versioned pg_dump binary (pg_wrapper resolves to the runner's local PG16)

### DIFF
--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -35,7 +35,11 @@ jobs:
           FILENAME="backup_${TIMESTAMP}.sql.gz"
 
           echo "Starting backup at $(date -u)"
-          pg_dump "$DATABASE_URL" \
+          # #618 (2nd leg): /usr/bin/pg_dump is Ubuntu's pg_wrapper, which resolves to the
+          # LOCAL cluster's version — the runner image ships a PostgreSQL 16 service, so the
+          # wrapper kept picking pg_dump 16 even with client-17 installed. Call the versioned
+          # binary explicitly.
+          /usr/lib/postgresql/17/bin/pg_dump "$DATABASE_URL" \
             --format=plain \
             --no-owner \
             --no-privileges \


### PR DESCRIPTION
Run `27303184764` provou: client-17 (17.10) instala, mas `/usr/bin/pg_dump` é o **pg_wrapper** do Ubuntu e resolve para a versão do **cluster local** — a imagem ubuntu-24.04 traz um serviço PostgreSQL 16. Binário versionado explícito `/usr/lib/postgresql/17/bin/pg_dump` é determinístico. (O `pipefail` do commit anterior é o que fez essa falha aparecer alto no passo certo.)

Smoke pós-merge: `workflow_dispatch` → esperado backup verde + artefato com tamanho real.

Refs #618