### PR TITLE
test(p277): de-flaka calc_attendance_pct — compara décimos inteiros, não float exato (#844)

### DIFF
--- a/tests/contracts/p277-419-m3-pr2-calc-attendance-pct-engagement.test.mjs
+++ b/tests/contracts/p277-419-m3-pr2-calc-attendance-pct-engagement.test.mjs
@@ -53,6 +53,15 @@ test('m3 PR2 DB: calc_attendance_pct == canonical engagement global, and is no l
   assert.ok(!eng.error, eng.error?.message);
   const calcPct = Number(calc.data);
   const engPct = Math.round(Number(eng.data.avg_rate) * 100 * 10) / 10;
-  assert.equal(calcPct, engPct, 'calc_attendance_pct must equal engagement avg_rate × 100 (delegation)');
+  // #844: compare at 1-decimal granularity, NOT bit-equality. calc_attendance_pct rounds
+  // avg_rate*100 to 1dp in Postgres `numeric` (half-away); this test recomputes it in JS float.
+  // When avg_rate lands exactly on an x.x5 boundary (e.g. 0.7615 → 76.1500), JS float makes
+  // 0.7615*100 === 76.14999999999999 and rounds DOWN to 76.1 while Postgres rounds UP to 76.2 —
+  // a spurious ±0.1 flake. Compare integer tenths with an off-by-one tolerance (float-safe: a
+  // raw `<= 0.1` itself flakes because 76.2 - 76.1 === 0.10000000000000853 in IEEE-754). A real
+  // delegation bug would diverge by many tenths, not one rounding ulp.
+  const tenths = (x) => Math.round(x * 10);
+  assert.ok(Math.abs(tenths(calcPct) - tenths(engPct)) <= 1,
+    `calc_attendance_pct must match engagement avg_rate × 100 at 1dp (delegation); got calc=${calcPct} eng=${engPct}`);
   assert.ok(calcPct >= 0 && calcPct <= 100, `must be a 0..100 percentage, got ${calcPct}`);
 });


### PR DESCRIPTION
Closes #844.

## Problema
O subteste `m3 PR2 DB: calc_attendance_pct == canonical engagement global` falhava intermitentemente em `validate`, sempre por **±0.1**, sem relação com o PR em curso — flake crônico (provável causa dos reds de merge de #841/#802 no audit de bypass).

## Causa-raiz (aterrada ao vivo)
`avg_rate = 0.7615` → ×100 = **76.1500**, na fronteira `x.x5`:
- `calc_attendance_pct()` arredonda em **`numeric`** (Postgres half-away): `round(76.1500,1) = 76.2` ✅ correto.
- O teste recomputava em **float JS**: `0.7615*100 === 76.14999999999999` → arredonda para 76.1.

A asserção é que era frágil, não a RPC.

## Fix
Comparar os **décimos como inteiros** com tolerância off-by-one:
```js
const tenths = (x) => Math.round(x * 10);
assert.ok(Math.abs(tenths(calcPct) - tenths(engPct)) <= 1, ...)
```
O contrato é delegação-a-1-decimal, não bit-equality. (Uma tolerância float crua `<= 0.1` **também** flaka, porque `76.2 - 76.1 === 0.10000000000000853` em IEEE-754 — por isso a comparação inteira.) Uma divergência real de delegação seria de muitos décimos, não de um ulp.

## Validação
Ao vivo no limite (avg_rate=0.7615): calc=76.2, eng=76.1 → 762 vs 761, diff=1 → **passa**. Off-boundary → diff=0 → passa. Suíte do arquivo 3/3.

> Desbloqueia o #843 (governança de comentários, #842) sem queimar bypass — a janela está em 2/2.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>