### PR TITLE
test(p599-600): excluir iniciativas confidenciais da paridade header/roster

### DIFF
--- a/tests/contracts/p599-600-initiative-roster-parity-gamification-gate.test.mjs
+++ b/tests/contracts/p599-600-initiative-roster-parity-gamification-gate.test.mjs
@@ -147,9 +147,16 @@ describe('p599-600 — DB-gated (skip without env)', () => {
     // get_initiative_detail has no auth gate on member_count (caller context only enriches
     // user_engagement), so the service-role client can probe the full surface.
     // Concurrent pairs (council LOW): keeps the probe O(1) wall-clock as initiatives grow.
-    const { data: inits, error } = await sb.from('initiatives').select('id, title');
+    // Confidential initiatives (ADR-0105 / #785) are intentionally gated out of
+    // get_initiative_detail for a non-engaged / service-role caller → member_count
+    // comes back undefined BY DESIGN, which is not a header/roster parity violation.
+    // Exclude them from the sweep; the confidential gate itself is covered by the
+    // 785-confidential-initiative-{rls,rpcs} contracts.
+    const { data: inits, error } = await sb.from('initiatives').select('id, title, visibility');
     if (error) { console.warn(`[p599-600] initiatives unavailable: ${error.message}`); return; }
-    const results = await Promise.all((inits ?? []).map(async (i) => {
+    const results = await Promise.all((inits ?? [])
+      .filter((i) => i.visibility !== 'confidential')
+      .map(async (i) => {
       const [{ data: detail }, { data: roster }] = await Promise.all([
         sb.rpc('get_initiative_detail', { p_initiative_id: i.id }),
         sb.rpc('get_initiative_roster_count', { p_initiative_id: i.id }),


### PR DESCRIPTION
## Problema
O `validate` está **vermelho na `main` e em todo PR** (descoberto no CI do #840) por **1 teste**:

```
p599-600 — denominator parity holds for EVERY initiative
✖ GP × Presidência — Governança do Núcleo: header=undefined roster=0
```

A varredura compara `get_initiative_detail.member_count` (header) com `get_initiative_roster_count` (roster) para **todas** as iniciativas. A iniciativa **confidencial** (ADR-0105 / #785) é **intencionalmente ocultada** de `get_initiative_detail` para um chamador não-engajado / service-role → `member_count` volta `undefined` **por design**. Como o teste roda contra o **DB compartilhado** e a iniciativa confidencial foi criada na fase downstream do #785 (após o baseline deste teste), a paridade quebrou para todos.

## Fix (test-only)
Exclui `visibility='confidential'` da varredura de paridade, com comentário citando ADR-0105/#785. Não é mascaramento: header `undefined` é o comportamento **correto** da iniciativa confidencial sob service-role; o gate em si segue coberto por `785-confidential-initiative-{rls,rpcs}`.

## Escopo / risco
- **Somente teste** — sem migração, RPC ou código de produto.
- Validado local (com env DB): subtest de paridade ✔ (antes ✖).
- Destrava o `validate` para a `main` e todos os PRs abertos (incl. #840).

⚠️ Não mergear sem o "vai" do PM.