### PR TITLE
feat(cycle4): Fatia 0/A — community_vertical kind + vertical-piloto Construção [#680]

### DIFF
--- a/docs/adr/ADR-0103-vertical-as-initiative-kind.md
+++ b/docs/adr/ADR-0103-vertical-as-initiative-kind.md
@@ -1,9 +1,10 @@
 # ADR-0103 — Vertical (PMI credential community) as an `initiative_kind`
 
-- **Status:** Proposed (draft / skeleton — 2026-06-12)
-- **Issue:** #661 ([Discussão] Modelo Verticais × Quadrantes × Tribos)
-- **Origin:** Conceptual model `docs/strategy/verticals_x_quadrants_model.md` (a IA como linha de costura entre os silos do PMI). Ratified in principle by PM (Vitor) on 2026-06-12.
+- **Status:** Accepted (2026-06-19 — Ciclo 4 Fatia 0/A)
+- **Issue:** #661 ([Discussão] Modelo Verticais × Quadrantes × Tribos) · #680 (Ciclo 4 frontpage)
+- **Origin:** Conceptual model `docs/strategy/verticals_x_quadrants_model.md` (a IA como linha de costura entre os silos do PMI). Ratified in principle by PM (Vitor) on 2026-06-12; **ratified + implemented (kind config + piloto Construção)** on 2026-06-19.
 - **Refs:** ADR-0005 (`initiative` as domain primitive), ADR-0009 (config-driven `initiative_kinds`), ADR-0004 (`organization_id`), ADR-0007 (`can()` / engagement grants).
+- **Migration:** `supabase/migrations/20260805000221_community_vertical_kind_seed.sql` (kind + engagement_kinds `vertical_lead`/`vertical_member`). Vertical-piloto Construção criada via `create_initiative` em runtime (`81fdbdfa-4a92-401f-9e50-9318be9b94fe`).
 
 ## Context
 
@@ -62,12 +63,26 @@ The question this ADR settles: **is a vertical a first-class `initiative_kind`, 
 - **(B) Vertical as a new top-level entity peer to `initiative`.** Rejected: fragments the model, contradicts ADR-0005 (one primitive) and ADR-0009 (config-driven kinds).
 - **(C) Vertical contains the tribe's deliverables (containment, not reference).** Rejected: breaks the anti-silo invariant — would make verticals owners of knowledge and recreate the silos.
 
-## Open questions (for council / issue #661)
+## Open questions — resolved at ratification (PM, 2026-06-19)
 
-1. Verticals **curated** (fixed catalog, `max_concurrent_per_org`) or **open** (any community proposes)?
-2. `verticals` as `text[]` on the deliverable vs. a `deliverable_verticals` join table (join table if we need per-routing metadata like framing/owner).
-3. Does each vertical get its **own** anchor credential *in addition to* the shared Champion→CPMAI ladder (current assumption: yes), or is the ladder the only credential surface?
-4. Pilot vertical for Ciclo 4 (institutional timing favors ESG or Agile).
+1. **Curated vs. open → CURATED.** Verticals são um catálogo curado: só GP/liderança cria via `create_initiative`. `max_concurrent_per_org = 8` (config). O teto é um botão de config (ADR-0009, editável no admin **sem migration**) e pode ser elevado quando uma vertical específica precisar de mais — reversível por design. Abrir a proposta à comunidade fica como evolução futura (fluxo request-to-join), não bloqueia o Ciclo 4.
+2. **`verticals text[]` vs. join → DEFERIDA.** O roteamento deliverable↔vertical não é necessário para a landing (que só lê a existência da vertical + `metadata.status`). Decidir quando o relatório `GROUP BY vertical` ou metadata de roteamento (framing/owner) for necessário. Sem impacto na Fatia A.
+3. **Âncora própria + escada → SIM.** Cada vertical tem sua credencial-âncora (`metadata.anchor_credential`, ex.: Construção = PMI-CP) **além** da escada transversal Champion→CPMAI. Bakeado no `custom_fields_schema`.
+4. **Vertical-piloto → CONSTRUÇÃO** (PM sobrepôs a sugestão ESG/Ágil): Henrique Diniz já em pré-onboarding como líder fundador = âncora real, não vaporware.
+
+## Implementação (Fatia A, 2026-06-19) — o que foi feito vs. adiado
+
+**Feito** (migration `20260805000221` + runtime):
+- Kind `community_vertical`: `has_board/meeting_notes/deliverables/attendance/certificate = false` (a vertical referencia, não executa — anti-silo §3), `max_concurrent_per_org = 8`, `lifecycle_states` no domínio do engine (`draft/active/concluded/archived`). `metadata.status` (`forming|open|paused`) é ortogonal ao `initiatives.status` e é o que a landing lê para o CTA.
+- `custom_fields_schema` com `required: [anchor_credential, status]` (validado por `validate_initiative_metadata` — presença + tipo; enum não é validado no trigger, controlado pela app).
+- Par dedicado de engagement kinds `vertical_lead` (legal_basis=consent) + `vertical_member` (legitimate_interest), `initiative_kinds_allowed=['community_vertical']`. **Não** se reusou `committee_*`/`workgroup_*` para não contaminar a CASE WHEN de `operational_role` (`sync_operational_role_cache`) nem a semântica legal.
+- Vertical Construção criada (`81fdbdfa…`, `initiatives.status=active`, `metadata.status=forming`, anchor PMI-CP, parceiro Global Construction Ambassadors). Henrique registrado como **líder pretendido em `metadata.intended_lead`** (`engagement_status=pending_volunteer_term`).
+
+**Adiado para a ativação** (kickoff do Ciclo 4 / termo de voluntário do Henrique — decisão PM "não promover ainda"):
+- **Engajar o Henrique** como `vertical_lead × leader` (via `manage_initiative_engagement`) — só após o termo de voluntário assinado.
+- **Seeds de `engagement_kind_permissions`** para `vertical_lead × leader` (manage_member/initiative, view_pii/initiative, write/initiative): não conceder PII/gestão a um líder ainda em pré-onboarding; gestão da coorte fundadora é GP-only por ora.
+- **Elevação de `operational_role`**: `vertical_lead` hoje deriva `guest` (não está na CASE WHEN); elevar (ex.: → researcher) só quando a vertical for `open`. Evita mexer em trigger crítico sem necessidade.
+- **Invariante `AJ_vertical_no_tribe_child`** (guard: `community_vertical` não pode parentear `research_tribe` — inverteria o eixo produção/distribuição, §Costs): só relevante quando existir fluxo de criação de filhos de vertical. `create_initiative` não cria filhos automaticamente; o guard entra junto com esse fluxo (Fatia B+).
 
 ---
-*Skeleton authored with PMO (Claude); decision and ratification are the PM/council's. Fill Context constraints against prod before moving to Accepted.*
+*Authored with PMO (Claude); decision and ratification are the PM/council's. Ratified + implemented against prod 2026-06-19.*

--- a/docs/strategy/cycle4_frontpage_execution_plan.md
+++ b/docs/strategy/cycle4_frontpage_execution_plan.md
@@ -1,0 +1,100 @@
+# Plano de Execução — Frontpage do Ciclo 4 (verticais-first)
+
+- **Status:** Plano de execução / startpoint para sessão limpa
+- **Data:** 2026-06-19 (autor: Vitor PM + Claude PMO)
+- **Issue-mãe:** #680 ([Ciclo 4] Frontpage: value-prop CoP/pós-IA + ponto de conexão de parceiros) · relacionado #661 (discussão do modelo) · #661 entrada do Ciclo 4
+- **SSOT que este plano orquestra (não substitui):**
+  - `cycle4_landing_value_prop.md` — brief de execução da landing (6 blocos + checklist de aceite)
+  - `verticals_x_quadrants_model.md` — modelo conceitual (a IA como linha de costura)
+  - `vertical_pitch_kit.md` — kit de pitches por vertical (ordem de ativação)
+  - `deck_outline.md` — outline do deck executivo (entregável **separado**, ver §Referências)
+  - `docs/adr/ADR-0103-vertical-as-initiative-kind.md` — decisão de modelagem (hoje *Proposed*)
+
+> **Para que serve este doc.** Os 4 docs de estratégia (12/jun) são SSOT maduro, mas **assumem um modelo de domínio que ainda não existe no banco**. Este plano adiciona a camada que faltava: (1) o *grounding* do que já existe vs. net-new vs. bloqueado, medido ao vivo; (2) as fatias ordenadas por dependência; (3) as decisões travadas com o PM em 2026-06-19. É o startpoint organizado para a sessão limpa — não recomeçar do zero.
+
+---
+
+## 1. Decisões travadas (PM, 2026-06-19)
+
+| # | Decisão |
+|---|---------|
+| Sequência | **Verticais primeiro** (mais perto do kickoff do C4). Caminho crítico = 0 → A → B; C em paralelo/depois. |
+| Modo de operação | Toda a onda: **branch → QA visual → só então deploy pra produção.** Sem deploy direto. |
+| Vertical-piloto | **Construção** — Henrique Diniz já em pré-onboarding como líder = âncora real (não vaporware). |
+| Parceiros (C) | Parceria entra **pelo Programa/Núcleo** (porta única de 1º contato) mas é **firmada VIA PMI-GO**, capítulo-sede e dono da relação. Copy precisa deixar isso explícito. |
+| Deck | **Não é entregável de build** — é conhecimento/inspiração para layout e organização dos temas. `branded-deck-build` numa sessão separada. |
+| Landing — regra de ferro | **Nada hardcoded** (indicadores e verticais saem de dado ao vivo) + **mudar a informação, preservar o sistema visual** (sem rebrand na virada de ciclo). |
+
+---
+
+## 2. Grounding ao vivo (medido 2026-06-19 — re-verificar no build)
+
+> Números/estado são snapshot. Re-consultar a fonte (`pg_proc`, `initiatives`, grep FE) no início de cada fatia antes de agir.
+
+### ✅ Já existe (reusar, não recriar)
+- **Home (`src/pages/index.astro`) com 14 seções**: `HomepageHero`, `NucleoSection`, `ChaptersSection`, `PlatformStatsSection`, `QuadrantsSection`, `TribesSection`, `RulesSection`, `KpiSection`, `TrailSection`, `TeamSection`, `CpmaiSection`, `VisionSection`, `WeeklyScheduleSection`, `ResourcesSection`.
+  - Mapeamento aos 6 blocos do brief: bloco 1 herói → `HomepageHero` ✅ · bloco 2 prova viva → `PlatformStatsSection`+`KpiSection` ✅ (em grande parte) · bloco 4 escada → `TrailSection`+`CpmaiSection` ✅ · blocos 3/5 → parciais (`QuadrantsSection`/`ChaptersSection`).
+- **RPCs públicas exigidas pelo brief — todas existem**: `get_public_impact_data`, `get_public_platform_stats`, `get_public_trail_ranking`, `get_champions_ranking`, **`capture_visitor_lead`** (primitivo de inbound de parceiro pronto).
+- **ADR-0103 escrito** (modelagem da vertical).
+
+### 🔴 Net-new ou BLOQUEADO
+- ~~**`community_vertical` kind NÃO existe.**~~ ✅ **RESOLVIDO 2026-06-19 (Fatia A):** kind `community_vertical` configurado + vertical Construção seedada (`forming`). Os blocos 3/6 da landing já têm dado ao vivo para ler (`kind='community_vertical'`, `metadata.status`).
+- ~~**ADR-0103 = *Proposed***~~ ✅ **Accepted** (Fatia 0).
+- → Blocos 3 (hub-and-spoke) e 6 (CTA por `status`) **desbloqueados** — agora dependem só do FE (Fatia B).
+- **Ponto de contato de parceiros público**: net-new. Só existe admin-side (`PartnerPipelineIsland`, `/admin/partnerships`). Backend (`capture_visitor_lead`) pronto; falta a porta pública.
+- **Diagrama hub-and-spoke** (bloco 3) e **mapa Brasil/LatAm** (bloco 5): visuais net-new (mapa pode reusar o componente do PMAIrevolution).
+
+---
+
+## 3. Fatias (ordenadas por dependência — verticais primeiro)
+
+### Fatia 0 — Ratificar ADR-0103 (governança) — ✅ CONCLUÍDA (2026-06-19)
+- ADR-0103 movido *Proposed* → **Accepted**; open questions resolvidas (curado/teto 8 ajustável; roteamento deferido; âncora própria+escada=sim; piloto=Construção).
+- **Saída:** ADR-0103 aceito; `community_vertical` autorizado e configurado.
+
+### Fatia A — Modelo de vertical no banco (caminho crítico) — ✅ CONCLUÍDA (2026-06-19)
+> Migration `20260805000221` (kind `community_vertical` + engagement_kinds `vertical_lead`/`vertical_member`) + vertical Construção criada via `create_initiative` (`81fdbdfa-4a92-401f-9e50-9318be9b94fe`, status engine=active, `metadata.status='forming'`, anchor PMI-CP, parceiro Global Construction Ambassadors). Henrique = líder pretendido em `metadata.intended_lead` (engajamento adiado p/ termo assinado). `has_board=false` honrado (0 boards), invariantes 0 violações. Adiados p/ ativação: engajar Henrique, seeds de permissão do líder, elevação de operational_role, invariante AJ guard-parent (detalhe no ADR-0103 §Implementação).
+- Configurar o **kind `community_vertical`** via config ADR-0009 (admin, **sem migration**), `custom_fields_schema` do ADR-0103: `anchor_credential`, `predecessor_credential`, `credential_body`, `partner_org`, `status` (`forming|open|paused` — dirige o CTA da landing), `pmi_registry_url`.
+- **Aterrar Henrique** (person/engagement reais) **antes de seedar**; criar a vertical **Construção** como `community_vertical` (âncora **PMI-CP**, parceiro Global Construction Ambassadors, `status`) com Henrique como líder.
+- Roteamento deliverable↔vertical (ADR-0103 §3, `verticals text[]` vs. join) pode ficar para fatia posterior — a landing só precisa das verticais existirem + `status`.
+- **Council:** `data-architect` (config do kind + seed + autoridade de quem gere vertical; confirmar zero-migration).
+- **Aceite:** ≥1 `community_vertical` consultável com `status`; landing consegue lê-la ao vivo.
+
+### Fatia B — Landing value-prop (FE; branch → QA visual → prod)
+- **Copy CoP/pós-IA** no herói/núcleo/visão (espinha narrativa do brief §1) — i18n nas 3 dicts.
+- **Bloco 3 — hub-and-spoke**: raios = lista dinâmica de `community_vertical` (não fixos). Componente visual net-new; *este visual É o pitch*.
+- **Bloco 6 — "Seja protagonista"**: CTA dirigido por `status='forming'`; interesse entra como `capture_visitor_lead` (`target_vertical`).
+- **Bloco 5 — mapa Brasil/LatAm** em 1º plano + presença internacional como legenda nomeada; **LGPD: agregar por capítulo/estado/país, pins individuais só com opt-in** (`set_my_gamification_visibility` como precedente). Reusar/re-projetar o mapa do PMAIrevolution.
+- **Bloco 2 — prova viva**: estender contadores (verticais, champions) se faltarem; tudo derivado.
+- **Identidade:** sem rebrand; no máximo **1 token** de acento para o CTA protagonista; componentes net-new aditivos e tokenizados.
+- **Council:** `ux-leader` (layout/jornada) + `code-reviewer`; `security-engineer` no mapa (LGPD).
+- **Aceite:** checklist §7 do brief (nada hardcoded; verticais de `community_vertical`; CTA por `status`; mapa agrega; internacional visível; paleta preservada; hub-and-spoke comunica integração de silos).
+
+### Fatia C — Ponto de conexão de parceiros (FE + wiring; independente)
+- Porta pública **"Seja parceiro / fale com o programa de parcerias"** (seção na frontpage e/ou página dedicada). Copy: **Núcleo = porta de entrada; PMI-GO = capítulo-sede e dono da relação.**
+- Inbound → `capture_visitor_lead` (intenção de parceria) → pipeline existente (`get_partner_pipeline` / `PartnerPipelineIsland`).
+- Linguagem ancorada em `docs/strategy/partnerships/PMI_PARTNERSHIP_FRAMEWORK_NOTES.md` + playbook `nucleo-ia-gp/frameworks` §6. (Material PMI Global já disponível localmente — abrir issue no projeto pmigo só se faltar diretriz específica.)
+- **Council:** `ux-leader` + `legal-counsel` (enquadramento de parceria / brand guidelines PMI / titularidade PMI-GO) + `code-reviewer`.
+- **Aceite:** inbound roteia para o processo de parceria sem furar a titularidade do PMI-GO; LGPD na captura de lead.
+
+### Rider — domínio canonical (pmigo) — encaixar antes dos certificados do C3
+- Camada A (divulgar pmigo na copy/links) = livre dentro da B.
+- Camada B (flip canonical pra `nucleoia.pmigo.org.br`): **centralizar o host num ponto único primeiro** → flip mantendo `vitormr.dev` **co-hospedado** (certificados já emitidos + clients MCP) → checklist: identificador OAuth do MCP (`.well-known/*`, `mcp.ts`), allowlist do Supabase Auth, confirmar Bot Fight Mode no subdomínio pmigo, GSC.
+- **Janela:** Ciclo 3 = "2026/1" fechando em semanas → priorizar o flip **antes** da leva de certificados do fim do C3 (o PDF crava a URL no momento da emissão). Não depende da migração do servidor (subdomínio já está no Cloudflare).
+- Host hoje chumbado como literal em ~6 arquivos: `astro.config.mjs` (`site`), `middleware.ts` (`CANONICAL_HOST`), `mcp.ts`, `mcp/semantic.ts`, `.well-known/oauth-authorization-server.ts`, `.well-known/oauth-protected-resource.ts`, `oauth-security.ts`, `certificates/pdf.ts`.
+
+---
+
+## 4. Referências (inspiração/conhecimento — não build)
+- **Decks** em `docs/strategy/deck/`: `Nucleo_IA_GP_PMI_LATAM_Natalia.pdf`, `Nucleo_IA_GP_Pitch_Executive_EN.pdf`, `Nucleo_IA_GP_Pitch_Executivo.pdf`, `Nucleo_IA_GP_Pitch_ALUN_Kruel.pdf`, `Nucleo_IA_GP_CEIA_UFG_PnD.pdf` — minerar para layout (hub-and-spoke visual) e ordem dos temas na Fatia B.
+- **Parceria** em `docs/strategy/partnerships/`: `PMI_PARTNERSHIP_FRAMEWORK_NOTES.md`, `partnership_value_exchange_canvas.md`, `partner_dossier_TEMPLATE.md`, `partner_ceia_ufg.md` (parceiro real), `README.md` — base da copy e do fluxo da Fatia C.
+- **Deck executivo** (`deck_outline.md`): renderização dos 3 docs via `branded-deck-build` em sessão limpa, com template `.pptx` PMIGO. Separado da engenharia de frontpage.
+
+## 5. Ordem de ativação das verticais (do pitch kit, para fatias futuras pós-piloto)
+1. **Construção** (líder aceito + 2 Ambassadors BR/EUA) — piloto da Fatia A · 2. PMO (PMI-PMOCP recém-lançada) · 3. ESG (CSPP, janela de mídia) · 4. Ágil (Agile Alliance + refresh PMP) · 5. Negócio/Portfólio (definir parceiro).
+
+## 6. Perguntas abertas (herdadas dos SSOT — resolver no build)
+- Prova viva mostra todos os indicadores ou subconjunto curado (não poluir o herói)? (landing §perguntas)
+- Verticais = catálogo curado fixo ou abertas a proposta? (`max_concurrent_per_org`, ADR-0009)
+- Escada Champion→CPMAI é a única costura de credencial, ou cada vertical tem âncora própria além dela?
+- Roteamento deliverable↔vertical: `verticals text[]` vs. join table (ADR-0103 §3) — decidir quando o relatório `GROUP BY vertical` for necessário.

--- a/supabase/migrations/20260805000221_community_vertical_kind_seed.sql
+++ b/supabase/migrations/20260805000221_community_vertical_kind_seed.sql
@@ -1,0 +1,73 @@
+-- Ciclo 4 — Fatia A: vertical de comunidade como initiative_kind (ADR-0103, ADR-0009 config-driven)
+-- Modelagem de arquitetura para o kickoff do Ciclo 4. Zero impacto em features existentes (aditivo).
+-- A vertical-piloto (Construção) e o engagement do líder (Henrique) NÃO entram aqui:
+--   - a vertical é criada via create_initiative em runtime (dado de produção, não schema);
+--   - o líder só é engajado após o termo de voluntário assinado (decisão PM 2026-06-19).
+-- Adiado p/ a ativação (kickoff/termo, documentado no ADR-0103): seeds de engagement_kind_permissions
+-- do vertical_lead (manage_member/view_pii/write), elevação de operational_role e o invariante
+-- AJ_vertical_no_tribe_child (guard parent — só relevante quando houver criação de filhos).
+
+-- 1) O kind community_vertical (catálogo curado; teto 8 ajustável via config ADR-0009 sem migration)
+INSERT INTO public.initiative_kinds (
+  slug, display_name, description, icon, icon_emoji,
+  default_duration_days, max_concurrent_per_org,
+  has_board, has_meeting_notes, has_deliverables, has_attendance, has_certificate,
+  custom_fields_schema, lifecycle_states,
+  allowed_engagement_kinds, required_engagement_kinds,
+  organization_id
+) VALUES (
+  'community_vertical',
+  'Vertical de Comunidade',
+  'Comunidade durável organizada em torno de uma credencial PMI (ex.: Construção/PMI-CP). É o eixo "para quem / onde aterrissa" (Eixo B): conecta a produção das tribos ao mercado da credencial via parceria. Não produz nem contém entregas — referencia (ADR-0103, anti-silo).',
+  'layers', '🏛️',
+  NULL, 8,
+  false, false, false, false, false,
+  '{"$schema":"http://json-schema.org/draft-07/schema#","type":"object","required":["anchor_credential","status"],"additionalProperties":false,"properties":{"anchor_credential":{"type":"string","description":"Credencial PMI atual que ancora a vertical (ex.: PMI-CP, PMI-PMOCP, PMI-ACP, CSPP)"},"predecessor_credential":{"type":"string","description":"Credencial predecessora na linha de sucessão (ex.: PMO-CP -> PMI-PMOCP). Nullable."},"credential_body":{"type":"string","description":"Organismo certificador (ex.: PMI, PMI+GPM, Agile Alliance)"},"partner_org":{"type":"string","description":"Organização parceira estratégica (ex.: Global Construction Ambassadors). Nullable."},"status":{"type":"string","enum":["forming","open","paused"],"description":"Estado público da vertical que dirige o CTA da landing: forming = chamada de protagonistas; open = operacional; paused = inativa temporariamente"},"pmi_registry_url":{"type":"string","format":"uri","description":"URL da página oficial PMI da credencial"}}}'::jsonb,
+  ARRAY['draft','active','concluded','archived'],
+  ARRAY['vertical_lead','vertical_member'],
+  ARRAY[]::text[],
+  '2b4f58ab-7c45-4170-8718-b77ee69ff906'
+);
+
+-- 2) Engagement kinds da vertical (par dedicado — não reusar committee_*/workgroup_* p/ não
+--    contaminar a CASE WHEN de operational_role nem a semântica legal; ver ADR-0103 §Consequences).
+-- vertical_lead: líder fundador, relação com parceiro PMI e curadoria da comunidade. legal_basis=consent.
+INSERT INTO public.engagement_kinds (
+  slug, display_name, description,
+  legal_basis, requires_agreement, agreement_template,
+  default_duration_days, retention_days_after_end, is_initiative_scoped,
+  requires_vep, requires_selection, max_duration_days,
+  anonymization_policy, renewable, auto_expire_behavior, notify_before_expiry_days,
+  created_by_role, revocable_by_role, initiative_kinds_allowed,
+  metadata_schema, display_i18n, organization_id
+) VALUES (
+  'vertical_lead', 'Líder de Vertical',
+  'Responsável por uma vertical de comunidade: curadoria do hub, relação com o parceiro PMI e convite da coorte fundadora.',
+  'consent', false, NULL,
+  NULL, 1825, true,
+  false, false, NULL,
+  'anonymize', false, 'notify_only', 90,
+  ARRAY['manager','deputy_manager'], ARRAY['manager','deputy_manager'], ARRAY['community_vertical'],
+  NULL, '{"en":"Vertical Lead","es":"Líder de Vertical"}'::jsonb, '2b4f58ab-7c45-4170-8718-b77ee69ff906'
+);
+
+-- vertical_member: membro da comunidade da vertical. legal_basis=legitimate_interest. Gestão GP-only
+-- por ora (created_by_role sem vertical_lead) — self-service do líder fica p/ a ativação (decisão PM).
+INSERT INTO public.engagement_kinds (
+  slug, display_name, description,
+  legal_basis, requires_agreement, agreement_template,
+  default_duration_days, retention_days_after_end, is_initiative_scoped,
+  requires_vep, requires_selection, max_duration_days,
+  anonymization_policy, renewable, auto_expire_behavior, notify_before_expiry_days,
+  created_by_role, revocable_by_role, initiative_kinds_allowed,
+  metadata_schema, display_i18n, organization_id
+) VALUES (
+  'vertical_member', 'Membro de Vertical',
+  'Membro da comunidade de uma vertical PMI: acesso ao hub, conteúdo e conexão com o parceiro.',
+  'legitimate_interest', false, NULL,
+  NULL, 1825, true,
+  false, false, NULL,
+  'anonymize', false, 'notify_only', 90,
+  ARRAY['manager','deputy_manager'], ARRAY['manager','deputy_manager'], ARRAY['community_vertical'],
+  NULL, '{"en":"Vertical Member","es":"Miembro de Vertical"}'::jsonb, '2b4f58ab-7c45-4170-8718-b77ee69ff906'
+);


