### PR TITLE
fix(security): close SECDEF bypass on 3 authenticated-only functions — closes #684

### DIFF
--- a/supabase/migrations/20260805000169_684_secfix_authenticated_only_md.sql
+++ b/supabase/migrations/20260805000169_684_secfix_authenticated_only_md.sql
@@ -1,0 +1,383 @@
+-- =====================================================================================
+-- #684 follow-up — fix the 3 authenticated-only MED functions carrying the same
+-- always-true current_user bypass (the anon-reachable ones were fixed in mig 168 / PR #685).
+--
+-- No anon path (granted to authenticated only), so lower severity, but any authenticated
+-- member (not just the intended manage_member / view_internal_analytics holders) bypassed
+-- the capability check. Fix: the same role-GUC discriminator `_request_is_rest_caller()`
+-- (shipped in mig 168). Bodies re-emitted verbatim except the v_cron_context assignment.
+-- Closes #684.
+-- =====================================================================================
+
+CREATE OR REPLACE FUNCTION public.auto_promote_eligible_leads_for_cycle(p_cycle_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_cycle record;
+  v_lead record;
+  v_app_id uuid;
+  v_first text;
+  v_last text;
+  v_count integer := 0;
+  v_skipped integer := 0;
+  v_dedup_skipped integer := 0;
+  v_caller_id uuid;
+  v_cron_context boolean;
+BEGIN
+  -- #684: role-GUC discriminator (current_user is always the SECDEF owner under SECDEF).
+  v_cron_context := NOT public._request_is_rest_caller();
+
+  IF NOT v_cron_context THEN
+    SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+    IF v_caller_id IS NULL THEN
+      RAISE EXCEPTION 'Unauthorized: not authenticated';
+    END IF;
+    IF NOT public.can_by_member(v_caller_id, 'manage_member') THEN
+      RAISE EXCEPTION 'Unauthorized: requires manage_member';
+    END IF;
+  END IF;
+
+  SELECT * INTO v_cycle FROM public.selection_cycles WHERE id = p_cycle_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error', 'Cycle not found');
+  END IF;
+  IF v_cycle.status <> 'open' THEN
+    RETURN jsonb_build_object('error', 'Cycle is not open: ' || v_cycle.status);
+  END IF;
+
+  FOR v_lead IN
+    SELECT vl.*
+    FROM public.visitor_leads vl
+    WHERE vl.status = 'new'
+      AND vl.auto_promote_eligible = true
+      AND vl.lgpd_consent = true
+      AND NOT EXISTS (
+        SELECT 1 FROM public.selection_applications sa
+        WHERE sa.cycle_id = p_cycle_id
+          AND LOWER(TRIM(sa.email)) = vl.dedupe_email_normalized
+      )
+    ORDER BY vl.created_at ASC
+  LOOP
+    BEGIN
+      v_first := SPLIT_PART(v_lead.name, ' ', 1);
+      v_last := NULLIF(TRIM(SUBSTRING(v_lead.name FROM POSITION(' ' IN v_lead.name) + 1)), '');
+
+      INSERT INTO public.selection_applications (
+        cycle_id, applicant_name, first_name, last_name, email, phone, chapter,
+        referral_source, referrer_member_id, utm_data, status, created_at, application_date
+      ) VALUES (
+        p_cycle_id, v_lead.name, v_first, v_last, v_lead.email, v_lead.phone,
+        v_lead.chapter_interest,
+        COALESCE(v_lead.source, 'lead_promote_cron'),
+        v_lead.referrer_member_id,
+        v_lead.utm_data,
+        'submitted', now(), CURRENT_DATE
+      )
+      RETURNING id INTO v_app_id;
+
+      UPDATE public.visitor_leads SET
+        status = 'promoted', promoted_at = now(), promoted_by = NULL,
+        promoted_to_application_id = v_app_id
+      WHERE id = v_lead.id;
+
+      INSERT INTO public.admin_audit_log (actor_id, action, target_type, target_id, changes, metadata)
+      VALUES (
+        v_caller_id, 'visitor_lead.auto_promoted', 'visitor_lead', v_lead.id,
+        jsonb_build_object('application_id', v_app_id, 'cycle_id', p_cycle_id, 'via', 'cron'),
+        jsonb_strip_nulls(jsonb_build_object('lead_email', v_lead.email))
+      );
+
+      v_count := v_count + 1;
+    EXCEPTION
+      WHEN unique_violation THEN
+        v_dedup_skipped := v_dedup_skipped + 1;
+      WHEN OTHERS THEN
+        v_skipped := v_skipped + 1;
+        INSERT INTO public.admin_audit_log (actor_id, action, target_type, target_id, changes, metadata)
+        VALUES (
+          v_caller_id, 'visitor_lead.auto_promote_failed', 'visitor_lead', v_lead.id,
+          jsonb_build_object('error', SQLERRM),
+          jsonb_build_object('lead_email', v_lead.email, 'cycle_id', p_cycle_id)
+        );
+    END;
+  END LOOP;
+
+  UPDATE public.selection_cycles SET leads_auto_promoted_at = now() WHERE id = p_cycle_id;
+
+  RETURN jsonb_build_object(
+    'cycle_id', p_cycle_id,
+    'cycle_code', v_cycle.cycle_code,
+    'promoted', v_count,
+    'dedup_skipped', v_dedup_skipped,
+    'errors', v_skipped,
+    'completed_at', now()
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.compute_ai_calibration_stats(p_cycle_id uuid, p_drift_threshold numeric DEFAULT 2.0)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_cron_context boolean;
+  v_n integer;
+  v_mean_signed numeric;
+  v_mean_abs numeric;
+  v_drift_high integer;
+  v_sample_payload jsonb;
+  v_validator_breakdown jsonb;
+  v_run_id uuid;
+  v_triggered_by text;
+  v_window_start timestamptz := now() - interval '4 weeks';
+  v_cycle record;
+  v_max_research numeric;
+BEGIN
+  -- #684: role-GUC discriminator (current_user is always the SECDEF owner under SECDEF).
+  v_cron_context := NOT public._request_is_rest_caller();
+
+  IF v_cron_context THEN
+    v_triggered_by := 'cron';
+  ELSE
+    SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+    IF v_caller_id IS NULL THEN
+      RETURN jsonb_build_object('error','Not authenticated');
+    END IF;
+    IF NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+      RETURN jsonb_build_object('error','Not authorized: requires view_internal_analytics');
+    END IF;
+    v_triggered_by := 'admin_request';
+  END IF;
+
+  -- Load cycle for normalization scale
+  SELECT * INTO v_cycle FROM public.selection_cycles WHERE id = p_cycle_id;
+  IF v_cycle IS NULL THEN
+    RETURN jsonb_build_object('error','Cycle not found');
+  END IF;
+
+  -- Compute max_research = sum(max × weight) for objective + interview criteria
+  v_max_research := COALESCE((
+    SELECT SUM((c->>'max')::numeric * COALESCE((c->>'weight')::numeric, 1))
+    FROM jsonb_array_elements(v_cycle.objective_criteria) c
+  ), 0) + COALESCE((
+    SELECT SUM((c->>'max')::numeric * COALESCE((c->>'weight')::numeric, 1))
+    FROM jsonb_array_elements(v_cycle.interview_criteria) c
+  ), 0);
+
+  -- Guard: if criteria are missing/empty, fall back to legacy /10 to avoid div-by-zero
+  IF v_max_research IS NULL OR v_max_research <= 0 THEN
+    v_max_research := 100;  -- legacy fallback, equivalent to /10 normalization
+  END IF;
+
+  -- ====================================================================
+  -- BLOCO 1: delta ai_triage_score vs final_score (normalized to 0-10)
+  -- ====================================================================
+  WITH paired AS (
+    SELECT
+      a.id AS application_id,
+      a.applicant_name,
+      a.ai_triage_score::numeric AS ai_score,
+      ROUND((a.final_score::numeric / v_max_research) * 10, 2) AS human_score_normalized,
+      ROUND(((a.final_score::numeric / v_max_research) * 10) - a.ai_triage_score::numeric, 2) AS delta_signed
+    FROM public.selection_applications a
+    WHERE a.cycle_id = p_cycle_id
+      AND a.ai_triage_score IS NOT NULL
+      AND a.final_score IS NOT NULL
+  )
+  SELECT
+    COUNT(*),
+    ROUND(AVG(delta_signed), 3),
+    ROUND(AVG(ABS(delta_signed)), 3),
+    COUNT(*) FILTER (WHERE ABS(delta_signed) > p_drift_threshold)
+  INTO v_n, v_mean_signed, v_mean_abs, v_drift_high
+  FROM paired;
+
+  -- Top-5 outliers
+  SELECT jsonb_agg(jsonb_build_object(
+    'application_id', application_id,
+    'applicant_name', applicant_name,
+    'ai_score', ai_score,
+    'human_score_normalized', human_score_normalized,
+    'delta_signed', delta_signed
+  ) ORDER BY ABS(delta_signed) DESC)
+  INTO v_sample_payload
+  FROM (
+    SELECT
+      a.id AS application_id,
+      a.applicant_name,
+      a.ai_triage_score::numeric AS ai_score,
+      ROUND((a.final_score::numeric / v_max_research) * 10, 2) AS human_score_normalized,
+      ROUND(((a.final_score::numeric / v_max_research) * 10) - a.ai_triage_score::numeric, 2) AS delta_signed
+    FROM public.selection_applications a
+    WHERE a.cycle_id = p_cycle_id
+      AND a.ai_triage_score IS NOT NULL
+      AND a.final_score IS NOT NULL
+    ORDER BY ABS(((a.final_score::numeric / v_max_research) * 10) - a.ai_triage_score::numeric) DESC
+    LIMIT 5
+  ) top;
+
+  -- ====================================================================
+  -- BLOCO 2: validator breakdown (unchanged from p110)
+  -- ====================================================================
+  WITH cycle_validations AS (
+    SELECT v.*, m.name AS validator_name
+    FROM public.ai_score_validations v
+    JOIN public.selection_applications a ON a.id = v.application_id
+    LEFT JOIN public.members m ON m.id = v.validator_id
+    WHERE a.cycle_id = p_cycle_id
+      AND v.validated_at >= v_window_start
+  ),
+  global_agg AS (
+    SELECT jsonb_build_object(
+      'total_validations', COUNT(*),
+      'agree_n', COUNT(*) FILTER (WHERE validation_action = 'agree'),
+      'disagree_n', COUNT(*) FILTER (WHERE validation_action = 'disagree'),
+      'override_n', COUNT(*) FILTER (WHERE validation_action = 'override'),
+      'mean_override_delta', ROUND(AVG(override_score - ai_score) FILTER (WHERE validation_action = 'override' AND override_score IS NOT NULL), 3),
+      'window_start', v_window_start,
+      'window_end', now()
+    ) AS payload
+    FROM cycle_validations
+  ),
+  by_validator AS (
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+      'validator_id', validator_id,
+      'name', validator_name,
+      'validations_n', validations_n,
+      'agreement_rate', ROUND(agreement_rate, 3),
+      'bias_signal', ROUND(bias_signal, 3),
+      'override_n', override_n
+    ) ORDER BY validations_n DESC), '[]'::jsonb) AS payload
+    FROM (
+      SELECT
+        validator_id,
+        validator_name,
+        COUNT(*) AS validations_n,
+        COUNT(*) FILTER (WHERE validation_action = 'agree')::numeric / NULLIF(COUNT(*), 0) AS agreement_rate,
+        AVG(override_score - ai_score) FILTER (WHERE validation_action = 'override' AND override_score IS NOT NULL) AS bias_signal,
+        COUNT(*) FILTER (WHERE validation_action = 'override') AS override_n
+      FROM cycle_validations
+      WHERE validator_id IS NOT NULL
+      GROUP BY validator_id, validator_name
+    ) v
+  ),
+  by_purpose AS (
+    SELECT COALESCE(jsonb_object_agg(ai_purpose, purpose_payload), '{}'::jsonb) AS payload
+    FROM (
+      SELECT
+        ai_purpose,
+        jsonb_build_object(
+          'total', COUNT(*),
+          'agree_n', COUNT(*) FILTER (WHERE validation_action = 'agree'),
+          'disagree_n', COUNT(*) FILTER (WHERE validation_action = 'disagree'),
+          'override_n', COUNT(*) FILTER (WHERE validation_action = 'override'),
+          'mean_override_delta', ROUND(AVG(override_score - ai_score) FILTER (WHERE validation_action = 'override' AND override_score IS NOT NULL), 3)
+        ) AS purpose_payload
+      FROM cycle_validations
+      WHERE ai_purpose IS NOT NULL
+      GROUP BY ai_purpose
+    ) p
+  )
+  SELECT jsonb_build_object(
+    'global', (SELECT payload FROM global_agg),
+    'by_validator', (SELECT payload FROM by_validator),
+    'by_purpose', (SELECT payload FROM by_purpose),
+    'normalization_max', v_max_research
+  )
+  INTO v_validator_breakdown;
+
+  -- INSERT
+  INSERT INTO public.ai_calibration_runs (
+    cycle_id, n_compared, mean_delta_signed, mean_delta_abs, drift_count_high,
+    drift_threshold, triggered_by, sample_payload, validator_breakdown
+  ) VALUES (
+    p_cycle_id, COALESCE(v_n, 0),
+    v_mean_signed, v_mean_abs,
+    COALESCE(v_drift_high, 0),
+    p_drift_threshold, v_triggered_by,
+    v_sample_payload, v_validator_breakdown
+  )
+  RETURNING id INTO v_run_id;
+
+  RETURN jsonb_build_object(
+    'run_id', v_run_id,
+    'cycle_id', p_cycle_id,
+    'n_compared', COALESCE(v_n, 0),
+    'mean_delta_signed', v_mean_signed,
+    'mean_delta_abs', v_mean_abs,
+    'drift_count_high', COALESCE(v_drift_high, 0),
+    'drift_threshold', p_drift_threshold,
+    'triggered_by', v_triggered_by,
+    'top_outliers', COALESCE(v_sample_payload, '[]'::jsonb),
+    'validator_breakdown', v_validator_breakdown,
+    'normalization_max', v_max_research,
+    'ran_at', now()
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.list_ai_calibration_runs(p_cycle_id uuid DEFAULT NULL::uuid, p_limit integer DEFAULT 50)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_cron_context boolean;
+  v_runs jsonb;
+  v_effective_limit integer;
+BEGIN
+  -- #684: role-GUC discriminator (current_user is always the SECDEF owner under SECDEF).
+  v_cron_context := NOT public._request_is_rest_caller();
+
+  IF NOT v_cron_context THEN
+    SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+    IF v_caller_id IS NULL THEN
+      RETURN jsonb_build_object('error','Not authenticated');
+    END IF;
+    IF NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+      RETURN jsonb_build_object('error','Not authorized: requires view_internal_analytics');
+    END IF;
+  END IF;
+
+  v_effective_limit := LEAST(GREATEST(COALESCE(p_limit, 50), 1), 200);
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'id', r.id,
+    'cycle_id', r.cycle_id,
+    'cycle_code', c.cycle_code,
+    'ran_at', r.ran_at,
+    'n_compared', r.n_compared,
+    'mean_delta_signed', r.mean_delta_signed,
+    'mean_delta_abs', r.mean_delta_abs,
+    'drift_count_high', r.drift_count_high,
+    'drift_threshold', r.drift_threshold,
+    'triggered_by', r.triggered_by,
+    'sample_payload', r.sample_payload,
+    'validator_breakdown', r.validator_breakdown
+  ) ORDER BY r.ran_at DESC), '[]'::jsonb) INTO v_runs
+  FROM (
+    SELECT * FROM public.ai_calibration_runs
+    WHERE p_cycle_id IS NULL OR cycle_id = p_cycle_id
+    ORDER BY ran_at DESC
+    LIMIT v_effective_limit
+  ) r
+  LEFT JOIN public.selection_cycles c ON c.id = r.cycle_id;
+
+  RETURN jsonb_build_object(
+    'runs', v_runs,
+    'count', jsonb_array_length(v_runs),
+    'cycle_filter', p_cycle_id,
+    'limit', v_effective_limit
+  );
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/684-secdef-role-gate-anon-reachable.test.mjs
+++ b/tests/contracts/684-secdef-role-gate-anon-reachable.test.mjs
@@ -7,6 +7,7 @@ import { createClient } from '@supabase/supabase-js';
 // current_user bypass (the systemic case behind #676/#683) must (a) use the role-GUC
 // discriminator and (b) deny anon.
 const MIG = 'supabase/migrations/20260805000168_684_secfix_role_gate_anon_reachable.sql';
