### PR TITLE
chore(rbac): seed write_board (initiative) para kind=speaker [#819][#820]

### DIFF
--- a/supabase/migrations/20260621215828_speaker_write_board_initiative_grant.sql
+++ b/supabase/migrations/20260621215828_speaker_write_board_initiative_grant.sql
@@ -1,0 +1,24 @@
+-- #819/#820 Camada 1 — speaker (palestrante externo de webinar/evento) é um kind
+-- initiative-scoped cujo engagement não concedia NENHUMA escrita de board, então
+-- promover um speaker a role='leader' na iniciativa era inerte (a UI já foi alinhada
+-- em #829 para honrar write_board via canFor, mas um speaker sem papel org não tinha
+-- write_board em scope nenhum).
+--
+-- Concede a capability de contribuidor de board (write_board) em scope='initiative'
+-- APENAS — espelha o padrão *participant* de workgroup_member/committee_member, e
+-- deliberadamente NÃO o padrão *leader* (que carrega manage_member/view_pii/
+-- manage_board_admin/write e seria escalada de privilégio, anti-pattern do
+-- procedimento V4 authority audit em docs/reference/V4_AUTHORITY_MODEL.md).
+--
+-- Efeito: um speaker pode editar o board de planejamento do webinar específico em que
+-- palestra (board_items na sua iniciativa), nada além disso.
+--
+-- NB: checklists/assignments de card usam rls_can('write_board') (org/tribe-scope,
+-- pré-existente) e não honram grant initiative-scoped — limitação pré-existente que
+-- afeta todos os contribuidores initiative-scoped por igual; fora do escopo desta seed.
+INSERT INTO public.engagement_kind_permissions (kind, role, action, scope, description, organization_id)
+SELECT 'speaker', r.role, 'write_board', 'initiative',
+       'Speaker can use the event/webinar planning board (initiative-scoped)',
+       '2b4f58ab-7c45-4170-8718-b77ee69ff906'::uuid
+FROM (VALUES ('leader'),('lead_presenter'),('co_presenter'),('participant')) AS r(role)
+ON CONFLICT (kind, role, action) DO NOTHING;


### PR DESCRIPTION
## O que

Camada 1 (modelo de engagement) do #819/#820 — complementa o gate de UI já mergeado em **#829**.

`speaker` (palestrante externo de webinar/evento, initiative-scoped) **não tinha nenhuma** permissão de board em `engagement_kind_permissions`, então promover um speaker a `role='leader'` na iniciativa era **inerte**. Esta seed concede `write_board` em **scope='initiative'** aos 4 roles em uso (`leader`, `lead_presenter`, `co_presenter`, `participant`).

## Least-privilege (decisão deliberada)

Espelha o conjunto do role **`participant`** dos kinds de trabalho (workgroup_member/committee_member) = só `write_board` initiative-scoped. **NÃO** replica o conjunto do role `leader` desses kinds (`manage_member` / `view_pii` / `manage_board_admin` / `write`) — isso seria escalada de privilégio, o anti-pattern documentado no procedimento V4 authority audit (`docs/reference/V4_AUTHORITY_MODEL.md`). Um speaker passa a editar **só o board da própria iniciativa**, nada além.

## Estado

- **Já aplicado ao banco** (prod é a fonte de verdade das migrations via MCP): migration `20260621215828`, `statements` populados → gate ADR-0097 ok. Este PR captura o `.sql` para reprodutibilidade/rebuild (padrão R2/R6 de levar só o `.sql` à main).
- Verificado ao vivo: `(speaker, leader/lead_presenter/co_presenter/participant, write_board, initiative)` presentes.

## Fora de escopo (pré-existente)

Checklists/assignments de card usam `rls_can('write_board')` (org/tribe-scope), que não honra grant initiative-scoped — limita um speaker **externo puro** nessas sub-entidades. Afeta todos os contribuidores initiative-scoped por igual; não introduzido aqui. Anotado na #820 como follow-up.

## QA
- Contratos `v4-engagement-canonical` + `rpc-migration-coverage` (offline): 11 pass / 0 fail.
- Sem mudança de código/TS (só migration aditiva idempotente `ON CONFLICT DO NOTHING`).