### PR DESCRIPTION
## Ciclo 4 — Frontpage verticais-first · Fatia 0 (ratificar ADR-0103) + Fatia A (modelo de vertical no banco)

Abre o **caminho crítico** do Ciclo 4 (verticais-first): a landing value-prop (Fatia B) precisa de verticais existirem no banco com `status` para os blocos hub-and-spoke (3) e CTA "seja protagonista" (6) sem nada hardcoded. **Aditivo, zero impacto em features existentes.**

### Fatia 0 — ADR-0103 *Proposed → Accepted*
Open questions resolvidas pelo PM (2026-06-19):
- **Catálogo CURADO**, `max_concurrent_per_org=8` — teto ajustável via config ADR-0009 (admin, **sem migration**) quando uma vertical precisar de mais.
- Cada vertical tem **âncora de credencial própria** (`metadata.anchor_credential`) **além** da escada transversal Champion→CPMAI.
- Roteamento deliverable↔vertical **deferido** (não bloqueia a landing).
- Vertical-piloto = **Construção** (Henrique Diniz, líder fundador real em pré-onboarding).

### Fatia A — modelagem no banco
**Migration `20260805000221`** (config; precedente committee/workgroup):
- Kind `community_vertical`: `has_board/meeting_notes/deliverables/attendance/certificate = false` (a vertical *referencia*, não executa — anti-silo ADR-0103 §3). `custom_fields_schema` com `required: [anchor_credential, status]`. `metadata.status` (`forming|open|paused`) dirige o CTA da landing, **ortogonal** ao `initiatives.status` (engine).
- Par dedicado `vertical_lead` (consent) + `vertical_member` (legitimate_interest) em `engagement_kinds` — **não** reusa `committee_*`/`workgroup_*` para não contaminar a CASE WHEN de `operational_role` (`sync_operational_role_cache`) nem a semântica legal.

