### PR TITLE
fix(lgpd): k-anon no get_public_country_reach (PD-MAP-1)

### DIFF
--- a/supabase/migrations/20260805000225_pd_map_1_country_reach_kanon_suppress.sql
+++ b/supabase/migrations/20260805000225_pd_map_1_country_reach_kanon_suppress.sql
@@ -1,0 +1,51 @@
+-- PD-MAP-1 (Ciclo 4, 2026-06-21): LGPD k-anonimidade no alcance por país.
+-- Países com < 3 membros (e os não-reconhecidos 'XX') são agrupados num bucket genérico 'ZZ'
+-- ("Internacional") para que NENHUM país de membro único seja NOMEADO na superfície pública
+-- (parecer legal-counsel 2026-06-21). O total continua somando a população canônica de
+-- active_members (o bucket preserva a contagem; só esconde a identidade do país).
+CREATE OR REPLACE FUNCTION public.get_public_country_reach()
+RETURNS TABLE(country_code text, member_count bigint)
+LANGUAGE sql
+STABLE SECURITY DEFINER
+SET search_path TO ''
+AS $function$
+  WITH normalized AS (
+    SELECT
+      CASE
+        WHEN lower(trim(m.country)) ~ 'bras|brazil'                     OR lower(trim(m.country)) = 'br'            THEN 'BR'
+        WHEN lower(trim(m.country)) ~ 'portug'                          OR lower(trim(m.country)) = 'pt'            THEN 'PT'
+        WHEN lower(trim(m.country)) ~ 'estados unidos|united states|usa' OR lower(trim(m.country)) IN ('us','eua')  THEN 'US'
+        WHEN lower(trim(m.country)) ~ 'ital'                            OR lower(trim(m.country)) = 'it'            THEN 'IT'
+        WHEN lower(trim(m.country)) ~ 'espanha|spain|espana'            OR lower(trim(m.country)) = 'es'            THEN 'ES'
+        WHEN lower(trim(m.country)) ~ 'argentin'                        OR lower(trim(m.country)) = 'ar'            THEN 'AR'
+        WHEN lower(trim(m.country)) ~ 'reino unido|united kingdom'      OR lower(trim(m.country)) IN ('uk','gb')    THEN 'GB'
+        WHEN lower(trim(m.country)) ~ 'canad'                           OR lower(trim(m.country)) = 'ca'            THEN 'CA'
+        WHEN lower(trim(m.country)) ~ 'fran'                            OR lower(trim(m.country)) = 'fr'            THEN 'FR'
+        WHEN lower(trim(m.country)) ~ 'aleman|german|deutsch'           OR lower(trim(m.country)) = 'de'            THEN 'DE'
+        WHEN m.country IS NULL OR trim(m.country) = ''                                                              THEN NULL
+        ELSE 'XX'
+      END AS code
+    FROM public.members m
+    WHERE m.is_active
+      AND m.current_cycle_active
+      AND NOT public.member_is_pre_onboarding(m.person_id, m.member_status)
+  ),
+  counted AS (
+    SELECT code, count(*)::bigint AS n
+    FROM normalized
+    WHERE code IS NOT NULL
+    GROUP BY code
+  )
+  SELECT
+    CASE WHEN n >= 3 AND code <> 'XX' THEN code ELSE 'ZZ' END AS country_code,
+    sum(n)::bigint AS member_count
+  FROM counted
+  GROUP BY CASE WHEN n >= 3 AND code <> 'XX' THEN code ELSE 'ZZ' END
+  ORDER BY member_count DESC, country_code;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_public_country_reach() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_public_country_reach() TO anon, authenticated, service_role;
+
+COMMENT ON FUNCTION public.get_public_country_reach() IS
+  'R6 + PD-MAP-1 (Ciclo 4): zero-PII named-country reach para a landing. Países com <3 membros (e não-reconhecidos) agrupados em ZZ ("Internacional") por k-anonimidade LGPD — nenhum país de membro único é nomeado. Base legal/finalidade: estatística de alcance agregada. anon-safe.';


### PR DESCRIPTION
## Contexto
Parecer do legal-counsel (2026-06-21): a RPC pública `get_public_country_reach()` expunha **Portugal com 1 membro** — titular identificável por país (k-anonimidade violada). A RPC é `anon`-callable via API.

## Mudança
Agrupa países com **< 3 membros** (e não-reconhecidos) num bucket genérico `ZZ` ("Internacional") — nenhum país de membro único é **nomeado** na superfície pública. O total preserva a população canônica: **BR 41 · US 5 · ZZ 1 = 47**.

## Por que só o .sql vai à main
A migration foi aplicada ao banco **compartilhado** durante trabalho da branch `cycle4-landing-redesign` (a banda de cobertura que consome a RPC é branch-only; no FE da main a RPC fica dormente). Este PR leva **só o .sql** para restaurar os drift gates da main — **padrão R2/#823 (R6)**. Aditivo, FE-invisível na main.

## Grounding (live)
`SELECT * FROM get_public_country_reach()` → `BR 41 · US 5 · ZZ 1`. Migration já aplicada + `repair` + `NOTIFY pgrst`.

Autorizado pelo PM (PD-MAP-1, 2026-06-21). Doc: `docs/strategy/cycle4_member_heatmap_audit_spec.md`.