### PR TITLE
fix(625): pré-onboarding fora do ranking público de trilha + baselines tribe-6 pós-offboarding

### DIFF
--- a/supabase/migrations/20260805000145_trail_ranking_exclude_pre_onboarding.sql
+++ b/supabase/migrations/20260805000145_trail_ranking_exclude_pre_onboarding.sql
@@ -1,0 +1,62 @@
+-- #625 C1 (instância trilha) — surfaced pelo M6 pós-offboarding 2026-06-11:
+-- get_public_trail_ranking exibia NOMINALMENTE membro da coorte pré-onboarding
+-- ciclo-4 (ativo, sem termo satisfeito, sem login) no ranking público de trilha.
+-- Decisão PM #629: público = só operando-no-ciclo. Mesmo fix-pattern da mig 143
+-- (get_public_platform_stats / get_homepage_stats): excluir via helper canônico
+-- member_is_pre_onboarding (regra única, mig 143).
+-- Efeito também converge as coortes de calc_trail_completion_pct (headline) e
+-- deste ranking — o contrato M6 (home == ranking ± rounding) volta a ser estrutural.
+-- Rollback: re-aplicar o corpo anterior sem a linha do helper (mig de origem do body:
+-- ver capture anterior de get_public_trail_ranking).
+
+CREATE OR REPLACE FUNCTION public.get_public_trail_ranking()
+ RETURNS TABLE(member_name text, photo_url text, completed integer, in_progress integer, pct integer)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH trail_courses AS (
+    SELECT id FROM courses WHERE is_trail = true
+  ),
+  trail_total AS (
+    SELECT count(*)::int AS cnt FROM trail_courses
+  ),
+  eligible_members AS (
+    SELECT DISTINCT m.id, m.name, m.photo_url
+    FROM members m
+    WHERE m.is_active AND m.current_cycle_active
+      AND m.gamification_opt_out = false
+      AND NOT public.member_is_pre_onboarding(m.person_id, m.member_status)
+      AND (
+        m.tribe_id IS NOT NULL
+        OR EXISTS(
+          SELECT 1 FROM engagements e
+          WHERE e.person_id = m.person_id AND e.status = 'active'
+            AND e.role IN ('leader', 'coordinator', 'manager', 'participant')
+        )
+      )
+  ),
+  progress AS (
+    SELECT cp.member_id, cp.status
+    FROM course_progress cp
+    JOIN trail_courses tc ON tc.id = cp.course_id
+  ),
+  member_stats AS (
+    SELECT
+      p.member_id,
+      COUNT(*) FILTER (WHERE p.status = 'completed') AS completed,
+      COUNT(*) FILTER (WHERE p.status = 'in_progress') AS in_progress
+    FROM progress p
+    GROUP BY p.member_id
+  )
+  SELECT
+    em.name,
+    em.photo_url,
+    COALESCE(ms.completed, 0)::int,
+    COALESCE(ms.in_progress, 0)::int,
+    CASE WHEN tt.cnt > 0 THEN ROUND(COALESCE(ms.completed, 0)::numeric / tt.cnt * 100)::int ELSE 0 END
+  FROM eligible_members em
+  CROSS JOIN trail_total tt
+  LEFT JOIN member_stats ms ON ms.member_id = em.id
+  ORDER BY COALESCE(ms.completed, 0) DESC, COALESCE(ms.in_progress, 0) DESC, em.name;
+$function$;

--- a/tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs
+++ b/tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs
@@ -161,7 +161,8 @@ test('M4-gam DB: native forks KILLED — Mesa=4, LATAM=3, Grupo=3 (== get_initia
 
 test('M4-gam DB: only tribe-8 changed — other tribes stable (drift-tolerant baselines)', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
-  const expect = { 1: 4, 2: 5, 6: 6 };
+  // tribe-6 6→5: offboarding legítimo de membro em 2026-06-11 (alumni, ROI & Portfólio)
+  const expect = { 1: 4, 2: 5, 6: 5 };
   for (const [tid, n] of Object.entries(expect)) {
     const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: Number(tid) });
     const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });

