### PR TITLE
feat(agenda-viva): #701 add public /reunioes-gerais to the menu tree (Explorar)

### DIFF
--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -25,6 +25,7 @@ const enUS: Record<string, string> = {
   'nav.artifacts': 'Artifacts',
   'nav.attendance': 'Attendance',
   'nav.gamification': '🏆 Gamification',
+  'nav.reunioesGerais': '⭐ General Meetings',
   'hero.cycleActive': 'Cycle 3 In Progress',
   'hero.cycleTribes': 'active tribes',
   'hero.cycleMembers': 'researchers',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -25,6 +25,7 @@ const esLATAM: Record<string, string> = {
   'nav.artifacts': 'Artefactos',
   'nav.attendance': 'Asistencia',
   'nav.gamification': '🏆 Gamificación',
+  'nav.reunioesGerais': '⭐ Reuniones Generales',
   'hero.cycleActive': 'Ciclo 3 en Curso',
   'hero.cycleTribes': 'tribus activas',
   'hero.cycleMembers': 'investigadores',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -25,6 +25,7 @@ const ptBR: Record<string, string> = {
   'nav.artifacts': 'Artefatos',
   'nav.attendance': 'Presença',
   'nav.gamification': '🏆 Gamificação',
+  'nav.reunioesGerais': '⭐ Reuniões Gerais',
   'hero.cycleActive': 'Ciclo 3 em Andamento',
   'hero.cycleTribes': 'tribos ativas',
   'hero.cycleMembers': 'pesquisadores',

--- a/src/lib/navigation.config.ts
+++ b/src/lib/navigation.config.ts
@@ -66,6 +66,8 @@ export const NAV_ITEMS: NavItem[] = [
   { key: 'library',      labelKey: 'nav.library',      href: '/library',      minTier: 'visitor', requiresAuth: false, section: 'both', group: 'tools', navSlot: 'none', drawerSection: 'explorar' },
   { key: 'onboarding',   labelKey: 'nav.onboarding',   href: '/onboarding',   minTier: 'member',  requiresAuth: true,  section: 'main', group: 'profile', navSlot: 'none' },
   { key: 'gamification', labelKey: 'nav.gamification',  href: '/gamification', minTier: 'visitor', requiresAuth: false, section: 'both', group: 'tools', navSlot: 'none', drawerSection: 'explorar' },
+  // #701 Agenda Viva — public General Meetings agenda (anon-OK; reservation gated in-page).
+  { key: 'reunioes-gerais', labelKey: 'nav.reunioesGerais', href: '/reunioes-gerais', minTier: 'visitor', requiresAuth: false, section: 'both', group: 'tools', navSlot: 'none', drawerSection: 'explorar' },
   { key: 'presentations', labelKey: 'nav.presentations', href: '/presentations', minTier: 'member', requiresAuth: true, section: 'main', group: 'tools', navSlot: 'none' },
 
   // ─── Authenticated pages ───


### PR DESCRIPTION
## Tornar `/reunioes-gerais` descoberta no menu

A página pública da Agenda Viva (entregue no #701) só era alcançável pelo CTA da homepage. Este PR adiciona a entrada no **menu (drawer "Explorar")**, com o mesmo shape das páginas públicas `gamification`/`governance`: `minTier: visitor`, `requiresAuth: false`, `group: tools`, `drawerSection: explorar`, `navSlot: none` + chave `nav.reunioesGerais` nos 3 dicionários.

### Verificação no navegador (Playwright + Chromium, anon)
- `/reunioes-gerais?lang=pt-BR` renderiza as **2 próximas Reuniões Gerais** (Qui 18/Jun e Qui 02/Jul, 19:00 · America/Sao_Paulo), barra de **CAPACIDADE "90 min livres"**, estado vazio "Nenhum bloco reservado ainda — seja o primeiro" e o login hint.
- **0 erros de console / 0 falhas de rede** na página.
- Link do nav resolve (drawer) e o CTA da homepage continua apontando para a página.
- `npx astro build` 0 erro · testes `navigation-visibility`+`route-acl`+`i18n-mobile-readiness`+`routing` **58/0** · paridade i18n 3/3.

Relacionado a #701 (já CLOSED).

Assisted-By: Claude (Anthropic)