**Runtime** (dado de produção, via `create_initiative`):
- Vertical **Construção** `81fdbdfa-4a92-401f-9e50-9318be9b94fe` — engine `status=active`, `metadata.status=forming`, anchor `PMI-CP`, parceiro Global Construction Ambassadors.
- Henrique = **líder pretendido** em `metadata.intended_lead` (`engagement_status=pending_volunteer_term`). **Engajamento NÃO criado** — decisão PM: não promover até o termo de voluntário assinado.

### Adiado p/ ativação (kickoff/termo — documentado no ADR-0103 §Implementação)
Engajar o Henrique como `vertical_lead`; seeds de `engagement_kind_permissions` (manage_member/view_pii/write); elevação de `operational_role`; invariante `AJ_vertical_no_tribe_child` (guard parent — só relevante com fluxo de criação de filhos).

### Verificação (ao vivo)
- `has_board=false` honrado → **0 boards** criados para a vertical.
- `check_schema_invariants()` → **0 violações**.
- `npx astro build` verde · contracts **3755/0** (347 DB-aware skip local, rodam no CI).
- Estado: kind=1, engagement_kinds=2, engagements=0 (líder não engajado, correto).

**Council:** `data-architect` (verdict *safe-with-changes* — migration-capture, par dedicado, ortogonalidade engine/metadata.status, AJ como próxima letra livre).

Refs #680 (Fatia 0/A — Fatias B/C ainda pendentes, NÃO fechar a issue-mãe). Refs #661.