+const MIG_MED = 'supabase/migrations/20260805000169_684_secfix_authenticated_only_md.sql';
 const read = (p) => (existsSync(p) ? readFileSync(p, 'utf8') : '');
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
@@ -33,6 +34,17 @@ test('#684 static: generic role-GUC discriminator + 6 functions adopt it', () =>
   // anon revoked on all six
   for (const fn of FIXED) {
     assert.match(body, new RegExp(`REVOKE EXECUTE ON FUNCTION public\\.${fn}\\(`), `anon revoked on ${fn}`);
+  }
+});
+
+test('#684 static: the 3 authenticated-only MED functions also adopt the role-GUC discriminator', () => {
+  const body = read(MIG_MED);
+  assert.ok(body, 'follow-up migration present');
+  const occ = (body.match(/v_cron_context := NOT public\._request_is_rest_caller\(\);/g) || []).length;
+  assert.equal(occ, 3, `expected 3 fixed gates, found ${occ}`);
+  assert.ok(!/v_cron_context := \(current_setting/.test(body), 'old current_user heuristic removed');
+  for (const fn of ['auto_promote_eligible_leads_for_cycle', 'compute_ai_calibration_stats', 'list_ai_calibration_runs']) {
+    assert.match(body, new RegExp(`CREATE OR REPLACE FUNCTION public\\.${fn}\\(`), `${fn} re-emitted`);
   }
 });
 


### PR DESCRIPTION
Follow-up to PR #685. Fixes the same always-true `current_user` SECDEF bypass on the 3 authenticated-only MED functions (`auto_promote_eligible_leads_for_cycle`, `compute_ai_calibration_stats`, `list_ai_calibration_runs`) via the shared `_request_is_rest_caller()` discriminator (bodies re-emitted verbatim except the `v_cron_context` line). Verified live: authenticated-without-uid denied on all three; cron/service preserved. Every REST-reachable function carrying the bypass is now fixed.

- `astro build` OK · `npm test` green (the one failing run was the pre-existing p276 parallel-suite leaderboard race — unrelated, passes isolated) · body-drift/ADR-0097/coverage gates green · migration `20260805000169`, no shadow rows · branch base verified.

Closes #684.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>