### PR TITLE
docs(deck): enriquece deck CEIA (capa ANSI + badges + fotos) — supersedes #688

### DIFF
--- a/docs/strategy/deck/build_ceia.py
+++ b/docs/strategy/deck/build_ceia.py
@@ -5,8 +5,10 @@
 # Grounding: CEIA = UFG AI Center of Excellence, EMBRAPII unit, 30+ companies, GPAI (UFG/EMBRAPII/FAPEG).
 # Numbers do Núcleo = get_public_impact_data; ANSI 26-007 = selo da capa oficial. Sem travessao (guard).
 from pathlib import Path
+from pathlib import Path as _P
 from deck_engine import Deck, PURPLE, TEAL, ORANGE, LIGHT, GRAY, FONT
-from build_kruel import two_col, caption, linked_line, A1, A2, A3
+from build_kruel import (two_col, caption, linked_line, cover_slot, place_fit,
+                         A1, A2, A3, COVERS, CERTS_PROC, PEOPLE)
 
 BASE = Path("/home/vitormrodovalho/projects/ai-pm-research-hub/docs/strategy/deck")
 TEMPLATE = BASE / "build/pmi_template.pptx"
@@ -54,14 +56,43 @@ C = {
             ["ANSI/PMI 08-002", "Standard for Program Management (2024)."],
             ["ANSI/PMI 08-003", "Standard for Portfolio Management (2017)."],
         ],
