### PR TITLE
fix(onboarding): unblock pre-onboarding (guest-role) members from /profile lock

### DIFF
--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -287,7 +287,7 @@ const NAV_PUBLIC_SUPABASE_ANON_KEY = (import.meta.env.PUBLIC_SUPABASE_ANON_KEY |
 
 <script>
   import { getSupabase, ROLE_COLORS, setSupabaseRuntimeConfig } from '../../lib/supabase';
-  import { getMemberRole } from '../../lib/routing';
+  import { getMemberRole, isRegisteredMember } from '../../lib/routing';
   import { resolveTierFromMember, hasMinimumTier, type AccessTier } from '../../lib/admin/constants';
   import { TIER_RANK } from '../../lib/navigation.config';
   import { canExploreTribes, canSeeInactiveTribes } from '../../lib/tribes/access';
@@ -630,7 +630,7 @@ const NAV_PUBLIC_SUPABASE_ANON_KEY = (import.meta.env.PUBLIC_SUPABASE_ANON_KEY |
   }
 
   function renderAuth() {
-    if (!_member || getMemberRole(_member) === 'guest') {
+    if (!isRegisteredMember(_member)) {
       if (_user) { renderGuestWithSession(); } else { renderLoggedOut(); }
       return;
     }
@@ -1177,7 +1177,7 @@ const NAV_PUBLIC_SUPABASE_ANON_KEY = (import.meta.env.PUBLIC_SUPABASE_ANON_KEY |
       _member = data;
       renderAuth();
       window.dispatchEvent(new CustomEvent('nav:member', { detail: _member }));
-      if (!_member || getMemberRole(_member) === 'guest') {
+      if (!isRegisteredMember(_member)) {
         window.dispatchEvent(new CustomEvent('nav:guest-with-session', { detail: { user: _user } }));
       }
     }
@@ -1201,7 +1201,7 @@ const NAV_PUBLIC_SUPABASE_ANON_KEY = (import.meta.env.PUBLIC_SUPABASE_ANON_KEY |
           _member = data;
           renderAuth();
           window.dispatchEvent(new CustomEvent('nav:member', { detail: _member }));
-          if (!_member || getMemberRole(_member) === 'guest') {
+          if (!isRegisteredMember(_member)) {
             window.dispatchEvent(new CustomEvent('nav:guest-with-session', { detail: { user: _user } }));
           }
         }

--- a/src/lib/routing.js
+++ b/src/lib/routing.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {{ operational_role?: string | null, role?: string | null }} MemberLike
+ * @typedef {{ id?: string | null, operational_role?: string | null, role?: string | null }} MemberLike
  */
 
 /**
@@ -12,11 +12,27 @@ export function getMemberRole(member) {
 }
 
 /**
+ * Is this a registered member? A member record returned by `get_member_by_auth`
+ * carries an `id`, which means the person IS registered — regardless of
+ * `operational_role`. Pre-onboarding members carry `operational_role='guest'`,
+ * so the role MUST NOT be used as a "not a member" proxy: they need /profile to
+ * complete consent, Credly, alternate emails, name fixes and the volunteer-term
+ * signature BEFORE being promoted out of the guest role. The genuine
+ * authenticated-but-no-member case yields a null member (handled separately via
+ * the WS-B account-claim flow).
+ * @param {MemberLike | null | undefined} member
+ * @returns {boolean}
+ */
+export function isRegisteredMember(member) {
+  return !!(member && member.id);
+}
+
+/**
  * @param {MemberLike | null | undefined} member
  * @returns {boolean}
  */
 export function shouldRedirectFromProfile(member) {
-  return getMemberRole(member) === 'guest';
+  return !isRegisteredMember(member);
 }
 
 /**

--- a/src/pages/attendance.astro
+++ b/src/pages/attendance.astro
@@ -276,7 +276,7 @@ const i18nBundle = buildPageI18n(['attendance', 'meetings', 'comp.common', 'comp
 
   import { hasMinimumTier, resolveTierFromMember } from '../lib/admin/constants';
   import { ROLE_LABELS, ROLE_COLORS } from '../lib/supabase';
-  import { getMemberRole } from '../lib/routing';
+  import { isRegisteredMember } from '../lib/routing';
   import { buildWebinarCommsHref, getAttendanceEditAssistantCopy, getAttendanceHandoffCopy } from '../lib/webinars/context-aids';
   import { marked } from 'marked';
 
@@ -2605,7 +2605,7 @@ const i18nBundle = buildPageI18n(['attendance', 'meetings', 'comp.common', 'comp
 
     // Listen for future auth changes
     window.addEventListener('nav:member', ((e: CustomEvent) => {
-      if (e.detail && getMemberRole(e.detail) !== 'guest') {
+      if (isRegisteredMember(e.detail)) {
         MEMBER = e.detail;
         onMemberReady();
       } else if (!e.detail) {
@@ -2619,7 +2619,7 @@ const i18nBundle = buildPageI18n(['attendance', 'meetings', 'comp.common', 'comp
 
     // 1) Check if nav already has a member loaded
     const m = (window as any).navGetMember?.();
-    if (m && getMemberRole(m) !== 'guest') {
+    if (isRegisteredMember(m)) {
       MEMBER = m;
       onMemberReady();
       return;
@@ -2629,7 +2629,7 @@ const i18nBundle = buildPageI18n(['attendance', 'meetings', 'comp.common', 'comp
     const { data: { session } } = await sb.auth.getSession();
     if (session) {
       const { data } = await sb.rpc('get_member_by_auth');
-      if (data && getMemberRole(data) !== 'guest') {
+      if (isRegisteredMember(data)) {
         MEMBER = data;
         onMemberReady();
         return;

--- a/src/pages/gamification.astro
+++ b/src/pages/gamification.astro
@@ -535,7 +535,7 @@ const SCORING_I18N = {
   window.__GAMIFICATION_I18N = typeof GAM_I18N !== 'undefined' ? GAM_I18N : {};
 </script>
 <script>
-  import { getMemberRole } from '../lib/routing';
+  import { isRegisteredMember } from '../lib/routing';
   import { aggregateCredlyByMember } from '../lib/gamification';
   import { buildTrailProgressByMember } from '../lib/trail-progress';
   import { buildTribeLabel, getTribeColor } from '../lib/tribes/catalog';
@@ -1410,7 +1410,7 @@ const SCORING_I18N = {
     await loadRuntimeTribes();
 
     window.addEventListener('nav:member', ((e: CustomEvent) => {
-      if (e.detail && getMemberRole(e.detail) !== 'guest') {
+      if (isRegisteredMember(e.detail)) {
         MEMBER = e.detail;
         setupUI();
       }
@@ -1421,7 +1421,7 @@ const SCORING_I18N = {
     }) as EventListener);
 
     const m = (window as any).navGetMember?.();
-    if (m && getMemberRole(m) !== 'guest') {
+    if (isRegisteredMember(m)) {
       MEMBER = m;
       setupUI();
       return;
@@ -1430,7 +1430,7 @@ const SCORING_I18N = {
     const { data: { session } } = await sb.auth.getSession();
     if (session) {
       const { data } = await sb.rpc('get_member_by_auth');
-      if (data && getMemberRole(data) !== 'guest') {
+      if (isRegisteredMember(data)) {
         MEMBER = data;
         setupUI();
         return;

--- a/tests/routing.test.mjs
+++ b/tests/routing.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { buildLanguageHref, shouldRedirectFromProfile } from '../src/lib/routing.js';
+import { buildLanguageHref, shouldRedirectFromProfile, isRegisteredMember } from '../src/lib/routing.js';
 
 test('buildLanguageHref keeps index paths correct', () => {
   assert.equal(buildLanguageHref('/', ''), '/');
@@ -14,14 +14,33 @@ test('buildLanguageHref preserves non-index path across locale switches', () => 
   assert.equal(buildLanguageHref('/es/attendance', ''), '/attendance');
 });
 
-test('shouldRedirectFromProfile redirects guest or missing member', () => {
+test('shouldRedirectFromProfile redirects only when there is no member record', () => {
+  // No member at all → genuine "not registered" (handled via WS-B account-claim).
   assert.equal(shouldRedirectFromProfile(undefined), true);
   assert.equal(shouldRedirectFromProfile(null), true);
-  assert.equal(shouldRedirectFromProfile({ role: 'guest' }), true); // legacy-only payload treated as guest
+  // Payload without an id is not a real member record → redirect.
+  assert.equal(shouldRedirectFromProfile({ role: 'guest' }), true);
   assert.equal(shouldRedirectFromProfile({ operational_role: 'guest' }), true);
 });
 
 test('shouldRedirectFromProfile allows authenticated non-guest members', () => {
-  assert.equal(shouldRedirectFromProfile({ operational_role: 'manager' }), false);
-  assert.equal(shouldRedirectFromProfile({ operational_role: 'researcher' }), false);
+  assert.equal(shouldRedirectFromProfile({ id: 'm1', operational_role: 'manager' }), false);
+  assert.equal(shouldRedirectFromProfile({ id: 'm2', operational_role: 'researcher' }), false);
+});
+
+test('pre-onboarding guest members (real member record, guest role) reach their profile', () => {
+  // The bug class fixed here: a returned member record with operational_role='guest'
+  // is a registered pre-onboarding member and MUST NOT be redirected to the
+  // "not registered" dead-end. They need /profile to complete consent, Credly,
+  // alternate emails, name fixes and term signature before promotion.
+  const preOnb = { id: 'm3', operational_role: 'guest', member_status: 'active' };
+  assert.equal(isRegisteredMember(preOnb), true);
+  assert.equal(shouldRedirectFromProfile(preOnb), false);
+});
+
+test('isRegisteredMember distinguishes member record from null/sentinel', () => {
+  assert.equal(isRegisteredMember(null), false);
+  assert.equal(isRegisteredMember(undefined), false);
+  assert.equal(isRegisteredMember({ operational_role: 'guest' }), false); // no id → not a record
+  assert.equal(isRegisteredMember({ id: 'm4', operational_role: 'researcher' }), true);
 });


### PR DESCRIPTION
## Problema (aterrado ao vivo)

19 membros **ativos, logados, registrados** estão presos na tela "Sua conta foi autenticada, mas ainda não está cadastrada no Núcleo" ao tentar acessar **/perfil** — entre eles Henrique Diniz e ~17 voluntários novos aprovados (researcher/leader) com `consent_status='pending'` e os 12 passos de onboarding já semeados.

Resultado: a galera que mais precisa entrar pra **aceitar privacidade/consentimento, adicionar Credly, e-mails adicionais, corrigir nome e assinar o termo** está bloqueada — gerando o ruído relatado nos áudios/WhatsApp.

## Causa raiz

Membros em **pré-onboarding** carregam `operational_role='guest'` (estado legítimo até serem promovidos ao papel real após o onboarding). O frontend tratava `operational_role==='guest'` como **"autenticou mas NÃO é membro"**, em 4 páginas:

- `src/lib/routing.js` → `shouldRedirectFromProfile()`
- `src/components/nav/Nav.astro` → auth chip (`renderAuth`) + dispatch de `nav:guest-with-session` (linhas 633/1180/1204)
- `src/pages/gamification.astro` (3 gates)
- `src/pages/attendance.astro` (3 gates)

O **backend está correto**: `get_member_by_auth()` retorna o member do guest normalmente (verificado ao vivo com a auth.uid do Henrique). O bug é 100% nas guardas de roteamento.

Nota: o "Vincular minha conta" (WS-B, #735) **não** resolvia esses casos — eles já estão linkados (`member.auth_id` = auth.uid). O claim é só para os órfãos de verdade (member null).

## Fix

Introduz `isRegisteredMember(member)` = `!!(member && member.id)`. **Um member record retornado = registrado, qualquer que seja o role.** Os gates de pertencimento passam a usar isso em vez de `role === 'guest'`. O caso genuíno autenticado-sem-member continua dando member `null` e cai no fluxo de account-claim.

`getMemberRole` é preservado onde faz styling de papel real (Nav 641/758).

## Validação

- `tests/routing.test.mjs` atualizado: trava o comportamento novo (guest **com** id não redireciona) + cobre `isRegisteredMember`.
- `npx astro build` ✅ (warning de CSS é pré-existente)
- Suíte DB-aware completa: **4092/4092, 0 falhas**
- Frontend-only, **sem migration**

Closes nada (bug novo); desbloqueia os 19 imediatamente após deploy.

Assisted-By: Claude (Anthropic)