### PR TITLE
feat(onboarding): W4 Block J — channel matrix (J2) + Disney milestone celebration (J5) [Wave 4 #740]

### DIFF
--- a/docs/reference/PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md
+++ b/docs/reference/PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md
@@ -1,0 +1,80 @@
+# Matriz de Canais & Marcos "jeito Disney" — Jornada de Pré-Onboarding (J2 + J5)
+
+> **Status:** vivo · **Origem:** discovery #740 (gaps J2 + J5) · **Aterrado:** 2026-06-16 (Wave 4)
+> **Escopo:** primeira pernada (aprovação na seleção → aceite VEP → pré-onboarding → termo → promoção → 1ºs dias).
+> **Companheiro de:** [`PRE_ONBOARDING_COMMS_MAP_2026-06-16.md`](./PRE_ONBOARDING_COMMS_MAP_2026-06-16.md) (J1 — o mapa
+> de **o que** é comunicado por etapa). Este doc define **por qual canal** (J2) e **como celebramos marcos** (J5).
+
+O J1 mapeou a malha de comunicação por etapa, mas o discovery apontou que **falta o princípio de decisão de canal**
+("sem matriz definida") e que o **tom de celebração de marcos é inconsistente** (existe em perfil 100%, ausente nos
+demais marcos). Este doc fecha esses dois gaps de *definição*. Onde algo ainda **não está implementado**, está rotulado
+explicitamente como **FUTURO** — sem doc-fake (mesma disciplina do J1/J4 na Wave 2).
+
+---
+
+## Parte A — Matriz de decisão de canal (J2)
+
+Três canais, três propósitos distintos. A regra é **propósito → canal**, não "manda em todos".
+
+| Canal | Propósito | Quando usar | Fonte de verdade |
+|---|---|---|---|
+| **E-mail** | Formal, externo, acionável fora da plataforma | Marcos oficiais (aprovação, termo disponível, promoção), lembretes com prazo, qualquer coisa que o usuário precise ver **mesmo sem entrar na plataforma** | `_delivery_mode_for(type)` → `transactional_immediate` (na hora) ou `digest_weekly` (junta no digest de sábado) |
+| **In-app (sino + painel)** | Operacional, contextual, status | Nudges de progresso, fila de ação da liderança (D1/E1), status que só faz sentido **dentro** da plataforma | tabela `notifications`; `_delivery_mode_for(type)` → `suppress` (só sino, sem e-mail) |
+| **WhatsApp (grupo coletivo)** | Comunidade, dúvidas, calor humano | Acolhimento, dúvidas abertas (candidato ↔ Núcleo ↔ diretorias), avisos coletivos informais. **Nunca** dado individual/PII (é grupo) | grupo `chat.whatsapp.com/Gl6eUqK45DJGQxZ8VFE2bs` (link único, ver `PreOnboardingChecklist.tsx`) |
+
+### Regras de decisão (heurística)
+1. **É individual e tem PII?** → nunca WhatsApp coletivo. E-mail (formal) ou in-app (operacional).
+2. **Precisa de ação fora da plataforma ou é um marco formal?** → e-mail (`transactional_immediate`).
+3. **É status/nudge que só importa dentro da plataforma?** → in-app `suppress` (sino), sem poluir a caixa de e-mail.
+4. **Pode esperar e agregar?** → `digest_weekly` (digest de sábado), não e-mail individual.
+5. **É acolhimento / dúvida aberta / comunidade?** → WhatsApp coletivo (complementa, nunca substitui o canal formal).
+
+### Anti-padrões
+- **Duplicar o mesmo aviso em e-mail + sino + WhatsApp** "por garantia" → ruído; escolha o canal pelo propósito.
+- **Mandar dado individual (status, nome, capítulo) no grupo de WhatsApp** → vazamento (LGPD): o grupo é coletivo.
+- **E-mail para nudge puramente operacional** (ex.: "seu onboarding está 60%") → use o sino (`suppress`).
+
+### Roteamento já implementado (referência cruzada)
+A coluna "Canal / tipo" do [comms map (J1)](./PRE_ONBOARDING_COMMS_MAP_2026-06-16.md#mapa-por-etapa) lista o canal
+de cada etapa. O **roteador** é `public._delivery_mode_for(p_type)` (SSOT). Esta matriz é o **princípio** por trás
+daquelas escolhas — use-a ao adicionar um tipo novo de notificação.
+
+---
+
+## Parte B — Matriz de marcos "jeito Disney" (J5)
+
+Princípio: **todo marco merece um momento.** Celebrar reforça pertencimento e reduz desengajamento silencioso.
+Tom: caloroso, segunda pessoa, orientado ao próximo passo — **sem números fabricados** (regra de grounding).
+
+| Marco | Celebração | Canal | Status |
+|---|---|---|---|
+| **Perfil 100%** | Recompensa de XP + feedback visual | in-app (gamificação) | ✅ **EXISTE** (pré-Wave 4) |
+| **Onboarding completo** (todos os passos pós-promoção) | Card celebrativo "🎉 Onboarding concluído!" no lugar do checklist (antes sumia em silêncio); mostrado 1× (localStorage-gated) + CTA explorar | in-app (`OnboardingChecklist`) | ✅ **NOVO nesta fatia (J5)** |
+| **Termo de voluntariado assinado** | Hoje: notifica a **liderança** (`volunteer_agreement_signed`) + tela de sucesso do membro (A4, Wave 1). Celebração member-side dedicada ("você é oficialmente voluntário") | in-app / e-mail | 🟡 **PARCIAL** — sucesso existe; celebração de marco dedicada = FUTURO |
+| **Promoção** (contra-assinatura do GP) | Momento "bem-vindo, membro ativo" no primeiro acesso pós-promoção (hoje o membro só vê o checklist de 1ºs dias — H1) | in-app | 🟡 **PARCIAL** — card de 1ºs dias existe (Block H); celebração de promoção dedicada = FUTURO |
+| **1ª presença registrada** | "Sua primeira presença! 🎯" | in-app | 🔴 **FUTURO** — nudge existe (Block H beat 2); celebração ao registrar = não implementado |
+| **1ª entrega / deliverable** | "Primeira entrega no quadro! 🚀" | in-app | 🔴 **FUTURO** — não implementado |
+
+### Diretrizes de tom (para qualquer celebração futura)
+- **Segunda pessoa, presente:** "Você concluiu…", não "O usuário concluiu…".
+- **Nomeie o marco + aponte o próximo passo:** celebrar sem deixar o membro perdido ("e agora?").
+- **Uma vez, não a cada visita:** persistir "já celebrado" (localStorage no client, ou flag no `onboarding_progress`
+  para marcos server-side) — evita o nag que mata o efeito.
+- **Sem inventar métrica:** "você completou todas as etapas" (fato), nunca "você é o 42º a completar" sem query viva.
+- **Reusar a malha existente:** marcos server-side podem virar `notifications` roteadas por `_delivery_mode_for`;
+  marcos client-side (como o onboarding-complete) ficam no componente da superfície.
+
+---
+
+## Lacunas / próximos passos (honestos)
+- **J5 marcos server-side** (termo assinado member-side, promoção, 1ª presença, 1ª entrega): exigem gatilho no
+  evento (trigger/cron) + persistência de "já celebrado" — **feature futura**, não simulada aqui. Severidade 🟢.
+- **J4 — cadência/SLA configurável** (já registrado no comms map): janelas fixas no código dos crons; config = futuro.
+- **J6 — cópia operacional canônica** embutida nos e-mails/telas: ver §9 do discovery; parcialmente embutido
+  (aceite VEP, sync de filiação privada já estão em telas/banners).
+
+## Cross-ref
+- [`PRE_ONBOARDING_COMMS_MAP_2026-06-16.md`](./PRE_ONBOARDING_COMMS_MAP_2026-06-16.md) (J1)
+- discovery `docs/project-governance/PRE_ONBOARDING_JOURNEY_DISCOVERY_2026-06-16.md` (Épico J)
+- `_delivery_mode_for` (SSOT de roteamento) · tabela `notifications` · `OnboardingChecklist.tsx` (celebração J5)
+- grupo WhatsApp: `chat.whatsapp.com/Gl6eUqK45DJGQxZ8VFE2bs`

--- a/docs/reference/PRE_ONBOARDING_COMMS_MAP_2026-06-16.md
+++ b/docs/reference/PRE_ONBOARDING_COMMS_MAP_2026-06-16.md
@@ -49,6 +49,10 @@ não substitui as fontes de verdade abaixo.
 - **Grupo de WhatsApp de pré-onboarding** (dúvidas; candidatos + Núcleo + diretorias):
   `chat.whatsapp.com/Gl6eUqK45DJGQxZ8VFE2bs`.
 
+> **J2 (decisão de canal) + J5 (marcos "jeito Disney")** agora têm doc próprio:
+> [`PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md`](./PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md)
+> (Wave 4) — o **princípio** por trás da coluna "Canal / tipo" acima + a matriz de celebração de marcos.
+
 ## Lacunas conhecidas (não cobertas aqui)
 - **J4 — cadência/SLA configurável** (oferta não aceita, termo não assinado, onboarding
   parado, convite sem agendamento): hoje as janelas são **fixas no código** dos crons. Um

--- a/src/components/onboarding/OnboardingChecklist.tsx
+++ b/src/components/onboarding/OnboardingChecklist.tsx
@@ -77,6 +77,36 @@ function hblock(lang: string): HBlock {
   return HBLOCK['pt-BR'];
 }
 
+// J5 #740 — "Disney tone": celebrate the onboarding-complete milestone instead of the
+// checklist silently vanishing. Shown once (localStorage-gated) when all steps are done.
+interface Celebrate { title: string; body: string; cta: string; dismiss: string }
+const CELEBRATE: Record<string, Celebrate> = {
+  'pt-BR': {
+    title: '🎉 Onboarding concluído!',
+    body: 'Parabéns! Você completou todas as etapas e agora faz parte ativa do Núcleo. Bora construir IA aplicada a projetos com a gente!',
+    cta: '🚀 Explorar a plataforma',
+    dismiss: 'Fechar',
+  },
+  'en-US': {
+    title: '🎉 Onboarding complete!',
+    body: 'Congratulations! You\'ve finished every step and you\'re now an active member of the Hub. Let\'s build AI applied to projects together!',
+    cta: '🚀 Explore the platform',
+    dismiss: 'Close',
+  },
+  'es-LATAM': {
+    title: '🎉 ¡Integración completa!',
+    body: '¡Felicitaciones! Completaste todos los pasos y ya eres parte activa del Núcleo. ¡Vamos a construir IA aplicada a proyectos juntos!',
+    cta: '🚀 Explorar la plataforma',
+    dismiss: 'Cerrar',
+  },
+};
+function celebrate(lang: string): Celebrate {
+  if (lang.startsWith('en')) return CELEBRATE['en-US'];
+  if (lang.startsWith('es')) return CELEBRATE['es-LATAM'];
+  return CELEBRATE['pt-BR'];
+}
+const CELEBRATION_SEEN_KEY = 'nia_onboarding_celebrated';
+
 export default function OnboardingChecklist({ lang = 'pt-BR' }: Props) {
   const l = L[lang] || L['pt-BR'];
   const h = hblock(lang);
@@ -88,7 +118,11 @@ export default function OnboardingChecklist({ lang = 'pt-BR' }: Props) {
   const [allComplete, setAllComplete] = useState(false);
   const [expanded, setExpanded] = useState(true); // auto-expand for new members
   const [loading, setLoading] = useState(true);
-  const [dismissed, setDismissed] = useState(false);
+  // J5 #740 — seed `dismissed` from the once-seen flag so a member who already saw the
+  // onboarding-complete celebration short-circuits at the first guard (no render-branch read, no flash).
+  const [dismissed, setDismissed] = useState(() => {
+    try { return localStorage.getItem(CELEBRATION_SEEN_KEY) === '1'; } catch { return false; }
+  });
 
   const getSb = useCallback(() => (window as any).navGetSb?.(), []);
 
@@ -122,8 +156,28 @@ export default function OnboardingChecklist({ lang = 'pt-BR' }: Props) {
     (window as any).toast?.(l.done + '!', 'success');
   };
 
-  if (loading || allComplete || dismissed) return null;
+  if (loading || dismissed) return null;
   if (steps.length === 0) return null;
+
+  // J5 #740 — celebrate the onboarding-complete milestone once (instead of the checklist
+  // silently vanishing). Already-seen members were filtered by the `dismissed` guard above.
+  if (allComplete) {
+    const c = celebrate(lang);
+    const dismissCelebration = () => {
+      try { localStorage.setItem(CELEBRATION_SEEN_KEY, '1'); } catch { /* SSR/private mode */ }
+      setDismissed(true);
+    };
+    return (
+      <div className="rounded-2xl border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/40 dark:bg-emerald-900/15 p-5 mb-6 shadow-sm text-center">
+        <h2 className="text-base font-extrabold text-emerald-700 dark:text-emerald-300">{c.title}</h2>
+        <p className="text-[12px] text-emerald-800 dark:text-emerald-200 mt-1.5 leading-relaxed">{c.body}</p>
+        <div className="mt-3 flex items-center justify-center gap-2">
+          <a href={`${lp}/gamification`} className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-[11px] font-bold no-underline hover:bg-emerald-700">{c.cta}</a>
+          <button onClick={dismissCelebration} className="px-3 py-1.5 rounded-lg border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 text-[11px] font-semibold bg-transparent cursor-pointer hover:bg-emerald-100/50">{c.dismiss}</button>
+        </div>
+      </div>
+    );
+  }
 
   const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
   const member = (window as any).navGetMember?.();


### PR DESCRIPTION
## Wave 4 — Block J (comunicações & cadência), encerra a Wave 4

Continuação da Wave 4 (após B Termo v2, F comunidade, H primeiros dias). Fecha os gaps de **definição** do Épico J do pré-onboarding (#740). **Sem SQL/RPC/migração** — 1 componente FE + 1 doc novo + cross-ref.

### O que entra
- **J5 — celebração concreta (Disney).** O `OnboardingChecklist` pós-promoção retornava `null` quando `allComplete` (o checklist **sumia em silêncio** — momento Disney perdido). Agora renderiza um card celebrativo "🎉 Onboarding concluído!" **uma única vez** (gated por `localStorage` `nia_onboarding_celebrated`), com CTA de explorar. `dismissed` é semeado da flag → quem já viu curto-circuita no 1º guard. Trilíngue inline (`CELEBRATE`), idioma do componente. Sem números.
- **J2 + J5 — doc de referência.** Novo `docs/reference/PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md`: **matriz de decisão de canal** (WhatsApp = comunidade/dúvidas · in-app = operacional · e-mail = formal/externo, fundamentada em `_delivery_mode_for`) + **matriz de marcos Disney** rotulando honestamente o que **EXISTE vs FUTURO** (celebrações de termo/promoção/1ª presença/1ª entrega = futuro, sem doc-fake). Cross-ref adicionado ao comms map (J1).

### Validação
- `npx astro build` verde.
- Suíte offline: **0 fail / 331 skip** (DB-aware no CI).
- **code-reviewer: 0 BLOCKERS.** 1 MEDIUM (nota de qualidade) aplicada in-commit: semear `dismissed` do localStorage via lazy `useState`, eliminando a leitura no caminho de render + flash de 1 tick.

### Wave 4 completa
B (Termo v2) + F (comunidade) + H (primeiros dias) + J (canais) fechados. Umbrella **#740** pode ser revisada para fechamento (resta higiene/itens 🟢 dispersos: J4 SLA configurável, marcos server-side futuros, buddy H5).

🤖 Assisted-By: Claude (Anthropic)