### PR TITLE
fix(board): UI gate honra write_board por engagement em board de iniciativa [#819][#820]

### DIFF
--- a/src/hooks/useBoardPermissions.ts
+++ b/src/hooks/useBoardPermissions.ts
@@ -5,7 +5,7 @@
 import { useState, useEffect } from 'react';
 import type { Board } from '../types/board';
 import { waitForSb } from './useBoard';
-import { getSimulation, type OperationalTier } from '../lib/permissions';
+import { getSimulation, canFor, type OperationalTier } from '../lib/permissions';
 
 interface MemberContext {
   id: string;
@@ -130,7 +130,24 @@ export function useBoardPermissions(board: Board | null): Permissions {
   const isComms = effectiveDesig.some((d: string) => ['comms_leader', 'comms_member'].includes(d));
   const isCurator = effectiveDesig.includes('curator') || effectiveDesig.includes('co_gp');
 
-  const canManageBoard = isSuperadmin || isManager || (isLeader && isOwnTribe);
+  // V4 (ADR-0007): honor engagement-derived write_board for the board's
+  // initiative/tribe scope. The tier-only logic above ignores the canonical
+  // `can()` model, so a board linked to an initiative but created with
+  // board_scope='global' locked out its own engaged team (only the
+  // operational_role cache + board_scope were consulted). This realigns the UI
+  // gate with the board_items RLS (rls_can_for_initiative('write_board', ...)),
+  // which already grants these members write. `canFor` short-circuits on
+  // org-scoped write_board (tribe/vertical leaders, GP, comms_leader, curator)
+  // and also honors per-initiative grants. Suppressed under simulation (W144)
+  // so the simulated tier stays authoritative — canFor reads the real caller's
+  // capability cache, not the overlay. Scoped to boards that carry an
+  // initiative/tribe link, so unlinked global boards keep their current gate.
+  const canWriteScopedBoard = !sim.active && (
+    (board.initiative_id ? canFor('write_board', { type: 'initiative', id: board.initiative_id }) : false)
+    || (board.tribe_id != null ? canFor('write_board', { type: 'tribe', id: board.tribe_id }) : false)
+  );
+
+  const canManageBoard = isSuperadmin || isManager || (isLeader && isOwnTribe) || canWriteScopedBoard;
   // Comms team has full editorial control over global boards (communication hub)
   const isCommsOnGlobal = isComms && isGlobal;
 

--- a/tests/ui-stabilization.test.mjs
+++ b/tests/ui-stabilization.test.mjs
@@ -1146,6 +1146,22 @@ test('BoardEngine hooks use correct Supabase RPC patterns (no .catch on rpc)', (
   assert.equal(useFilters.includes('curationStatus'), true);
 });
 
+test('useBoardPermissions honors engagement-derived write_board for initiative/tribe-linked boards (#819/#820)', () => {
+  const usePerms = read('src/hooks/useBoardPermissions.ts');
+  // Must consult the V4 capability model (canFor), not just operational_role tier.
+  assert.equal(usePerms.includes('canFor'), true, 'must import/use canFor');
+  assert.equal(/canFor\(\s*'write_board'\s*,\s*\{\s*type:\s*'initiative'/.test(usePerms), true,
+    'must check write_board on the board initiative scope');
+  assert.equal(/canFor\(\s*'write_board'\s*,\s*\{\s*type:\s*'tribe'/.test(usePerms), true,
+    'must check write_board on the board tribe scope');
+  // Folded into canManageBoard so canCreate/canEditAny/canMove inherit it.
+  assert.equal(/canManageBoard\s*=[^;]*canWriteScopedBoard/.test(usePerms), true,
+    'canWriteScopedBoard must feed canManageBoard');
+  // Suppressed under simulation so the simulated tier stays authoritative (W144).
+  assert.equal(/canWriteScopedBoard\s*=\s*!sim\.active/.test(usePerms), true,
+    'scoped write_board must be gated behind !sim.active');
+});
+
 test('BoardEngine orchestrator integrates all sub-components and DnD', () => {
   const engine = read('src/components/islands/BoardEngine.tsx');
   assert.equal(engine.includes('import BoardHeader'), true);


### PR DESCRIPTION
## Contexto / incidente

Iniciativa **Webinar — Do hype ao padrão: o novo standard ANSI/PMI de IA** (`56f0cde5-4f0b-46cb-85e2-2052a16b89c1`, webinar **30/06**), board **"Webinar ANSI/PMI 26-007 — Planning Board"** (`board_scope='global'`). Reporte: "só o Fabrício consegue editar o board e os cards". Marcos Antunes (líder da tribo 7) e demais palestrantes travados.

## Diligência (DB ao vivo) — diagnóstico corrige a #819/#820

A issue suspeitava do **role do engagement** ("só `role=leader` dá escrita"). O mecanismo real é outro:

1. **O gate de edição é 100% frontend** (`useBoardPermissions.ts`) e **não lê engagements**. Decide por `operational_role` (escalar) + `board_scope`.
2. Num board **global**, `canManageBoard = superadmin || manager(tier≤2.5) || (leader && isOwnTribe)`. `isOwnTribe` exige `board_scope==='tribe'` → **falso** aqui. Logo um `tribe_leader` (tier 3) sem comms/superadmin fica sem create/edit-any.
3. **A "promoção a leader" da issue foi inerte**: os 6 estão `role='leader'` mas `kind='speaker'`, e `engagement_kind_permissions` **não concede `write_board` a `kind='speaker'` em role nenhum**.
4. **Divergência de 3 camadas**: a RLS de `board_items` (`rls_can_for_initiative('write_board')`) **JÁ liberaria** Marcos/Jefferson/Fernando (líderes de tribo têm `write_board` org-scoped). `can()` idem. **Só a UI negava** — era a camada mais restritiva.

Quem de fato editava: Fabricio (superadmin/manager) + Mayanna/Leticia (carve-out comms em board global). Os bloqueados eram os palestrantes-líderes-de-tribo.

## Correção

`useBoardPermissions` passa a consultar `canFor('write_board', { type:'initiative'|'tribe', id })` para boards com vínculo, dobrando em `canManageBoard` (e por herança `canCreate`/`canEditAny`/`canMove`/`canAssign`). Alinha a UI à RLS já vigente. Honra grants org-scoped e per-iniciativa; **suprimido sob simulação** (W144); boards globais **sem** vínculo mantêm o gate atual (sem broadening).

Verificação ao vivo: Marcos/Jefferson/Fernando têm `write_board` em `org_actions` → destravam. Mayanna/Leticia seguem via comms.

## Fora de escopo (segue aberto na #819/#820)

A camada do **modelo de engagement**: decidir se `speaker`/`coordinator`/`participant` numa iniciativa deve conceder `write_board` (seed em `engagement_kind_permissions`) é decisão de produto + **procedimento V4 authority audit** (`docs/reference/V4_AUTHORITY_MODEL.md`), não unilateral. Este PR resolve o incidente porque os bloqueados são líderes de tribo (org-scope); um palestrante **externo** sem role org continuaria dependendo dessa decisão.

## QA
- `npx astro build` ✅
- `npm test` → **4130 pass / 0 fail / 366 skip** (DB-aware pulados sem service-role key)
- Teste estático novo travando o comportamento em `tests/ui-stabilization.test.mjs`

⚠️ Sem auto-merge — aguardando "vai" do PM.