### PR TITLE
fix(governance): lista de TAPs mostra versão atual + chain ativa

### DIFF
--- a/src/pages/admin/governance/charters.astro
+++ b/src/pages/admin/governance/charters.astro
@@ -188,8 +188,21 @@ const I18N = {
         .from('approval_chains')
         .select('id, document_id, status, gates, opened_at')
         .in('document_id', docIds);
+      // A doc can have multiple chains (e.g. a superseded R00 chain + the active
+      // R01 chain after a re-circulation). Pick the most relevant per doc instead
+      // of letting an arbitrary last-wins overwrite the active one with a superseded
+      // chain. Rank: active > review > anything else; tie-break by latest opened_at.
+      var chainRank = { active: 3, approved: 3, review: 2, under_review: 2 };
       var chainsByDoc = {};
-      (chainsRes.data || []).forEach(function(c){ chainsByDoc[c.document_id] = c; });
+      (chainsRes.data || []).forEach(function(c){
+        var prev = chainsByDoc[c.document_id];
+        if (!prev) { chainsByDoc[c.document_id] = c; return; }
+        var rNew = chainRank[c.status] || 0;
+        var rOld = chainRank[prev.status] || 0;
+        if (rNew > rOld || (rNew === rOld && (c.opened_at || '') > (prev.opened_at || ''))) {
+          chainsByDoc[c.document_id] = c;
+        }
+      });
 
       // Fetch initiatives info (titles)
       var initIds = docs.map(function(d){return d.initiative_id;}).filter(Boolean);
@@ -200,6 +213,19 @@ const I18N = {
           .select('id, title, kind')
           .in('id', initIds);
         (initsRes.data || []).forEach(function(i){ initsByid[i.id] = i; });
+      }
+
+      // Resolve the CURRENT version label from current_version_id. The doc.version
+      // column is a denormalized label that can lag behind the current version
+      // (e.g. stays "R00" after R01 is published), so prefer the live version row.
+      var verIds = docs.map(function(d){return d.current_version_id;}).filter(Boolean);
+      var verLabelById = {};
+      if (verIds.length) {
+        var versRes = await sb
+          .from('document_versions')
+          .select('id, version_label')
+          .in('id', verIds);
+        (versRes.data || []).forEach(function(v){ verLabelById[v.id] = v.version_label; });
       }
 
       var tbody = document.getElementById('charters-tbody');
@@ -217,7 +243,7 @@ const I18N = {
               '<div class="font-semibold text-[var(--text-primary)] text-[13px]">' + esc(d.title) + '</div>' +
               '<div class="text-[11px] text-[var(--text-muted)] mt-0.5">' + initLabel + '</div>' +
             '</td>' +
-            '<td class="py-3 pr-3 text-[12px]">' + esc(d.version || '—') + '</td>' +
+            '<td class="py-3 pr-3 text-[12px]">' + esc(verLabelById[d.current_version_id] || d.version || '—') + '</td>' +
             '<td class="py-3 pr-3">' + badgeForStatus(d.status) + '</td>' +
             '<td class="py-3 pr-3">' + summarizeChain(chain) + '</td>' +
             '<td class="py-3 pr-3">' + actions + '</td>' +


### PR DESCRIPTION
## Problema
Na tela **/admin/governance/charters** (lista de TAPs), o TAP do Grupo de Estudos CPMAI aparecia como **R00 / 0-de-4 gates / chain `897aeddf` (superseded)** — dando a impressão de que a **R01 havia sumido**. Na verdade o banco está íntegro: o doc `d7447a94` tem a chain **`fa5fd11d` (R01, `review`, gate 1 assinado)** ativa, e a `897aeddf` (R00) está `superseded`. O erro era só de renderização.

## Causa-raiz (2 bugs de frontend)
1. **Versão:** a coluna mostrava `governance_documents.version` — um label **desnormalizado e defasado** (continua `"R00"` mesmo com `current_version_id` apontando p/ a R01).
2. **Cadeia:** ao indexar as chains (`chainsByDoc[document_id] = c`), a **última do resultado vencia**, sem filtrar status — uma chain `superseded` podia sobrescrever a ativa.

## Fix
- Resolve o **label da versão corrente** via `current_version_id` → `document_versions` (fallback p/ o label antigo).
- **Ranqueia a chain por doc**: `active`/`approved` > `review` > demais; desempate pelo `opened_at` mais recente. Uma chain `superseded` nunca sobrescreve a ativa.

## Escopo / risco
- **Admin-only** (`manage_member`); **bug de UI apenas**, sem migração/RPC — dados intactos.
- `en/es` são redirects (4 linhas) → sem alteração; sem novas chaves i18n.
- `npx astro build` ✅ (0 erros novos).

## QA manual sugerido pós-merge
Abrir /admin/governance/charters e confirmar que o TAP CPMAI aparece como **R01** com a chain **`fa5fd11d`** (1/4, aguardando Fernando→Welma→Ivan).

⚠️ Não mergear sem o "vai" do PM.