### PR TITLE
fix(profile): upload de foto/assinatura via Edge Function (service role) — Bug 2 da RLS de storage

### DIFF
--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -1952,6 +1952,25 @@ const PROFILE_I18N = {
     input.type = input.type === 'password' ? 'text' : 'password';
   }
 
+  // Upload a member asset (photo/signature) via the upload-member-asset Edge Function.
+  // Direct browser storage uploads are rejected by storage RLS (400) for authenticated users;
+  // the EF performs the write with the service role after authenticating the caller. The EF
+  // returns the public URL; the caller persists it via update_my_profile (which works). The
+  // user's JWT is attached automatically by functions.invoke.
+  async function uploadMemberAsset(sb: any, kind: 'photo' | 'signature', file: File): Promise<string> {
+    const fd = new FormData();
+    fd.append('kind', kind);
+    fd.append('file', file);
+    const { data, error } = await sb.functions.invoke('upload-member-asset', { body: fd });
+    if (error) {
+      let msg = error.message;
+      try { const b = await error.context?.json?.(); if (b?.error) msg = b.error; } catch { /* keep generic */ }
+      throw new Error(msg);
+    }
+    if (!data?.url) throw new Error('upload failed');
+    return data.url as string;
+  }
+
   // ── Photo upload (event delegation — #self-photo-input is re-rendered by renderProfile) ──
   document.addEventListener('change', async (e) => {
     const target = e.target as HTMLInputElement;
@@ -1963,13 +1982,7 @@ const PROFILE_I18N = {
     const member = currentMember || (window as any).navGetMember?.();
     if (!sb || !member) return;
     try {
-      const sanitized = (member.email || 'user').replace(/[@.]/g, '_');
-      const ext = file.type === 'image/png' ? 'png' : 'jpg';
-      const path = `avatars/${sanitized}.${ext}`;
-      const { error: uploadErr } = await sb.storage.from('member-photos').upload(path, file, { upsert: true });
-      if (uploadErr) throw uploadErr;
-      const { data: urlData } = sb.storage.from('member-photos').getPublicUrl(path);
-      const photoUrl = urlData.publicUrl + '?t=' + Date.now();
+      const photoUrl = await uploadMemberAsset(sb, 'photo', file);
       await sb.rpc('update_my_profile', { p_fields: { photo_url: photoUrl } });
       const avatarEl = document.getElementById('self-avatar');
       if (avatarEl) avatarEl.innerHTML = `<img src="${photoUrl}" class="w-16 h-16 rounded-full object-cover" alt="">`;
@@ -1992,11 +2005,7 @@ const PROFILE_I18N = {
     const member = (window as any).navGetMember?.();
     if (!sb || !member) return;
     try {
-      const path = `signatures/${(member.email || 'user').replace(/[@.]/g, '_')}.png`;
-      const { error } = await sb.storage.from('member-signatures').upload(path, file, { upsert: true });
-      if (error) throw error;
-      const { data: urlData } = sb.storage.from('member-signatures').getPublicUrl(path);
-      const sigUrl = urlData.publicUrl + '?t=' + Date.now();
+      const sigUrl = await uploadMemberAsset(sb, 'signature', file);
       await sb.rpc('update_my_profile', { p_fields: { signature_url: sigUrl } });
       const preview = document.getElementById('sig-preview');
       if (preview) preview.innerHTML = `<img src="${sigUrl}" class="max-w-[200px] max-h-[70px] border border-[var(--border-subtle)] rounded p-1" alt="">`;

--- a/supabase/functions/upload-member-asset/index.ts
+++ b/supabase/functions/upload-member-asset/index.ts
@@ -1,0 +1,90 @@
+/**
+ * upload-member-asset — authenticated storage write for a member's own photo / signature.
+ *
+ * WHY THIS EXISTS (2026-06-19):
+ *   Direct browser `supabase.storage.from(bucket).upload(...)` for member-photos AND
+ *   member-signatures returns HTTP 400 "new row violates row-level security policy" for an
+ *   authenticated user, even though (a) the request carries a valid `authenticated` JWT,
+ *   (b) the identical INSERT as the `authenticated` role passes at the SQL level, and
+ *   (c) the WITH CHECK expression evaluates true. The storage-api's evaluation of the
+ *   members-subquery storage RLS policy does not match the SQL-level result. Rather than
+ *   depend on that fragile cross-table storage RLS, the upload is performed here with the
+ *   service role (PROVEN to succeed) AFTER authenticating the caller and resolving THEIR OWN
+ *   canonical path — so no user can write as another. The caller still updates members
+ *   (photo_url / signature_url) via the existing `update_my_profile` RPC, which works.
+ *
+ * Auth: caller's user JWT (sent automatically by supabase-js `functions.invoke`).
+ * Body: multipart/form-data with fields `kind` ("photo" | "signature") and `file`.
+ * Returns: { success: true, url, path, bucket }
+ */
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_ROLE = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+const ANON = Deno.env.get("SUPABASE_ANON_KEY")!;
+
+const cors = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+};
+const json = (d: unknown, s = 200) =>
+  new Response(JSON.stringify(d), { status: s, headers: { ...cors, "Content-Type": "application/json" } });
+
+type KindCfg = { bucket: string; prefix: string; maxBytes: number; mimes: string[] };
+const KINDS: Record<string, KindCfg> = {
+  photo:     { bucket: "member-photos",     prefix: "avatars/",    maxBytes: 2 * 1024 * 1024, mimes: ["image/jpeg", "image/png"] },
+  signature: { bucket: "member-signatures", prefix: "signatures/", maxBytes: 512 * 1024,      mimes: ["image/png", "image/jpeg", "image/webp"] },
+};
+
+const extFor = (mime: string) => (mime === "image/png" ? "png" : mime === "image/webp" ? "webp" : "jpg");
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: cors });
+  if (req.method !== "POST") return json({ error: "POST only" }, 405);
+
+  const authHeader = req.headers.get("Authorization") ?? "";
+  if (!authHeader.startsWith("Bearer ")) return json({ error: "missing bearer token" }, 401);
+
+  // 1) authenticate the caller (their own JWT)
+  const userClient = createClient(SUPABASE_URL, ANON, {
+    global: { headers: { Authorization: authHeader } },
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+  const { data: { user }, error: authErr } = await userClient.auth.getUser();
+  if (authErr || !user) return json({ error: "not authenticated" }, 401);
+
+  // 2) parse multipart body
+  let form: FormData;
+  try { form = await req.formData(); }
+  catch { return json({ error: "expected multipart form-data" }, 400); }
+
+  const kind = String(form.get("kind") ?? "");
+  const cfg = KINDS[kind];
+  if (!cfg) return json({ error: "invalid kind (expected photo|signature)" }, 400);
+
+  const file = form.get("file");
+  if (!(file instanceof File)) return json({ error: "missing file" }, 400);
+  if (file.size === 0) return json({ error: "empty file" }, 400);
+  if (file.size > cfg.maxBytes) return json({ error: "file too large", max_bytes: cfg.maxBytes }, 413);
+  if (!cfg.mimes.includes(file.type)) return json({ error: "unsupported type", got: file.type, allowed: cfg.mimes }, 415);
+
+  // 3) resolve the caller's OWN member record (service role) — path is always the caller's
+  const admin = createClient(SUPABASE_URL, SERVICE_ROLE, { auth: { persistSession: false, autoRefreshToken: false } });
+  const { data: member, error: mErr } = await admin
+    .from("members").select("id,email").eq("auth_id", user.id).maybeSingle();
+  if (mErr) return json({ error: "member lookup failed", detail: mErr.message }, 500);
+  if (!member?.email) return json({ error: "no member record for caller" }, 403);
+
+  // 4) canonical path (same convention as the legacy FE: email with [@.] -> _)
+  const sanitized = String(member.email).replace(/[@.]/g, "_");
+  const path = `${cfg.prefix}${sanitized}.${extFor(file.type)}`;
+
+  // 5) privileged write (service role bypasses the storage RLS that rejects authed uploads)
+  const bytes = new Uint8Array(await file.arrayBuffer());
+  const { error: upErr } = await admin.storage.from(cfg.bucket).upload(path, bytes, { upsert: true, contentType: file.type });
+  if (upErr) return json({ error: "upload failed", detail: upErr.message }, 500);
+
+  const { data: urlData } = admin.storage.from(cfg.bucket).getPublicUrl(path);
+  return json({ success: true, url: `${urlData.publicUrl}?t=${Date.now()}`, path, bucket: cfg.bucket });
+});


### PR DESCRIPTION
## Contexto

Segue #798 (que corrigiu o listener morto do input de foto). Ao destravar o listener, ficou exposto um **segundo bug, pré-existente e mais amplo**: o upload direto do browser para **member-photos E member-signatures** é rejeitado com `400 — new row violates row-level security policy` para usuários **autenticados**.

## Diagnóstico (resumo do que foi isolado)

- Upload como **service_role** → **200** (bucket/validação OK).
- INSERT em `storage.objects` como role **`authenticated`** com as claims do usuário, no SQL → **passa**; a expressão `WITH CHECK` avalia **true**.
- O request real **carrega o JWT correto** (`role=authenticated, sub=…`) — não é anon.
- Mesma lógica de RLS: **passa no SQL, falha pelo storage-api** (a avaliação da subquery em `members` pelo storage-api diverge do resultado SQL). Afeta **foto e assinatura** igualmente.

Em vez de depender dessa RLS de storage frágil, a escrita passa a ser feita server-side com service_role — que comprovadamente funciona.

## Mudança

- **NOVO `supabase/functions/upload-member-asset`** (já deployada): autentica o chamador pelo JWT (`getUser`), resolve o membro pelo `auth_id` (service role), valida `kind`/MIME/tamanho server-side, grava no bucket+path **canônico do próprio chamador** (sem spoofing) com `upsert`, e devolve a URL pública.
- **`profile.astro`**: handlers de foto e assinatura agora invocam a EF (`functions.invoke` anexa o JWT automaticamente) e seguem persistindo via `update_my_profile` (RPC, que funciona hoje). Helper `uploadMemberAsset` extrai a mensagem de erro real da EF.

## Validação

- EF deployada com guards verificados: **sem token → 401**, **anon-sem-usuário → 401**, **OPTIONS → 200**. Escrita service_role já provada (200).
- `npx astro build` verde · `npm test` 4090/0/361skip.
- **Pendente:** confirmação final do happy-path autenticado no browser pelo PM (não reproduzível no servidor sem forjar sessão).

Ref: runbook `reference-profile-photo-upload` (memory).