-        "caption": "1º standard de IA aprovado pela ANSI + a certificação PMI-CPMAI. PMIxAI: 4 cursos de IA (+350 mil inscritos), o AI Practice Guide e a plataforma PMI Infinity.",
+        "caption": "E não só padrão: um roadmap de carreira do PMP às especializações, até a fronteira (a IA). PMIxAI: 4 cursos de IA (+350 mil inscritos), AI Practice Guide e PMI Infinity.",
+        "covers": [
+            {"slot": "ansi_ai_standard", "label": "Standard de IA · ANSI/PMI 26-007 (2026)"},
+        ],
+        "certs": [
+            {"file": "PMP.png", "label": "PMP", "desc": "Gerenciamento de projetos"},
+            {"file": "PMI-ACP.png", "label": "PMI-ACP", "desc": "Práticas ágeis"},
+            {"file": "PMI-PMOCP.png", "label": "PMI-PMOCP", "desc": "Gestão de PMO"},
+            {"file": "PMI-CP.png", "label": "PMI-CP", "desc": "Construção"},
+            {"file": "PMI CSPP.png", "label": "CSPP", "desc": "Sustentabilidade · ESG"},
+            {"file": "PMI-CPMAI.png", "label": "PMI-CPMAI", "desc": "Gestão de IA", "hero": True},
+        ],
+    },
+    "managers": {
+        "eyebrow": "Quem conduz",
+        "title": "Gestores do projeto",
+        "people": [
+            {"name": "Vitor Maia Rodovalho", "role": "Idealizador e líder · Núcleo IA & GP",
+             "sub": "Senior Cost Manager na Linesight (grupo Berkshire Hathaway), em projetos de data centers para a Google.",
+             "photo": "vitor.jpg", "linkedin": "linkedin.com/in/vitor-rodovalho-pmp",
+             "phone": "+1 267-874-8329"},
+            {"name": "Fabrício Costa", "role": "Co-gestor · Núcleo IA & GP",
+             "sub": "Program Manager de Design e Engenharia na AWS; doutorando em Business.",
+             "photo": "fabricio.jpg", "linkedin": "linkedin.com/in/fabriciorcc",
+             "phone": "+1 503-544-7898"},
+        ],
+        "links": [
+            ("Plataforma do Núcleo", "nucleoia.pmigo.org.br", "https://nucleoia.pmigo.org.br"),
+            ("PMI", "pmi.org", "https://www.pmi.org"),
+        ],
     },
     "how": {
         "eyebrow": "Como cooperar",
         "title": "Três jeitos leves de começar",
         "cols": [
             ["1 · Co-pesquisa", ["A lente de gestão (CPMAI) sobre um caso de IA do CEIA.", "Vira artigo e case para os dois lados.", "Sem acordo, começa já."]],
-            ["2 · Mesa-redonda", ["Seminário conjunto, modelo SESTEC.", "Já rodamos um com +1.000 espectadores.", "Palco e marca compartilhados."]],
+            ["2 · Mesa-redonda", ["Seminário conjunto sobre IA aplicada à gestão.", "Palco e marca compartilhados.", "Formato ao vivo, com transmissão."]],
             ["3 · Tribo de pesquisa", ["Pesquisadores do CEIA numa tribo do Núcleo.", "Pesquisa aplicada, com PI conjunta.", "Funil para certificação e comunidade."]],
         ],
         "caption": "Mesmo estado (Goiás), sem MoU, mensurável. Horizonte (não a abertura): acordo-âncora de P&D como ICT sob a Lei de Inovação (10.973).",
@@ -74,8 +105,7 @@ C = {
                "Um café de 30 min ou async, no seu tempo.",
                "Mesmo estado: PMI-GO e CEIA-UFG, lado a lado."],
         "h2": "Pontes já abertas",
-        "l2": ["Mentoria do Mário Trentim (PMI Global Board).",
-               "SGPL 24-26/set (Goiânia) como primeiro palco.",
+        "l2": ["SGPL 24-26/set (Goiânia) como primeiro palco.",
                "Janela quente: standard de IA recém-publicado; sede do CEIA inaugura set/2026."],
         "cta_h": "CEIA + PMI",
         "cta": "Pesquisa que entrega valor. Vamos fechar o ciclo.",
@@ -105,8 +135,20 @@ def compose(d):
 
     a = C["ansi"]
     def b_ansi(s, top):
-        d.add_table(s, [a["head"]] + a["rows"], top + 0.2, left=0.62, width=12.1, widths=[2.4, 9.7], fs=11.5)
-        d.add_box(s, 0.62, top + 3.5, 12.1, 1.0, "", [a["caption"]], hcolor=A2, fs=13)
+        d.add_table(s, [a["head"]] + a["rows"], top + 0.05, left=0.62, width=7.1, widths=[2.1, 5.0], fs=10)
+        cv = a["covers"][0]
+        cover_slot(d, s, 8.2, top + 0.05, 4.3, 2.2, cv["slot"], cv["label"], framed=True)
+        d.add_box(s, 0.62, top + 2.55, 12.1, 0.5, "", [a["caption"]], hcolor=A2, fs=11.5)
+        n = len(a["certs"]); cw = 12.1 / n; bw = 1.05
+        for i, c in enumerate(a["certs"]):
+            cx = 0.62 + i * cw + (cw - bw) / 2
+            proc = CERTS_PROC / (_P(c["file"]).stem + ".png")
+            if proc.exists():
+                place_fit(d, s, cx, top + 3.0, bw, 1.0, str(proc))
+            else:
+                d.add_box(s, cx, top + 3.0, bw, 1.0, "[ " + c["label"] + " ]", [], hcolor=GRAY, hfs=10, body=GRAY)
+            hc = A3 if c.get("hero") else A1
+            d.add_box(s, 0.62 + i * cw + 0.05, top + 4.05, cw - 0.1, 0.75, c["label"], [c["desc"]], hcolor=hc, hfs=10.5, fs=9)
     d.content(a["eyebrow"], a["title"], b_ansi, "")
 
     h = C["how"]
@@ -118,6 +160,30 @@ def compose(d):
         d.add_box(s, 8.86, top, 3.85, 2.9, h3, l3, hcolor=A3)
         caption(d, s, top + 3.05, h["caption"], color=A1)
     d.content(h["eyebrow"], h["title"], b_how, "")
+
+    mg = C["managers"]
+    def b_mgr(s, top):
+        pw, txw = 2.0, 3.6
+        for left, person in ((0.7, mg["people"][0]), (6.9, mg["people"][1])):
+            photo = PEOPLE / person["photo"]
+            if photo.exists():
+                d.add_image(s, top + 0.05, pw, left=left, path=str(photo))
+            else:
+                d.add_box(s, left, top + 0.05, pw, pw, "[ FOTO ]", [person["photo"]],
+                          hcolor=GRAY, hfs=14, fs=10, body=GRAY)
+            tx = left + pw + 0.3
+            d.add_box(s, tx, top + 0.05, txw, 1.9, person["name"],
+                      [person["role"], person["sub"]], hcolor=A1, hfs=15, fs=11)
+            linked_line(d, s, tx, top + 2.05, txw, 0.4,
+                        [("LinkedIn: " + person["linkedin"], "https://" + person["linkedin"], A2)], fs=11)
+            linked_line(d, s, tx, top + 2.45, txw, 0.4,
+                        [("Tel: ", None, GRAY), (person["phone"], "tel:" + person["phone"].replace(" ", ""), A2)], fs=11)
+        segs = []
+        for i, (lbl, shown, url) in enumerate(mg["links"]):
+            if i: segs.append(("    ·    ", None, GRAY))
+            segs.append((lbl + ": ", None, GRAY)); segs.append((shown, url, A2))
+        linked_line(d, s, 0.62, top + 4.05, 12.1, 0.5, segs, fs=11)
+    d.content(mg["eyebrow"], mg["title"], b_mgr, "")
 
     ak = C["ask"]
     def b_ask(s, top):


### PR DESCRIPTION
Cherry-pick do commit `badb2595` do PR #688, sobre a main atual.

**Contexto:** o batch do subsistema de deck (commit `55d2177e` do #688) já entrou na main via #689 — um commit concorrente do PM foi carregado por engano na branch do #689 (lição: rodar `git diff origin/main..HEAD --stat` antes do push, não só `merge-base --is-ancestor`). O #688 ficou conflitante, com apenas **1 commit de valor restante** — este `badb2595`.

**O que entra:** só `docs/strategy/deck/build_ceia.py` (+73/-7) — enriquecimento do deck CEIA: capa/slide do "encaixe" liderado pelo infográfico ANSI, badges, fotos; remove a menção a Mário/seminário. Docs/estratégia, sem superfície de código/produto.

**Substitui o #688** (que será fechado como superseded: batch já na main via #689 + este enriquecimento aqui).

Refs #688.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>