### PR TITLE
fix(profile): legenda explícita de limite 2MB no upload de foto

### DIFF
--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -1259,6 +1259,7 @@ const enUS: Record<string, string> = {
   'profile.volunteerBanner.missingLabel': 'Required fields pending: ',
   'profile.volunteerBanner.fillAction': '✏️ Fill in',
   'profile.photoUploadError': 'Error uploading photo',
+  'profile.photoHint': 'JPG or PNG, max 2 MB',
   'profile.exportError': 'Error exporting data',
   'cert.contributions': 'Key contributions:',
   'gamification.cert.filterAll': 'All',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -1259,6 +1259,7 @@ const esLATAM: Record<string, string> = {
   'profile.volunteerBanner.missingLabel': 'Campos obligatorios pendientes: ',
   'profile.volunteerBanner.fillAction': '✏️ Completar',
   'profile.photoUploadError': 'Error al subir foto',
+  'profile.photoHint': 'JPG o PNG, máx. 2 MB',
   'profile.exportError': 'Error al exportar datos',
   'cert.contributions': 'Contribuciones principales:',
   'gamification.cert.filterAll': 'Todos',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -1261,6 +1261,7 @@ const ptBR: Record<string, string> = {
   'profile.volunteerBanner.missingLabel': 'Campos obrigatórios pendentes: ',
   'profile.volunteerBanner.fillAction': '✏️ Preencher',
   'profile.photoUploadError': 'Erro ao enviar foto',
+  'profile.photoHint': 'JPG ou PNG, máx. 2 MB',
   'profile.exportError': 'Erro ao exportar dados',
   'cert.contributions': 'Principais contribuições:',
   'gamification.cert.filterAll': 'Todos',

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -201,6 +201,7 @@ const PROFILE_I18N = {
   historyTypeExterno: t('profile.history.typeExterno', lang),
   noSignature: t('profile.noSignature', lang),
   photoUploadError: t('profile.photoUploadError', lang),
+  photoHint: t('profile.photoHint', lang),
   exportError: t('profile.exportError', lang),
   // p134 Ω-A: LGPD section + delete confirm prompt + toasts
   lgpdPrivacyTitle: t('profile.lgpdPrivacyTitle', lang),
@@ -1626,6 +1627,7 @@ const PROFILE_I18N = {
             <label class="block text-[.7rem] font-bold text-[var(--text-muted)] uppercase tracking-wide mb-1">Nome</label>
             <input type="text" id="self-name" value="${m.name || ''}"
               class="w-full px-3 py-2 border-[1.5px] border-[var(--border-default)] rounded-xl text-sm font-semibold focus:outline-none focus:border-teal">
+            <p class="text-[.7rem] text-[var(--text-muted)] mt-1">📷 ${PROFILE_I18N.photoHint || 'JPG ou PNG, máx. 2 MB'}</p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Problema
Candidato em onboarding (Henrique Diniz) relatou que a foto de perfil não salvava.

## Diagnóstico (não é tier/role)
- **Descartado gate por tier/nível** — a RLS do bucket `member-photos` passa para guests (provado simulando o INSERT sob a identidade real do usuário: `insert_policy_passes=true`); não há gate de `operational_role` no FE, na RPC `update_my_profile` nem nas policies.
- Bucket `member-photos` é público, sem limite de tamanho/MIME no servidor.
- Logs de storage (24h): **só GET 200**, nenhum POST/PUT de upload → a tentativa **nunca chega ao servidor**, logo não há erro de backend.
- Causa: a trava de **2 MB client-side** (`profile.astro`) rejeita foto de celular antes do upload. A UI só tinha o 📷 no hover (invisível no mobile).

## Fix
Legenda explícita `📷 JPG ou PNG, máx. 2 MB` ao lado do avatar, nos 3 idiomas (nova chave `profile.photoHint` em pt-BR/en-US/es-LATAM).

## Backlog (não-bloqueante)
Redimensionar/comprimir no cliente antes de subir (eleva o teto efetivo; resolve a causa de vez para fotos de celular).

## Validação
- `npx astro build` verde.
- i18n: chave presente nos 3 dicionários (paridade).