### PR TITLE
chore: cross-tool shared-brain bridge for Codex sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,3 +171,36 @@ Para trabalho paralelo de múltiplos agentes/modelos (Claude Code, Cursor, Codex
 5. **Deploy** — commit + push + tag + verificar produção.
 
 Detalhes em `docs/project-governance/SPRINT_IMPLEMENTATION_PRACTICES.md`.
+
+## Shared brain & cross-tool sessions (Codex / non-Claude agents)
+
+This repo lives under Vitor's portfolio PMO. Claude Code auto-loads `CLAUDE.md`
++ its memory namespace; you (Codex/Cursor/Gemini) do not, so:
+
+1. **Read for context, don't rewrite the brain.** Read `CLAUDE.md`, the docs map
+   above, and (read-only) the Claude memory namespace at
+   `~/.claude/projects/-home-vitormrodovalho-projects-ai-pm-research-hub/`.
+   **Never create or edit files under that `memory/` namespace** — it is curated
+   by Claude in a strict format; writing it in another shape causes recall drift.
+   Brain curation stays with Claude.
+
+2. **Hand work back via `_handoff/`, not memory.** Copy `_handoff/TEMPLATE.md` to
+   `_handoff/codex-<YYYY-MM-DD>.md`, fill it in, and **commit it**. Tuesday's
+   Claude session reconciles it into memory + the `[LL]` issue. Do NOT post `[LL]`
+   GitHub issues/comments yourself — the harvest loop depends on exact format;
+   just record lessons in the handoff file.
+
+3. **Grounding rule still applies (CLAUDE.md).** Any count/%/metric you state must
+   come from a live tool result THIS session. Never recite numbers from memory or
+   a prior handoff.
+
+4. **Commit attribution:** trailer (LAST line of body) =
+   `Assisted-By: Codex (OpenAI) <noreply@openai.com>`. **NEVER `Co-Authored-By:`**
+   (pollutes the authorship/IP chain). Human is sole author of record. No
+   `🤖 Generated with…` footers unless asked.
+
+5. **Governance is unchanged:** branch + PR, the 5-phase sprint closure, the gates
+   in `SPRINT_IMPLEMENTATION_PRACTICES.md`, and the `--admin`/bypass protocol
+   (`.claude/rules/bypass-protocol.md`) bind you too. Never force-push, never
+   `--no-verify`, never merge a Dependabot PR (#611 policy). Work within your p201
+   lane only.

--- a/_handoff/TEMPLATE.md
+++ b/_handoff/TEMPLATE.md
@@ -1,0 +1,38 @@
+# Codex session handoff — <YYYY-MM-DD>
+
+> Copy to `codex-<YYYY-MM-DD>.md`, fill in, and COMMIT it (this repo is git-tracked).
+> Tuesday's Claude session reads this to re-ground before reconciling the brain.
+> Do NOT edit the Claude memory namespace (`~/.claude/projects/.../memory/`).
+
+## Scope
+- Tool/model: Codex CLI (<model>)
+- Lane (p201): <Foundation | Frontend | MCP/AI | Governance | Infra/Security | QA>
+- Branch(es) / worktree:
+
+## What changed (with evidence)
+- <change> — commit `<sha>` / PR #<n>
+-
+
+## Gates run (5-phase / DoD — see SPRINT_IMPLEMENTATION_PRACTICES.md)
+- [ ] `npx astro build` passed
+- [ ] `npm test` passed
+- [ ] `npm run smoke:routes` passed (if routes/nav touched)
+- [ ] Migrations applied via `apply_migration` + local file + repair (if SQL touched)
+- [ ] RELEASE_LOG / GOVERNANCE_CHANGELOG updated (if production-impacting)
+
+## Numbers / state observed
+> GROUNDING RULE (CLAUDE.md): every count/%/metric must come from a live tool
+> result THIS session (execute_sql read-only, MCP RPC, npm test). Never recite
+> from memory or a prior handoff. Label estimates as estimates.
+-
+
+## Open threads / not done
+-
+
+## Lessons learned (for Claude to formalize on the [LL] issue — do NOT post yourself)
+- **What happened:**
+- **Why it matters:**
+- **Framework/skill/kit candidate:**
+
+## Anything Claude must re-verify before trusting this handoff
+-


### PR DESCRIPTION
## Why
Vitor has a low-Claude-token window until Monday and will run the **Codex CLI** team on this repo. This adds a contract so non-Claude agents work without degrading the shared brain or compromising Tuesday's Claude handoff.

## What
- **AGENTS.md** — new *"Shared brain & cross-tool sessions"* section: Claude memory namespace is **read-only** (curation stays with Claude), hand work back via `_handoff/` (not memory, not `[LL]`), grounding rule still applies, commit trailer `Assisted-By:` (never `Co-Authored-By:`), p201 lanes + bypass protocol still bind.
- **_handoff/TEMPLATE.md** — session handoff template (scope, evidence, gates run, grounded numbers, open threads, lessons for Claude to formalize).

Doc/infra only — no code, schema, or route changes.

Assisted-By: Claude (Anthropic)