--- a/tests/contracts/p277-419-m4a-roster-primitive.test.mjs
+++ b/tests/contracts/p277-419-m4a-roster-primitive.test.mjs
@@ -83,5 +83,6 @@ test('M4-A behavioural: helper count == COUNT(DISTINCT person) over the view, pe
   const { data: rows } = await sb.from('v_initiative_roster').select('person_id').eq('initiative_id', initId);
   const distinct = new Set(rows.map((r) => r.person_id)).size;
   assert.equal(Number(count), distinct, 'helper == distinct person over the view');
-  assert.equal(Number(count), 6, 'tribe-6 canonical roster = 6');
+  // 6→5 em 2026-06-11: offboarding legítimo (alumni, ROI & Portfólio)
+  assert.equal(Number(count), 5, 'tribe-6 canonical roster = 5');
 });

--- a/tests/contracts/p277-419-m4c-exec-tribe-dashboard-roster.test.mjs
+++ b/tests/contracts/p277-419-m4c-exec-tribe-dashboard-roster.test.mjs
@@ -118,7 +118,8 @@ test('M4-C DB: tribe-8 canonical roster == 5 (participants-only, mig 088); the v
 test('M4-C DB: only tribe 8 changed — other tribes stable (drift-tolerant)', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
   // canonical roster per tribe is what members.total now reads; assert the stable baselines hold
-  const expect = { 1: 4, 6: 6 };
+  // tribe-6 6→5: offboarding legítimo de membro em 2026-06-11 (alumni, ROI & Portfólio)
+  const expect = { 1: 4, 6: 5 };
   for (const [tid, n] of Object.entries(expect)) {
     const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: Number(tid) });
     const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });


### PR DESCRIPTION
## Contexto

O `validate` do PR #636 ficou vermelho em **4 testes DB-aware** após uma mudança **legítima de dados**: offboarding (alumni) de membro da tribo 6 (ROI & Portfólio) em 2026-06-11, solicitado pelo próprio membro e formalizado via `offboard_member` canônico (preview→confirm, ADR-0018). Este PR é o fix-forward — **nenhum bypass**.

## O que muda

### 1. Baselines tribe-6: 6 → 5 (3 testes)
`p277-419-m4a-roster-primitive`, `p277-419-m4-gamification-cohort-roster`, `p277-419-m4c-exec-tribe-dashboard-roster` pinavam `tribe-6 roster == 6`. A paridade real (helper == COUNT DISTINCT da view) continuou passando — só o pin estava stale.

### 2. M6 expôs bug REAL (classe #625-C1) → mig `20260805000145`
O contrato M6 (`home trail ±1 ranking avg`) só passava por coincidência de arredondamento. Grounding vivo: `get_public_trail_ranking` incluía **nominalmente** (nome + foto) um membro da coorte **pré-onboarding ciclo-4** (ativo sem termo satisfeito, sem login) no ranking **público** de trilha — contra a decisão PM #629 (público = só operando-no-ciclo). O fix #629 cobriu homepage/stats; as superfícies de trilha ficaram de fora.

Fix: exclusão via helper canônico `member_is_pre_onboarding` (mig 143) no `eligible_members` — as coortes headline×ranking **convergem estruturalmente** (antes: 34×35 com 1 extra; depois: 34×34).

**Antes→depois (queries vivas):** ranking 35→34 rows · avg 52.37→53.91 · home 54 · |home − round(avg)| = 1.63 → **0**.

### Ritual GC-097 / Q-C
- `pg_get_function_arguments` FULL verificado antes do CREATE OR REPLACE (42P13 guard)
- `apply_migration` + arquivo local + `migration repair --status applied 20260805000145` + shadow `20260611043502` deletada por versão exata + `NOTIFY pgrst`
- Testes afetados **35/35** + `rpc-migration-coverage` (orphan + body-hash) **22/22** DB-aware contra prod

## Cross-refs
- #625 C1 (comentário com a instância trilha a seguir) · #629 (decisão público=operando + fix-pattern) · #636 (PR bloqueado por este red — re-run após merge)