### PR TITLE
chore(chapters): seed missing BR chapters Amazonas (AM) + Paraíba (PB) [C4]

### DIFF
--- a/supabase/migrations/20260805000211_c4_seed_amazonas_chapter.sql
+++ b/supabase/migrations/20260805000211_c4_seed_amazonas_chapter.sql
@@ -1,0 +1,20 @@
+-- C4 (#740 / ADR-0104) — seed the PMI Amazonas (AM) chapter into chapter_registry.
+--
+-- Context: chapter_registry held the 13 participating Brazil chapters (Wave 3a migration
+-- 20260805000190). Amazonas (https://pmiam.org/) was missing from the participating set;
+-- the PM confirmed the canonical list on 2026-06-18. This adds the 14th chapter so it
+-- becomes a valid entry-chapter choice (set_my_entry_chapter) and a valid FK target for
+-- member_chapter_affiliations / members.entry_chapter_code.
+--
+-- Non-contracting (PMI-GO stays the ONLY contracting chapter — the volunteer term signatory
+-- is always derived from chapter_registry.is_contracting_chapter). CNPJ omitted: only the
+-- contracting chapter needs it. Idempotent (ON CONFLICT DO NOTHING).
+--
+-- No backfill: 0 members had members.chapter = 'PMI-AM' at apply time (queried 2026-06-18).
+--
+-- Rollback: DELETE FROM public.chapter_registry WHERE chapter_code = 'AM';
+--   (safe only while no member_chapter_affiliations / members.entry_chapter_code reference 'AM'.)
+
+INSERT INTO public.chapter_registry (chapter_code, legal_name, state, country, is_contracting_chapter, is_active, display_order)
+VALUES ('AM', 'PMI Amazonas, Brazil Chapter', 'Amazonas', 'BR', false, true, 14)
+ON CONFLICT (chapter_code) DO NOTHING;

--- a/supabase/migrations/20260805000212_c4_seed_paraiba_chapter.sql
+++ b/supabase/migrations/20260805000212_c4_seed_paraiba_chapter.sql
@@ -1,0 +1,20 @@
+-- C4 (#740 / ADR-0104) — seed the PMI Paraíba (PB) chapter into chapter_registry.
+--
+-- Context: completes the participating Brazil chapter set. After Amazonas (mig
+-- 20260805000211) the registry had 14; the PM confirmed PMI Paraíba (PB) as the 15th
+-- participating chapter on 2026-06-18. This adds it so it becomes a valid entry-chapter
+-- choice (set_my_entry_chapter) and a valid FK target for member_chapter_affiliations /
+-- members.entry_chapter_code. Now 15 participating BR chapters.
+--
+-- Non-contracting (PMI-GO stays the ONLY contracting chapter — the volunteer term signatory
+-- is always derived from chapter_registry.is_contracting_chapter). CNPJ omitted: only the
+-- contracting chapter needs it. Idempotent (ON CONFLICT DO NOTHING).
+--
+-- No backfill: 0 members had members.chapter = 'PMI-PB' at apply time (queried 2026-06-18).
+--
+-- Rollback: DELETE FROM public.chapter_registry WHERE chapter_code = 'PB';
+--   (safe only while no member_chapter_affiliations / members.entry_chapter_code reference 'PB'.)
+
+INSERT INTO public.chapter_registry (chapter_code, legal_name, state, country, is_contracting_chapter, is_active, display_order)
+VALUES ('PB', 'PMI Paraíba, Brazil Chapter', 'Paraíba', 'BR', false, true, 15)
+ON CONFLICT (chapter_code) DO NOTHING;


### PR DESCRIPTION
## C4 — completa o conjunto de capítulos participantes (13 → 15)

`chapter_registry` tinha **13** capítulos BR participantes (Wave 3a, mig `20260805000190`).
O PM confirmou a lista canônica em 2026-06-18: faltavam **2** — **PMI Amazonas (AM)**
(https://pmiam.org/) e **PMI Paraíba (PB)**. Este PR adiciona ambos → **15** capítulos.

### Grounding (queries vivas 2026-06-18)
- Antes = 13; AM ausente, PB ausente.
- **0 membros** com `members.chapter` = `'PMI-AM'` ou `'PMI-PB'` → sem backfill.
- Depois do apply: **15** capítulos BR ativos.

### Mudanças
- `20260805000211_c4_seed_amazonas_chapter.sql` → `('AM','PMI Amazonas, Brazil Chapter','Amazonas','BR',false,true,14)`
- `20260805000212_c4_seed_paraiba_chapter.sql` → `('PB','PMI Paraíba, Brazil Chapter','Paraíba','BR',false,true,15)`

Ambos: não-contratantes (PMI-GO segue o **único** contratante do termo via
`chapter_registry.is_contracting_chapter`), CNPJ omitido, `ON CONFLICT DO NOTHING`.
Aplicados ao DB remoto via `execute_sql` (DML) + `migration repair` (211, 212).

Tornam AM e PB escolhas válidas de entry-chapter (`set_my_entry_chapter`) e alvos de FK
(`member_chapter_affiliations` / `members.entry_chapter_code`). **C4 completo (15/15).**

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>