### PR TITLE
feat(agenda-viva): #701 Frontend slice 3 — protagonismo pillar in /admin/gamification

### DIFF
--- a/src/pages/admin/gamification.astro
+++ b/src/pages/admin/gamification.astro
@@ -394,6 +394,7 @@ const LANG_FOR_CRITERIA = (lang === 'en-US' || lang === 'es-LATAM') ? lang : 'pt
           case 'producao':       return 'bg-emerald-50 text-emerald-700';
           case 'curadoria':      return 'bg-orange-50 text-orange-700';
           case 'champions':      return 'bg-amber-50 text-amber-700';
+          case 'protagonismo':   return 'bg-teal-50 text-teal-700'; // #701 Agenda Viva
           default:               return 'bg-gray-50 text-gray-600';
         }
       };


### PR DESCRIPTION
## #701 Agenda Viva [Frontend] — Slice 3/3 (final)

Fecha os itens de display herdados do Foundation que são **visíveis hoje**.

### O que entra
- `/admin/gamification` — adiciona o caso `protagonismo` (teal) em `pillarColor()`. As 4 rules novas (`agenda_block_protagonismo` + 3 bônus) já eram listadas (query direta em `gamification_rules`), mas o badge do pilar caía no default cinza. Agora renderizam como grupo de primeira classe.

### Diferido para follow-up (#718)
O item mais pesado — split do `protagonismo` fora do catch-all `bonus_points` nos breakdowns de `get_gamification_leaderboard` + `get_tribe_gamification` + `get_initiative_gamification` — foi diferido por grounding ao vivo:
- Esses breakdowns **não exibem** o bucket `bonus` hoje (sem mis-lumping visível).
- protagonismo XP = **0** agora (nenhum bloco confirmado).
- Toca 3 assinaturas `RETURNS TABLE` hot (DROP+CREATE + gate body-drift) + 2-3 consumidores. Melhor quando houver XP real. **Nenhum ponto é perdido** (totais + `get_member_xp_pillars` já agrupam protagonismo).

### Verificação
- `npx astro build` — 0 erro novo.
- 4 rules `protagonismo` confirmadas ao vivo.

Decisão de escopo ratificada pelo PM (2026-06-15). Fecha #701.

Closes #701
Assisted-By: Claude (Anthropic)