### PR TITLE
feat(rls): coluna initiatives.visibility + helper rls_can_see_initiative — PR-1 [#785]

### DIFF
--- a/supabase/migrations/20260805000231_p785_pr1_initiative_visibility_and_helper.sql
+++ b/supabase/migrations/20260805000231_p785_pr1_initiative_visibility_and_helper.sql
@@ -1,0 +1,29 @@
+-- PR-1 (#785) — Iniciativas confidenciais: coluna de visibilidade + helper RLS.
+-- Behavior-neutral: default 'standard' + helper devolve true p/ standard e p/ NULL,
+-- preservando read-all da curadoria (decisão #5 CLAUDE.md). Só confidenciais exigem engagement.
+
+ALTER TABLE public.initiatives
+  ADD COLUMN IF NOT EXISTS visibility text NOT NULL DEFAULT 'standard'
+  CHECK (visibility IN ('standard','confidential'));
+
+COMMENT ON COLUMN public.initiatives.visibility IS
+  'Visibilidade da iniciativa (#785). standard = piso org-members-only atual; confidential = board/eventos/atas/docs visíveis só a engajados + GP/superadmin. Tribos herdam via bridge ADR-0005.';
+
+-- Helper canônico de visibilidade (espelha rls_can_for_initiative).
+-- Reusa o padrão V4: engajamento autoritativo via auth_engagements.initiative_id.
+CREATE OR REPLACE FUNCTION public.rls_can_see_initiative(p_initiative_id uuid)
+RETURNS boolean LANGUAGE sql SECURITY DEFINER STABLE
+SET search_path TO 'public','pg_temp' AS $$
+  SELECT
+    p_initiative_id IS NULL  -- boards/eventos org-level sem iniciativa: visíveis
+    OR NOT EXISTS (SELECT 1 FROM public.initiatives i
+                   WHERE i.id = p_initiative_id AND i.visibility = 'confidential')
+    OR EXISTS (SELECT 1 FROM public.auth_engagements ae
+               WHERE ae.auth_id = auth.uid() AND ae.initiative_id = p_initiative_id
+                 AND ae.is_authoritative = true)
+    OR public.rls_is_superadmin()
+    OR public.rls_can('manage_platform');  -- decisão PM #1: GP vê sempre
+$$;
+
+COMMENT ON FUNCTION public.rls_can_see_initiative(uuid) IS
+  'Gate de visibilidade de iniciativa (#785, PR-1). true p/ standard e p/ NULL; confidencial exige engajamento autoritativo ou GP/superadmin. Usado nas policies SELECT (PR-2) e nas RPCs SECURITY DEFINER de leitura (PR-3).';

--- a/tests/contracts/schema-cache-columns.test.mjs
+++ b/tests/contracts/schema-cache-columns.test.mjs
@@ -88,6 +88,11 @@ const STORAGE_ONLY_ALLOWLIST = new Map([
   // governance choice). members.chapter is now the derived/compat value (Wave 3b-ii) maintained
   // by triggers — registered in KNOWN_CACHE_COLUMNS below.
   ['members.entry_chapter_code', 'Member-chosen chapter of entry (Wave 3a #740, ADR-0104); governance choice, not derived'],
+  // Visibility gate for confidential initiatives (#785, PR-1). enum 'standard'|'confidential',
+  // DEFAULT 'standard' (behavior-neutral). Curator/admin governance CHOICE set via
+  // create/update_initiative (PR-4), not derived from any other state. The companion helper
+  // rls_can_see_initiative() reads it; no cache/sync relationship to maintain.
+  ['initiatives.visibility', 'Confidential-initiative visibility gate (#785); governance choice set on create/update, no derivation source'],
 ]);
 
 // ADR-0011 contract reuses this allowlist — keep it sorted for review.


### PR DESCRIPTION
## PR-1/4 — Iniciativas confidenciais (#785): infra (behavior-neutral)

Primeira de 4 PRs do épico de **iniciativas confidenciais** (#785). Esta PR só monta a **infra**; nenhum comportamento muda em produção.

### O que entra
- **Coluna** `initiatives.visibility` enum `'standard'|'confidential'`, `NOT NULL DEFAULT 'standard'` (CHECK). Tribos herdam via bridge dual-write (ADR-0005).
- **Helper** `public.rls_can_see_initiative(uuid)` (SECURITY DEFINER, STABLE) que reusa o padrão V4 (`auth_engagements.initiative_id`). Devolve `true` para:
  - `initiative_id IS NULL` (boards/eventos org-level sem iniciativa);
  - iniciativa `'standard'` (piso org-members-only atual → **read-all da curadoria intacto**, decisão #5 CLAUDE.md);
  - membro com engajamento autoritativo na iniciativa;
  - `rls_is_superadmin()` **ou** `rls_can('manage_platform')` → **GP vê sempre** (decisão PM #1).

### Por que é behavior-neutral
Nenhuma policy ou RPC consome o helper ainda. Como o default é `'standard'` e o helper retorna `true` p/ standard e p/ NULL, tudo que existe hoje continua igual.

### Governança / contrato
- `initiatives.visibility` é **storage puro** (escolha de governança via `create/update_initiative` na PR-4, não derivada) → registrada no `STORAGE_ONLY_ALLOWLIST` do contract ADR-0012 (`tests/contracts/schema-cache-columns.test.mjs`).
- DDL aplicado via `apply_migration`; arquivo local + `migration repair --status applied 20260805000231` (head anterior `20260805000230`); `NOTIFY pgrst` aplicado.

### Verificação
- `rls_can_see_initiative(NULL)` = `true`; `(standard)` = `true` (live).
- `npx astro build` — 0 erros.
- `npm test` — **4144 pass / 0 fail / 368 skipped** (skips = DB-aware sem service-role; contract ADR-0012 estático passa).

### Sequência restante
- **PR-2** — reescrita das policies SELECT (7 tabelas) + invariante `check_schema_invariants()` + contract test de confidencialidade (não-engajado/engajado/GP/curador).
- **PR-3** — gate nas RPCs `SECURITY DEFINER` de leitura/listagem + curadoria EXCLUI confidenciais + agregados públicos excluem.
- **PR-4** — ADR novo + `V4_AUTHORITY_MODEL.md` + CLAUDE.md decisão #5 + `create/update_initiative` aceitam `visibility`.

Refs #785.