### PR TITLE
docs(625): SPEC — affiliation verification loop via sede + chapter visibility + renewal radar

### DIFF
--- a/docs/specs/SPEC_625_AFFILIATION_VERIFICATION_LOOP.md
+++ b/docs/specs/SPEC_625_AFFILIATION_VERIFICATION_LOOP.md
@@ -1,0 +1,194 @@
+# SPEC #625 — Loop de Verificação de Filiação + Visibilidade por Capítulo + Radar de Renovação
+
+**Status:** Draft v2 (pós-council `wf_c040df9e`: product-leader + legal-counsel, 2/2 GO_W_FIXES — folds incorporados)
+**Origem:** Auditoria da jornada de pré-onboarding ciclo 4 (2026-06-10) + decisões PM 2026-06-10/11.
+**Refs:** #625 (camadas 1-2), ADR-0004 (`organization_id`), ADR-0007 (`can()`), ADR-0012 (cache columns),
+ADR-0042 (chapter dashboards), ADR-0076 (PMI data/LIA/opt-out), GC-162 (RLS/LGPD), #573 (EEE/UK), #571 (re-aceite).
+
+---
+
+## 1. Contexto e problema (grounded 2026-06-10)
+
+| Achado (vivo) | Evidência |
+|---|---|
+| `members.pmi_id_verified = false` nos 25 do ciclo 4 | Campo existe; nenhum processo o marca |
+| Filiação real (VEP `pmi_memberships`, multi-capítulo) diverge do perfil (`members.chapter`, single) | ≥5 casos (GO×RS, MG×PE/SE/UK, GO×MG/DF…) |
+| Filiação PMI **expira** e nada monitora | Caso real: membro com filiação vencida declarada |
+| `selection_applications.membership_status` órfã (vazia nos 25) | Coluna sem pipeline |
+| Relatórios para diretorias = export manual sem loop de retorno | Relatório 2026-06-10 (`pii_access_log` ✓) |
+
+## 2. Decisões ratificadas (PM 2026-06-10/11 + council folds)
+
+1. **Verificação operacionalizada via Capítulo SEDE (PMI-GO)** — Diretoria de Filiação
+   (Welma Alves). A sede verifica TODOS os membros do Núcleo, de qualquer capítulo.
+2. **Capítulos parceiros = visibilidade, não operação** — e no **v1 SÓ AGREGADOS**
+   (counts por status). Lista nominal = F2.1, gated em pré-requisitos jurídicos (§6.3).
+3. **Radar de renovação da filiação é obrigatório** (F3).
+4. **Re-sync VEP antes de qualquer relatório/reunião** com diretorias.
+5. **Termo v2.7 não exige dados novos do assinante** (0 ocorrências de CPF no draft;
+   identificação via `{chapterName}` + nome/e-mail + evidência hash/IP/UA). Atenção ao regime
+   EEE/UK (cláusulas 13/14 → #573) se algum assinante residir fora do Brasil.
+6. **Versionamento**: documentos aprovados entram como **v0 real** (numeração de draft não migra).
+7. **Autoridade (decidido AGORA, não na implementação)**: Welma = engagement
+   `chapter_board/liaison` no PMI-GO (kind sem termo de voluntário; ADR-0042 já dá
+   `view_chapter_dashboards`) **+ designation `diretoria_filiacao`**. O RPC de verificação
+   gateia na **designation** (Path 2 do `V4_AUTHORITY_MODEL.md`) com escopo inline (Path 3)
+   — **NÃO criar seed novo em `engagement_kind_permissions`** (anti-pattern documentado).
+   PM/superadmin via `manage_member` como sempre.
+8. **Gate do termo no v1 = FAROL, não bloqueio** — bloquear sobre um campo que nunca foi
+   escrito travaria a coorte inteira antes do loop operar. A assinatura grava
+   `affiliation_unverified=true` nos metadados do audit (permite ao v2 distinguir termos
+   pré-loop × pós-loop ao avaliar a política de bloqueio).
+9. **Cache `members.pmi_id_verified` = atualizado pelo RPC no v1** (não trigger):
+   `pmi_id_verified := p_active AND (p_expires_on IS NULL OR p_expires_on > CURRENT_DATE)`
+   como efeito do INSERT. Trigger só se surgirem outros caminhos de escrita (aí ADR-0012).
+
+## 3. Atores e contatos institucionais (sede PMI-GO)
+
+| Papel no loop | Diretoria / contato |
+|---|---|
+| **Verificador operacional** (escreve na plataforma) | Diretoria de Filiação — `filiacao@pmigo.org.br` · Welma Alves `welma@pmigo.org.br` |
+| Consumidor primário do status | Diretoria de Voluntariado — `diretoriavoluntariado@pmigo.org.br` |
+| Patrocínio/escalação | Presidência (Ivan Lourenço `ivan.lourenco@pmigo.org.br`) · `vice-presidencia@pmigo.org.br` |
+| Interlocução com capítulos parceiros | Relações Institucionais — `relacoesinstitucionais@pmigo.org.br` |
+| Demais (informativo) | Certificação `certificacao@pmigo.org.br` · Desenv. Profissional `desenvolvimento.profissional@pmigo.org.br` · Eventos `diretoria.eventos@pmigo.org.br` · Adm/Finanças `diretoria.financas@pmigo.org.br` |
+| **Capítulos parceiros** (visibilidade agregada v1) | Diretorias de filiação + voluntariado de cada capítulo conveniado (Acordos de Cooperação vigentes) |
+
+## 4. Modelo de dados
+
+### 4.1 Nova tabela `member_affiliation_verifications` (histórico append-only)
+
+```sql
+id uuid PK · organization_id (ADR-0004, FK RESTRICT) · member_id FK members
+verified_by_member_id FK members           -- quem da sede verificou
+chapter_verified text                      -- capítulo confirmado na verificação
+membership_active boolean                  -- filiação ativa no momento da verificação
+membership_expires_on date NULL            -- ⚓ âncora do radar de renovação (F3)
+method text CHECK (method IN ('vep_sync','sede_manual','self_attested'))
+source_ref text NULL                       -- APENAS identificador técnico (lote/relatório); nunca texto livre sobre pessoas
+verification_obs text NULL CHECK (char_length(verification_obs) <= 500)
+                                           -- observação EXCLUSIVAMENTE sobre o resultado da
+                                           -- verificação; UI exibe aviso "não incluir dados
+                                           -- pessoais além do necessário" (council legal MEDIUM)
+created_at timestamptz DEFAULT now()
+```
+- **Append-only** (re-verificação = nova linha; o histórico é a trilha).
+- RLS deny-all + acesso exclusivamente via SECURITY DEFINER RPCs (GC-162).
+- `COMMENT ON TABLE`: retenção (5y de inatividade do membro), campos anonimizados vs retidos,
+  referência à entrada do RoPA.
+- **Anonimização (critério de aceitação F1, não "confirmar depois")**: a migration estende o
+  escopo do cron LGPD — `member_id`/`verified_by_member_id` → UUID neutro, `verification_obs`
+  → NULL, `source_ref` → hash; `chapter_verified` + `membership_expires_on` mantidos
+  (estatística não-nominal). Cuidado ADR-0076 Risco 2: o cron usa UPDATE, não cascata de FK.
+- **Direito de acesso (Art. 18 II)**: `export_my_data()` passa a incluir as linhas de
+  verificação do titular (incl. `verification_obs` — dado de terceiro sobre o titular).
+
+### 4.2 Autoridade — DECIDIDA (ver §2.7)
+
+Designation `diretoria_filiacao` + escopo inline no RPC. Sem seed novo em
+`engagement_kind_permissions`. Provisionamento da Welma = critério de aceitação F1 (§8).
+
+## 5. Superfícies (fases)
+
+### F1 — Loop de verificação (prioridade)
+- **RPC `verify_member_affiliation(p_member_id, p_chapter, p_active, p_expires_on, p_method, p_obs)`**
+  — gate por designation (§2.7); INSERT na tabela; atualiza cache (§2.9); `admin_audit_log`
+  (`affiliation.verified`); `pii_access_log` quando a chamada envolver leitura nominal prévia.
+- **RPC batch `verify_member_affiliations_bulk(p_member_ids uuid[], ...)`** (council HIGH):
+  a fila exibe `vep_status_raw` + `vep_last_seen_at` inline (já presentes no
+  `admin_list_members`) e permite seleção múltipla + "marcar como verificado via VEP"
+  (`method='vep_sync'`) num clique — sem isso, "25 em ≤1h" é irreal (seria navegação +
+  conferência manual × 25).
+- **Fila de verificação** em `/admin/members` (aproveita o filtro `pre_onboarding` de #626).
+- **Farol no gate do termo** (§2.8) — sem bloqueio no v1.
+
+### F2 — Painel de visibilidade por capítulo (AGREGADOS no v1)
+- RPC `get_chapter_member_dimension(p_chapter)` → **somente counts** por status de exibição
+  (ativos operando, pré-onboarding, onboarding, alumni, desligados). Sem PII no v1.
+- Acesso: `chapter_board` do capítulo vê **só o próprio capítulo**; sede vê consolidado.
+- **Limitação documentada (council HIGH)**: o filtro usa `members.chapter` (single) — membros
+  multi-capítulo (≥5 hoje) aparecem APENAS no capítulo declarado no perfil. A investigação
+  do modelo multi-capítulo é **pré-requisito da camada 2 do #625**; se a camada 2 mudar o
+  modelo (junction), F2 é re-avaliado. Não construir silenciosamente sobre o single-value.
+- **F2.1 (lista nominal p/ parceiros) — gated em 3 pré-requisitos**: (a) cláusula de
+  compartilhamento nos Acordos de Cooperação (texto-modelo no §6.3), (b) RoPA atualizado,
+  (c) `pii_access_log` em toda chamada nominal.
+
+### F3 — Radar de renovação de filiação
+- **Cron NOVO `v4_notify_expiring_affiliations`** (council MEDIUM: NÃO estender
+  `v4_notify_expiring_engagements` — opera em tabela diferente; apenas SEGUE o padrão dele):
+  lê `membership_expires_on`, D-30/D-7, **`p_dry_run=true` até sign-off do PM** (lição Gap-1).
+- Template da notificação (ADR-0076 §9): remetente identificado, referência ao requisito de
+  filiação do termo, **link de opt-out dos lembretes** (não do voluntariado).
+- Farol no card do membro (verde vigente · amarelo ≤30d · vermelho vencida/não-verificada).
+
+## 6. LGPD / governança do compartilhamento
+
+### 6.1 Bases legais (duais, registradas no RoPA — council legal LOW)
+- **Pré-onboarding**: Art. 7º, II (procedimento preparatório a contrato) + Art. 7º, IX
+  (legítimo interesse em verificar elegibilidade) — **com LIA documentada** (ADR-0076 Princ. 2).
+- **Membro ativo / renovação (F3)**: Art. 7º, V (execução do termo de voluntariado vigente,
+  que exige filiação PMI ativa) + Art. 7º, IX (radar) — a notificação D-30/D-7 referencia a
+  cláusula do termo.
+- **Transparência (Art. 9º, I)**: o termo v2.7+ (ou notificação de onboarding) menciona que
+  "dados de participação podem ser compartilhados com o capítulo PMI de filiação do membro
+  para fins de gestão de voluntariado".
+
+### 6.2 Instrumento de operadora (PRÉ-REQUISITO de F1 — council legal HIGH)
+A Welma/Diretoria de Filiação PMI-GO tratará dados pessoais de membros do Núcleo em nome do
+Núcleo → relação de **operadora** (Art. 5º, VII; mesma lógica do RF-E/parecer 2026-04-19).
+**Antes do acesso de escrita**: DPA ou cláusula nos Acordos de Cooperação PMI-GO×Núcleo com:
+(1) finalidade restrita ao loop de verificação; (2) vedação de uso próprio pela diretoria;
+(3) notificação de incidente ao Núcleo ≤24h (Art. 48); (4) identificação nominal dos agentes
+autorizados (Welma) + confidencialidade + revogação de acesso ao deixar o cargo;
+(5) submissão às políticas de segurança da plataforma. *Avaliar com o advogado licenciado se
+o enquadramento correto é operadora ou controladores conjuntos (Art. 42, §1º).*
+
+### 6.3 Compartilhamento com capítulos parceiros
+v1 = agregados (sem base contratual nova necessária). Para F2.1 (nominal), cláusula-modelo a
+inserir nos Acordos de Cooperação:
+> "O Núcleo IA poderá compartilhar com a Diretoria de Filiação e de Voluntariado do CAPÍTULO a
+> relação nominal de membros filiados ao CAPÍTULO que estejam participando do Núcleo IA,
+> incluindo status de participação e situação de filiação PMI, para fins exclusivos de
+> coordenação de voluntariado e renovação de filiação, vedado uso para fins próprios do CAPÍTULO."
+
+### 6.4 Minimização e trilha
+Relatórios por capítulo contêm SÓ os membros daquele capítulo; consolidado só para a sede.
+Campos mínimos por finalidade. Todo export/leitura nominal → `pii_access_log` (Art. 37) —
+já praticado (relatório 2026-06-10, 25 leituras logadas). Telefone: coletar no onboarding com
+finalidade declarada; armazenar em `phone_encrypted`.
+
+## 7. Fora de escopo (v1)
+
+- Write-back automático para o VEP/PMI (verificação é interna; VEP segue fonte de leitura).
+- Multi-organização.
+- Lista nominal para parceiros (= F2.1, gated §6.3).
+- `selection_applications.membership_status`: permanece órfã no v1 (não escrever nela);
+  depreciação ou backfill em follow-up próprio (**filar issue de tracking** — council NIT).
+- Modelo multi-capítulo no perfil (pré-requisito de investigação da camada 2 do #625).
+
+## 8. Critérios de aceitação
+
+- **F1**:
+  - [ ] Welma provisionada (`chapter_board/liaison` PMI-GO + designation `diretoria_filiacao`)
+        e smoke: auth dela chama `verify_member_affiliation` com sucesso (council LOW — sem
+        isso F1 passa no teste e nasce morto em produção)
+  - [ ] **Instrumento de operadora assinado ANTES do acesso de escrita** (§6.2)
+  - [ ] Fila com VEP inline + ação bulk: 25 membros verificáveis em ≤1h REAL
+  - [ ] `pmi_id_verified` reflete via RPC (§2.9); trilha completa (quem/quando/método)
+  - [ ] Migration estende o cron LGPD para a nova tabela (§4.1 — critério, não "confirmar depois")
+  - [ ] `export_my_data()` inclui as verificações do titular
+  - [ ] Assinatura do termo grava o estado do farol nos metadados (§2.8)
+- **F2**: parceiro vê SÓ agregados do próprio capítulo; sede vê consolidado; limitação
+  single-chapter documentada na superfície.
+- **F3**: farol ≥30 dias antes; zero notificação em dry-run até sign-off; template com
+  remetente/base/opt-out (ADR-0076 §9).
+
+## 9. Perguntas abertas (PM) — reduzidas pós-council
+
+1. ~~Farol ou bloqueio~~ → **FAROL no v1** (decidido, §2.8).
+2. ~~Kind da Welma~~ → **`chapter_board/liaison` + designation** (decidido, §2.7) — resta
+   apenas o instrumento de operadora (§6.2) com o jurídico.
+3. ~~Nominal ou agregados no F2~~ → **agregados no v1** (decidido; nominal = F2.1 gated).
+4. Periodicidade da re-verificação em massa: anual no aniversário do ciclo, ou contínua via
+   radar F3? (única pergunta remanescente — pode ser decidida no kickoff de F1).


### PR DESCRIPTION
## SPEC pedido pelo PM ('para não sairmos desenvolvendo sem boas práticas')

Decisões PM 2026-06-10/11 viram contrato de build: **verificação via capítulo SEDE** (Diretoria de Filiação PMI-GO/Welma) · parceiros = **visibilidade agregada v1** · radar de renovação obrigatório · re-sync VEP pré-relatório · termo v2.7 sem dados novos (CPF=0 verificado no draft jurídico).

## 🏛 Council no draft (`wf_c040df9e`, product-leader + legal-counsel): 2/2 GO_W_FIXES — tudo foldado

**Product:** autoridade DECIDIDA no spec (designation `diretoria_filiacao` + Path 2/3, sem seed novo — guarda contra o anti-pattern) · cache DECIDIDO (RPC-side v1) · superfície batch specada (bulk + VEP inline; "25 em ≤1h" virou real) · limitação single-chapter do F2 documentada como pré-requisito da camada 2 · F3 = cron NOVO (não estender o de engagements) · farol grava metadado na assinatura (otimiza análise do bloqueio v2).

**Legal:** bases duais c/ LIA no RoPA · **instrumento de operadora (DPA) = PRÉ-REQUISITO de F1** antes do acesso de escrita da Welma · `verification_obs` c/ envelope de finalidade (CHECK 500) · nova tabela no cron de anonimização como CRITÉRIO (não "confirmar depois") · verificações do titular no `export_my_data` (Art. 18 II) · cláusula-modelo p/ Acordos de Cooperação (F2.1 nominal).

3 das 4 perguntas abertas fechadas em spec-stage; resta só a periodicidade de re-verificação (decidível no kickoff F1).

Refs #625