### PR TITLE
feat(cycle4): R1 — refino do herói (absorve nucleo, 1 CTA, 1 número, Ciclo 3) [#680]

### DIFF
--- a/src/components/sections/HomepageHero.astro
+++ b/src/components/sections/HomepageHero.astro
@@ -24,36 +24,29 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
       {t('hero.title.line3', lang)}
     </h1>
 
-    <h2 class="text-[clamp(.9rem,2.5vw,1.3rem)] text-white/60 font-normal mb-8">
+    <h2 class="text-[clamp(.9rem,2.5vw,1.3rem)] text-white/60 font-normal mb-4">
       {t('hero.subtitle', lang)}
     </h2>
 
-    <!-- Stats counters -->
-    <div class="flex flex-wrap justify-center gap-6 sm:gap-10 mb-8">
+    <!-- Protagonist gain + PMI hook (absorbed from nucleo) -->
+    <p class="text-[clamp(.85rem,2vw,1.05rem)] text-white/75 font-normal max-w-[680px] mx-auto mb-8">
+      {t('hero.gain', lang)}
+    </p>
+
+    <!-- Single live proof number -->
+    <div class="flex justify-center mb-8">
       <div class="text-center">
-        <div class="text-3xl sm:text-4xl font-extrabold text-[#05BFE0]" id="stat-members">--</div>
-        <div class="text-[.7rem] text-white/50 uppercase tracking-wider mt-1">{t('hero.stat.members', lang)}</div>
-      </div>
-      <div class="text-center">
-        <div class="text-3xl sm:text-4xl font-extrabold text-[#05BFE0]" id="stat-tribes">--</div>
-        <div class="text-[.7rem] text-white/50 uppercase tracking-wider mt-1">{t('hero.stat.tribes', lang)}</div>
-      </div>
-      <div class="text-center">
-        <div class="text-3xl sm:text-4xl font-extrabold text-[#05BFE0]" id="stat-initiatives">--</div>
-        <div class="text-[.7rem] text-white/50 uppercase tracking-wider mt-1">{t('hero.stat.initiatives', lang)}</div>
-      </div>
-      <div class="text-center">
-        <div class="text-3xl sm:text-4xl font-extrabold text-[#05BFE0]" id="stat-hours">--</div>
+        <div class="text-4xl sm:text-5xl font-extrabold text-[#05BFE0]" id="stat-hours">--</div>
         <div class="text-[.7rem] text-white/50 uppercase tracking-wider mt-1">{t('hero.stat.hours', lang)}</div>
       </div>
     </div>
 
     <!-- CTAs -->
     <div class="flex flex-wrap justify-center gap-3 mb-6">
-      <a href="#nucleo" class="px-6 py-3 bg-white/10 border border-white/20 text-white rounded-xl text-[.9rem] font-semibold no-underline hover:bg-white/15 transition-all">
-        {t('hero.cta.learn', lang)}
+      <a href="#verticals" class="px-6 py-3 bg-[#05BFE0] text-navy rounded-xl text-[.9rem] font-bold no-underline hover:opacity-90 transition-all">
+        {t('hero.cta.protagonist', lang)}
       </a>
-      <button id="hero-auth-btn" class="px-6 py-3 bg-[#05BFE0] text-navy rounded-xl text-[.9rem] font-bold border-0 cursor-pointer hover:opacity-90 transition-all">
+      <button id="hero-auth-btn" class="px-6 py-3 bg-white/10 border border-white/20 text-white rounded-xl text-[.9rem] font-semibold cursor-pointer hover:bg-white/15 transition-all">
         {t('hero.cta.login', lang)}
       </button>
     </div>
@@ -195,9 +188,6 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
     try {
       const { data: stats } = await sb.rpc('get_homepage_stats');
       if (stats) {
-        animateCounter('stat-members', stats.members);
-        animateCounter('stat-tribes', stats.tribes);
-        animateCounter('stat-initiatives', stats.initiatives || 0);
         animateCounter('stat-hours', stats.impact_hours, 'h');
       }
     } catch (e) { console.warn('homepage stats:', e); }

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -13,7 +13,7 @@ const enUS: Record<string, string> = {
   'meetings.meta.description': 'Searchable archive of all Hub meeting minutes. Full-text search, filters by tribe and type, cross-tribe view.',
 
   // ── Nav ──
-  'nav.brand': 'AI & PM Research Hub — Cycle 03',
+  'nav.brand': 'AI & PM Research Hub — Cycle 3',
   'nav.agenda': 'Agenda',
   'nav.quadrants': 'Quadrants',
   'nav.tribes': 'Research Streams',
@@ -647,7 +647,9 @@ const enUS: Record<string, string> = {
   'hero.chaptersAnnounce': '15 PMI Brazil Chapters',
   'hero.chaptersAnnounceSub': 'Union announced · CBGPL Apr 2026',
   'hero.cta.learn': 'Learn More ↓',
-  'hero.cta.login': 'Sign In / Register',
+  'hero.cta.protagonist': 'Be a protagonist',
+  'hero.cta.login': 'Sign in',
+  'hero.gain': 'Research, publish and lead a vertical alongside peers of every credential — and earn PMI co-branded credentials. The practical read of PMI:Next and M.O.R.E.',
   'hero.member.greeting': 'Hello,',
   'hero.member.nextMeeting': '📅 Next Meeting',
   'hero.member.yourTribe': '🔬 Your Tribe',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -13,7 +13,7 @@ const esLATAM: Record<string, string> = {
   'meetings.meta.description': 'Archivo buscable de todas las actas de reunión del Núcleo. Búsqueda full-text, filtros por tribu y tipo, vista cross-tribu.',
 
   // ── Nav ──
-  'nav.brand': 'Núcleo IA & GP — Ciclo 03',
+  'nav.brand': 'Núcleo IA & GP — Ciclo 3',
   'nav.agenda': 'Agenda',
   'nav.quadrants': 'Cuadrantes',
   'nav.tribes': 'Líneas de Investigación',
@@ -647,7 +647,9 @@ const esLATAM: Record<string, string> = {
   'hero.chaptersAnnounce': '15 Capítulos PMI Brasil',
   'hero.chaptersAnnounceSub': 'Unión anunciada · CBGPL Abr 2026',
   'hero.cta.learn': 'Conocer el Núcleo ↓',
-  'hero.cta.login': 'Ingresar / Crear cuenta',
+  'hero.cta.protagonist': 'Sé protagonista',
+  'hero.cta.login': 'Ingresar',
+  'hero.gain': 'Investiga, publica y lidera una vertical junto a gente de toda credencial — y obtén credenciales PMI co-branded. La lectura práctica de PMI:Next y del M.O.R.E.',
   'hero.member.greeting': 'Hola,',
   'hero.member.nextMeeting': '📅 Próxima Reunión',
   'hero.member.yourTribe': '🔬 Tu Tribu',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -13,7 +13,7 @@ const ptBR: Record<string, string> = {
   'meetings.meta.description': 'Arquivo pesquisável de todas as atas de reunião do Núcleo. Busca full-text, filtros por tribo e tipo, visão cross-tribo.',
 
   // ── Nav ──
-  'nav.brand': 'Núcleo IA & GP — Ciclo 03',
+  'nav.brand': 'Núcleo IA & GP — Ciclo 3',
   'nav.agenda': 'Pauta',
   'nav.quadrants': 'Quadrantes',
   'nav.tribes': 'Tribos',
@@ -647,7 +647,9 @@ const ptBR: Record<string, string> = {
   'hero.chaptersAnnounce': '15 Capítulos PMI Brasil',
   'hero.chaptersAnnounceSub': 'União anunciada · CBGPL Abr 2026',
   'hero.cta.learn': 'Conhecer o Núcleo ↓',
-  'hero.cta.login': 'Entrar / Criar conta',
+  'hero.cta.protagonist': 'Seja protagonista',
+  'hero.cta.login': 'Entrar',
+  'hero.gain': 'Pesquise, publique e lidere uma vertical ao lado de gente boa de toda credencial — e conquiste credenciais PMI co-branded. É a leitura prática de PMI:Next e do M.O.R.E.',
   'hero.member.greeting': 'Olá,',
   'hero.member.nextMeeting': '📅 Próxima Geral',
   'hero.member.yourTribe': '🔬 Sua Tribo',

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -3,7 +3,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Toast from '../../components/ui/Toast.astro';
 import OnboardingCockpitNudge from '../../components/onboarding/OnboardingCockpitNudge';
 import HomepageHero from '../../components/sections/HomepageHero.astro';
-import NucleoSection from '../../components/sections/NucleoSection.astro';
 import { getHomeSchedule } from '../../lib/schedule';
 import QuadrantsSection from '../../components/sections/QuadrantsSection.astro';
 import VerticalsSection from '../../components/sections/VerticalsSection.tsx';
@@ -30,7 +29,6 @@ const deadlineIso = homeSchedule?.selectionDeadlineAt ?? null;
   <Toast />
   <OnboardingCockpitNudge client:load lang={lang} />
   <HomepageHero lang={lang} />
-  <NucleoSection lang={lang} />
   <PlatformStatsSection lang={lang} />
   <QuadrantsSection lang={lang} />
   <VerticalsSection client:load lang={lang} />

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -3,7 +3,6 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import Toast from '../../components/ui/Toast.astro';
 import OnboardingCockpitNudge from '../../components/onboarding/OnboardingCockpitNudge';
 import HomepageHero from '../../components/sections/HomepageHero.astro';
-import NucleoSection from '../../components/sections/NucleoSection.astro';
 import { getHomeSchedule } from '../../lib/schedule';
 import QuadrantsSection from '../../components/sections/QuadrantsSection.astro';
 import VerticalsSection from '../../components/sections/VerticalsSection.tsx';
@@ -30,7 +29,6 @@ const deadlineIso = homeSchedule?.selectionDeadlineAt ?? null;
   <Toast />
   <OnboardingCockpitNudge client:load lang={lang} />
   <HomepageHero lang={lang} />
-  <NucleoSection lang={lang} />
   <PlatformStatsSection lang={lang} />
   <QuadrantsSection lang={lang} />
   <VerticalsSection client:load lang={lang} />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,7 +3,6 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 import Toast from '../components/ui/Toast.astro';
 import OnboardingCockpitNudge from '../components/onboarding/OnboardingCockpitNudge';
 import HomepageHero from '../components/sections/HomepageHero.astro';
-import NucleoSection from '../components/sections/NucleoSection.astro';
 import { getHomeSchedule } from '../lib/schedule';
 import QuadrantsSection from '../components/sections/QuadrantsSection.astro';
 import VerticalsSection from '../components/sections/VerticalsSection.tsx';
@@ -30,7 +29,6 @@ const deadlineIso = homeSchedule?.selectionDeadlineAt ?? null;
   <Toast />
   <OnboardingCockpitNudge client:load lang={lang} />
   <HomepageHero lang={lang} />
-  <NucleoSection lang={lang} />
   <ChaptersSection lang={lang} />
   <PlatformStatsSection lang={lang} />
   <QuadrantsSection lang={lang} />


### PR DESCRIPTION
## R1 — Refino do Herói (slice 1 do redesign da landing C4)

Primeiro slice do redesign faseado da landing. Alvo travado em `docs/strategy/cycle4_landing_redesign_target.md` (§7, decisões PM 2026-06-20). Mexe **só na visão visitante** do hero; visão membro intacta.

### O que muda
- **Absorve `nucleo`** — o gist (tese-costura + linha de ganho do protagonista + gancho PMI:Next/M.O.R.E. curto) sobe pro hero via nova chave `hero.gain`. Seção standalone removida das 3 páginas de locale. **`nucleo.*` e `NucleoSection.astro` preservados** (não deletados) para o R3 "O modelo" reusar — princípio "não perder contexto" (a home é também apresentação institucional).
- **CTA-duplo → 1 primário + 1 secundário** — primário **"Seja protagonista"** (nova chave `hero.cta.protagonist`, idêntica aos labels do `VerticalsSection`; ancorada em `#verticals` = o funil único) + secundário **"Entrar"** (`hero.cta.login` encurtado).
- **4 contadores → 1 número ao vivo** — hero mostra só **horas de impacto** (`get_homepage_stats.impact_hours`, 807h ao vivo). O cluster dos 4 migra para a "Prova viva" no R2; o denominador 47≠44 fica para o R2 reconciliar.
- **Corrige "Ciclo 03" → "Ciclo 3"** no `nav.brand` (3 dicts). Ciclo operacional atual aterrado ao vivo = **C3** (`get_current_cycle`).

### Travas respeitadas
- **No-rebrand** (sem mexer em `theme.css`/paleta/tokens).
- **Nada hardcoded** (número do hero ao vivo via RPC).
- **i18n 3-dicionário** em paridade (pt-BR/en-US/es-LATAM).

### Fora de escopo (slices seguintes)
Reconciliar denominador (R2) · hub-and-spoke radial (R3) · demover member-facing + nav + rodapé (R5). **A seção de Metas do ano NÃO é tocada no R1.**

### Verificação
- `npx astro build` verde.
- `npm test` → **4120 pass / 0 fail** (365 skip DB-aware sem service-role env).
- Grep anti-regressão: zero "Ciclo 03"/"Cycle 03", zero `href="#nucleo"`, zero render de NucleoSection nas páginas.
- **QA visual Playwright** verde nos 3 locales × desktop/mobile (807h animando, CTA "Seja protagonista"→#verticals, "Entrar"→auth-modal, sem seção `nucleo`).

Assisted-By: Claude (Anthropic)