### PR TITLE
feat(onboarding): W4 Slice 2 — affiliation farol member-side + i18n hardening [Wave 4 #740]

### DIFF
--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -4925,6 +4925,27 @@ const enUS: Record<string, string> = {
   'profile.volunteerBanner.rejectedTitle': 'Volunteer Agreement returned',
   'profile.volunteerBanner.rejectedDescription': 'Your agreement for this year was returned and needs to be re-signed. Review your data and sign again.',
   'profile.volunteerBanner.rejectedAction': 'Re-sign',
+  // --- Wave 4 Slice 2 (B2/B3/B6) — affiliation farol + volunteer-agreement i18n ---
+  // B2: PMI affiliation status farol (member-side, /profile)
+  'profile.affiliation.title': 'PMI Membership',
+  'profile.affiliation.expiresLabel': 'Expires on',
+  'profile.affiliation.verifiedOnLabel': 'Verified on',
+  'profile.affiliation.unverifiedDesc': 'Your PMI membership has not been verified by the Membership Office yet. You will be notified once it is confirmed.',
+  'profile.affiliation.inactiveDesc': 'Our latest check shows your PMI membership is inactive. The Volunteer Agreement requires an active membership — renew at pmi.org.',
+  'profile.affiliation.expiredDesc': 'Your PMI membership has expired. Renew at pmi.org to keep your Volunteer Agreement in effect.',
+  'profile.affiliation.expiringDesc': 'Your PMI membership expires soon. Renew at pmi.org so it stays valid.',
+  'profile.affiliation.verifiedDesc': 'Active membership, verified by {verifiedBy}.',
+  'profile.affiliation.renewCta': 'Renew at pmi.org',
+  // B3: rationale line on the /profile pending-term banner (mirrors the volunteer-agreement gate)
+  'profile.volunteerBanner.fieldsRationale': 'These details are required by Law No. 9,608/1998 and the LGPD, and are used only in the Volunteer Agreement and institutional communication.',
+  // B6: volunteer-agreement.astro login gate + missing-fields block (were hardcoded)
+  'volunteer.loginRequired': 'Login required',
+  'volunteer.loginButton': 'Log in',
+  'volunteer.missing.title': 'Complete your profile before signing',
+  'volunteer.missing.description': 'To sign the Volunteer Agreement, you need to complete the following required personal details:',
+  'volunteer.missing.rationale': 'These details are required by Law No. 9,608/1998 and the LGPD. They are used only in the Volunteer Agreement and institutional communication.',
+  'volunteer.missing.action': '✏️ Complete profile now',
+  'volunteer.missing.toastPrefix': 'Incomplete profile: ',
 
   // Governance Dashboard / Approvals
   'governance.dashboard.title': 'Governance — Change Requests',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -4926,6 +4926,27 @@ const esLATAM: Record<string, string> = {
   'profile.volunteerBanner.rejectedTitle': 'Acuerdo de Voluntariado devuelto',
   'profile.volunteerBanner.rejectedDescription': 'Tu acuerdo de este año fue devuelto y debe volver a firmarse. Revisa tus datos y firma nuevamente.',
   'profile.volunteerBanner.rejectedAction': 'Volver a firmar',
+  // --- Wave 4 Slice 2 (B2/B3/B6) — affiliation farol + volunteer-agreement i18n ---
+  // B2: PMI affiliation status farol (member-side, /profile)
+  'profile.affiliation.title': 'Afiliación PMI',
+  'profile.affiliation.expiresLabel': 'Vence el',
+  'profile.affiliation.verifiedOnLabel': 'Verificada el',
+  'profile.affiliation.unverifiedDesc': 'Tu afiliación al PMI aún no fue verificada por la Dirección de Afiliación. Serás avisado en cuanto sea confirmada.',
+  'profile.affiliation.inactiveDesc': 'Nuestra última verificación indica que tu afiliación al PMI está inactiva. El Acuerdo de Voluntariado exige afiliación activa — renueva en pmi.org.',
+  'profile.affiliation.expiredDesc': 'Tu afiliación al PMI venció. Renueva en pmi.org para mantener tu Acuerdo de Voluntariado vigente.',
+  'profile.affiliation.expiringDesc': 'Tu afiliación al PMI vence pronto. Renueva en pmi.org para no perder la vigencia.',
+  'profile.affiliation.verifiedDesc': 'Afiliación activa y verificada por la {verifiedBy}.',
+  'profile.affiliation.renewCta': 'Renovar en pmi.org',
+  // B3: rationale line on the /profile pending-term banner (mirrors the volunteer-agreement gate)
+  'profile.volunteerBanner.fieldsRationale': 'Estos datos son exigidos por la Ley nº 9.608/1998 y la LGPD, y se usan solo en el Acuerdo de Voluntariado y en la comunicación institucional.',
+  // B6: volunteer-agreement.astro login gate + missing-fields block (were hardcoded)
+  'volunteer.loginRequired': 'Inicio de sesión requerido',
+  'volunteer.loginButton': 'Iniciar sesión',
+  'volunteer.missing.title': 'Completa tu perfil antes de firmar',
+  'volunteer.missing.description': 'Para firmar el Acuerdo de Voluntariado, debes completar los siguientes datos personales obligatorios:',
+  'volunteer.missing.rationale': 'Estos datos son obligatorios conforme a la Ley nº 9.608/1998 y la LGPD. Se usan solo en el Acuerdo de Voluntariado y en la comunicación institucional.',
+  'volunteer.missing.action': '✏️ Completar perfil ahora',
+  'volunteer.missing.toastPrefix': 'Perfil incompleto: ',
 
   // Governance Dashboard / Approvals
   'governance.dashboard.title': 'Gobernanza — Change Requests',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -4931,6 +4931,27 @@ const ptBR: Record<string, string> = {
   'profile.volunteerBanner.rejectedTitle': 'Termo de Voluntariado devolvido',
   'profile.volunteerBanner.rejectedDescription': 'Seu termo deste ano foi devolvido e precisa ser reassinado. Revise seus dados e assine novamente.',
   'profile.volunteerBanner.rejectedAction': 'Reassinar',
+  // --- Wave 4 Slice 2 (B2/B3/B6) — affiliation farol + volunteer-agreement i18n ---
+  // B2: PMI affiliation status farol (member-side, /profile)
+  'profile.affiliation.title': 'Filiação PMI',
+  'profile.affiliation.expiresLabel': 'Vence em',
+  'profile.affiliation.verifiedOnLabel': 'Verificada em',
+  'profile.affiliation.unverifiedDesc': 'Sua filiação ao PMI ainda não foi verificada pela Diretoria de Filiação. Você será avisado assim que for confirmada.',
+  'profile.affiliation.inactiveDesc': 'Nossa última verificação indica que sua filiação ao PMI está inativa. O Termo de Voluntariado exige filiação ativa — renove em pmi.org.',
+  'profile.affiliation.expiredDesc': 'Sua filiação ao PMI venceu. Renove em pmi.org para manter seu Termo de Voluntariado vigente.',
+  'profile.affiliation.expiringDesc': 'Sua filiação ao PMI vence em breve. Renove em pmi.org para não perder a vigência.',
+  'profile.affiliation.verifiedDesc': 'Filiação ativa e verificada pela {verifiedBy}.',
+  'profile.affiliation.renewCta': 'Renovar no pmi.org',
+  // B3: rationale line on the /profile pending-term banner (mirrors the volunteer-agreement gate)
+  'profile.volunteerBanner.fieldsRationale': 'Esses dados são exigidos pela Lei nº 9.608/1998 e pela LGPD, e usados apenas no Termo de Voluntariado e na comunicação institucional.',
+  // B6: volunteer-agreement.astro login gate + missing-fields block (were hardcoded)
+  'volunteer.loginRequired': 'Login necessário',
+  'volunteer.loginButton': 'Entrar',
+  'volunteer.missing.title': 'Complete seu perfil antes de assinar',
+  'volunteer.missing.description': 'Para assinar o Termo de Voluntariado, você precisa completar os seguintes dados pessoais obrigatórios:',
+  'volunteer.missing.rationale': 'Esses dados são obrigatórios conforme a Lei nº 9.608/1998 e a LGPD. São usados apenas no Termo de Voluntariado e na comunicação institucional.',
+  'volunteer.missing.action': '✏️ Completar perfil agora',
+  'volunteer.missing.toastPrefix': 'Perfil incompleto: ',
 
   // Governance Dashboard / Approvals
   'governance.dashboard.title': 'Governança — Change Requests',

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -103,6 +103,21 @@ const PROFILE_I18N = {
   entryChapterEmptyGuide: t('profile.entryChapter.emptyGuide', lang),
   entryChapterSaved: t('profile.entryChapter.saved', lang),
   entryChapterErrorPrefix: t('profile.entryChapter.errorPrefix', lang),
+  // B2 (Wave 4) — PMI affiliation farol. Farol labels reuse the admin queue dictionary.
+  affTitle: t('profile.affiliation.title', lang),
+  affExpiresLabel: t('profile.affiliation.expiresLabel', lang),
+  affVerifiedOnLabel: t('profile.affiliation.verifiedOnLabel', lang),
+  affUnverifiedDesc: t('profile.affiliation.unverifiedDesc', lang),
+  affInactiveDesc: t('profile.affiliation.inactiveDesc', lang),
+  affExpiredDesc: t('profile.affiliation.expiredDesc', lang),
+  affExpiringDesc: t('profile.affiliation.expiringDesc', lang),
+  affVerifiedDesc: t('profile.affiliation.verifiedDesc', lang),
+  affRenewCta: t('profile.affiliation.renewCta', lang),
+  affUnverified: t('comp.affiliationQueue.affUnverified', lang),
+  affInactive: t('comp.affiliationQueue.affInactive', lang),
+  affExpired: t('comp.affiliationQueue.affExpired', lang),
+  affExpiring: t('comp.affiliationQueue.affExpiring', lang),
+  affVerified: t('comp.affiliationQueue.affVerified', lang),
   verifyCredly: t('profile.verifyCredly', lang),
   saveChanges: t('profile.saveChanges', lang),
   pmiIdPlaceholder: t('profile.pmiIdPlaceholder', lang),
@@ -224,6 +239,7 @@ const PROFILE_I18N = {
           <div id="va-missing-fields" class="hidden mt-2 text-[11px] text-amber-800 dark:text-amber-300">
             <span class="font-semibold">{t('profile.volunteerBanner.missingLabel', lang)}</span>
             <span id="va-missing-list"></span>
+            <p class="mt-1 italic text-amber-600 dark:text-amber-400">{t('profile.volunteerBanner.fieldsRationale', lang)}</p>
           </div>
         </div>
         <a id="va-action-btn" href={`${langPrefix}/volunteer-agreement`} class="flex-shrink-0 px-3 py-1.5 rounded-lg bg-amber-500 text-white text-xs font-semibold no-underline hover:bg-amber-600 transition-colors">
@@ -329,6 +345,7 @@ const PROFILE_I18N = {
   let _xpScopeInitialized = false;
   let attendanceHoursData = null;
   let chapterAffiliations = [];  // Wave 3b-i — caller's BR chapter affiliations (FACT)
+  let affiliationStatus = null;  // B2 (Wave 4) — caller's latest PMI affiliation verification (self-scoped)
   let currentCycleCode = '';
   let currentCycleLabel = '';
   let cycleMeta = {};
@@ -404,6 +421,9 @@ const PROFILE_I18N = {
     refreshVolunteerAgreementCTA(sb);
     // Wave 3b-i — load the member's BR chapter affiliations for the entry-chapter card.
     await loadChapterAffiliations(sb);
+    // B2 (Wave 4) — load the member's PMI affiliation status (farol). Non-blocking: a
+    // failure just leaves the farol card hidden (the card only renders when data exists).
+    await loadAffiliationStatus(sb);
     // Load cycle history
     try {
       const { data: hist } = await sb.from('member_cycle_history')
@@ -1417,6 +1437,73 @@ const PROFILE_I18N = {
       </div>`;
   }
 
+  // B2 (Wave 4) — PMI affiliation farol (member-side). Makes the otherwise-invisible
+  // membership verification status visible to the member, mirroring the admin queue farol
+  // (AffiliationQueueIsland). Informational only in this wave; the hard gate (B5) is deferred.
+  function affiliationFarolDate(value: string | null | undefined): string {
+    if (!value) return '';
+    const dt = new Date(value);
+    if (Number.isNaN(dt.getTime())) return '';
+    return dt.toLocaleDateString(PROFILE_I18N.dateLocale || 'pt-BR', { day: '2-digit', month: 'short', year: 'numeric' });
+  }
+
+  function affiliationStatusHtml(m: any): string {
+    const status: any = affiliationStatus;
+    const latest: any = status?.latest || null;
+    // Only render when the member has a PMI affiliation context — otherwise the card is noise.
+    const hasContext = !!(latest || status?.pmi_id_verified || m?.pmi_id);
+    if (!status || !hasContext) return '';
+
+    // Farol state — byte-mirror of AffiliationQueueIsland.farol() so member + admin agree.
+    let emoji = '🟢', label = PROFILE_I18N.affVerified, cls = 'bg-emerald-50 text-emerald-700 dark:bg-emerald-900/20 dark:text-emerald-300';
+    // Substitute raw; the whole `desc` string is escaped once at render (avoids double-encoding).
+    let desc = PROFILE_I18N.affVerifiedDesc.replace('{verifiedBy}', latest?.verified_by || 'Diretoria de Filiação');
+    let showRenew = false;
+    let dateRow = '';
+
+    if (!latest) {
+      emoji = '⚪'; label = PROFILE_I18N.affUnverified; cls = 'bg-slate-100 text-slate-500 dark:bg-slate-800 dark:text-slate-400';
+      desc = PROFILE_I18N.affUnverifiedDesc;
+    } else if (latest.membership_active === false) {
+      emoji = '🔴'; label = PROFILE_I18N.affInactive; cls = 'bg-rose-50 text-rose-700 dark:bg-rose-900/20 dark:text-rose-300';
+      desc = PROFILE_I18N.affInactiveDesc; showRenew = true;
+    } else {
+      const exp = latest.membership_expires_on;
+      const days = exp ? Math.ceil((new Date(exp).getTime() - Date.now()) / 86400000) : null;
+      if (days !== null && days < 0) {
+        emoji = '🔴'; label = PROFILE_I18N.affExpired; cls = 'bg-rose-50 text-rose-700 dark:bg-rose-900/20 dark:text-rose-300';
+        desc = PROFILE_I18N.affExpiredDesc; showRenew = true;
+      } else if (days !== null && days <= 30) {
+        emoji = '🟡'; label = PROFILE_I18N.affExpiring; cls = 'bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-300';
+        desc = PROFILE_I18N.affExpiringDesc; showRenew = true;
+      }
+      // else stays verified 🟢
+      const expFmt = affiliationFarolDate(exp);
+      if (expFmt) dateRow = `<div class="text-[.72rem] text-[var(--text-muted)] mt-2"><span class="font-semibold">${PROFILE_I18N.affExpiresLabel}:</span> ${escapeHtmlSafe(expFmt)}</div>`;
+    }
+
+    // For a verified term, also surface when it was verified (trust signal).
+    if (latest && emoji === '🟢') {
+      const verFmt = affiliationFarolDate(latest.created_at);
+      if (verFmt) dateRow += `<div class="text-[.72rem] text-[var(--text-muted)] mt-1"><span class="font-semibold">${PROFILE_I18N.affVerifiedOnLabel}:</span> ${escapeHtmlSafe(verFmt)}</div>`;
+    }
+
+    const renewHtml = showRenew
+      ? `<a href="https://www.pmi.org" target="_blank" rel="noopener noreferrer" class="inline-block mt-3 px-3 py-1.5 rounded-lg bg-navy text-white text-[.72rem] font-semibold no-underline hover:opacity-90 transition-opacity">${PROFILE_I18N.affRenewCta} →</a>`
+      : '';
+
+    return `
+      <div class="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)] p-6">
+        <div class="flex items-center justify-between gap-3 mb-2">
+          <h2 class="text-sm font-bold text-navy">${PROFILE_I18N.affTitle}</h2>
+          <span class="inline-flex items-center gap-1 text-[.72rem] font-semibold px-2.5 py-1 rounded-full ${cls}">${emoji} ${escapeHtmlSafe(label)}</span>
+        </div>
+        <p class="text-[.78rem] text-[var(--text-secondary)] leading-relaxed">${escapeHtmlSafe(desc)}</p>
+        ${dateRow}
+        ${renewHtml}
+      </div>`;
+  }
+
   function renderProfile(m: any) {
     const el = document.getElementById('profile-content');
     if (!el) return;
@@ -1475,6 +1562,9 @@ const PROFILE_I18N = {
 
       <!-- Entry chapter choice (Wave 3b-i / ADR-0104) -->
       ${entryChapterHtml(m)}
+
+      <!-- PMI affiliation farol (Wave 4 / B2) -->
+      ${affiliationStatusHtml(m)}
 
       <!-- My Week -->
       ${myWeekHtml(m)}
@@ -1903,6 +1993,21 @@ const PROFILE_I18N = {
     } catch (e) {
       console.warn('Profile: failed to load chapter affiliations:', e);
       chapterAffiliations = [];
+    }
+  }
+
+  // B2 (Wave 4) — load the member's own PMI affiliation status. get_member_affiliation_status
+  // is SECURITY DEFINER + self-scoped: passing the caller's own member id returns pmi_id_verified
+  // + the latest verification (membership_active / membership_expires_on / verified_by as a ROLE,
+  // never the agent name). LGPD: verification_obs is withheld for self (only via export_my_data).
+  async function loadAffiliationStatus(sb: any) {
+    if (!currentMember?.id) return;
+    try {
+      const { data } = await sb.rpc('get_member_affiliation_status', { p_member_id: currentMember.id });
+      affiliationStatus = data || null;
+    } catch (e) {
+      console.warn('Profile: failed to load affiliation status:', e);
+      affiliationStatus = null;
     }
   }
 

--- a/src/pages/volunteer-agreement.astro
+++ b/src/pages/volunteer-agreement.astro
@@ -262,7 +262,7 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
       }
     }
     if (!member) {
-      app.innerHTML = `<div class="text-center py-12"><p class="text-[var(--text-muted)]">Login required</p><button class="mt-3 px-4 py-2 bg-navy text-white rounded-lg border-0 cursor-pointer text-sm font-semibold" onclick="document.dispatchEvent(new CustomEvent('open-auth'))">Login</button></div>`;
+      app.innerHTML = `<div class="text-center py-12"><p class="text-[var(--text-muted)]">${esc(t('volunteer.loginRequired', lang))}</p><button class="mt-3 px-4 py-2 bg-navy text-white rounded-lg border-0 cursor-pointer text-sm font-semibold" onclick="document.dispatchEvent(new CustomEvent('open-auth'))">${esc(t('volunteer.loginButton', lang))}</button></div>`;
       return;
     }
 
@@ -306,15 +306,16 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
       return;
     }
 
-    // Pre-flight: check profile completeness before showing form
+    // Pre-flight: check profile completeness before showing form.
+    // Labels reuse the shared profile.field.* dictionary so the missing-fields list is localized.
     const requiredFields: Record<string, string> = {
-      pmi_id: 'PMI ID',
-      phone: 'Telefone',
-      address: 'Endereço',
-      city: 'Cidade',
-      state: 'Estado',
-      country: 'País',
-      birth_date: 'Data de Aniversário',
+      pmi_id: t('profile.field.pmiId', lang),
+      phone: t('profile.field.phone', lang),
+      address: t('profile.field.address', lang),
+      city: t('profile.field.city', lang),
+      state: t('profile.field.state', lang),
+      country: t('profile.field.country', lang),
+      birth_date: t('profile.field.birthDate', lang),
     };
     const missing: string[] = [];
     for (const [key, label] of Object.entries(requiredFields)) {
@@ -328,19 +329,18 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
       app.innerHTML = rejectedBanner + `
         <div class="rounded-2xl border-2 border-amber-300 bg-amber-50 dark:bg-amber-900/20 dark:border-amber-700 p-6 text-center">
           <div class="text-4xl mb-3">📋</div>
-          <h2 class="text-lg font-bold text-amber-800 dark:text-amber-300 mb-2">Complete seu perfil antes de assinar</h2>
+          <h2 class="text-lg font-bold text-amber-800 dark:text-amber-300 mb-2">${esc(t('volunteer.missing.title', lang))}</h2>
           <p class="text-sm text-amber-700 dark:text-amber-400 mb-4">
-            Para assinar o Termo de Voluntariado, você precisa completar os seguintes dados pessoais obrigatórios:
+            ${esc(t('volunteer.missing.description', lang))}
           </p>
           <ul class="inline-block text-left text-sm text-amber-800 dark:text-amber-300 mb-4 space-y-1">
-            ${missing.map(f => `<li>• <b>${f}</b></li>`).join('')}
+            ${missing.map(f => `<li>• <b>${esc(f)}</b></li>`).join('')}
           </ul>
           <p class="text-xs text-amber-600 dark:text-amber-400 mb-4 italic">
-            Esses dados são obrigatórios conforme a Lei nº 9.608/1998 e a LGPD.<br/>
-            São usados apenas no Termo de Voluntariado e comunicação institucional.
+            ${esc(t('volunteer.missing.rationale', lang))}
           </p>
           <a href="${profileUrl}#personal-data" class="inline-block px-5 py-2.5 rounded-lg bg-amber-500 text-white text-sm font-bold no-underline hover:bg-amber-600 transition-colors">
-            ✏️ Completar perfil agora →
+            ${esc(t('volunteer.missing.action', lang))} →
           </a>
         </div>`;
       return;
@@ -368,7 +368,7 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
         if (data?.error === 'already_signed') { app.innerHTML = renderAlreadySigned(lang); return; }
         if (data?.error === 'profile_incomplete') {
           const missing = Array.isArray(data.missing_fields) ? data.missing_fields : [];
-          (window as any).toast?.(`Perfil incompleto: ${missing.join(', ')}`, 'error');
+          (window as any).toast?.(`${t('volunteer.missing.toastPrefix', lang)}${missing.join(', ')}`, 'error');
           const profileUrl = lang === 'pt-BR' ? '/profile' : lang === 'en-US' ? '/en/profile' : '/es/profile';
           setTimeout(() => { window.location.href = profileUrl; }, 1500);
           return;


### PR DESCRIPTION
## Wave 4 Slice 2 (B2 + B3 + B6) — FE-only

Continuation of Wave 4 (Termo v2 block B2–B5). **No SQL/RPC changes.**

### B2 — PMI affiliation farol, member-side (`/profile`)
Surfaces the otherwise-invisible PMI membership verification status to the member, fed by the existing self-scoped `SECURITY DEFINER` RPC `get_member_affiliation_status` (called with the caller's own member id). The new card **mirrors the admin queue farol byte-for-byte** on state thresholds:

| State | Light | Trigger |
|---|---|---|
| Unverified | ⚪ | no verification on record |
| Inactive | 🔴 | `membership_active === false` |
| Expired | 🔴 | `membership_expires_on < today` |
| Expiring | 🟡 | expires within 30 days |
| Verified | 🟢 | active + not expiring |

Non-green states get a member-facing explanation + a **renew-at-pmi.org** CTA; the verified state shows the verification date as a trust signal. **LGPD:** only self-data is shown — the RPC withholds `verification_obs` for self and returns `verified_by` as the role string `Diretoria de Filiação` (never the agent name). Informational only this wave; the hard gate (B5) stays deferred per PM call.

### B3 — explanatory copy i18n
i18n-abstracts the "why these fields" rationale (Lei 9.608/98 + LGPD) in the volunteer-agreement missing-fields block, and adds the same rationale line to the `/profile` pending-term banner (which previously explained nothing).

### B6 — i18n hardening (`volunteer-agreement.astro`)
i18n-abstracts the remaining hardcoded strings: login gate, missing-fields title/description/action, required-field labels (now reuse the shared `profile.field.*` dictionary), and the incomplete-profile toast.

### Validation
- 17 new i18n keys across all 3 dictionaries (parity verified)
- `npx astro build` clean
- offline suite **0 fail** (DB-aware contract tests run in CI with secrets; this change touches no SQL/RPC)
- **code-reviewer: 0 blockers** (LOW double-escape nit fixed in-commit)

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>