### PR TITLE
fix(landing): copy pública sem 'silo/costura' no hero+nucleo (linguagem estratégica)

### DIFF
--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -620,7 +620,7 @@ const enUS: Record<string, string> = {
   'hero.title.line1': 'Study and Research Hub in',
   'hero.title.accent': 'Artificial Intelligence',
   'hero.title.line3': 'and Project Management',
-  'hero.subtitle': 'The seam across PMI\'s silos — a volunteer community for research, development and networking, with AI as the thread that crosses every credential',
+  'hero.subtitle': 'The AI & PM Study and Research Hub — A Joint Initiative of the PMI Brazilian Chapters',
   'hero.date': 'Kick-off schedule published in the current cycle agenda',
   'hero.countdown.days': 'Days',
   'hero.countdown.hours': 'Hours',
@@ -668,7 +668,7 @@ const enUS: Record<string, string> = {
 
   // ── Nucleo Section ──
   'nucleo.title': 'What is the AI & PM Research Hub?',
-  'nucleo.desc': 'Núcleo IA & GP is the seam across PMI\'s silos: a volunteer community that brings good people from every credential — researchers, leaders and curators from Brazilian chapters — together in research, development and networking, with AI as the thread that crosses the silos. Volunteers produce papers, prototypes and webinars on how AI is transforming the profession. It is the human expression of the very integration PMI itself has been pursuing (PMO Global Alliance, GPM, Agile Alliance) — a practical reading of PMI:Next and M.O.R.E.',
+  'nucleo.desc': 'A collaborative research group across PMI chapters in Brazil, focused on the intersection of Artificial Intelligence and Project Management. Volunteer researchers — selected via an AI-assisted (copilot) process — produce papers, prototypes, and webinars on how AI is transforming the profession.',
 
   // ── Weekly Schedule ──
   'schedule.label': 'Schedule',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -620,7 +620,7 @@ const esLATAM: Record<string, string> = {
   'hero.title.line1': 'Núcleo de Estudios e Investigación en',
   'hero.title.accent': 'Inteligencia Artificial',
   'hero.title.line3': 'y Gestión de Proyectos',
-  'hero.subtitle': 'La costura entre los silos del PMI — comunidad voluntaria de investigación, desarrollo y networking, con la IA como el hilo que atraviesa toda credencial',
+  'hero.subtitle': 'IA aplicada a la Gestión de Proyectos — investigación colaborativa entre capítulos PMI de Brasil',
   'hero.date': 'Cronograma del kick-off publicado en la agenda del ciclo',
   'hero.countdown.days': 'Días',
   'hero.countdown.hours': 'Horas',
@@ -668,7 +668,7 @@ const esLATAM: Record<string, string> = {
 
   // ── Nucleo Section ──
   'nucleo.title': '¿Qué es el Núcleo IA & GP?',
-  'nucleo.desc': 'El Núcleo IA & GP es la costura entre los silos del PMI: una comunidad voluntaria que reúne buena gente de toda credencial — investigadores, líderes y curadores de capítulos de Brasil — en investigación, desarrollo y networking, con la IA como el hilo que atraviesa los silos. Voluntarios producen artículos, prototipos y webinars sobre cómo la IA transforma la profesión. Es la expresión humana de la misma integración que el propio PMI viene haciendo (PMO Global Alliance, GPM, Agile Alliance) — una lectura práctica de PMI:Next y del M.O.R.E.',
+  'nucleo.desc': 'Grupo colaborativo de investigación entre capítulos PMI de Brasil, enfocado en la intersección entre Inteligencia Artificial y Gestión de Proyectos. Investigadores voluntarios — seleccionados vía proceso asistido por IA (copilot) — producen artículos, prototipos y webinars sobre cómo la IA está transformando la profesión.',
 
   // ── Weekly Schedule ──
   'schedule.label': 'Agenda',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -620,7 +620,7 @@ const ptBR: Record<string, string> = {
   'hero.title.line1': 'Núcleo de Estudos e Pesquisa em',
   'hero.title.accent': 'Inteligência Artificial',
   'hero.title.line3': '& Gestão de Projetos',
-  'hero.subtitle': 'A costura entre os silos do PMI — comunidade voluntária de pesquisa, desenvolvimento e networking, com a IA como o fio que atravessa toda credencial',
+  'hero.subtitle': 'IA aplicada à Gestão de Projetos — pesquisa colaborativa entre capítulos PMI do Brasil',
   'hero.date': 'Cronograma do kick-off publicado na agenda do ciclo',
   'hero.countdown.days': 'Dias',
   'hero.countdown.hours': 'Horas',
@@ -668,7 +668,7 @@ const ptBR: Record<string, string> = {
 
   // ── Nucleo Section ──
   'nucleo.title': 'O que é o Núcleo IA & GP?',
-  'nucleo.desc': 'O Núcleo IA & GP é a costura entre os silos do PMI: uma comunidade voluntária que reúne gente boa de toda credencial — pesquisadores, líderes e curadores de capítulos do Brasil — em pesquisa, desenvolvimento e networking, com a IA como o fio que atravessa os silos. Voluntários produzem artigos, protótipos e webinars sobre como a IA transforma a profissão. É a expressão humana da mesma integração que o próprio PMI vem fazendo (PMO Global Alliance, GPM, Agile Alliance) — uma leitura prática de PMI:Next e do M.O.R.E.',
+  'nucleo.desc': 'Grupo colaborativo de pesquisa entre capítulos PMI do Brasil, focado na interseção entre Inteligência Artificial e Gestão de Projetos. Pesquisadores voluntários — selecionados via processo assistido por IA (copilot) — produzem artigos, protótipos e webinars sobre como a IA está transformando a profissão.',
 
   // ── Weekly Schedule ──
   'schedule.label': 'Agenda',


### PR DESCRIPTION
Decisão PM: a metáfora **"silo/costura"** é linguagem de comunicação **interna** com diretorias/times do PMI — declará-la no **site público** gera ruído e deve ser usada com cautela/estratégia.

Reverte para a redação anterior (factual, sem "silo/costura"), **só 2 chaves × 3 idiomas**:
- `hero.subtitle` → "IA aplicada à Gestão de Projetos — pesquisa colaborativa entre capítulos PMI do Brasil"
- `nucleo.desc` → "Grupo colaborativo de pesquisa entre capítulos PMI do Brasil…"

Escopo mínimo — não toca seções, componentes nem banco. Build verde.

Assisted-By: Claude (Anthropic)