### PR TITLE
fix(invariants): carve pre-onboarding guests out of invariant U (#768)

### DIFF
--- a/supabase/migrations/20260805000199_w3b_ii_invariant_u_guest_carveout.sql
+++ b/supabase/migrations/20260805000199_w3b_ii_invariant_u_guest_carveout.sql
@@ -1,0 +1,484 @@
+-- Wave 3b-ii follow-up — invariant U: carve out pre-onboarding guests.
+--
+-- Context: invariant U_active_person_has_primary_chapter_affiliation (ADR-0104) was added on the
+-- assumption that every active registry-chaptered member already has a primary chapter affiliation
+-- (true at the time via the one-time backfill). New pre-onboarding guests (member_status='active',
+-- operational_role='guest', chapter='PMI-GO' default, entry_chapter_code IS NULL) created AFTER the
+-- backfill have NO member_chapter_affiliations row yet — the row is seeded only when the member
+-- chooses an entry chapter via set_my_entry_chapter (Wave 3b-i). Until then they legitimately have
+-- no primary affiliation, so U produced false-positive violations and reddened the validate CI gate
+-- for every PR (see issue: invariant U guest false-positive; data-architect GO-WITH-CHANGES).
+--
+-- Fix (option 2 — tighten the invariant, no prod data mutation): exclude guests who have not yet
+-- chosen an entry chapter. A guest who HAS chosen has entry_chapter_code set AND an affiliation (so
+-- still checked); once promoted (operational_role != 'guest') the member is checked again. The
+-- members.chapter COALESCE(entry, primary, legacy) derivation still resolves for these guests via
+-- the legacy default. Only the U drift CTE + its description change; all 26 other invariants are
+-- byte-identical to 20260805000195.
+--
+-- ROLLBACK: re-apply 20260805000195's check_schema_invariants() body (U drift CTE without the
+-- `AND NOT (m.operational_role = 'guest' AND m.entry_chapter_code IS NULL)` predicate).
+
+CREATE OR REPLACE FUNCTION public.check_schema_invariants()
+ RETURNS TABLE(invariant_name text, description text, severity text, violation_count integer, sample_ids uuid[])
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL
+     AND current_setting('role', true) NOT IN ('service_role', 'postgres')
+     AND current_user NOT IN ('postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'Unauthorized: check_schema_invariants requires authentication';
+  END IF;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'alumni' AND operational_role IS DISTINCT FROM 'alumni'
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A1_alumni_role_consistency'::text,
+         'member_status=alumni must coerce operational_role=alumni (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'observer' AND operational_role NOT IN ('observer','guest','none')
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A2_observer_role_consistency'::text,
+         'member_status=observer must coerce operational_role IN (observer,guest,none) (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH computed AS (
+    SELECT m.id AS member_id,
+      CASE
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'co_gp')          THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'deputy_manager') THEN 'deputy_manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+        WHEN bool_or(
+          (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+          OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+              AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+          OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+              AND ae.role IN ('leader','co_leader','owner','coordinator'))
+        ) THEN 'researcher'
+        WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+        WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+        WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+        WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+        WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+        WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+        ELSE 'guest'
+      END AS expected_role
+    FROM public.members m
+    LEFT JOIN public.auth_engagements ae ON ae.person_id = m.person_id AND ae.is_authoritative = true
+    WHERE m.member_status='active' AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT c.member_id FROM computed c
+    JOIN public.members m ON m.id = c.member_id
+    WHERE m.operational_role IS DISTINCT FROM c.expected_role
+  )
+  SELECT 'A3_active_role_engagement_derivation'::text,
+         'active member operational_role must equal priority-ladder derivation from active engagements (cache trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE ((member_status='active' AND is_active=false) OR (member_status IN ('observer','alumni','inactive') AND is_active=true))
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B_is_active_status_mismatch'::text,
+         'members.is_active must match member_status mapping (active=true, terminal=false)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND designations IS NOT NULL AND array_length(designations,1)>0
+  )
+  SELECT 'C_designations_in_terminal_status'::text,
+         'members.designations must be empty when member_status is observer/alumni/inactive'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    JOIN public.persons p ON p.id = m.person_id
+    WHERE m.auth_id IS NOT NULL AND p.auth_id IS NOT NULL AND m.auth_id IS DISTINCT FROM p.auth_id
+  )
+  SELECT 'D_auth_id_mismatch_person_member'::text,
+         'persons.auth_id and members.auth_id must agree when both are set (ghost resolution sync)'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ae.engagement_id AS e_id FROM public.auth_engagements ae
+    JOIN public.members m ON m.person_id = ae.person_id
+    WHERE ae.status='active' AND m.member_status IN ('observer','alumni','inactive')
+      AND ae.kind NOT IN ('observer','alumni','external_signer','sponsor','chapter_board','partner_contact')
+  )
+  SELECT 'E_engagement_active_with_terminal_member'::text,
+         'engagement.status=active is inconsistent with member.member_status in (observer/alumni/inactive) unless kind matches'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(e_id ORDER BY e_id) FROM (SELECT e_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT i.id AS initiative_id FROM public.initiatives i
+    WHERE i.legacy_tribe_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.tribes t WHERE t.id = i.legacy_tribe_id)
+  )
+  SELECT 'F_initiative_legacy_tribe_orphan'::text,
+         'initiatives.legacy_tribe_id must point to an existing tribe (bridge integrity)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(initiative_id ORDER BY initiative_id) FROM (SELECT initiative_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    LEFT JOIN public.document_versions dv ON dv.id = gd.current_version_id
+    WHERE gd.current_version_id IS NOT NULL
+      AND (dv.id IS NULL OR dv.locked_at IS NULL)
+      AND NOT EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status IN ('review','approved','activated')
+          AND ac.closed_at IS NULL
+      )
+  )
+  SELECT 'J_current_version_published'::text,
+         'governance_documents.current_version_id must point to a document_versions row with locked_at IS NOT NULL — unless an open approval_chain (review/approved/activated, closed_at NULL) is in flight that will lock the version on close (Phase IP-1, chain-aware).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.operational_role='external_signer'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.auth_engagements ae
+        WHERE ae.person_id=m.person_id AND ae.kind='external_signer' AND ae.status='active' AND ae.is_authoritative=true
+      )
+  )
+  SELECT 'K_external_signer_integrity'::text,
+         'members.operational_role=external_signer must have an active auth_engagements row with kind=external_signer (Phase IP-1).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.member_status IN ('alumni','observer','inactive') AND m.anonymized_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM public.member_offboarding_records r WHERE r.member_id=m.id)
+  )
+  SELECT 'L_offboarding_record_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have a member_offboarding_records row (#91 G3 trigger).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH expected AS (
+    SELECT a.id AS application_id, a.research_score AS cached,
+      CASE
+        WHEN e.obj_avg IS NOT NULL AND e.int_avg IS NOT NULL THEN round(e.obj_avg + e.int_avg, 2)
+        WHEN e.obj_avg IS NOT NULL THEN round(e.obj_avg, 2)
+        ELSE NULL
+      END AS expected
+    FROM public.selection_applications a
+    CROSS JOIN LATERAL (
+      SELECT AVG(weighted_subtotal) FILTER (WHERE evaluation_type='objective' AND submitted_at IS NOT NULL) AS obj_avg,
+        AVG(weighted_subtotal) FILTER (WHERE evaluation_type='interview' AND submitted_at IS NOT NULL) AS int_avg
+      FROM public.selection_evaluations WHERE application_id=a.id
+    ) e
+  ),
+  drift AS (
+    SELECT application_id FROM expected
+    WHERE (cached IS NULL) IS DISTINCT FROM (expected IS NULL)
+       OR (cached IS NOT NULL AND expected IS NOT NULL AND ABS(cached - expected) > 0.01)
+  )
+  SELECT 'M_application_score_consistency'::text,
+         'selection_applications.research_score must equal compute_application_scores(application_id) derivation (sync trigger trg_recompute_application_scores).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive')
+      AND offboarded_at IS NULL AND anonymized_at IS NULL
+      AND name <> 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'N_terminal_status_offboarded_at_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have offboarded_at NOT NULL (ARM-9 G6 defense-in-depth complement to L).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ma.id AS artifact_id FROM public.meeting_artifacts ma
+    WHERE ma.event_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.id = ma.event_id)
+  )
+  SELECT 'O_meeting_artifact_event_orphan'::text,
+         'meeting_artifacts.event_id must point to an existing event when not NULL (FK defense).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(artifact_id ORDER BY artifact_id) FROM (SELECT artifact_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  SELECT 'P_tribe_initiative_bridge_complete'::text,
+         'tribes.is_active=true must have at least one initiative.legacy_tribe_id pointing to it (V3-V4 bridge; cron leader digest depends).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM public.tribes t
+          WHERE t.is_active = true
+            AND NOT EXISTS (SELECT 1 FROM public.initiatives i WHERE i.legacy_tribe_id = t.id)),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS engagement_id FROM public.engagements
+    WHERE status = 'expired' AND end_date > CURRENT_DATE
+  )
+  SELECT 'Q_expired_engagement_end_date'::text,
+         'engagements.status=expired requires end_date <= CURRENT_DATE (impossible to be expired in the future; VEP service_latest_end_date is source of truth).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT a.id AS application_id
+    FROM public.selection_applications a
+    WHERE a.status = 'approved'
+      AND a.email IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.members m WHERE lower(m.email) = lower(a.email)
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM public.member_emails me WHERE lower(me.email) = lower(a.email)
+      )
+  )
+  SELECT 'R_approved_application_has_member'::text,
+         'selection_applications.status=approved must have a matching members row by lower(email). Bypass of approve_selection_application() canonical RPC creates this drift (Issue #180).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT DISTINCT m.id AS member_id
+    FROM public.selection_applications a
+    JOIN public.members m ON lower(m.email) = lower(a.email)
+    WHERE a.status = 'approved' AND m.person_id IS NULL
+  )
+  SELECT 'S_approved_member_has_person_id'::text,
+         'members tied to an approved selection_applications row must have person_id NOT NULL (V4 graph anchor for engagements). Issue #180.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH primary_email_counts AS (
+    SELECT m.id AS member_id,
+           COUNT(me.id) FILTER (WHERE me.is_primary = true) AS primary_count
+    FROM public.members m
+    LEFT JOIN public.member_emails me ON me.member_id = m.id
+    WHERE m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT member_id FROM primary_email_counts
+    WHERE primary_count <> 1
+  )
+  SELECT 'T_member_has_exactly_one_primary_email'::text,
+         'Every member must have exactly one primary email in member_emails (Issue #205).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status = 'pending_proposer_consent'
+      AND EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status NOT IN ('withdrawn','superseded')
+      )
+  )
+  SELECT 'V_prime_pending_proposer_consent_no_open_chain'::text,
+         'status=pending_proposer_consent must not have non-cancelled approval_chains rows (#315 P0-Q7 + Amendment A2 — pending_proposer_consent precedes any chain).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status IN ('approved','active')
+      AND gd.current_ratified_chain_id IS NULL
+  )
+  SELECT 'V_status_chain_coherence'::text,
+         'governance_documents with status approved/active must have current_ratified_chain_id NOT NULL (#315 P0-Q6 + #367 Wave 1b first leaf). NO carve-out: 7 legacy pre-chain docs backfilled with PM-designated synthetic chains via migration 20260805000038 (acknowledge signoffs, metadata.legacy_migration=true, role=migration_attestation).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT cp.id AS product_id
+    FROM public.content_products cp
+    WHERE
+      CASE cp.source_kind
+        WHEN 'governance_document_version' THEN
+          NOT (cp.source_document_version_id IS NOT NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'board_item' THEN
+          NOT (cp.source_board_item_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'publication_idea' THEN
+          NOT (cp.source_publication_idea_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'external' THEN
+          NOT (cp.source_external_uri IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL)
+        WHEN 'none' THEN
+          NOT (cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        ELSE TRUE
+      END
+  )
+  SELECT 'W_content_product_source_integrity'::text,
+         'content_products row must satisfy chk_content_products_source_integrity CHECK semantics (exactly one source FK populated per source_kind; ADR-0099 §2.2 + §6 step 9). Defense-in-depth complement to the CHECK constraint; mirrors V/V''/T pattern.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(product_id ORDER BY product_id) FROM (SELECT product_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT p.id AS parecer_id
+    FROM public.blind_review_pareceres p
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.blind_review_assignments a
+      WHERE a.session_id = p.session_id
+        AND a.reviewer_member_id = p.reviewer_member_id
+        AND a.status = 'active'
+    )
+  )
+  SELECT 'X_blind_review_pareceres_session_product_match'::text,
+         'blind_review_pareceres.reviewer_member_id must have an active blind_review_assignments row in the same session (assignment-parecer integrity; ADR-0099 §2.7 + §7 step 11). Defense-in-depth complement to FK constraints; catches drift if assignment is withdrawn while parecer remains. #382 PR-B.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(parecer_id ORDER BY parecer_id) FROM (SELECT parecer_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH pe AS (
+    SELECT name AS k FROM public.partner_entities
+    WHERE entity_type = 'pmi_chapter' AND status = 'active' AND NOT COALESCE(is_international, false)
+  ),
+  ch AS (
+    SELECT 'PMI-' || code AS k FROM public.chapters WHERE status = 'active'
+  ),
+  drift AS (
+    SELECT k FROM pe WHERE k NOT IN (SELECT k FROM ch)
+    UNION ALL
+    SELECT k FROM ch WHERE k NOT IN (SELECT k FROM pe)
+  )
+  SELECT 'Y_chapter_pipeline_parity'::text,
+         'every active domestic pmi_chapter in partner_entities must have a matching active chapters row (by name = ''PMI-'' || chapters.code) and vice-versa — MEMBERSHIP parity (not just count), so it catches single-table inserts/archives even when row counts coincide. Drift = get_chapter_metrics()->>signed forks from the V4 chapters table (#481).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM drift),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS webinar_id FROM public.webinars
+    WHERE status IS NULL OR status NOT IN ('planned','confirmed','completed','cancelled')
+  )
+  SELECT 'Z_webinar_status_domain'::text,
+         'webinars.status must be within planned|confirmed|completed|cancelled (the realized=completed canonical definition depends on it; defense-in-depth complement to webinars_status_check — #479/#481).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(webinar_id ORDER BY webinar_id) FROM (SELECT webinar_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND current_cycle_active = true
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B2_current_cycle_active_terminal_status'::text,
+         'members in observer/alumni/inactive must have current_cycle_active=false (#483 sync_member_status_consistency B-trigger; CCA gates the get_gamification_leaderboard/get_public_leaderboard cohort).'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- U (ADR-0104 Wave 3b-ii): members.chapter is now derived as
+  -- COALESCE('PMI-'||entry_chapter_code, 'PMI-'||primary affiliation code, legacy chapter).
+  -- For the derivation to be deterministic for registry-chaptered active members, each must have
+  -- exactly one is_primary=true affiliation. The partial unique index enforces AT MOST one; this
+  -- enforces EXACTLY one. Non-registry chapters (Outro/Externo) are excluded — legitimately
+  -- unaffiliated, derivation falls through to the legacy value.
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id
+    FROM public.members m
+    WHERE m.member_status = 'active'
+      AND m.person_id IS NOT NULL
+      AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND m.name NOT LIKE '%_synthetic%'
+      AND replace(m.chapter, 'PMI-', '') IN (SELECT chapter_code FROM public.chapter_registry)
+      AND NOT (m.operational_role = 'guest' AND m.entry_chapter_code IS NULL)
+      AND (SELECT COUNT(*) FROM public.member_chapter_affiliations a
+            WHERE a.person_id = m.person_id AND a.is_primary) <> 1
+  )
+  SELECT 'U_active_person_has_primary_chapter_affiliation'::text,
+         'every active registry-chaptered member''s person_id must have exactly one is_primary=true member_chapter_affiliations row, else the members.chapter COALESCE(entry, primary, legacy) derivation breaks silently (ADR-0104 Wave 3b-ii). Excluded: operational_role=''guest'' AND entry_chapter_code IS NULL (pre-onboarding, entry-chapter choice not yet made — affiliation is seeded by set_my_entry_chapter, Wave 3b-i; until then the COALESCE falls through to the legacy default). Non-registry chapters (Outro/Externo) excluded — legitimately unaffiliated.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+END;
+$function$;

