### PR TITLE
chore(docs): sync metric numbers — MCP 320, Edge Functions 38, i18n 6.2k

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-300%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
+[![MCP](https://img.shields.io/badge/MCP-320%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,9 +43,9 @@ Fundado en 2024 como piloto en PMI Goias, el proyecto evoluciono hacia una alian
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de gobernanza | 160+ |
 | Posts en el blog | 9 |
-| Herramientas MCP | 300+ |
-| Edge Functions | 37 |
-| Claves i18n | 4.000+ (3 idiomas) |
+| Herramientas MCP | 320+ |
+| Edge Functions | 38 |
+| Claves i18n | 6.200+ (3 idiomas) |
 | Tests | 1.418 pasando (1.456 con service-role) |
 | Costo mensual | $0 |
 
@@ -81,7 +81,7 @@ graph LR
     subgraph "Supabase"
         G --> H[Auth<br/>Google · LinkedIn · Microsoft]
         E --> I[PostgreSQL<br/>795 RPC · RLS]
-        F --> J[Edge Functions<br/>37 deployed]
+        F --> J[Edge Functions<br/>38 deployed]
         I --> K[pg_cron<br/>34 jobs]
     end
 
@@ -108,8 +108,8 @@ graph LR
 | **Hospedaje** | Cloudflare Workers | SSR en el edge, proxy OAuth, proxy MCP |
 | **Base de Datos** | Supabase PostgreSQL | 795 RPCs y helpers SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor personalizado (300+ herramientas) | Asistentes de IA consultan la plataforma via lenguaje natural |
-| **Logica Server** | Supabase Edge Functions (37) | Sync Credly, asistencia, MCP, campañas, PostHog proxy, AI/video |
+| **MCP** | Servidor personalizado (320+ herramientas) | Asistentes de IA consultan la plataforma via lenguaje natural |
+| **Logica Server** | Supabase Edge Functions (38) | Sync Credly, asistencia, MCP, campañas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de producto, session replay |
 | **Errores** | Sentry | Monitoreo de errores en tiempo real |
 | **Cron** | pg_cron (34 jobs) | Sync Credly, asistencia, alertas detractores, recordatorios, LGPD, AI/video y digests |
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracion con IA
 
-Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. 300+ herramientas autenticadas via OAuth 2.1 con Row Level Security. Auto-refresh server-side mantiene sesiones activas por hasta 30 dias sin reconexion manual. Capa de conocimiento dinamica adapta orientaciones al rol y permisos de cada miembro.
+Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. 320+ herramientas autenticadas via OAuth 2.1 con Row Level Security. Auto-refresh server-side mantiene sesiones activas por hasta 30 dias sin reconexion manual. Capa de conocimiento dinamica adapta orientaciones al rol y permisos de cada miembro.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -227,7 +227,7 @@ npm test
 │   ├── lib/            # Cliente Supabase, auth, utilitarios
 │   └── middleware/      # CSP, auth, i18n
 ├── supabase/
-│   ├── functions/      # 37 Edge Functions
+│   ├── functions/      # 38 Edge Functions
 │   └── migrations/     # Migraciones de base de datos
 ├── tests/              # 1.418 tests pasando
 ├── docs/               # Gobernanza, guias, specs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-300%2B%20Tools-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
+[![MCP](https://img.shields.io/badge/MCP-320%2B%20Tools-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -44,11 +44,11 @@ Founded in 2024 as a pilot within PMI Goiás, the initiative has grown into a st
 | Events held | 209 |
 | Governance entries | 141+ (GC-001 → GC-141+) |
 | Blog posts | 9 |
-| MCP tools | 300+ |
-| Edge Functions | 37 |
+| MCP tools | 320+ |
+| Edge Functions | 38 |
 | pg_cron jobs | 34 |
 | RPCs (SECURITY DEFINER + helpers) | 795 |
-| i18n keys | 4,000+ (3 locales) |
+| i18n keys | 6,200+ (3 locales) |
 | Tests | 1,449 passing (1,501 with service-role env) |
 | Monthly cost | $0 |
 
@@ -84,7 +84,7 @@ graph LR
     subgraph "Supabase"
         G --> H[Auth<br/>Google · LinkedIn · Microsoft]
         E --> I[PostgreSQL<br/>795 RPC · RLS]
-        F --> J[Edge Functions<br/>37 deployed]
+        F --> J[Edge Functions<br/>38 deployed]
         I --> K[pg_cron<br/>34 jobs]
     end
 
@@ -111,8 +111,8 @@ graph LR
 | **Hosting** | Cloudflare Workers | Edge SSR, OAuth proxy, MCP proxy |
 | **Database** | Supabase PostgreSQL | 200+ SECURITY DEFINER functions, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, dynamic client registration |
-| **MCP** | Custom server (300+ tools) | AI assistants query platform via natural language |
-| **Server Logic** | Supabase Edge Functions (37) | Credly sync, attendance, MCP, campaigns, Artia sync, PostHog proxy, AI triage |
+| **MCP** | Custom server (320+ tools) | AI assistants query platform via natural language |
+| **Server Logic** | Supabase Edge Functions (38) | Credly sync, attendance, MCP, campaigns, Artia sync, PostHog proxy, AI triage |
 | **Analytics** | PostHog | Product analytics, session replay |
 | **Errors** | Sentry | Real-time error monitoring |
 | **Cron** | pg_cron (34 jobs) | Credly sync, attendance batch, detractor alerts, weekly digests (member · leader · tribe), MCP anomaly detection, LGPD anonymize, log retention, R2 backup, AI retry queues, Artia sync, drive-discover-atas, V4 engagement expiry/anonymize |
@@ -123,7 +123,7 @@ graph LR
 
 ## MCP Server — AI Integration
 
-Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. 300+ tools authenticated via OAuth 2.1 with full Row Level Security enforcement. Server-side auto-refresh keeps sessions alive for up to 30 days without manual reconnection. Dynamic knowledge layer adapts guidance to each member's role and permissions.
+Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. 320+ tools authenticated via OAuth 2.1 with full Row Level Security enforcement. Server-side auto-refresh keeps sessions alive for up to 30 days without manual reconnection. Dynamic knowledge layer adapts guidance to each member's role and permissions.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -236,7 +236,7 @@ npm test
 │   ├── lib/            # Supabase client, auth, utilities
 │   └── middleware/      # CSP, auth, i18n
 ├── supabase/
-│   ├── functions/      # 35 Edge Functions
+│   ├── functions/      # 38 Edge Functions
 │   └── migrations/     # Database migrations
 ├── tests/              # 1,383 passing tests
 ├── docs/               # Governance, guides, specs

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-300%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
+[![MCP](https://img.shields.io/badge/MCP-320%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,9 +43,9 @@ Fundado em 2024 como piloto no PMI Goias, o projeto evoluiu para uma alianca est
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de governanca | 160+ |
 | Posts no blog | 9 |
-| Ferramentas MCP | 300+ |
-| Edge Functions | 37 |
-| Chaves i18n | 4.000+ (3 idiomas) |
+| Ferramentas MCP | 320+ |
+| Edge Functions | 38 |
+| Chaves i18n | 6.200+ (3 idiomas) |
 | Testes | 1.418 passando (1.456 com service-role) |
 | Custo mensal | $0 |
 
@@ -81,7 +81,7 @@ graph LR
     subgraph "Supabase"
         G --> H[Auth<br/>Google · LinkedIn · Microsoft]
         E --> I[PostgreSQL<br/>795 RPC · RLS]
-        F --> J[Edge Functions<br/>37 deployed]
+        F --> J[Edge Functions<br/>38 deployed]
         I --> K[pg_cron<br/>34 jobs]
     end
 
@@ -108,8 +108,8 @@ graph LR
 | **Hospedagem** | Cloudflare Workers | SSR na edge, proxy OAuth, proxy MCP |
 | **Banco de Dados** | Supabase PostgreSQL | 795 RPCs e helpers SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor customizado (300+ ferramentas) | Assistentes de IA consultam a plataforma via linguagem natural |
-| **Logica Server** | Supabase Edge Functions (37) | Sync Credly, presenca, MCP, campanhas, PostHog proxy, AI/video |
+| **MCP** | Servidor customizado (320+ ferramentas) | Assistentes de IA consultam a plataforma via linguagem natural |
+| **Logica Server** | Supabase Edge Functions (38) | Sync Credly, presenca, MCP, campanhas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de produto, session replay |
 | **Erros** | Sentry | Monitoramento de erros em tempo real |
 | **Cron** | pg_cron (34 jobs) | Sync Credly, presenca, alertas detratores, lembretes, LGPD, AI/video e digests |
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracao com IA
 
-Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. 300+ ferramentas autenticadas via OAuth 2.1 com Row Level Security. Auto-refresh server-side mantem sessoes ativas por ate 30 dias sem reconexao manual. Camada de conhecimento dinamica adapta orientacoes ao papel e permissoes de cada membro.
+Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. 320+ ferramentas autenticadas via OAuth 2.1 com Row Level Security. Auto-refresh server-side mantem sessoes ativas por ate 30 dias sem reconexao manual. Camada de conhecimento dinamica adapta orientacoes ao papel e permissoes de cada membro.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -227,7 +227,7 @@ npm test
 │   ├── lib/            # Cliente Supabase, auth, utilitarios
 │   └── middleware/      # CSP, auth, i18n
 ├── supabase/
-│   ├── functions/      # 37 Edge Functions
+│   ├── functions/      # 38 Edge Functions
 │   └── migrations/     # Migracoes do banco de dados
 ├── tests/              # 1.418 testes passando
 ├── docs/               # Governanca, guias, specs

--- a/scripts/check-doc-metrics.sh
+++ b/scripts/check-doc-metrics.sh
@@ -2,6 +2,14 @@
 # check-doc-metrics.sh — Warns when documentation metrics drift from codebase reality.
 # Run manually: ./scripts/check-doc-metrics.sh
 # Or add to pre-commit / CI to prevent stale docs.
+#
+# Scope note (2026-06-17): this script asserts ONLY on the public-facing README
+# numbers (the reader-facing contract). It deliberately does NOT check CLAUDE.md
+# or .claude/rules/mcp.md: both files explicitly decided NOT to pin volatile
+# counts (CLAUDE.md "Current state … NOT pinned per Anthropic guidance";
+# rules/mcp.md "## Current State (do NOT pin counts here) … never pin it here").
+# Demanding a pinned number there was a permanent false-positive. Get the live
+# MCP tool count from the running server (see .claude/rules/mcp.md), not from docs.
 
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
@@ -18,37 +26,27 @@ echo "  Edge Functions (actual): $EF_COUNT"
 echo "  i18n keys (actual): ~$I18N_KEYS"
 echo ""
 
-# ── Check CLAUDE.md ──
-CLAUDE_MCP=$(grep -oP '\d+ MCP tools' "$ROOT/CLAUDE.md" | grep -oP '^\d+' || echo "?")
-CLAUDE_EF=$(grep -oP '\d+ Edge Functions' "$ROOT/CLAUDE.md" | grep -oP '^\d+' || echo "?")
-
-if [ "$CLAUDE_MCP" != "$MCP_TOOLS" ]; then
-  echo "DRIFT: CLAUDE.md says $CLAUDE_MCP MCP tools, actual is $MCP_TOOLS"
-  ERRORS=$((ERRORS + 1))
-fi
-if [ "$CLAUDE_EF" != "$EF_COUNT" ]; then
-  echo "DRIFT: CLAUDE.md says $CLAUDE_EF Edge Functions, actual is $EF_COUNT"
-  ERRORS=$((ERRORS + 1))
-fi
-
-# ── Check README.md Key Numbers table ──
-README_MCP=$(grep -P 'MCP tools.*\d+' "$ROOT/README.md" | grep -oP '^\| MCP tools \| (\d+)' | grep -oP '\d+$' || echo "?")
+# ── Check README.md Key Numbers table (public-facing contract) ──
+# The "320+" soft-growth form is fine: we only compare the leading integer.
+README_MCP=$(grep -P '^\| MCP tools \| \d+' "$ROOT/README.md" | grep -oP '\d+' | head -1 || echo "?")
 if [ "$README_MCP" != "$MCP_TOOLS" ]; then
   echo "DRIFT: README.md Key Numbers says $README_MCP MCP tools, actual is $MCP_TOOLS"
   ERRORS=$((ERRORS + 1))
 fi
 
-# ── Check .claude/rules/mcp.md ──
-RULES_MCP=$(grep -oP '^\- \d+ tools' "$ROOT/.claude/rules/mcp.md" | grep -oP '\d+' || echo "?")
-if [ "$RULES_MCP" != "$MCP_TOOLS" ]; then
-  echo "DRIFT: .claude/rules/mcp.md says $RULES_MCP tools, actual is $MCP_TOOLS"
+README_EF=$(grep -P '^\| Edge Functions \| \d+' "$ROOT/README.md" | grep -oP '\d+' | head -1 || echo "?")
+if [ "$README_EF" != "$EF_COUNT" ]; then
+  echo "DRIFT: README.md Key Numbers says $README_EF Edge Functions, actual is $EF_COUNT"
   ERRORS=$((ERRORS + 1))
 fi
+
+# i18n keys in the README are an approximate ("6,200+") and the live count is a
+# fuzzy quote-grep, so it is reported above for reference but not asserted.
 
 # ── Summary ──
 echo ""
 if [ "$ERRORS" -eq 0 ]; then
-  echo "All docs in sync."
+  echo "All public docs in sync."
 else
   echo "$ERRORS drift(s) found. Update docs to match codebase."
   echo "Tip: search for the old number and replace with the actual value."

--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -1,5 +1,5 @@
 // supabase/functions/nucleo-mcp/index.ts
-// MCP server v2.80.0 — /mcp 308 tools + 4 prompts + 3 resources + /semantic 4 tools (bridge, v0.2.0)
+// MCP server v2.80.0 — /mcp 320 tools + 4 prompts + 3 resources + /semantic 4 tools (bridge, v0.2.0)
 // #459 (2026-06-07): governance clause-body read — +1 tool (get_governance_document_body, wraps the
 //   canonical get_governance_document_reader RPC + EF-side Markdown/section-anchor enrichment via
 //   ./governance-html.mjs; legal guard-rails: public/active_members channel ceiling, ratification


### PR DESCRIPTION
## O quê

Sincroniza os números de métricas defasados na documentação pública com a realidade do código (medida ao vivo via `scripts/check-doc-metrics.sh`):

| Métrica | Antes (docs) | Agora (live) |
|---|---|---|
| MCP tools | 300+ | **320+** |
| Edge Functions | 37 (e um "35" perdido no tree do README.md) | **38** |
| Chaves i18n | 4.000+ | **6.200+** |

Atualizados nos **três READMEs** (en/pt/es): badge, tabela "Key Numbers", Technical Stack, prosa do bloco MCP, label do mermaid e o comentário do repo-tree. Também o header stale de `supabase/functions/nucleo-mcp/index.ts` (`308 → 320 tools`).

## Decisão sobre o script

`scripts/check-doc-metrics.sh` foi realinhado para asserir **apenas sobre o README público** (MCP tools + Edge Functions — o contrato factual com o leitor). Os checks de `CLAUDE.md` e `.claude/rules/mcp.md` foram **removidos**: ambos decidiram **explicitamente não pinar** contagens voláteis —

- `CLAUDE.md` L36: *"Current state (counts…): NOT pinned in CLAUDE.md (per Anthropic guidance…)"*
- `.claude/rules/mcp.md`: seção *"## Current State (do NOT pin counts here)"* + *"never recite it from memory or pin it here"*

…então exigir um número fixo nesses arquivos era um falso-positivo permanente. A contagem viva de tools sai do servidor MCP, não dos docs. Por isso `~300` em `rules/mcp.md` e a ausência de pin em `CLAUDE.md` **foram deixados como estão** — de propósito.

## Fora de escopo (follow-up)

- Tornar `check-doc-metrics.sh` um gate de CI (hoje é manual). Combinado: este PR é higiene de números, não mudança de pipeline.
- A contagem de i18n é aproximada (`grep` de aspas em `pt-BR.ts`), então o script a reporta mas **não asserta**.

## Validação

- `bash scripts/check-doc-metrics.sh` → **All public docs in sync** (exit 0)
- `npx astro build` → verde
- `npm test` → **0 fail / 331 skip** (DB-aware offline, esperado)
- Não toca SQL/RPC/i18n runtime → sem GC-097, sem shadow migration.

🤖 Doc-only hygiene · `Assisted-By: Claude (Anthropic)`
