### PR TITLE
feat(onboarding): entry-chapter adoption nudge on /workspace [#625]

### DIFF
--- a/src/components/onboarding/EntryChapterNudge.tsx
+++ b/src/components/onboarding/EntryChapterNudge.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect, useCallback } from 'react';
+
+// Entry-chapter adoption nudge (#625 follow-up / ADR-0104 Wave 3b-i).
+//
+// The /profile entry-chapter CARD already exists (set_my_entry_chapter), but adoption among the
+// established membership is 0/48 live (the screen is passive — you only see it if you go look).
+// This island PULLS the member to it: a dismissible banner on /workspace that links straight to
+// the card. PM decision 2026-06-18: FE-only, no new DB state.
+//
+// Eligibility mirrors what the /profile card itself can act on, so the nudge never dead-ends:
+//   - non-guest, active member (guests have their own pre-onboarding flow + islands)
+//   - get_my_chapter_affiliations() returns >= 1 BR affiliation (the RPC is BR-only)
+//   - none of those affiliations is already the entry chapter (is_entry === false for all)
+// Live grounding 2026-06-18: 48/48 eligible members have >= 1 BR affiliation → 0 dead-ends.
+//
+// Dismissal is a localStorage flag ("not now", per device) with a 14-day TTL — a fat-finger
+// dismiss should not silence a 0/48-adoption governance nudge forever (ux-leader R2). Once an
+// entry chapter is chosen, is_entry flips true on the next load and the banner disappears on its
+// own regardless of the flag — dismiss is only for members who want to defer.
+
+const DISMISS_KEY = 'nucleo:entryChapterNudgeDismissed';
+const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+interface Affiliation {
+  chapter_code: string;
+  is_entry: boolean;
+}
+
+interface Copy {
+  title: string;
+  body: string;
+  cta: string;
+  dismiss: string;
+  ariaLabel: string;
+}
+
+const COPY: Record<string, Copy> = {
+  'pt-BR': {
+    title: 'Defina seu capítulo de entrada',
+    body: 'Escolha por qual capítulo do PMI você entra no Núcleo. Leva um clique e ajuda na governança e nos indicadores do seu capítulo.',
+    cta: 'Escolher meu capítulo',
+    dismiss: 'Agora não',
+    ariaLabel: 'Aviso: defina seu capítulo de entrada',
+  },
+  'en-US': {
+    title: 'Set your entry chapter',
+    body: 'Pick which PMI chapter you join the Núcleo through. It takes one click and supports your chapter’s governance and metrics.',
+    cta: 'Choose my chapter',
+    dismiss: 'Not now',
+    ariaLabel: 'Notice: set your entry chapter',
+  },
+  'es-LATAM': {
+    title: 'Define tu capítulo de entrada',
+    body: 'Elige por cuál capítulo del PMI ingresas al Núcleo. Toma un clic y apoya la gobernanza y los indicadores de tu capítulo.',
+    cta: 'Elegir mi capítulo',
+    dismiss: 'Ahora no',
+    ariaLabel: 'Aviso: define tu capítulo de entrada',
+  },
+};
+
+interface Props {
+  lang?: string;
+}
+
+export default function EntryChapterNudge({ lang = 'pt-BR' }: Props) {
+  const copy = COPY[lang] || COPY['pt-BR'];
+  const [show, setShow] = useState(false);
+
+  const getSb = useCallback(() => (window as any).navGetSb?.(), []);
+
+  const evaluate = useCallback(async () => {
+    // Per-device "not now" with a 14-day TTL (older flag = re-nudge once).
+    try {
+      const raw = localStorage.getItem(DISMISS_KEY);
+      if (raw) {
+        const ts = Number(JSON.parse(raw)?.ts);
+        if (Number.isFinite(ts) && Date.now() - ts < DISMISS_TTL_MS) return;
+      }
+    } catch { /* localStorage blocked / corrupt — proceed without the dismiss flag */ }
+
+    const m = (window as any).navGetMember?.();
+    // Guests have their own pre-onboarding flow; alumni/inactive are out of cohort.
+    if (!m || m.operational_role === 'guest') return;
+    if (m.member_status && m.member_status !== 'active') return;
+
+    const sb = getSb();
+    if (!sb) return;
+    const { data, error } = await sb.rpc('get_my_chapter_affiliations');
+    if (error) return;
+    const affils: Affiliation[] = Array.isArray(data) ? data : [];
+    // BR-only RPC. Eligible = has affiliations AND none is already the entry chapter.
+    if (affils.length === 0) return;
+    if (affils.some((a) => a.is_entry === true)) return;
+    setShow(true);
+  }, [getSb]);
+
+  // Boot like the sibling islands: wait for the nav member, then evaluate once.
+  useEffect(() => {
+    const boot = () => {
+      const m = (window as any).navGetMember?.();
+      if (m) evaluate();
+      else setTimeout(boot, 500);
+    };
+    boot();
+  }, [evaluate]);
+
+  const dismiss = useCallback(() => {
+    try { localStorage.setItem(DISMISS_KEY, JSON.stringify({ ts: Date.now() })); } catch { /* ignore */ }
+    setShow(false);
+  }, []);
+
+  if (!show) return null;
+
+  return (
+    <section role="region" aria-label={copy.ariaLabel} className="mb-6">
+      <div className="rounded-2xl border border-teal/40 bg-teal/5 p-5">
+        <div className="flex items-start gap-3">
+          {/* map-pin (heroicons) — consistent with the chapter context icon used elsewhere. */}
+          <svg className="w-6 h-6 text-teal flex-shrink-0" fill="none" viewBox="0 0 24 24" strokeWidth="1.8" stroke="currentColor" aria-hidden="true">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M15 10.5a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+            <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
+          </svg>
+          <div className="flex-1 min-w-0">
+            <h2 className="text-base font-extrabold text-navy dark:text-teal">{copy.title}</h2>
+            <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{copy.body}</p>
+            <div className="mt-3 flex items-center gap-2 flex-wrap">
+              <a
+                href={`/profile?lang=${lang}#entry-chapter-card`}
+                className="min-h-[44px] inline-flex items-center px-4 rounded-lg bg-teal text-white text-sm font-bold no-underline hover:bg-teal/90"
+              >
+                {copy.cta}
+              </a>
+              <button
+                type="button"
+                onClick={dismiss}
+                className="min-h-[44px] px-4 rounded-lg border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm font-semibold cursor-pointer bg-transparent hover:bg-[var(--surface-hover)]"
+              >
+                {copy.dismiss}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -1412,7 +1412,7 @@ const PROFILE_I18N = {
     // C5 — no BR affiliations found (the observable symptom of a hidden PMI profile).
     if (affils.length === 0) {
       return `
-        <div class="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)] p-6">
+        <div id="entry-chapter-card" class="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)] p-6">
           ${head}
           <div class="mt-1 px-3 py-2.5 rounded-lg bg-amber-50 border border-amber-200 text-[.75rem] text-amber-800">
             ${PROFILE_I18N.entryChapterEmptyGuide}
@@ -1434,7 +1434,7 @@ const PROFILE_I18N = {
     }).join('');
 
     return `
-      <div class="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)] p-6">
+      <div id="entry-chapter-card" class="bg-[var(--surface-card)] rounded-2xl border border-[var(--border-default)] p-6">
         ${head}
         <div class="text-[.7rem] font-bold text-[var(--text-muted)] uppercase tracking-wide mb-2">${PROFILE_I18N.entryChapterAffiliationsLabel}</div>
         ${rows}
@@ -1915,6 +1915,20 @@ const PROFILE_I18N = {
     // Load notification preferences + linked providers after render
     loadNotifPrefs();
     loadLinkedProviders();
+
+    // Deep-link from the /workspace entry-chapter nudge (EntryChapterNudge island):
+    // scroll the entry-chapter card into view once. Affiliations are loaded by loadExtras
+    // before renderProfile, so #entry-chapter-card normally exists by now; retry a few times
+    // in case this render beats the DOM insertion (code-reviewer LOW).
+    if (location.hash === '#entry-chapter-card' && !(window as any).__entryChapterScrolled) {
+      (window as any).__entryChapterScrolled = true;
+      const scrollToCard = (tries: number) => {
+        const card = document.getElementById('entry-chapter-card');
+        if (card) card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        else if (tries > 0) setTimeout(() => scrollToCard(tries - 1), 150);
+      };
+      scrollToCard(5);
+    }
   }
 
   function normalizeCredlyFieldValue(input?: HTMLInputElement | null) {

--- a/src/pages/workspace.astro
+++ b/src/pages/workspace.astro
@@ -13,6 +13,7 @@ import OnboardingChecklist from '../components/onboarding/OnboardingChecklist';
 import PreOnboardingChecklist from '../components/onboarding/PreOnboardingChecklist';
 import PostPromotionJourney from '../components/onboarding/PostPromotionJourney';
 import BuddyBlock from '../components/buddy/BuddyBlock';
+import EntryChapterNudge from '../components/onboarding/EntryChapterNudge';
 import { t, getLangFromURL, type Lang } from '../i18n/utils';
 
 const lang: Lang = getLangFromURL(Astro.url.pathname + Astro.url.search);
@@ -128,6 +129,13 @@ const WK = {
          replacement for the static HBLOCK that vanished with the onboarding card. Appears AFTER
          onboarding completes; reads first_attendance/first_deliverable milestones. -->
     <PostPromotionJourney client:load lang={lang} />
+
+    <!-- #625 follow-up / ADR-0104: entry-chapter adoption nudge. Dismissible pull to the existing
+         /profile entry-chapter card (0/48 adoption live). Self-gates: non-guest active members
+         with >= 1 BR affiliation and no entry chapter chosen yet. FE-only, no new DB state.
+         Placed BEFORE BuddyBlock (ux-leader R1): a one-click governance action outranks the
+         optional social pointer when both surface for the same established member. -->
+    <EntryChapterNudge client:load lang={lang} />
 
     <!-- #766 H5: Buddy/padrinho social pointer (below the journey block; sibling, not wrapped) -->
     <div class="mb-6">

--- a/tests/contracts/625-entry-chapter-nudge.test.mjs
+++ b/tests/contracts/625-entry-chapter-nudge.test.mjs
@@ -1,0 +1,103 @@
+/**
+ * Contract: #625 follow-up / ADR-0104 — entry-chapter adoption nudge (EntryChapterNudge island).
+ *
+ * The /profile entry-chapter card already exists (set_my_entry_chapter, Wave 3b-i), but adoption
+ * among the established membership was 0/48 live (2026-06-18) — the screen is passive. This island
+ * PULLS the member to it: a dismissible /workspace banner that deep-links to the card.
+ *
+ * Design anchors (PM decision 2026-06-18 — FE-only, no new DB state):
+ *  - Self-gating mirrors what the /profile card can act on, so the nudge never dead-ends:
+ *    non-guest active member with >= 1 BR affiliation and no entry chapter chosen yet.
+ *  - Eligibility derived from get_my_chapter_affiliations() (BR-only RPC) — the same read /profile
+ *    uses; is_entry === true on any row ⇒ already chose ⇒ hide.
+ *  - FE-only: the island READS but never writes. The write (set_my_entry_chapter) stays on /profile.
+ *  - Dismiss is a localStorage flag ("not now"), not a DB seen-state.
+ *  - Deep-link: /profile#entry-chapter-card, with a stable anchor + scroll-on-hash on /profile.
+ *
+ * Offline-only (static source assertions); no DB gating.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => (existsSync(resolve(ROOT, p)) ? readFileSync(resolve(ROOT, p), 'utf8') : '');
+
+const NUDGE = read('src/components/onboarding/EntryChapterNudge.tsx');
+const WK = read('src/pages/workspace.astro');
+const PROFILE = read('src/pages/profile.astro');
+
+// ── Component exists & reads the canonical affiliations RPC ──────────────────────
+test('EntryChapterNudge: component exists', () => {
+  assert.ok(NUDGE, 'EntryChapterNudge.tsx exists');
+});
+
+test('EntryChapterNudge: derives eligibility from get_my_chapter_affiliations (existing RPC)', () => {
+  assert.match(NUDGE, /rpc\(['"]get_my_chapter_affiliations['"]\)/);
+});
+
+// ── FE-only: reads, never writes ────────────────────────────────────────────────
+test('EntryChapterNudge: FE-only — never calls the write RPC (that stays on /profile)', () => {
+  assert.ok(!/rpc\(['"]set_my_entry_chapter['"]\)/.test(NUDGE), 'no set_my_entry_chapter write');
+  assert.ok(!/rpc\(['"]upsert_chapter_affiliation['"]\)/.test(NUDGE), 'no affiliation write');
+});
+
+// ── Self-gating: non-guest, active, has BR affiliation, none is entry yet ────────
+test('EntryChapterNudge: excludes guests and non-active members', () => {
+  assert.match(NUDGE, /operational_role === ['"]guest['"]/);
+  assert.match(NUDGE, /member_status !== ['"]active['"]/);
+});
+
+test('EntryChapterNudge: requires >= 1 affiliation and hides once an entry chapter exists', () => {
+  // dead-end guard: no affiliations → do not show
+  assert.match(NUDGE, /affils\.length === 0/);
+  // already chose → some row is_entry → do not show
+  assert.match(NUDGE, /is_entry === true/);
+});
+
+// ── Dismiss is a per-device localStorage flag with TTL, not DB state ─────────────
+test('EntryChapterNudge: dismiss uses localStorage with a TTL (no new DB seen-state)', () => {
+  assert.match(NUDGE, /localStorage\.getItem/);
+  assert.match(NUDGE, /localStorage\.setItem/);
+  // TTL so a fat-finger dismiss does not silence the nudge forever (ux-leader R2)
+  assert.match(NUDGE, /DISMISS_TTL_MS/);
+});
+
+// ── Deep-link to the existing /profile card (hash-preserving, not via lang redirect) ──
+test('EntryChapterNudge: deep-links to the /profile entry-chapter anchor', () => {
+  assert.match(NUDGE, /#entry-chapter-card/);
+  // must NOT use the /en|/es redirect prefix — meta-refresh drops the hash (GAP-625.A)
+  assert.ok(!/\/en\/profile#|\/es\/profile#/.test(NUDGE), 'no locale-prefixed profile path');
+});
+
+// ── a11y + trilingual inline copy (OnboardingChecklist/H1 idiom) ─────────────────
+test('EntryChapterNudge: region role with aria-label + trilingual inline copy', () => {
+  assert.match(NUDGE, /role=['"]region['"]/);
+  assert.match(NUDGE, /aria-label=/);
+  assert.match(NUDGE, /'pt-BR':/);
+  assert.match(NUDGE, /'en-US':/);
+  assert.match(NUDGE, /'es-LATAM':/);
+});
+
+// ── Mounted on /workspace as a sibling, BEFORE BuddyBlock (governance > social, R1) ──
+test('workspace: mounts EntryChapterNudge before BuddyBlock', () => {
+  assert.match(WK, /import EntryChapterNudge from/);
+  assert.match(WK, /<EntryChapterNudge client:load lang=\{lang\} \/>/);
+  const buddyIdx = WK.indexOf('<BuddyBlock');
+  const nudgeIdx = WK.indexOf('<EntryChapterNudge');
+  assert.ok(buddyIdx > -1 && nudgeIdx > -1, 'both islands mounted');
+  // ux-leader R1: governance one-click action outranks the optional social pointer.
+  assert.ok(nudgeIdx < buddyIdx, 'order: entry-chapter nudge → buddy');
+});
+
+// ── /profile provides the stable anchor + scroll-on-hash for the deep-link ───────
+test('profile: entry-chapter card has the deep-link anchor id', () => {
+  assert.match(PROFILE, /id="entry-chapter-card"/);
+});
+
+test('profile: scrolls the entry-chapter card into view on the deep-link hash', () => {
+  assert.match(PROFILE, /location\.hash === ['"]#entry-chapter-card['"]/);
+  assert.match(PROFILE, /scrollIntoView/);
+});


### PR DESCRIPTION
## Contexto

A tela de **capítulo de entrada** no `/profile` (`set_my_entry_chapter`, ADR-0104 Wave 3b-i) já existe, mas a adoção entre membros estabelecidos é **0/48 ao vivo** (medido 2026-06-18) — a tela é passiva, só vê quem procura. Esta PR adiciona `EntryChapterNudge`, um banner **dispensável** no `/workspace` que **puxa** o membro para a tela existente. FE-only, sem novo estado DB (decisão PM 2026-06-18).

## Eixo "guest→ativo": já shipado (não entra nesta PR)

A premissa "27 guests parados" foi aterrada e **não se confirma**: a state machine já existe (`operational_role` auto-deriva via `sync_operational_role_cache`; cron `detect-onboarding-overdue-daily`), e a coorte está fresca (28 guests, idade média 13d, **só 1 travado >30d**). PM decidiu: nada novo nesse eixo — a máquina cobre.

## O que esta PR faz

- **Novo** `src/components/onboarding/EntryChapterNudge.tsx` — ilha React (espelha o idioma do `BuddyBlock`: `navGetSb`/`navGetMember`, boot loop, `lp`).
- **Self-gating** (nunca beco sem saída — 48/48 elegíveis têm ≥1 afiliação BR ao vivo): não-guest ativo, `get_my_chapter_affiliations()` (RPC BR-only, self-scoped) retorna ≥1 afiliação, e nenhuma é o entry chapter ainda. Escolheu → `is_entry` vira true → banner some sozinho.
- **Dismiss** via localStorage com **TTL de 14 dias** (não silencia para sempre por fat-finger).
- **Deep-link** `/profile?lang=…#entry-chapter-card` + âncora `id` no card + scroll-on-hash (com retry) no `/profile`.

## Council

- **ux-leader: GO-with-changes** — R1 (nudge antes do BuddyBlock: governança 1-clique > ponteiro social) ✅; R2 (TTL no dismiss) ✅; R4 (ícone SVG no lugar do emoji) ✅. R3 (toast de retorno) diferido — back-button + auto-dismiss já fecham o loop.
- **code-reviewer: 0 blockers** — GAP-625.A (MEDIUM) corrigido: href via `?lang=` evita a meta-refresh de `/en|/es/profile` que descartava o hash.

## Validação

- Build `npx astro build` verde
- Suíte `npm test`: **4013 pass / 0 fail** (356 skip DB-gated)
- Contrato `625-entry-chapter-nudge` 11/11
- Números aterrados ao vivo no projeto `ldrfrvwhxsmgaabwmaik` nesta sessão (0/48 adoção, 48/48 com afiliação BR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)