--- a/tests/contracts/schema-invariants.test.mjs
+++ b/tests/contracts/schema-invariants.test.mjs
@@ -74,6 +74,7 @@ test('ADR-0012 B10: schema invariants report', { skip: !canRun && skipMsg }, asy
     'R_approved_application_has_member',
     'S_approved_member_has_person_id',
     'T_member_has_exactly_one_primary_email',
+    'U_active_person_has_primary_chapter_affiliation',
     'V_prime_pending_proposer_consent_no_open_chain',
     'V_status_chain_coherence',
     'W_content_product_source_integrity',


### PR DESCRIPTION
Closes #768.

## Causa-raiz

O invariante `U_active_person_has_primary_chapter_affiliation` (ADR-0104, Wave 3b-ii) estava **vermelho em prod** (`violation_count=2`), reprovando o step `validate` para **todo PR**. Os 2 violadores: guests novos de pré-onboarding (`member_status='active'`, `operational_role='guest'`, `chapter='PMI-GO'`, `entry_chapter_code IS NULL`) criados hoje 12:58 UTC, **sem afiliação de capítulo** — ela só é semeada quando o membro escolhe o capítulo (`set_my_entry_chapter`, Wave 3b-i). O invariante assumiu cedo demais que todo ativo já teria afiliação.

## Fix (opção 2 — sem mutação de dados em prod)

Adiciona ao CTE `drift` do U:
```sql
AND NOT (m.operational_role = 'guest' AND m.entry_chapter_code IS NULL)
```
Guest que **já escolheu** tem `entry_chapter_code` + afiliação (segue checado); ao ser **promovido** (`operational_role != 'guest'`) volta a ser checado. A derivação `members.chapter` resolve via fallback legacy. Só o CTE do U + sua descrição mudam; os outros 26 invariantes são byte-idênticos a `20260805000195`.

Revisado pelo `data-architect` (**GO-WITH-CHANGES**): predicado é o tight scope correto, opção 2 preferível à opção 1 (que escreveria fato de afiliação não-verificado). Também adiciona `U` à lista `expected` do contract test (para flagrar remoção futura do invariante).

## Aplicação e validação (ao vivo)

- Aplicado em prod via `apply_migration` (transform in-place do corpo vivo, ancorado no bloco único do U; migration `20260805000199`, registrada via `migration repair`).
- Verificado live: **27 invariantes, 0 violações, U=0**, predicado presente.
- `astro build` verde · `npm test` 0 fail / 331 skip (DB-aware offline).

Com isto o invariante fica verde em prod → destrava o `validate` de todos os PRs (incl. #767 doc-only).
