### PR TITLE
feat(selection): go-live do auto-rescue unbooked — agenda cron 15h30 UTC (Épico D, mig 220)

### DIFF
--- a/supabase/migrations/20260805000220_d3_schedule_unbooked_rescue_cron.sql
+++ b/supabase/migrations/20260805000220_d3_schedule_unbooked_rescue_cron.sql
@@ -1,0 +1,22 @@
+-- ─────────────────────────────────────────────────────────────────────────────
+-- D3 auto-rescue — GO-LIVE: agenda o cron _selection_unbooked_rescue_cron().
+--
+-- Follow-up de 20260805000219 (D3 auto-rescue unbooked), que CRIOU o cron mas o
+-- deixou NÃO AGENDADO atrás de 2 gates. Gates liberados pelo PM (2026-06-18):
+--   R1 — copy da linha de "saída por inação" no template selection_cutoff_approved: APROVADA.
+--   R5 — DPA do provedor do link de booking: VERIFICADO.
+--
+-- Horário: 15:30 UTC — ENTRE selection-stuck-scheduled-rescue-daily (15:00) e o
+-- detector #781 detect-stuck-selection-funnel-daily (16:00). Roda antes do detector de
+-- propósito: o re-convite re-seta cutoff_approved_email_sent_at=now(), então o detector
+-- às 16:00 não notifica o GP sobre um caso que o auto-rescue acabou de tratar.
+--
+-- cron.schedule UPSERTS por jobname (idempotente). Snippet original em COMMENT na §3 da
+-- mig 20260805000219. Sem NOTIFY pgrst: não muda a superfície PostgREST.
+-- Rollback: SELECT cron.unschedule('selection-unbooked-rescue-daily');
+-- ─────────────────────────────────────────────────────────────────────────────
+SELECT cron.schedule(
+  'selection-unbooked-rescue-daily',
+  '30 15 * * *',
+  $cron$SELECT public._selection_unbooked_rescue_cron()$cron$
+);


### PR DESCRIPTION
## Go-live do auto-rescue de candidato "convidado-preso" (Épico D)

Follow-up de #797 (mig 219), que **criou** o cron `_selection_unbooked_rescue_cron()` mas o deixou **NÃO AGENDADO** atrás de 2 gates legais (envia e-mail externo real a candidatos). Gates liberados pelo PM em 2026-06-18:

- **R1** — copy da linha de "saída por inação" no template `selection_cutoff_approved`: **aprovada**.
- **R5** — DPA do provedor do link de booking: **verificado**.

## O que esta migration faz

Agenda `cron.schedule('selection-unbooked-rescue-daily', '30 15 * * *', …)` — **15h30 UTC**, entre o `selection-stuck-scheduled-rescue-daily` (15h) e o detector #781 `detect-stuck-selection-funnel-daily` (16h). Posição deliberada: o re-convite re-seta `cutoff_approved_email_sent_at=now()` **antes** do detector às 16h, então o detector não notifica o GP sobre um caso que o auto-rescue acabou de tratar. `cron.schedule` faz upsert por jobname (idempotente).

## Estado / validação (live, antes do PR)

- `cron.schedule` **já aplicado** ao DB remoto via `execute_sql` (DML sobre `cron.job`, não DDL) — **jobid 62, active=true**, exatamente 1 row, schedule/command corretos.
- Versão `20260805000220` registrada via `supabase migration repair`.
- **Coorte do 1º run (read-only, função NÃO invocada — ela envia e-mail real):** 1 app, `c78b885b…` (caso vivo Hector, 23.1d desde o convite). `grace_days=10`.
- Invariantes **36/0**. Build verde. Suíte 4090/0/361skip.

**Épico D fica 100%** com este agendamento (D1 #745, D2 vazio, D3-detecção #781, D4/D5 #784, D7 #782, D3 auto-rescue #797 + este go-live).
