### PR TITLE
feat(milestones): server-side milestones foundation + onboarding_complete [#766]

### DIFF
--- a/docs/specs/SPEC_766_SERVER_SIDE_MILESTONES.md
+++ b/docs/specs/SPEC_766_SERVER_SIDE_MILESTONES.md
@@ -1,0 +1,140 @@
+# SPEC: Marcos server-side (celebração de marcos persistida) — #766 item 2/4
+
+**Status:** Draft (design + plano de disparo; nenhum código aplicado ainda)
+**Priority:** Green / non-blocking (resíduo Wave 5 de #740, rastreado em #766)
+**Created:** 2026-06-17
+**Author:** Claude (PM/Architect) + Vitor (GP)
+**Decisão de escopo (PM, 2026-06-17, AskUserQuestion):** **Framework de marcos (visão J5 ampla)** — não o substituto mínimo 1:1 do localStorage. Multi-PR, começando por este SPEC + plano de disparo.
+
+---
+
+## 1. Contexto & problema
+
+A celebração de "onboarding concluído" (J5, Wave 4) existe hoje **client-side**:
+
+- `src/components/onboarding/OnboardingChecklist.tsx:108-180` mostra o card "🎉 Onboarding concluído!" quando `get_my_onboarding().all_complete === true`.
+- O estado "já vi" mora em `localStorage['nia_onboarding_celebrated']` (`OnboardingChecklist.tsx:108,123-124,167`).
+
+**Limitações do localStorage:**
+1. **Por dispositivo/navegador** — quem limpa cache ou troca de device revê a celebração.
+2. **Servidor não sabe** que o membro foi recebido — nenhum registro auditável, nenhum gancho para e-mail/digest, nenhuma métrica.
+3. **Não generaliza** — só cobre 1 marco (onboarding-completo). O J5 do discovery (`PRE_ONBOARDING_JOURNEY_DISCOVERY_2026-06-16.md`, linha 170) pede celebrar **vários** marcos: termo assinado, promoção, 1ª presença, 1ª entrega, perfil 100%.
+
+**Meta:** mover o registro de marcos e o "já celebrei" para o servidor, com um modelo genérico que sirva a múltiplos marcos.
+
+---
+
+## 2. Inventário de fontes server-side (grounded — `execute_sql` 2026-06-17)
+
+Cada marco precisa de um ponto de disparo real no schema. Estado verificado ao vivo:
+
+| Marco | Fonte de verdade no schema | Verificado? | Gancho de disparo proposto |
+|-------|----------------------------|-------------|----------------------------|
+| `onboarding_complete` | `get_my_onboarding().all_complete` (todos os `onboarding_steps.is_required` em `completed`/`skipped`) | ✅ existe | `complete_onboarding_step` quando resulta em all_complete (ou trigger em `onboarding_progress`) |
+| `term_signed` | `certificates` `type='volunteer_agreement' AND status='issued'` (41 certs issued ao vivo) | ✅ existe | trigger `AFTER INSERT/UPDATE ON certificates` — espelha o padrão de `_trg_complete_volunteer_term_on_cert` (mig …018) |
+| `first_attendance` | `attendance.present=true` (categoria `attendance` tem 1036 linhas de pontos ao vivo) | ✅ existe | trigger `AFTER INSERT/UPDATE ON attendance WHEN present=true`; UNIQUE garante "primeira" |
+| `first_deliverable` | `tribe_deliverables.completed_at` + `assigned_member_id` | ✅ existe | trigger `AFTER UPDATE ON tribe_deliverables` quando `completed_at` é setado |
+| `promotion` | `promote_to_leader_track` RPC existe; **não há tabela `role_transitions` dedicada** (confirmado: 0 relations) | ⚠️ parcial | gancho dentro do RPC `promote_to_leader_track` + mudança de `members.operational_role` |
+| `profile_complete` (perfil completo) | `members.profile_completed_at` (timestamptz, 23/102 populados), setado pela RPC `update_my_profile` | ✅ existe | trigger `AFTER UPDATE OF profile_completed_at ON members WHEN OLD IS NULL AND NEW IS NOT NULL` |
+
+> ⚠️ **Correção de grounding (investigado 2026-06-17 a pedido do PM):** o marco `profile_complete` É viável (fonte server-side real = `profile_completed_at`), MAS a alegação do discovery "perfil 100% → **+50pts já existe** [pdf]" é **falsa** — não há `gamification_rule` nem `gamification_points` de perfil (as 31 regras vivas não incluem perfil; as linhas de 50pts são todas `cert_pmi_senior`). O que existe é um **badge cosmético client-side** (`gamification.astro:679/1026`, acende com foto+pmi_id+linkedin+phone+credly), que NÃO concede pontos. O marco celebra a conclusão do perfil; **não** prometer/exibir +50pts.
+
+**Infra reutilizável existente:** `notifications` (feed persistido, `is_read`/`read_at`) e `get_my_notifications`; `gamification_points`/`gamification_rules`. O framework de marcos **não** vira notification (decisão na §6) — celebração-única tem semântica distinta de feed.
+
+---
+
+## 3. Modelo de dados proposto
+
+Tabela única (em vez do split `member_milestones` + `member_milestone_acks` esboçado na pergunta de escopo — uma linha por `(member, marco)` com timestamp de ack é mais simples e dá semântica "celebrado uma vez"):
+
+```sql
+CREATE TABLE public.member_milestones (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  member_id       uuid NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  milestone_key   text NOT NULL,            -- ver CHECK abaixo
+  occurred_at     timestamptz NOT NULL DEFAULT now(),
+  source_type     text,                     -- 'certificate' | 'attendance' | 'tribe_deliverable' | 'onboarding' | 'promotion'
+  source_id       uuid,                     -- referência informacional SEM FK (fontes heterogêneas; padrão admin_audit_log.target_id) — COMMENT ON COLUMN obrigatório
+  metadata        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  acknowledged_at timestamptz,              -- substitui o localStorage: NULL = celebração pendente
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT member_milestones_key_chk CHECK (milestone_key IN
+    ('onboarding_complete','term_signed','first_attendance','first_deliverable','promotion','profile_complete')),
+  UNIQUE (member_id, milestone_key)         -- primeira ocorrência apenas; celebrado 1×
+);
+```
+
+- **RLS:** membro lê e reconhece (ack) apenas os próprios (`member_id` via `members.auth_id = auth.uid()`). Inserção só via RPCs `SECURITY DEFINER` / triggers (membro nunca insere direto). PII: nenhuma; tabela é por-membro do próprio dado. FK `ON DELETE CASCADE` cobre o apagamento LGPD Art. 18.
+- **`organization_id` removido do v1** (projeto single-org/PMI-GO hoje — YAGNI; readicionar com FK + COMMENT quando multi-tenant expandir). Evita coluna "flutuante" sem FK/policy (ADR-0012 P2).
+- **`milestone_key`:** validado por `CHECK` enumerado **no schema** (write-time, sem custo de query periódica), não em `check_schema_invariants()`.
+- **`UNIQUE(member_id, milestone_key)`:** garante idempotência dos triggers (re-INSERT vira no-op via `ON CONFLICT DO NOTHING`).
+- **Marcos `first_*` são lifetime-único por design:** segunda presença / segunda entrega **nunca** re-celebram — comportamento intencional do `ON CONFLICT DO NOTHING`, não bug do trigger. (Documentar para o revisor do PR 3.)
+- **Taxonomia:** tabela enquadra-se em **ADR-0013 Categoria B (Domain Lifecycle Events)** — shape semântico próprio; NÃO consolida em `admin_audit_log` nem em `notifications`.
+
+---
+
+## 4. RPCs
+
+| RPC | Assinatura | Papel |
+|-----|-----------|-------|
+| `get_my_milestones()` | `() → jsonb` | retorna `{ pending: [...marcos com acknowledged_at IS NULL], history: [...] }` para o membro atual. Canônico para a celebração FE. |
+| `acknowledge_milestone(p_milestone_key text)` | `(text) → jsonb` | seta `acknowledged_at = now()` no marco do membro atual. Substitui `localStorage.setItem`. Idempotente. |
+| `record_milestone(...)` | interno (SECURITY DEFINER) | helper compartilhado pelos triggers/RPCs de disparo: `INSERT ... ON CONFLICT (member_id, milestone_key) DO NOTHING`. |
+
+`get_my_onboarding` mantém `all_complete` (não quebrar consumidores). A celebração FE migra para `get_my_milestones`.
+
+---
+
+## 5. Frontend
+
+- **`OnboardingChecklist.tsx`:** remover `CELEBRATION_SEEN_KEY` / `localStorage`; o gate `dismissed` passa a ler `get_my_milestones().pending` (marco `onboarding_complete`); o dismiss chama `acknowledge_milestone('onboarding_complete')`. Preserva o comportamento "mostra 1×", agora cross-device.
+- **Superfície de celebração multi-marco:** card/toast genérico, dirigido por `get_my_milestones().pending`, capaz de celebrar qualquer marco pendente (não só onboarding). Cópia trilíngue no idioma do componente (padrão `CELEBRATE`/`HBLOCK` já no arquivo — i18n inline, não `t()`, ver sedimento Wave 4). Tom "Disney", **zero números** (grounding).
+- A UX exata (modal vs card no topo vs toast empilhável) é decisão do slice com `ux-leader`.
+
+---
+
+## 6. Decisões de design (registrar; não re-litigar sem motivo)
+
+1. **Tabela dedicada, não `notifications`.** Celebração é "marco único reconhecido", não item de feed. Reusar `notifications` acoplaria semânticas e contaminaria `is_read`. (Opção C da pergunta de escopo — rejeitada.)
+2. **Uma linha por `(member, marco)` com `acknowledged_at`**, não duas tabelas. Mais simples para a semântica "celebrado 1×".
+3. **Backfill é silencioso (`acknowledged_at = now()`).** Os 41 membros com cert issued / membros já `all_complete` **não** devem ser bombardeados com celebrações retroativas no primeiro deploy. Backfill marca como já-reconhecido; só marcos **novos** (pós-deploy) celebram. ⚠️ Crítico — confirmar com PM na §8.
+   - **Ordem obrigatória na migration (race-safe):** aplicar o **backfill ANTES** de `CREATE TRIGGER`. Senão há janela (banco compartilhado, writes concorrentes) em que o trigger insere uma row sem `acknowledged_at` entre o CREATE TRIGGER e o backfill, e o membro existente celebra indevidamente. Verificar a ordem no padrão de `_trg_complete_volunteer_term_on_cert` (mig …018). Regra vale para **todos** os PRs que instalam trigger + backfill.
+4. **`profile_complete` é viável** (fonte confirmada: `members.profile_completed_at` via `update_my_profile`). Entra como marco normal — **mas a celebração não menciona "+50pts"** (esse award não existe; ver correção de grounding §2).
+5. **Promoção recorrente NÃO é suportada na v1.** `UNIQUE(member_id,'promotion')` bloqueia uma 2ª celebração (promovido→despromovido→repromovido). Se o requisito surgir, exige nova chave (`promotion_2`) ou mudança do modelo UNIQUE — registrar como decisão, não bug.
+
+---
+
+## 7. Plano de fatiamento (multi-PR)
+
+Cada PR: build verde + suíte + council de domínio + (quando tocar SQL) GC-097 + sync de migração + consideração de invariante.
+
+- **PR 1 — Fundação + paridade com o localStorage atual.**
+  Schema `member_milestones` + RLS + `get_my_milestones` + `acknowledge_milestone` + `record_milestone` + backfill silencioso de `onboarding_complete` + gancho `onboarding_complete` + migrar `OnboardingChecklist` para fora do localStorage. **Já entrega o pedido literal do #766** (cross-device) e o esqueleto do framework. Council: `data-architect` (schema/RLS) + `ux-leader` (migração da celebração).
+  - **Opção de split** se ficar grande (padrão DB-first → FE, como Wave 3c-i → 3c-ii): **PR 1a** = schema + RLS + 3 RPCs (DB-only); **PR 1b** = backfill `onboarding_complete` + gancho + migração FE.
+- **PR 2 — `term_signed`.** Trigger em `certificates` (espelha `_trg_complete_volunteer_term_on_cert`) + backfill silencioso dos 41 (backfill **antes** do CREATE TRIGGER, §6.3) + celebração FE. Bulk em `certificates` (ex.: 33 contra-assinados históricos) dispara o trigger O(rows), mas é idempotente via `ON CONFLICT DO NOTHING`. Council: `data-architect`.
+- **PR 3 — `first_attendance` + `first_deliverable`.** Triggers em `attendance` / `tribe_deliverables` + backfill silencioso + celebração. Reforçar a semântica lifetime-único de `first_*` (§3). Council: `data-architect`.
+- **PR 4 — `promotion`.** **Avaliar trigger `AFTER UPDATE OF operational_role ON members WHEN (NEW='leader' AND OLD<>'leader')` vs gancho em `promote_to_leader_track`** — o trigger captura QUALQUER path de promoção (inclusive admin direto), o gancho RPC não. ⚠️ Se o trigger tocar `members`, verificar `schema-cache-columns.test.mjs` (gate ADR-0012). Council: `data-architect` + `security-engineer` (toca autoridade).
+- **PR 5 — `profile_complete`.** Trigger `AFTER UPDATE OF profile_completed_at ON members WHEN OLD IS NULL AND NEW IS NOT NULL` + backfill silencioso dos 23 + celebração FE. ⚠️ Cópia **sem** "+50pts" (award inexistente, §2). Se o trigger tocar `members`, idem nota de `schema-cache-columns.test.mjs` do PR 4. Council: `data-architect`.
+
+**Invariantes para `check_schema_invariants()`** (avaliar no PR que cria a tabela, com `data-architect`; o CHECK de `milestone_key` fica no DDL, não aqui):
+- (forte) `term_signed` sem cert `volunteer_agreement` issued correspondente para o mesmo membro = violação (captura backfill errado ou cert revogado pós-marco). Espelha o padrão do `AA`.
+- (média) milestone órfão: `member_milestones.member_id` sem `members.id` atual (o CASCADE cobre em teoria; pega delete via service_role que burle o CASCADE).
+Descartadas as candidatas fracas originais ("`acknowledged_at ⟹ occurred_at NOT NULL`" é trivial pelo `NOT NULL`; enum vira CHECK no DDL).
+
+---
+
+## 8. Perguntas abertas para o PM (antes do PR 1)
+
+1. **Conjunto de marcos do v1 do framework** além de `onboarding_complete`: incluir `term_signed` já no PR 1/2, ou só fundação primeiro?
+2. **Backfill silencioso (§6.3):** confirmar que membros existentes **não** recebem celebração retroativa (só marcos novos celebram). Recomendação: silencioso.
+3. **Superfície de celebração:** card no topo do workspace (como hoje) vs toast vs modal — ou deixar para o `ux-leader` no PR 1?
+4. **`profile_complete`:** investigar a fonte agora (gamification) ou cortar do escopo até surgir demanda?
+
+---
+
+## 9. Cross-ref
+
+- #766 (tracking dos resíduos verdes) item 2/4 · #740 (umbrella Wave 1–4, fechada) · J5 do discovery `docs/project-governance/PRE_ONBOARDING_JOURNEY_DISCOVERY_2026-06-16.md:170`
+- Celebração atual: `src/components/onboarding/OnboardingChecklist.tsx:80-180`
+- Padrão de trigger reutilizável: `_trg_complete_volunteer_term_on_cert` (mig …018), invariante `AA_volunteer_term_complete_when_cert_issued` (PR #770)
+- Infra adjacente: `notifications` + `get_my_notifications`; `gamification_points`/`gamification_rules`

--- a/src/components/onboarding/OnboardingChecklist.tsx
+++ b/src/components/onboarding/OnboardingChecklist.tsx
@@ -32,9 +32,9 @@ function getDesc(s: Step, lang: string): string {
 }
 
 const L: Record<string, Record<string, string>> = {
-  'pt-BR': { title: 'Complete seu Onboarding', progress: 'concluídos', expand: 'Ver todos', collapse: 'Minimizar', done: 'Concluído', pending: 'Pendente', accept: 'Li e aceito', complete: 'Onboarding concluído! 🎉', markDone: 'Marcar como feito', visitTribe: 'Visitar tribo', viewTrail: 'Ver Trilha', step: 'Passo', of: 'de' },
-  'en-US': { title: 'Complete your Onboarding', progress: 'completed', expand: 'View all', collapse: 'Minimize', done: 'Done', pending: 'Pending', accept: 'I have read and accept', complete: 'Onboarding complete! Welcome! 🎉', markDone: 'Mark as done', visitTribe: 'Visit stream', viewTrail: 'View Trail', step: 'Step', of: 'of' },
-  'es-LATAM': { title: 'Complete su Integración', progress: 'completados', expand: 'Ver todos', collapse: 'Minimizar', done: 'Hecho', pending: 'Pendiente', accept: 'He leído y acepto', complete: '¡Integración completa! 🎉', markDone: 'Marcar como hecho', visitTribe: 'Visitar línea', viewTrail: 'Ver Ruta', step: 'Paso', of: 'de' },
+  'pt-BR': { title: 'Complete seu Onboarding', progress: 'concluídos', expand: 'Ver todos', collapse: 'Minimizar', hide: 'Dispensar', done: 'Concluído', pending: 'Pendente', accept: 'Li e aceito', complete: 'Onboarding concluído! 🎉', markDone: 'Marcar como feito', visitTribe: 'Visitar tribo', viewTrail: 'Ver Trilha', step: 'Passo', of: 'de' },
+  'en-US': { title: 'Complete your Onboarding', progress: 'completed', expand: 'View all', collapse: 'Minimize', hide: 'Dismiss', done: 'Done', pending: 'Pending', accept: 'I have read and accept', complete: 'Onboarding complete! Welcome! 🎉', markDone: 'Mark as done', visitTribe: 'Visit stream', viewTrail: 'View Trail', step: 'Step', of: 'of' },
+  'es-LATAM': { title: 'Complete su Integración', progress: 'completados', expand: 'Ver todos', collapse: 'Minimizar', hide: 'Descartar', done: 'Hecho', pending: 'Pendiente', accept: 'He leído y acepto', complete: '¡Integración completa! 🎉', markDone: 'Marcar como hecho', visitTribe: 'Visitar línea', viewTrail: 'Ver Ruta', step: 'Paso', of: 'de' },
 };
 
 // H1/H4/H6 #740 — post-promotion "first days" journey: answers "I signed the term, now what?"
@@ -78,7 +78,7 @@ function hblock(lang: string): HBlock {
 }
 
 // J5 #740 — "Disney tone": celebrate the onboarding-complete milestone instead of the
-// checklist silently vanishing. Shown once (localStorage-gated) when all steps are done.
+// checklist silently vanishing. Shown once (server-side gated via member_milestones) when all steps are done.
 interface Celebrate { title: string; body: string; cta: string; dismiss: string }
 const CELEBRATE: Record<string, Celebrate> = {
   'pt-BR': {
@@ -105,7 +105,6 @@ function celebrate(lang: string): Celebrate {
   if (lang.startsWith('es')) return CELEBRATE['es-LATAM'];
   return CELEBRATE['pt-BR'];
 }
-const CELEBRATION_SEEN_KEY = 'nia_onboarding_celebrated';
 
 export default function OnboardingChecklist({ lang = 'pt-BR' }: Props) {
   const l = L[lang] || L['pt-BR'];
@@ -118,24 +117,37 @@ export default function OnboardingChecklist({ lang = 'pt-BR' }: Props) {
   const [allComplete, setAllComplete] = useState(false);
   const [expanded, setExpanded] = useState(true); // auto-expand for new members
   const [loading, setLoading] = useState(true);
-  // J5 #740 — seed `dismissed` from the once-seen flag so a member who already saw the
-  // onboarding-complete celebration short-circuits at the first guard (no render-branch read, no flash).
-  const [dismissed, setDismissed] = useState(() => {
-    try { return localStorage.getItem(CELEBRATION_SEEN_KEY) === '1'; } catch { return false; }
-  });
+  // J5 #740 / #766 PR1 — the celebration "seen" state now persists SERVER-SIDE
+  // (member_milestones via get_my_milestones/acknowledge_milestone): cross-device +
+  // auditable, replacing the old localStorage flag `nia_onboarding_celebrated`.
+  // `celebrationPending` = onboarding_complete milestone exists and is unacknowledged.
+  // `sessionHidden` = transient ✕ on the working checklist (not persisted).
+  const [celebrationPending, setCelebrationPending] = useState(false);
+  const [sessionHidden, setSessionHidden] = useState(false);
 
   const getSb = useCallback(() => (window as any).navGetSb?.(), []);
 
   const load = useCallback(async () => {
     const sb = getSb();
     if (!sb) return;
-    const { data } = await sb.rpc('get_my_onboarding');
+    // #766 PR1 — fetch onboarding + the server-side celebration state in PARALLEL so
+    // `allComplete` and `celebrationPending` resolve together (no flicker window where
+    // allComplete=true but celebrationPending still false on slow networks; ux R1).
+    const [onb, ms] = await Promise.all([
+      sb.rpc('get_my_onboarding'),
+      sb.rpc('get_my_milestones'),
+    ]);
+    const data = onb?.data;
     if (data?.steps) {
       setSteps(data.steps);
       setTotal(data.total_steps || 0);
       setCompleted(data.completed_steps || 0);
       setAllComplete(data.all_complete || false);
     }
+    const pending = ms?.data?.pending;
+    setCelebrationPending(
+      Array.isArray(pending) && pending.some((p: any) => p.milestone_key === 'onboarding_complete')
+    );
     setLoading(false);
   }, [getSb]);
 
@@ -156,28 +168,33 @@ export default function OnboardingChecklist({ lang = 'pt-BR' }: Props) {
     (window as any).toast?.(l.done + '!', 'success');
   };
 
-  if (loading || dismissed) return null;
+  if (loading) return null;
   if (steps.length === 0) return null;
 
-  // J5 #740 — celebrate the onboarding-complete milestone once (instead of the checklist
-  // silently vanishing). Already-seen members were filtered by the `dismissed` guard above.
+  // J5 #740 / #766 PR1 — celebrate the onboarding-complete milestone once. The "seen"
+  // state is server-side (member_milestones): show only while the milestone is pending
+  // (unacknowledged). Backfilled / already-seen members have it acknowledged and skip
+  // the card (cross-device, no localStorage). Dismiss persists via acknowledge_milestone.
   if (allComplete) {
+    if (!celebrationPending) return null;
     const c = celebrate(lang);
     const dismissCelebration = () => {
-      try { localStorage.setItem(CELEBRATION_SEEN_KEY, '1'); } catch { /* SSR/private mode */ }
-      setDismissed(true);
+      setCelebrationPending(false);
+      getSb()?.rpc('acknowledge_milestone', { p_milestone_key: 'onboarding_complete' });
     };
     return (
-      <div className="rounded-2xl border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/40 dark:bg-emerald-900/15 p-5 mb-6 shadow-sm text-center">
+      <div role="status" className="rounded-2xl border-2 border-emerald-300 dark:border-emerald-800 bg-emerald-50/40 dark:bg-emerald-900/15 p-5 mb-6 shadow-sm text-center">
         <h2 className="text-base font-extrabold text-emerald-700 dark:text-emerald-300">{c.title}</h2>
-        <p className="text-[12px] text-emerald-800 dark:text-emerald-200 mt-1.5 leading-relaxed">{c.body}</p>
+        <p className="text-xs text-emerald-800 dark:text-emerald-200 mt-1.5 leading-relaxed">{c.body}</p>
         <div className="mt-3 flex items-center justify-center gap-2">
-          <a href={`${lp}/gamification`} className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-[11px] font-bold no-underline hover:bg-emerald-700">{c.cta}</a>
-          <button onClick={dismissCelebration} className="px-3 py-1.5 rounded-lg border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 text-[11px] font-semibold bg-transparent cursor-pointer hover:bg-emerald-100/50">{c.dismiss}</button>
+          <a href={`${lp}/gamification`} className="px-3 py-1.5 rounded-lg bg-emerald-600 text-white text-[0.6875rem] font-bold no-underline hover:bg-emerald-700">{c.cta}</a>
+          <button onClick={dismissCelebration} className="px-3 py-1.5 rounded-lg border border-emerald-300 dark:border-emerald-700 text-emerald-700 dark:text-emerald-300 text-[0.6875rem] font-semibold bg-transparent cursor-pointer hover:bg-emerald-100/50">{c.dismiss}</button>
         </div>
       </div>
     );
   }
+
+  if (sessionHidden) return null;
 
   const pct = total > 0 ? Math.round((completed / total) * 100) : 0;
   const member = (window as any).navGetMember?.();
@@ -213,7 +230,7 @@ export default function OnboardingChecklist({ lang = 'pt-BR' }: Props) {
             className="text-[10px] text-teal font-semibold cursor-pointer bg-transparent border-0 hover:underline">
             {expanded ? l.collapse : l.expand}
           </button>
-          <button onClick={() => setDismissed(true)}
+          <button onClick={() => setSessionHidden(true)} aria-label={l.hide}
             className="text-[var(--text-muted)] hover:text-[var(--text-primary)] bg-transparent border-0 cursor-pointer text-sm">✕</button>
         </div>
       </div>

--- a/supabase/migrations/20260805000201_member_milestones_foundation.sql
+++ b/supabase/migrations/20260805000201_member_milestones_foundation.sql
@@ -1,0 +1,170 @@
+-- PR 1 of #766 item 2/4 (server-side milestones framework).
+-- See docs/specs/SPEC_766_SERVER_SIDE_MILESTONES.md.
+-- Foundation: member_milestones (ADR-0013 Cat B domain lifecycle events; NOT
+-- consolidated into admin_audit_log/notifications) + 3 RPCs + first milestone
+-- onboarding_complete, replacing the client-side localStorage flag
+-- nia_onboarding_celebrated in OnboardingChecklist.tsx (cross-device).
+-- RLS: deny-all (mirrors onboarding_progress rpc_only_deny_all); all access via
+-- SECURITY DEFINER RPCs gated by auth.uid(). PII: none (per-member own data).
+-- Backfill is SILENT (acknowledged_at=now()) so existing all-complete members are
+-- NOT re-celebrated. Race-safe: backfill runs BEFORE trigger creation (SPEC §6.3).
+--
+-- ROLLBACK:
+--   DROP TRIGGER IF EXISTS trg_record_onboarding_complete_milestone ON public.onboarding_progress;
+--   DROP FUNCTION IF EXISTS public._trg_record_onboarding_complete_milestone();
+--   DROP FUNCTION IF EXISTS public.acknowledge_milestone(text);
+--   DROP FUNCTION IF EXISTS public.get_my_milestones();
+--   DROP FUNCTION IF EXISTS public.record_milestone(uuid, text, text, uuid, jsonb);
+--   DROP TABLE IF EXISTS public.member_milestones CASCADE;
+--   NOTIFY pgrst, 'reload schema';
+
+-- 1. Table
+CREATE TABLE IF NOT EXISTS public.member_milestones (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  member_id       uuid NOT NULL REFERENCES public.members(id) ON DELETE CASCADE,
+  milestone_key   text NOT NULL,
+  occurred_at     timestamptz NOT NULL DEFAULT now(),
+  source_type     text,
+  source_id       uuid,
+  metadata        jsonb NOT NULL DEFAULT '{}'::jsonb,
+  acknowledged_at timestamptz,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT member_milestones_key_chk CHECK (milestone_key IN
+    ('onboarding_complete','term_signed','first_attendance','first_deliverable','promotion','profile_complete')),
+  CONSTRAINT member_milestones_uq UNIQUE (member_id, milestone_key)
+);
+
+COMMENT ON TABLE public.member_milestones IS
+  'ADR-0013 Cat B (domain lifecycle events). One row per (member, milestone), celebrated once. acknowledged_at NULL = celebration pending (replaces localStorage nia_onboarding_celebrated). See SPEC_766_SERVER_SIDE_MILESTONES.md.';
+COMMENT ON COLUMN public.member_milestones.source_id IS
+  'Informational reference WITHOUT FK (heterogeneous sources: certificate/attendance/onboarding/etc.); mirrors admin_audit_log.target_id.';
+COMMENT ON COLUMN public.member_milestones.acknowledged_at IS
+  'When the member dismissed/saw the celebration. NULL = pending. Not a cache column.';
+
+CREATE INDEX IF NOT EXISTS idx_member_milestones_member ON public.member_milestones(member_id);
+
+-- 2. RLS: deny-all; access only via SECURITY DEFINER RPCs below.
+ALTER TABLE public.member_milestones ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS member_milestones_rpc_only_deny_all ON public.member_milestones;
+CREATE POLICY member_milestones_rpc_only_deny_all ON public.member_milestones
+  FOR ALL USING (false);
+
+-- 3. record_milestone — internal SECURITY DEFINER helper (idempotent). Not granted
+--    to authenticated/anon; only triggers/other definer RPCs invoke it.
+CREATE OR REPLACE FUNCTION public.record_milestone(
+  p_member_id uuid, p_milestone_key text, p_source_type text DEFAULT NULL,
+  p_source_id uuid DEFAULT NULL, p_metadata jsonb DEFAULT '{}'::jsonb
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $fn$
+BEGIN
+  IF p_member_id IS NULL OR p_milestone_key IS NULL THEN RETURN; END IF;
+  INSERT INTO public.member_milestones (member_id, milestone_key, source_type, source_id, metadata)
+  VALUES (p_member_id, p_milestone_key, p_source_type, p_source_id, COALESCE(p_metadata, '{}'::jsonb))
+  ON CONFLICT (member_id, milestone_key) DO NOTHING;
+END; $fn$;
+REVOKE ALL ON FUNCTION public.record_milestone(uuid, text, text, uuid, jsonb) FROM PUBLIC;
+
+-- 4. get_my_milestones — canonical read for the FE celebration surface.
+CREATE OR REPLACE FUNCTION public.get_my_milestones()
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $fn$
+DECLARE
+  v_member_id uuid;
+  v_result jsonb;
+BEGIN
+  SELECT id INTO v_member_id FROM public.members WHERE auth_id = auth.uid();
+  IF NOT FOUND THEN RETURN jsonb_build_object('error', 'Not authenticated'); END IF;
+  SELECT jsonb_build_object(
+    'pending', COALESCE((SELECT jsonb_agg(row_to_json(p) ORDER BY p.occurred_at)
+       FROM (SELECT milestone_key, occurred_at, metadata FROM public.member_milestones
+             WHERE member_id = v_member_id AND acknowledged_at IS NULL) p), '[]'::jsonb),
+    'history', COALESCE((SELECT jsonb_agg(row_to_json(h) ORDER BY h.occurred_at DESC)
+       FROM (SELECT milestone_key, occurred_at, acknowledged_at, metadata FROM public.member_milestones
+             WHERE member_id = v_member_id AND acknowledged_at IS NOT NULL) h), '[]'::jsonb)
+  ) INTO v_result;
+  RETURN v_result;
+END; $fn$;
+REVOKE ALL ON FUNCTION public.get_my_milestones() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_my_milestones() TO authenticated;
+
+-- 5. acknowledge_milestone — sets acknowledged_at for the caller's own milestone.
+CREATE OR REPLACE FUNCTION public.acknowledge_milestone(p_milestone_key text)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $fn$
+DECLARE
+  v_member_id uuid;
+  v_rows int;
+BEGIN
+  SELECT id INTO v_member_id FROM public.members WHERE auth_id = auth.uid();
+  IF NOT FOUND THEN RETURN jsonb_build_object('error', 'Not authenticated'); END IF;
+  UPDATE public.member_milestones
+  SET acknowledged_at = now()
+  WHERE member_id = v_member_id AND milestone_key = p_milestone_key AND acknowledged_at IS NULL;
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RETURN jsonb_build_object('success', true, 'milestone_key', p_milestone_key, 'acknowledged', v_rows > 0);
+END; $fn$;
+REVOKE ALL ON FUNCTION public.acknowledge_milestone(text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.acknowledge_milestone(text) TO authenticated;
+
+-- 6. Backfill onboarding_complete SILENTLY (acknowledged_at=now()) for members who are
+--    ALREADY complete — they must NOT receive a retroactive celebration. Uses the
+--    STRICT predicate (every required step seeded+terminal, except conditional
+--    volunteer_term which non-agreement members legitimately lack) so it never
+--    suppresses a member who is only partially done. MUST run BEFORE the trigger.
+INSERT INTO public.member_milestones (member_id, milestone_key, occurred_at, source_type, acknowledged_at, metadata)
+SELECT m.id, 'onboarding_complete', now(), 'onboarding_backfill', now(),
+       jsonb_build_object('backfill', true, 'migration', '20260805000201')
+FROM public.members m
+WHERE EXISTS (SELECT 1 FROM public.onboarding_progress op WHERE op.member_id = m.id)
+  AND NOT EXISTS (
+    SELECT 1 FROM public.onboarding_steps s
+    WHERE s.is_required
+      AND (
+        EXISTS (SELECT 1 FROM public.onboarding_progress op
+                WHERE op.step_key = s.id AND op.member_id = m.id
+                  AND op.status NOT IN ('completed', 'skipped'))
+        OR (s.id <> 'volunteer_term'
+            AND NOT EXISTS (SELECT 1 FROM public.onboarding_progress op
+                            WHERE op.step_key = s.id AND op.member_id = m.id))
+      )
+  )
+ON CONFLICT (member_id, milestone_key) DO NOTHING;
+
+-- 7. onboarding_complete hook: trigger on onboarding_progress. Strict all-complete
+--    check (no required step non-terminal; no required step missing a row except the
+--    conditional volunteer_term). Fires only when the changed row is terminal.
+CREATE OR REPLACE FUNCTION public._trg_record_onboarding_complete_milestone()
+RETURNS trigger
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $fn$
+DECLARE
+  v_all_complete boolean;
+BEGIN
+  IF NEW.member_id IS NULL THEN RETURN NEW; END IF;
+  IF NEW.status NOT IN ('completed', 'skipped') THEN RETURN NEW; END IF;
+  SELECT NOT EXISTS (
+    SELECT 1 FROM public.onboarding_steps s
+    WHERE s.is_required
+      AND (
+        EXISTS (SELECT 1 FROM public.onboarding_progress op
+                WHERE op.step_key = s.id AND op.member_id = NEW.member_id
+                  AND op.status NOT IN ('completed', 'skipped'))
+        OR (s.id <> 'volunteer_term'
+            AND NOT EXISTS (SELECT 1 FROM public.onboarding_progress op
+                            WHERE op.step_key = s.id AND op.member_id = NEW.member_id))
+      )
+  ) INTO v_all_complete;
+  IF v_all_complete THEN
+    PERFORM public.record_milestone(NEW.member_id, 'onboarding_complete', 'onboarding', NEW.id,
+      jsonb_build_object('via', 'onboarding_progress_trigger'));
+  END IF;
+  RETURN NEW;
+END; $fn$;
+
+REVOKE ALL ON FUNCTION public._trg_record_onboarding_complete_milestone() FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS trg_record_onboarding_complete_milestone ON public.onboarding_progress;
+CREATE TRIGGER trg_record_onboarding_complete_milestone
+  AFTER INSERT OR UPDATE ON public.onboarding_progress
+  FOR EACH ROW EXECUTE FUNCTION public._trg_record_onboarding_complete_milestone();
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
PR **1/5** of **#766 item 2/4** (J5 "marcos server-side"). Replaces the client-side `localStorage` flag `nia_onboarding_celebrated` with a server-side, cross-device, auditable milestone framework, and ships its first milestone (`onboarding_complete`). Design + plan: `docs/specs/SPEC_766_SERVER_SIDE_MILESTONES.md`.

## DB — migration `20260805000201` (applied + validated live)
- **New table `member_milestones`** (ADR-0013 Cat B domain-lifecycle events; one row per `(member, milestone)`; `acknowledged_at` = celebration-seen, replacing localStorage; `CHECK` enum; `UNIQUE(member_id, milestone_key)`).
- **RLS deny-all** (mirrors `onboarding_progress`); access only via SECURITY DEFINER RPCs gated by `auth.uid()`: `record_milestone` (internal, REVOKEd from PUBLIC), `get_my_milestones`, `acknowledge_milestone`. No PII; `ON DELETE CASCADE` for LGPD Art. 18.
- **Silent backfill** of `onboarding_complete` (`acknowledged_at=now()`) for the **11** already-complete members — they are NOT re-celebrated; only post-deploy completions fire. Backfill runs **before** the trigger (race-safe, SPEC §6.3).
- **Trigger** `AFTER INSERT/UPDATE ON onboarding_progress` records `onboarding_complete` with a strict all-complete predicate (no required step non-terminal; no missing required row except the conditional `volunteer_term`) — avoids premature firing.

## FE — `OnboardingChecklist.tsx`
- Celebration gate now reads `get_my_milestones` (pending `onboarding_complete`) instead of localStorage; dismiss calls `acknowledge_milestone`. **Same card, now cross-device.**
- `sessionHidden` (transient ✕) separated from server-backed `celebrationPending`.
- Both RPCs load in **parallel** (no flicker on slow networks); a11y: `role=status`, `aria-label` on dismiss, `rem` font sizes.

## Validation
- All **54 DB-aware contracts** green (incl. `rpc-migration-coverage`, `schema-invariants`, `schema-cache-columns`); `npx astro build` green; full suite 0 fail.
- **Negative ROLLBACK probe**: completing a member's last step in a tx recorded a *pending* `onboarding_complete` milestone (proves the trigger), then rolled back — prod untouched.
- Migration synced: `repair` (18 statements), shadow row removed, `NOTIFY pgrst`.

## Council
- **data-architect**: GO-with-changes (design + applied SQL) — all 8 changes applied.
- **ux-leader**: Go-with-changes — R1 (parallel load) applied in-commit.
- **code-reviewer**: 0 blockers — HIGH (rollback header) + MEDIUM (`REVOKE FROM PUBLIC, anon` + `NOTIFY`) applied in-commit. 3 LOW logged as backlog.

## Next (deferred to follow-up PRs, per spec)
PR 2 `term_signed` · PR 3 `first_attendance`+`first_deliverable` · PR 4 `promotion` · PR 5 `profile_complete` (no "+50pts" — that award does not exist).

Refs #766

Assisted-By: Claude (Anthropic)