### PR TITLE
fix(selection): resolve /admin/selection/applications/[id] 404 deep-link [ÉPICO D]

### DIFF
--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -5532,6 +5532,7 @@ const enUS: Record<string, string> = {
   'admin.selection.noCandidates': 'No candidate',
   'admin.selection.errorPrefix': 'Error',
   // ── Selection modal — Ω-B+.10 p147 (modal Info tab) ──
+  'admin.selection.modal.deepLinkNotFound': 'Application not found in the current cycle. Check the cycle filter.',
   'admin.selection.modal.tabInfo': 'Information',
   'admin.selection.modal.tabEvaluate': 'Evaluate',
   'admin.selection.modal.tabInterview': 'Interview',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -5533,6 +5533,7 @@ const esLATAM: Record<string, string> = {
   'admin.selection.noCandidates': 'Ningún candidato',
   'admin.selection.errorPrefix': 'Error',
   // ── Selection modal — Ω-B+.10 p147 (modal Info tab) ──
+  'admin.selection.modal.deepLinkNotFound': 'Candidatura no encontrada en el ciclo actual. Revisa el filtro de ciclo.',
   'admin.selection.modal.tabInfo': 'Información',
   'admin.selection.modal.tabEvaluate': 'Evaluar',
   'admin.selection.modal.tabInterview': 'Entrevista',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -5538,6 +5538,7 @@ const ptBR: Record<string, string> = {
   'admin.selection.noCandidates': 'Nenhum candidato',
   'admin.selection.errorPrefix': 'Erro',
   // ── Selection modal — Ω-B+.10 p147 (modal Info tab) ──
+  'admin.selection.modal.deepLinkNotFound': 'Candidatura não encontrada no ciclo atual. Verifique o filtro de ciclo.',
   'admin.selection.modal.tabInfo': 'Informações',
   'admin.selection.modal.tabEvaluate': 'Avaliar',
   'admin.selection.modal.tabInterview': 'Entrevista',

--- a/src/pages/admin/selection.astro
+++ b/src/pages/admin/selection.astro
@@ -83,6 +83,7 @@ const SEL_I18N = {
     both: t('admin.selection.statusBoth', lang),
   },
   modal: {
+    deepLinkNotFound: t('admin.selection.modal.deepLinkNotFound', lang),
     tabInfo: t('admin.selection.modal.tabInfo', lang),
     tabEvaluate: t('admin.selection.modal.tabEvaluate', lang),
     tabInterview: t('admin.selection.modal.tabInterview', lang),
@@ -5463,10 +5464,28 @@ const SEL_I18N = {
   }
 
   /* ── permission gate ──────────────────────────────── */
+  // Deep-link: the selection crons (#781 detect_stuck_selection_funnel,
+  // _selection_interview_overdue_cron) notify the GP with a link to a specific
+  // application. The detail surface is the modal below, so /admin/selection/applications/[id]
+  // redirects here with ?app=<id>; open that applicant once, then strip the param
+  // so re-gates (nav:member events) don't re-open it.
+  function maybeOpenDeepLinkedApplicant() {
+    const id = new URLSearchParams(window.location.search).get('app');
+    if (!id) return;
+    const url = new URL(window.location.href);
+    url.searchParams.delete('app');
+    history.replaceState(null, '', url.pathname + url.search + url.hash);
+    if (allRows.some(r => r.id === id)) {
+      openApplicantModal(id);
+    } else {
+      toast(T.modal.deepLinkNotFound, 'error');
+    }
+  }
+
   function applyGate(m: any) {
     if (m && canAccessAdminRoute(m, 'admin_selection')) {
       showPanel();
-      loadCycles().then(() => loadDashboard());
+      loadCycles().then(() => loadDashboard()).then(() => maybeOpenDeepLinkedApplicant());
     } else {
       showDenied();
     }

--- a/src/pages/admin/selection/applications/[id].astro
+++ b/src/pages/admin/selection/applications/[id].astro
@@ -1,0 +1,14 @@
+---
+/**
+ * /admin/selection/applications/[id] — deep-link permalink to a single application.
+ * The application detail surface is the modal on /admin/selection (tabs Info/Evaluate/
+ * Interview/Comms/Videos/Audit), so this route redirects there with ?app=<id>, which
+ * the dashboard opens on load (maybeOpenDeepLinkedApplicant).
+ *
+ * Fixes the 404 the selection crons' notification links pointed at:
+ * #781 detect_stuck_selection_funnel + _selection_interview_overdue_cron.
+ */
+const { id } = Astro.params;
+if (!id) return Astro.redirect('/admin/selection');
+return Astro.redirect(`/admin/selection?app=${encodeURIComponent(id)}`);
+---

--- a/src/pages/en/admin/selection/applications/[id].astro
+++ b/src/pages/en/admin/selection/applications/[id].astro
@@ -1,0 +1,5 @@
+---
+const { id } = Astro.params;
+if (!id) return Astro.redirect('/admin/selection?lang=en-US');
+return Astro.redirect(`/admin/selection?app=${encodeURIComponent(id)}&lang=en-US`);
+---

--- a/src/pages/es/admin/selection/applications/[id].astro
+++ b/src/pages/es/admin/selection/applications/[id].astro
@@ -1,0 +1,5 @@
+---
+const { id } = Astro.params;
+if (!id) return Astro.redirect('/admin/selection?lang=es-LATAM');
+return Astro.redirect(`/admin/selection?app=${encodeURIComponent(id)}&lang=es-LATAM`);
+---


### PR DESCRIPTION
## Fix do 404 do deep-link de candidatura (Épico D, polish)

Os crons de seleção notificam o GP com link para uma candidatura específica — **#781** `detect_stuck_selection_funnel` e `_selection_interview_overdue_cron` apontam para `/admin/selection/applications/<id>`, mas **essa rota nunca existiu → 404**.

### Abordagem (zero-DB, baixo risco)
A superfície de detalhe da candidatura **já é o modal** em `/admin/selection` (abas Info/Avaliar/Entrevista/Comms/Vídeos/Auditoria). Em vez de duplicar num detail page, o deep-link passa a resolver lá:
- **Nova rota SSR redirect** `/admin/selection/applications/[id]` → `/admin/selection?app=<id>` (+ stubs en/es pela regra de paridade i18n; padrão espelha `admin/members/[id]`).
- `selection.astro` lê `?app=<id>` **após o dashboard carregar** (`maybeOpenDeepLinkedApplicant`), abre o modal daquela candidatura **1×**, e limpa o param via `history.replaceState` para que re-gates (`nav:member`) não reabram; toast i18n se a app não estiver nas linhas do ciclo atual.
- 1 chave i18n nova (`deepLinkNotFound`) nas 3 dicts.

**Sem mudança de DB** — os links das notificações continuam válidos; a rota os faz funcionar (não precisei re-aplicar os crons / Phase-C).

### Validação
- `npx astro build` verde · `npm test` **4416/0/0** · paridade i18n 3/3 · segue precedente `members/[id]` (rota de detalhe que não é item de nav → fora do `route-acl`).

Fecha o item "rota `/admin/selection/applications/[id]` (404)" do backlog do Épico D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)