### PR TITLE
chore(context-hygiene): fix dangling refs to archived V4 rule/agent + add routing discipline

### DIFF
--- a/.claude/agents/platform-guardian.md
+++ b/.claude/agents/platform-guardian.md
@@ -9,7 +9,7 @@ model: sonnet
 
 Você é o guardião contínuo da plataforma Núcleo IA. O refactor Domain Model V4 terminou em 2026-04-13. Sua função agora é garantir que o modelo V4 permaneça íntegro conforme a plataforma evolui, e que documentação + conhecimento acompanhem a realidade do código.
 
-Predecessor: `refactor-guardian.md` (LEGACY — cobria apenas V4 em curso). Para referência histórica do refactor, consulte `docs/refactor/DOMAIN_MODEL_V4_MASTER.md`.
+Predecessor: `docs/refactor/refactor-guardian-AGENT-ARCHIVED.md` (LEGACY — cobria apenas V4 em curso; arquivado fora do registry ativo 2026-06-11). Para referência histórica do refactor, consulte `docs/refactor/DOMAIN_MODEL_V4_MASTER.md`.
 
 ## Quando você é invocado
 

--- a/.claude/skills/guardian/SKILL.md
+++ b/.claude/skills/guardian/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: guardian
-description: Invoca o Platform Guardian (pós-V4) para auditar invariantes estruturais da plataforma, detectar drift entre docs e código, verificar cobertura ADR de mudanças recentes, e propor novos itens de backlog. Use no início/fim de sessão que toque SQL/RPC/MCP ou como smoke check periódico. Para referência histórica do refactor V4 (concluído 2026-04-13), veja `.claude/agents/refactor-guardian.md`.
+description: Invoca o Platform Guardian (pós-V4) para auditar invariantes estruturais da plataforma, detectar drift entre docs e código, verificar cobertura ADR de mudanças recentes, e propor novos itens de backlog. Use no início/fim de sessão que toque SQL/RPC/MCP ou como smoke check periódico. Para referência histórica do refactor V4 (concluído 2026-04-13), veja `docs/refactor/refactor-guardian-AGENT-ARCHIVED.md`.
 user_invocable: true
 ---
 
@@ -25,4 +25,4 @@ The guardian NEVER edits files — it only reads, greps, and proposes diffs. It 
 
 ## Legacy / historical
 
-For the V4 refactor in-progress period (2026-04-11 → 2026-04-13), the predecessor was `.claude/agents/refactor-guardian.md`. That agent covered specific phase-gating invariants for ADRs 0004-0009 during the 7-phase refactor. Kept as historical reference. Do NOT invoke refactor-guardian for new work — use platform-guardian.
+For the V4 refactor in-progress period (2026-04-11 → 2026-04-13), the predecessor was `docs/refactor/refactor-guardian-AGENT-ARCHIVED.md` (archived out of the active agent registry 2026-06-11). That agent covered specific phase-gating invariants for ADRs 0004-0009 during the 7-phase refactor. Kept as historical reference. Do NOT invoke refactor-guardian for new work — use platform-guardian.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ supabase functions deploy <name> --no-verify-jwt  # Deploy EF
 - MCP: `.claude/rules/mcp.md`
 - Deploy: `.claude/rules/deploy.md`
 - **Bypass protocol (--admin / direct push)**: `.claude/rules/bypass-protocol.md` (post-p209 governance — Option C Híbrido + weekly cron audit at `.github/workflows/bypass-audit-weekly.yml`)
-- V4 refactor invariants (historical): `.claude/rules/refactor-in-progress.md`
+- V4 refactor invariants (historical, archived): `docs/refactor/refactor-in-progress-RULES-ARCHIVED.md`
 
 ## Council (multi-agent review structure)
 **Active since 2026-04-18.** 12 specialized sub-agents em `.claude/agents/` (product-leader, ux-leader, c-level-advisor, stakeholder-persona, senior-software-engineer, ai-engineer, data-architect, security-engineer, startup-advisor, vc-angel-lens, legal-counsel, accountability-advisor) operando em 3 tiers:
@@ -97,6 +97,12 @@ supabase functions deploy <name> --no-verify-jwt  # Deploy EF
 - **Tier 3 (strategic)**: `/council-review [topic]` em milestones — output em `docs/council/`
 
 Todos são **consultivos** (não modificam código). PM/main loop decide ação. Decision log em `docs/council/decisions/`.
+
+### Routing discipline (MANDATORY — context-hygiene 2026-06-11)
+- **1 agente por subação.** Escolha o agente cujo domínio casa com a tarefa; não convoque mais de um "por garantia".
+- **NUNCA convocar o conselho inteiro por default.** Convocação múltipla (>1 agente) ou `/council-review` exige **justificativa explícita** (milestone, decisão estratégica de alto impacto, ou conflito de domínio real) — declare-a antes de invocar.
+- Tier 1 (`platform-guardian`/`code-reviewer`) e o agente de domínio (Tier 2) cobrem ~95% dos casos. Tier 3 é exceção, não rotina.
+- Agentes são lazy-loaded (custo ~0 em contexto fixo); o custo é **por spawn** — cada invocação extra é um context window inteiro. Trate convocação como gasto, não como hábito.
 
 ## Portfolio PMO (knowledge loop)
 


### PR DESCRIPTION
## What

Completes the context-hygiene work whose file-moves landed in `main` via the PR #650 squash, but whose **reference-text updates + agent routing rule were left uncommitted** in the shared working tree (the hygiene session and the cert-director-go session ran concurrently in the same checkout).

As a result, `main` (d06dab99) currently has **3 dangling references** to files that were archived/deleted:
- `.claude/agents/platform-guardian.md` → `refactor-guardian.md`
- `.claude/skills/guardian/SKILL.md` → `.claude/agents/refactor-guardian.md` (×2)
- `CLAUDE.md` → `.claude/rules/refactor-in-progress.md`

Those targets were moved to `docs/refactor/*-ARCHIVED.md` (already in `main`).

## Changes (doc-only)

- Point the 3 refs at the archived paths (`docs/refactor/refactor-guardian-AGENT-ARCHIVED.md`, `docs/refactor/refactor-in-progress-RULES-ARCHIVED.md`)
- Add **agent routing discipline** to the CLAUDE.md Council section: 1 agent per subaction; never summon the whole council by default; multi-agent / `/council-review` requires explicit justification

## Verification

- Stale refs to old deleted paths: **0**
- Routing rule present: **yes**
- No product code touched; doc/infra-only

Context-hygiene session summary (rounds 1+2): MEMORY.md 358KB→73KB, settings.local.json 905→551 lines, always-on rules 3→1 (mcp.md path-scoped, refactor-in-progress archived), orphan memory namespace removed (4 unique files rescued), ~506M disk freed. LL logged in #588.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
