### PR TITLE
fix(profile): foto de perfil não salva — handler ligado via event delegation (#796 follow-up)

### DIFF
--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -1952,15 +1952,18 @@ const PROFILE_I18N = {
     input.type = input.type === 'password' ? 'text' : 'password';
   }
 
-  // ── Photo upload ──
-  document.getElementById('self-photo-input')?.addEventListener('change', async (e) => {
-    const file = (e.target as HTMLInputElement).files?.[0];
+  // ── Photo upload (event delegation — #self-photo-input is re-rendered by renderProfile) ──
+  document.addEventListener('change', async (e) => {
+    const target = e.target as HTMLInputElement;
+    if (target.id !== 'self-photo-input') return;
+    const file = target.files?.[0];
     if (!file) return;
     if (file.size > 2 * 1024 * 1024) { (window as any).toast?.('Foto excede 2MB', 'error'); return; }
     const sb = (window as any).navGetSb?.();
-    if (!sb || !currentMember) return;
+    const member = currentMember || (window as any).navGetMember?.();
+    if (!sb || !member) return;
     try {
-      const sanitized = (currentMember.email || 'user').replace(/[@.]/g, '_');
+      const sanitized = (member.email || 'user').replace(/[@.]/g, '_');
       const ext = file.type === 'image/png' ? 'png' : 'jpg';
       const path = `avatars/${sanitized}.${ext}`;
       const { error: uploadErr } = await sb.storage.from('member-photos').upload(path, file, { upsert: true });
@@ -1971,6 +1974,7 @@ const PROFILE_I18N = {
       const avatarEl = document.getElementById('self-avatar');
       if (avatarEl) avatarEl.innerHTML = `<img src="${photoUrl}" class="w-16 h-16 rounded-full object-cover" alt="">`;
       (window as any).toast?.('Foto atualizada!', 'success');
+      target.value = '';
     } catch (err: any) {
       (window as any).toast?.(err.message || PROFILE_I18N.photoUploadError || 'Error uploading photo', 'error');
     }


### PR DESCRIPTION
## Problema

O upload de foto de perfil **não fazia nada** ao selecionar um arquivo — sem erro no console, sem requisição de rede. Reproduzido pelo PM com foto de **70KB** (bem abaixo do limite de 2MB), o que descarta a trava de tamanho como causa. #796 (`a344881c`) só adicionou a legenda "limite 2MB" e **não** corrigiu este bug silencioso separado.

## Causa-raiz

O handler era ligado **uma vez no init** via:

```js
document.getElementById('self-photo-input')?.addEventListener('change', …)
```

Mas o input `#self-photo-input` é renderizado **dinamicamente** dentro de `renderProfile()` (`profile.astro` L1623), que só roda **depois** — disparado pelo evento `nav:member` (async) ou após o RPC `get_member_by_auth`. No momento do binding, o elemento ainda não existe → o `?.` curto-circuita → **o listener nunca é ligado**. Selecionar arquivo não dispara nada, sem erro. Bate 100% com o sintoma.

O upload de **assinatura** logo abaixo já usava **event delegation** justamente porque o input é re-renderizado; o de foto não.

## Correção

Troca o handler de foto para **event delegation** em `document` (gated por `target.id === 'self-photo-input'`), espelhando o handler de assinatura. Adiciona `target.value = ''` ao final para que re-selecionar o mesmo arquivo dispare novamente.

## Validação
- `npx astro build` verde (0 novos erros)
- `npm test` → 4090 pass / 0 fail / 361 skip (DB-aware)
- Mudança é FE-only, zero SQL/RPC/i18n.

Ref: runbook `reference-profile-photo-upload` (memory).

