### PR TITLE
fix(cycle4): scrub credencial/parceria do payload público de verticais (PD-CERT) [#680]

### DIFF
--- a/src/components/sections/VerticalsSection.tsx
+++ b/src/components/sections/VerticalsSection.tsx
@@ -24,11 +24,10 @@ const VEP = {
 type Vertical = {
   id: string;
   title: string;
-  description: string | null;
   vertical_status: 'forming' | 'open' | 'paused' | null;
-  anchor_credential: string | null;
-  credential_body: string | null;
-  partner_org: string | null;
+  // PD-CERT scrub (mig 229): get_public_verticals() no longer returns description /
+  // anchor_credential / credential_body / partner_org — the public API stays credential-free
+  // and partnership-claim-free. The card describes the vertical by CONTEXT (i18n VERTICAL_DESC).
 };
 
 type Lang = 'pt-BR' | 'en-US' | 'es-LATAM';
@@ -139,7 +138,8 @@ const STATUS_STYLE: Record<string, string> = {
  * (which embeds "ancorada na credencial PMI-X") nor `anchor_credential` — this also localizes the
  * cards in en/es (was GAP-B2.C: DB prose is pt-only). Keyed by the live DB `title`; unknown title
  * → suppressed (never falls back to the credential-bearing DB description). CPMAI stays explicit
- * (the common spine line below). DB/RPC payload scrub of anchor_credential = tracked follow-up.
+ * (the common spine line below). DB/RPC payload scrub: DONE (mig 229) — get_public_verticals()
+ * no longer returns anchor_credential/credential_body/description/partner_org.
  */
 const VERTICAL_DESC: Record<Lang, Record<string, string>> = {
   'pt-BR': {
@@ -359,7 +359,7 @@ function VerticalCard({ v, l, lang }: { v: Vertical; l: Record<string, string>; 
       {/* partner_org NOT rendered: claiming "Parceria: Global Construction Ambassadors" without a
           signed agreement is an unsubstantiated partnership claim (same paper-trail rule as
           co-branding). Members may individually be ambassadors, but the org has no formal accord.
-          Re-enable per-vertical only when backed by a signed instrument. DB scrub = follow-up. */}
+          Re-enable per-vertical only when backed by a signed instrument. DB scrub: DONE (mig 229). */}
       {/* CTA → VEP (inscrição oficial). Dois cadastros distintos: pesquisador + líder. Substitui o
           antigo formulário de lead (FounderForm dead-code abaixo — limpeza trivial pendente). */}
       {isForming && (

--- a/supabase/migrations/20260805000229_pd_cert_scrub_public_verticals_credential.sql
+++ b/supabase/migrations/20260805000229_pd_cert_scrub_public_verticals_credential.sql
@@ -1,0 +1,25 @@
+CREATE OR REPLACE FUNCTION public.get_public_verticals()
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  -- Cycle4 PD-CERT scrub: o payload publico NAO expoe mais anchor_credential/credential_body
+  -- (credencial PMI implicita, sem MoU/co-branding), nem partner_org (claim de parceria sem
+  -- instrumento assinado), nem description (embute "ancorada na credencial PMI-X"). A FE
+  -- descreve a vertical por CONTEXTO de atuacao (i18n VERTICAL_DESC). So id/title/status saem.
+  SELECT COALESCE(jsonb_agg(
+           jsonb_build_object(
+             'id', i.id,
+             'title', i.title,
+             'vertical_status', i.metadata->>'status'
+           )
+           ORDER BY
+             CASE i.metadata->>'status'
+               WHEN 'open' THEN 1 WHEN 'forming' THEN 2 WHEN 'paused' THEN 3 ELSE 4 END,
+             i.title
+         ), '[]'::jsonb)
+  FROM public.initiatives i
+  WHERE i.kind = 'community_vertical'
+    AND i.status = 'active';
+$function$;

--- a/tests/contracts/cycle4-public-verticals.test.mjs
+++ b/tests/contracts/cycle4-public-verticals.test.mjs
@@ -21,6 +21,10 @@ import { createClient } from '@supabase/supabase-js';
 const MIG = 'supabase/migrations/20260805000222_cycle4_b1_public_verticals.sql';
 const body = existsSync(MIG) ? readFileSync(MIG, 'utf8') : '';
 
+// PD-CERT scrub (mig 229): the public verticals payload drops credential/partnership fields.
+const MIG_SCRUB = 'supabase/migrations/20260805000229_pd_cert_scrub_public_verticals_credential.sql';
+const scrubBody = existsSync(MIG_SCRUB) ? readFileSync(MIG_SCRUB, 'utf8') : '';
+
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const ANON_KEY = process.env.PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
@@ -44,6 +48,24 @@ test('mig 222 static: get_public_verticals is anon-executable and PII-safe', () 
   assert.ok(!/intended_lead/.test(fnBody), 'public RPC body must not select metadata.intended_lead');
   assert.ok(!/i\.metadata\b(?![-]>>'(status|anchor_credential|credential_body|partner_org)')/.test(fnBody),
     'only whitelisted metadata keys are surfaced');
+});
+
+test('mig 229 static: PD-CERT scrub drops credential/partnership fields from public payload', () => {
+  assert.ok(existsSync(MIG_SCRUB), 'migration 229 exists');
+  assert.match(scrubBody, /CREATE OR REPLACE FUNCTION public\.get_public_verticals\(\)/);
+  // the scrubbed jsonb_build_object surfaces ONLY id/title/vertical_status.
+  // Check the EMISSION patterns (accessors), so the explanatory comment naming the
+  // removed fields doesn't false-positive.
+  assert.match(scrubBody, /'vertical_status', i\.metadata->>'status'/);
+  for (const banned of [
+    /metadata->>'anchor_credential'/,
+    /metadata->>'credential_body'/,
+    /metadata->>'partner_org'/,
+    /'description', i\.description/,
+  ]) {
+    assert.ok(!banned.test(scrubBody),
+      `scrubbed RPC must not surface ${banned} (credential/partnership leak)`);
+  }
 });
 
 test('mig 222 static: target_vertical is a uuid FK resolved defensively in capture_visitor_lead', () => {
@@ -73,8 +95,8 @@ test('behavioural: get_public_verticals returns shaped rows with vertical_status
     'no intended_lead / person_id PII leaks to anon');
   for (const v of data) {
     assert.deepEqual(Object.keys(v).sort(),
-      ['anchor_credential', 'credential_body', 'description', 'id', 'partner_org', 'title', 'vertical_status'],
-      'exactly the whitelisted public keys');
+      ['id', 'title', 'vertical_status'],
+      'PD-CERT scrub (mig 229): exactly the credential-free public keys');
     assert.ok(['forming', 'open', 'paused', null].includes(v.vertical_status));
   }
 });


### PR DESCRIPTION
## Follow-up do redesign Ciclo 4 — fecha o vazamento de credencial no payload público

`get_public_verticals()` deixa de retornar **anchor_credential**, **credential_body**, **description** e **partner_org**. O payload público passa a expor apenas `id` / `title` / `vertical_status`.

### Por quê
- `anchor_credential` / `credential_body` = credencial PMI co-branded **sem MoU** → claim sem paper trail exposto na API pública.
- `partner_org` = "Parceria: Global Construction Ambassadors" **sem instrumento assinado**.
- `description` = embute "ancorada na credencial PMI-X" (prosa pt-only).

A FE já descrevia a vertical por **contexto de atuação** (i18n `VERTICAL_DESC`) e não renderizava nenhum desses campos desde o polish — este scrub fecha o vazamento no **dado/RPC**.

### Mudanças
- **DB:** migration `20260805000229` (`CREATE OR REPLACE get_public_verticals`, mesma assinatura). Aplicada ao DB compartilhado; `.sql` + `schema_migrations` reconciliado (version renomeada da auto-row do MCP, `statements` preservado — evita o gate empty-statements).
- **FE:** tipo `Vertical` perde os 4 campos mortos; comentários marcam o scrub como feito.
- **Contrato** `cycle4-public-verticals`: assert do payload → `id`/`title`/`vertical_status` + lock estático da mig 229.

### QA
- `astro build` verde · suíte **4129/0/366** · contrato DB-aware **8/8** (behavioural ao vivo confirma payload de 3 chaves, zero PII).

⚠️ Merge auto-deploya produção. Sem `--admin`/bypass: aguarda CI verde.