### PR TITLE
docs(comms): reconcile J1/J2 comms map with live state [ÉPICO J]

### DIFF
--- a/docs/reference/PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md
+++ b/docs/reference/PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md
@@ -1,6 +1,7 @@
 # Matriz de Canais & Marcos "jeito Disney" — Jornada de Pré-Onboarding (J2 + J5)
 
 > **Status:** vivo · **Origem:** discovery #740 (gaps J2 + J5) · **Aterrado:** 2026-06-16 (Wave 4)
+> · **Reconciliado:** 2026-06-18 (Épico J pós-D) — J4 saiu de FUTURO p/ ✅ feito; H1 (jornada pós-promoção) shipou.
 > **Escopo:** primeira pernada (aprovação na seleção → aceite VEP → pré-onboarding → termo → promoção → 1ºs dias).
 > **Companheiro de:** [`PRE_ONBOARDING_COMMS_MAP_2026-06-16.md`](./PRE_ONBOARDING_COMMS_MAP_2026-06-16.md) (J1 — o mapa
 > de **o que** é comunicado por etapa). Este doc define **por qual canal** (J2) e **como celebramos marcos** (J5).
@@ -69,9 +70,13 @@ Tom: caloroso, segunda pessoa, orientado ao próximo passo — **sem números fa
 ## Lacunas / próximos passos (honestos)
 - **J5 marcos server-side** (termo assinado member-side, promoção, 1ª presença, 1ª entrega): exigem gatilho no
   evento (trigger/cron) + persistência de "já celebrado" — **feature futura**, não simulada aqui. Severidade 🟢.
