### PR TITLE
fix(governance): broken PMI-GO logo on volunteer term (crossorigin + missing page header)

### DIFF
--- a/src/lib/certificates/pdf.ts
+++ b/src/lib/certificates/pdf.ts
@@ -251,7 +251,7 @@ export function buildVolunteerAgreementHTML(certData: CertificateData): string {
   // Header with PMI-GO logo (same reference as the example PDF)
   const headerBlock = `
     <div style="margin-bottom:20px">
-      <img src="https://nucleoia.vitormr.dev/assets/logos/pmigo.png" alt="PMI Goiás" style="height:52px;width:auto;display:block" crossorigin="anonymous" />
+      <img src="https://nucleoia.vitormr.dev/assets/logos/pmigo.png" alt="PMI Goiás" style="height:52px;width:auto;display:block" />
     </div>
     <h1 style="text-align:center;font-size:18px;font-weight:bold;color:#000;margin:20px 0 28px;letter-spacing:0.5px;line-height:1.3">
       TERMO DE COMPROMISSO DE<br/>VOLUNTÁRIO COM O PMI GOIÁS
@@ -363,7 +363,7 @@ export function buildVolunteerAgreementHTML(certData: CertificateData): string {
   const annexBlock = `
     <div class="cert-page" style="padding:32px 40px;background:#fff;box-sizing:border-box;page-break-before:always;font-family:Georgia,serif;color:#333;min-height:842px;width:595px">
       <div style="margin-bottom:20px">
-        <img src="https://nucleoia.vitormr.dev/assets/logos/pmigo.png" alt="PMI Goiás" style="height:44px;width:auto;display:block" crossorigin="anonymous" />
+        <img src="https://nucleoia.vitormr.dev/assets/logos/pmigo.png" alt="PMI Goiás" style="height:44px;width:auto;display:block" />
       </div>
       <h2 style="font-weight:bold;color:#000;font-size:16px;margin:24px 0 14px">ANEXO - LEI DO SERVIÇO VOLUNTÁRIO</h2>
       <p style="font-size:11px;color:#333;margin-bottom:4px"><b>Lei nº 9.608, de 18 de fevereiro de 1998</b></p>
@@ -435,7 +435,7 @@ export function buildCertificateHTML(certData: CertificateData): string {
     ? `<div style="margin:24px auto;max-width:420px;text-align:left"><div style="font-size:11px;font-weight:bold;color:#555;margin-bottom:6px">${tpl.contributions}</div><div style="font-size:12px;color:#666;line-height:1.6">${certData.description.replace(/\n/g, '<br>')}</div></div>`
     : '';
   const sigImg = certData.signature_url
-    ? `<img src="${certData.signature_url}" style="max-width:180px;max-height:60px;margin-bottom:4px" crossorigin="anonymous">`
+    ? `<img src="${certData.signature_url}" style="max-width:180px;max-height:60px;margin-bottom:4px">`
     : '';
 
   return `<div class="cert-page" style="width:595px;min-height:842px;padding:48px 40px;border:3px double #1a365d;position:relative;background:#fff;box-sizing:border-box;page-break-after:always">

--- a/src/pages/volunteer-agreement.astro
+++ b/src/pages/volunteer-agreement.astro
@@ -50,6 +50,7 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
 
     return `
       <header class="mb-6 text-center">
+        <img src="/assets/logos/pmigo.png" alt="PMI Goiás" class="h-12 w-auto mx-auto mb-2" />
         <div class="text-[10px] font-bold uppercase tracking-[.15em] text-[var(--text-muted)] mb-1">PMI Goiás — Núcleo de Estudos e Pesquisa em IA & GP</div>
         <h1 class="text-xl font-bold text-[var(--text-primary)]">${t('volunteer.title', lang)}</h1>
         <p class="text-[var(--text-secondary)] text-sm mt-1">${subtitle}</p>


### PR DESCRIPTION
## Sintoma
"A logo do PMI não aparece no topo do termo" (página + PDF exportado mostram imagem quebrada `🖼️ PMI Goiás`).

## Dois defeitos

**1. Render do PDF** (`buildVolunteerAgreementHTML` / `buildCertificateHTML`): a logo `<img src="https://nucleoia.vitormr.dev/assets/logos/pmigo.png">` tinha `crossorigin="anonymous"`. O PDF é gerado via `window.print()` num documento Blob-URL; o asset responde **HTTP 200 mas SEM header `access-control-allow-origin`** (verificado ao vivo: `curl -I` → 200, sem ACAO) → o fetch em modo CORS falha → imagem quebrada. Removido `crossorigin` das 2 imgs de logo + a da assinatura. Sob `window.print()` não há leitura de pixel em canvas, então não há risco de taint — exibição same-origin não precisa de CORS.

**2. Página viva** (`volunteer-agreement.astro`): o header era **só texto, sem elemento de logo**. Adicionada a marca PMI-GO (src relativo same-origin, sem crossorigin).

## Escopo
- PDFs **já congelados** (imutabilidade #648) **não mudam** — são artefato legal byte-exato. O fix vale para **novos renders + a página viva**.
- Asset `pmigo.png` já existe em `public/assets/logos/` (não era arquivo faltando).

## Validação
- `npx astro build` ✓ · `npm test` ✓ **3510 pass / 0 fail** · 0 `crossorigin` restante nas logos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
