### PR TITLE
fix(agenda): dono edita bloco mesmo com cache de capability vazio [#813]

### DIFF
--- a/src/components/agenda/AgendaVivaReservationIsland.tsx
+++ b/src/components/agenda/AgendaVivaReservationIsland.tsx
@@ -186,7 +186,15 @@ export default function AgendaVivaReservationIsland({ lang = 'pt-BR' }: { lang?:
     finally { setBusy(null); }
   };
 
-  if (loading || !allowed) return null; // anon/insufficient → public island already shows a login hint
+  // #813: the edit/cancel UI for a block the user already owns must NOT depend on
+  // the (async, fail-closed) capability cache. `is_mine` is server-derived from
+  // auth.uid() in get_geral_agenda_viva, so an authenticated owner always sees it
+  // even when canFor('reserve_agenda_block') is still false (cache not yet loaded
+  // or nav:member not re-fired). Render the island whenever the caller owns a block
+  // OR holds the reserve capability; the NEW-reservation form stays gated on `allowed`.
+  const ownsAnyBlock = events.some((ev) => ev.blocks.some((b) => b.is_mine));
+  if (loading) return null;
+  if (!allowed && !ownsAnyBlock) return null; // anon/insufficient → public island already shows a login hint
 
   const inputCls = 'mt-1 w-full rounded-lg border border-[var(--border)] bg-transparent px-3 py-2 text-sm';
 
@@ -233,7 +241,10 @@ export default function AgendaVivaReservationIsland({ lang = 'pt-BR' }: { lang?:
   return (
     <div className="mb-8 space-y-4">
       <h2 className="text-lg font-bold text-[var(--text-primary)] flex items-center gap-2">
-        <CalendarPlus size={18} className="text-orange" /> {t('comp.agendaViva.reserveHeading', 'Reservar um bloco')}
+        <CalendarPlus size={18} className="text-orange" />{' '}
+        {allowed
+          ? t('comp.agendaViva.reserveHeading', 'Reservar um bloco')
+          : t('comp.agendaViva.manageHeading', 'Seu bloco')}
       </h2>
       {events.map((ev) => {
         const myBlock = ev.blocks.find((b) => b.is_mine);
@@ -286,7 +297,7 @@ export default function AgendaVivaReservationIsland({ lang = 'pt-BR' }: { lang?:
                   </div>
                 )}
               </div>
-            ) : draft ? (
+            ) : allowed && draft ? (
               <>
                 {renderFields(drafts[ev.id] || draft, (p) => setDraft(ev.id, p), (slug) => onFormatChange(ev.id, slug))}
                 <div className="mt-3 flex justify-end">

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -6643,6 +6643,7 @@ const enUS: Record<string, string> = {
   'comp.agendaViva.homeCta': 'Reserve your block',
   // Reservation (signed in)
   'comp.agendaViva.reserveHeading': 'Reserve a block',
+  'comp.agendaViva.manageHeading': 'Your block',
   'comp.agendaViva.reserveCta': 'Reserve block',
   'comp.agendaViva.fEvent': 'Meeting',
   'comp.agendaViva.fFormat': 'Format',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -6643,6 +6643,7 @@ const esLATAM: Record<string, string> = {
   'comp.agendaViva.homeCta': 'Reserva tu bloque',
   // Reserva (con sesión)
   'comp.agendaViva.reserveHeading': 'Reservar un bloque',
+  'comp.agendaViva.manageHeading': 'Tu bloque',
   'comp.agendaViva.reserveCta': 'Reservar bloque',
   'comp.agendaViva.fEvent': 'Reunión',
   'comp.agendaViva.fFormat': 'Formato',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -6649,6 +6649,7 @@ const ptBR: Record<string, string> = {
   'comp.agendaViva.homeCta': 'Reserve seu bloco',
   // Reserva (logado)
   'comp.agendaViva.reserveHeading': 'Reservar um bloco',
+  'comp.agendaViva.manageHeading': 'Seu bloco',
   'comp.agendaViva.reserveCta': 'Reservar bloco',
   'comp.agendaViva.fEvent': 'Reunião',
   'comp.agendaViva.fFormat': 'Formato',


### PR DESCRIPTION
## #813 — Agenda Viva: dono não conseguia editar o título do bloco

### Causa-raiz (diagnóstico aterrado, não chute)
`AgendaVivaReservationIsland.tsx:189` fazia `if (loading || !allowed) return null` com
`allowed = canFor('reserve_agenda_block')`. Essa capability é lida do **cache assíncrono**
(`get_caller_capabilities`) com semântica **fail-closed**: em boots lentos — ou quando o
evento `nav:member` não re-dispara depois que o cache carrega — `allowed` fica `false` e o
**island inteiro desmonta**, derrubando o dono no `AgendaVivaPublic` (read-only). Some o
botão de editar/cancelar mesmo de quem já reservou.

### Por que é só FE (verificado em dados vivos)
- Os **5 donos** de blocos atuais têm `can_by_member(m.id,'reserve_agenda_block') = true`
  no servidor → autoridade server-side correta.
- `is_mine` é derivado de `auth.uid()` dentro de `get_geral_agenda_viva`
  (`bk.owner_member_id = v_caller`), **independente do cache de FE** → o dado para renderizar
  a edição já chega ao cliente mesmo com o cache de capability vazio.
- `update_agenda_block` já autoriza o dono até `start_at`. O gate de FE era o único bloqueio.

### Fix (FE-puro, ZERO migration → zero drift na main)
- Renderiza o island quando `allowed || ownsAnyBlock` (`ownsAnyBlock` = algum bloco com
  `is_mine`), restaurando edit/cancel para quem já reservou.
- O **form de nova reserva** permanece atrás de `reserve_agenda_block` (`allowed && draft`).
- Heading vira `manageHeading` ("Seu bloco" / "Your block" / "Tu bloque", 3 dicts) no modo
  só-gestão.

### QA
- `npx astro build` ✅ verde
- `npm test` ✅ **4130 pass / 0 fail / 366 skip**
- i18n parity ✅ `comp.agendaViva.manageHeading` nos 3 dicts (pt/en/es)

Closes #813.