-- **J4 — cadência/SLA configurável** (já registrado no comms map): janelas fixas no código dos crons; config = futuro.
+  Parcial: promoção agora tem jornada pós-promoção (H1, #780); celebração dedicada de marco segue futura.
+- **J4 — cadência/SLA configurável:** ✅ **feito [2026-06-18]** (#776/#777) — `sla_policies` + UI admin em
+  `/admin/settings`. Ver tabela de janelas no [comms map (J1)](./PRE_ONBOARDING_COMMS_MAP_2026-06-16.md#cadência--sla-configurável-j4--implementada-2026-06-18).
 - **J6 — cópia operacional canônica** embutida nos e-mails/telas: ver §9 do discovery; parcialmente embutido
-  (aceite VEP, sync de filiação privada já estão em telas/banners).
+  (aceite VEP, sync de filiação privada já estão em telas/banners; o template `vep_offer_accept_reminder` do D7
+  carrega o passo-a-passo de aceite — #782).
+- **J3 WhatsApp:** segue **manual** (link de grupo coletivo, sem gatilho automatizado); automação = projeto à parte.
 
 ## Cross-ref
 - [`PRE_ONBOARDING_COMMS_MAP_2026-06-16.md`](./PRE_ONBOARDING_COMMS_MAP_2026-06-16.md) (J1)

--- a/docs/reference/PRE_ONBOARDING_COMMS_MAP_2026-06-16.md
+++ b/docs/reference/PRE_ONBOARDING_COMMS_MAP_2026-06-16.md
@@ -1,8 +1,16 @@
 # Mapa de Comunicações — Jornada de Pré-Onboarding (J1)
 
 > **Status:** vivo · **Origem:** discovery #740 (gap J1) · **Aterrado:** 2026-06-16 (Wave 2)
+> · **Reconciliado:** 2026-06-18 (Épico J pós-D) com o estado live — ver nota abaixo.
 > **Escopo:** primeira pernada (aprovação na seleção → aceite VEP → pré-onboarding →
 > termo → promoção). Seleção de tribo é jornada separada (ver discovery #740).
+
+> **🔄 Reconciliação 2026-06-18:** entre 06-16 e 06-18 shiparam peças que este doc dava como
+> FUTURO. Corrigido contra queries vivas: **J4 (SLA configurável)** = ✅ feito (`sla_policies`
+> + UI admin, #776/#777); **D7 (auto-e-mail de aceite VEP)** = ✅ feito (#782) — supersede a nota
+> "painel basta"; **D5/D3 (push ao GP de funil travado)** = ✅ feito (#781), camada PUSH além do
+> pull do painel D1; catálogo `_delivery_mode_for` agora conhece os tipos novos (lacuna de higiene
+> fechada). Detalhes nas linhas marcadas **[2026-06-18]** e na seção "Lacunas".
 
 J1 do discovery pedia "definir quais e-mails/lembretes automáticos em cada estágio".
 Este doc **documenta o que JÁ existe** (não propõe) — o re-grounding da Wave 2 mostrou
@@ -25,6 +33,7 @@ não substitui as fontes de verdade abaixo.
 |---|---|---|---|---|
 | **Aprovado na seleção** | Candidato | sino + e-mail · `selection_approved` | trigger | imediato (sino); e-mail canônico vem no termo |
 | **Oferta VEP pendente** (aprovado, sem ACEITE no VEP) | Candidato | e-mail oficial do **PMI** (remetente `donotreply at pmi.org`) | externo (PMI) | no envio da oferta |
+| ⤷ **[2026-06-18] lembrete próprio (D7)** | Candidato | e-mail · template `vep_offer_accept_reminder` | cron `nudge-vep-offer-accept-daily` → `process_pending_vep_offer_reminders` (single-fire, SLA `offer_accept_grace` 7d a partir de `vep_offer_extended_at`) | diário 17:00 |
 | ⤷ visibilidade p/ liderança | GP/curadoria | painel **D1** (balde "Oferta VEP não aceita") | pull (in-app) | ao abrir `/admin` |
 | **Convite de entrevista** (cutoff aprovado) | Candidato | e-mail · `cutoff_approved_email_sent_at` | cron `selection-cutoff-pending-daily` (strict-above-target) | diário 14:00 |
 | ⤷ in-band/below-target (sem auto-convite) | GP | painel **D1** (balde "sem convite") — **decisão manual** (PM 2026-06-16) | pull (in-app) | ao abrir `/admin` |
@@ -33,7 +42,9 @@ não substitui as fontes de verdade abaixo.
 | **Entrevista vencida / nunca conduzida** | Entrevistadores | `selection_interview_overdue` (digest) | cron `selection-interview-overdue-daily` | diário 14:00 |
 | ⤷ agendamento travado >48h | — | rescue `selection-stuck-scheduled-rescue-daily` | cron | diário 15:00 |
 | ⤷ convite enviado, nunca agendado | GP | painel **D1** (balde correspondente) | pull (in-app) | ao abrir `/admin` |
+| ⤷ **[2026-06-18] push ao GP (D5)** | GP/managers | sino · `selection_candidate_unbooked` | cron `detect-stuck-selection-funnel-daily` → `detect_stuck_selection_funnel` (bucket `invited_never_booked`, SLA `interview_booking_grace` 10d a partir do convite) | diário 16:00 |
 | **No-show** | GP | painel **D1** (balde "no-show") | pull (in-app) | ao abrir `/admin` |
+| ⤷ **[2026-06-18] push ao GP (D3)** | GP/managers | sino · `selection_noshow_unrecovered` | cron `detect-stuck-selection-funnel-daily` → `detect_stuck_selection_funnel` (bucket `noshow_not_recovered`, SLA `noshow_recovery_grace` 3d) | diário 16:00 |
 | **Pré-onboarding — termo disponível** | Candidato | e-mail · `selection_termo_due` (e-mail principal pós-VEP-Active, com termo + próximos passos) | trigger p157/p159 | imediato |
 | ⤷ **apto a assinar (lado-liderança)** | GP + Dir. Voluntariado (`manage_member`) | sino · `selection_apto_to_sign_digest` (agregado) → link p/ fila **E1** | cron `selection-apto-to-sign-digest-daily` (Wave 2 E2) | diário 13:45 |
 | **Onboarding parado / overdue** | Candidato | `selection_onboarding_overdue` | cron `detect-onboarding-overdue-daily` | diário 13:00 |
@@ -53,17 +64,30 @@ não substitui as fontes de verdade abaixo.
 > [`PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md`](./PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md)
 > (Wave 4) — o **princípio** por trás da coluna "Canal / tipo" acima + a matriz de celebração de marcos.
 
+## Cadência / SLA configurável (J4) — ✅ implementada [2026-06-18]
+
+As janelas dos crons **não são mais fixas no código**: ficam na tabela `sla_policies` (SSOT),
+editáveis por GP em `/admin/settings` → "Janelas de SLA" (gate `manage_platform`, #776/#777).
+Valores vivos (queried 2026-06-18):
+
+| policy_key | Janela | Usado por |
+|---|---|---|
+| `interview_booking_grace` | 10 dias | `detect_stuck_selection_funnel` (bucket invited_never_booked) |
+| `noshow_recovery_grace` | 3 dias | `detect_stuck_selection_funnel` (bucket noshow_not_recovered) |
+| `offer_accept_grace` | 7 dias | `process_pending_vep_offer_reminders` (D7, single-fire) |
+| `interview_overdue_grace` | 24h | `_selection_interview_overdue_cron` |
+| `stuck_scheduled_grace` | 48h | `_selection_stuck_scheduled_rescue_cron` |
+| `reschedule_nudge_initial` | 3 dias | `process_pending_reschedule_nudges` (1º nudge) |
+| `reschedule_nudge_repeat` | 3 dias | `process_pending_reschedule_nudges` (subsequentes) |
+
 ## Lacunas conhecidas (não cobertas aqui)
-- **J4 — cadência/SLA configurável** (oferta não aceita, termo não assinado, onboarding
-  parado, convite sem agendamento): hoje as janelas são **fixas no código** dos crons. Um
-  mecanismo de config (tabela + UI) é **feature futura** — registrado em #740, **não** simulado
-  como configurável neste doc.
-- **D7 auto-e-mail próprio** (segundo nudge além do PMI p/ oferta não aceita): decisão PM
-  2026-06-16 = **painel basta** (nudge manual); não há auto-e-mail nosso.
-- Registro do tipo `selection_apto_to_sign_digest` no catálogo ADR-0022 + `_delivery_mode_for`:
-  follow-up de higiene (#740) — hoje o `delivery_mode` é setado direto no INSERT do cron.
+- **J5 marcos server-side** (termo assinado member-side, promoção, 1ª presença, 1ª entrega):
+  ainda parciais/futuros — ver a matriz de marcos no doc companheiro.
+- **J3 WhatsApp** segue **manual** (link de grupo coletivo, sem gatilho automatizado): decisão de
+  canal documentada no doc companheiro (Parte A); automação = projeto à parte (Business API).
 
 ## Cross-ref
 - Discovery: `docs/project-governance/PRE_ONBOARDING_JOURNEY_DISCOVERY_2026-06-16.md`
 - Modelo guest/pré-onboarding: `PRE_ONBOARDING_GUEST_MODEL.md`
 - PRs Wave 2: #745 (D1), #746 (E1), #747 (E2) · umbrella #740
+- PRs reconciliação 2026-06-18: #776/#777 (J4 SLA config + UI), #781 (D5/D3 push funil), #782 (D7 auto-e-mail VEP)


### PR DESCRIPTION
## Épico J — comms & cadência (definição/SSOT)

Os dois docs canônicos de comunicação da jornada de pré-onboarding já existiam
(aterrados 2026-06-16, Wave 2/4), mas ficaram **stale**: davam como FUTURO peças
que shiparam depois. O trabalho do Épico J foi **reconciliar** (não recriar) contra
o estado live.

### Grounding (queries vivas 2026-06-18)
`campaign_templates` (36) · `sla_policies` (8 keys) · `cron.job` · `_delivery_mode_for` · `pg_proc` (links gatilho→template).

### Mudanças
**`PRE_ONBOARDING_COMMS_MAP_2026-06-16.md` (J1)**
- Nota de reconciliação no cabeçalho
- Mapa por etapa: +auto-e-mail D7 (`vep_offer_accept_reminder`) · +2 linhas PUSH ao GP (`selection_candidate_unbooked`/`selection_noshow_unrecovered`, #781)
- Nova seção **J4 SLA configurável ✅** com as 7 janelas vivas de `sla_policies`
- Lacunas reescritas: removidos J4/D7/catálogo (fechados)

**`PRE_ONBOARDING_CHANNEL_AND_CELEBRATION_MATRIX_2026-06-16.md` (J2/J5)**
- J4 FUTURO → ✅ feito (#776/#777); H1 (#780) anotado; J3 explicitado como manual

### Estado do Épico J
| Gap | Estado |
|---|---|
| J1 mapa por etapa | ✅ doc SSOT reconciliado |
| J2 matriz de canal | ✅ doc |
| J3 convite WhatsApp | 📋 política documentada (manual; automação = projeto à parte) |
| J4 cadência/SLA | ✅ shipado (#776/#777) |
| J5 marcos Disney | ✅ matriz; celebrações server-side = futuro 🟢 |
| J6 cópia operacional | ✅ canônica + embutida no template D7 |

Docs-only · zero-DB · zero-código (sem necessidade de build/test).

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>