### PR TITLE
feat(cycle4): anotação "+N além do Brasil" ao lado do mapa [#680]

### DIFF
--- a/src/components/sections/ChaptersSection.astro
+++ b/src/components/sections/ChaptersSection.astro
@@ -35,6 +35,12 @@ try {
 const reachCountries = countryReach.length;
 const reachMembers = countryReach.reduce((sum, c) => sum + Number(c.member_count || 0), 0);
 
+// Anotação discreta de internacionais ao lado do mapa do Brasil (decisão PM 2026-06-21):
+// o mapa é Brasil-por-estado (honesto); membros fora do Brasil são contabilizados aqui, nomeados.
+// Reusa get_public_country_reach (já k-anon): tudo que não é BR = internacional.
+const intlReach = countryReach.filter((c) => c.country_code !== 'BR');
+const intlTotal = intlReach.reduce((sum, c) => sum + Number(c.member_count || 0), 0);
+
 // PD-MAP — Heatmap por estado (densidade de membros que autorizaram + supressão k>=5,
 // via get_public_state_reach). Gate de produto: a camada de densidade só ACENDE com >=2 UFs
 // (decisão PM — evita "mapa vazio" enquanto o opt-in não tem substrato). Abaixo disso o mapa
@@ -100,6 +106,12 @@ function flagEmoji(code: string): string {
       {hasDensity && (
         <p class="text-[.7rem] text-[var(--text-muted)] mt-2 max-w-[520px] mx-auto">
           {t('chapters.mapDensityNote', lang)}
+        </p>
+      )}
+      {intlTotal > 0 && (
+        <p class="text-[.8rem] text-[var(--text-secondary)] mt-3 max-w-[560px] mx-auto">
+          <span class="font-bold text-teal">+{intlTotal}</span> {t('chapters.intlBeyond', lang)}
+          <span class="text-[var(--text-muted)]"> — {intlReach.map((c) => `${flagEmoji(c.country_code)} ${t(`country.${c.country_code}`, lang)}`).join(' · ')}</span>
         </p>
       )}
     </div>

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -740,6 +740,7 @@ const enUS: Record<string, string> = {
   'chapters.mapLegendActive': 'Active chapter',
   'chapters.mapLegendDensity': 'Member density by state',
   'chapters.mapDensityNote': 'Aggregate density of members who authorized displaying their state. States with fewer than 5 members are omitted (privacy protection · LGPD).',
+  'chapters.intlBeyond': 'members beyond Brazil',
   'chapters.activeLabel': 'active partners',
   'chapters.onboardingLabel': 'onboarding',
   'chapters.goal': 'Union announced at CBGPL 2026 — PMI Brazil chapters in progressive integration',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -740,6 +740,7 @@ const esLATAM: Record<string, string> = {
   'chapters.mapLegendActive': 'Capítulo activo',
   'chapters.mapLegendDensity': 'Densidad de miembros por estado',
   'chapters.mapDensityNote': 'Densidad agregada de miembros que autorizaron mostrar su estado. Los estados con menos de 5 miembros se omiten (protección de privacidad · LGPD).',
+  'chapters.intlBeyond': 'miembros más allá de Brasil',
   'chapters.activeLabel': 'socios activos',
   'chapters.onboardingLabel': 'en integración',
   'chapters.goal': 'Unión anunciada en CBGPL 2026 — capítulos PMI Brasil en integración progresiva',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -740,6 +740,7 @@ const ptBR: Record<string, string> = {
   'chapters.mapLegendActive': 'Capítulo ativo',
   'chapters.mapLegendDensity': 'Densidade de membros por estado',
   'chapters.mapDensityNote': 'Densidade agregada de membros que autorizaram a exibição do seu estado. Estados com menos de 5 membros são omitidos (proteção à privacidade · LGPD).',
+  'chapters.intlBeyond': 'membros além do Brasil',
   'chapters.activeLabel': 'parceiros ativos',
   'chapters.onboardingLabel': 'em integração',
   'chapters.goal': 'União anunciada no CBGPL 2026 — capítulos PMI Brasil em integração progressiva',


### PR DESCRIPTION
## Reforço de alcance internacional sem virar mapa-múndi (decisão PM)

Em vez de trocar o mapa Brasil-por-estado por um planisfério (que, com ~87% Brasil + poucos no exterior, leria como vaporware e diluiria a identidade PMI-Brasil), adiciona uma **anotação discreta perto do mapa** nomeando os membros internacionais.

- `ChaptersSection`: linha sob a legenda → **"+{N} além do Brasil — 🇺🇸 EUA · 🌎 Internacional"**.
  - Reusa `get_public_country_reach` (já k-anon): internacionais = soma dos não-BR, nomeados.
  - Só renderiza se houver não-BR (`intlTotal > 0`). **Nenhuma query nova.**
- i18n `chapters.intlBeyond` nos 3 dicts.

## QA
FE-puro (sem migration/RPC) · `astro build` verde · suíte **4129/0/366** · SSR pt/en/es renderiza com dado ao vivo: **+6** (US 5 + 🌎 1) — "🇺🇸 EUA/USA · 🌎 Internacional/International".

⚠️ Merge auto-deploya produção — aguardando "vai" do PM.