### PR TITLE
fix(rls): gate confidencial nas RPCs de leitura de evento/roster/stats — #785

### DIFF
--- a/supabase/migrations/20260805000236_p785_gate_event_read_rpcs_confidential.sql
+++ b/supabase/migrations/20260805000236_p785_gate_event_read_rpcs_confidential.sql
@@ -1,0 +1,315 @@
+-- #785 follow-up — close confidential-initiative gate gaps on event / roster / stats read RPCs.
+--
+-- PR-3 (20260805000233) gated the initiative/board/artifact read RPCs, but THREE
+-- member-callable SECURITY DEFINER read paths were missed and leaked a confidential
+-- initiative's data to ANY authenticated member (verified live, non-engaged identity):
+--   * get_initiative_members          -> leaked the full roster (names + photos)
+--   * get_initiative_stats            -> leaked card counts + contributor names
+--   * get_initiative_events_timeline  -> leaked events (titles/dates/minutes) once linked
+--
+-- This migration adds public.rls_can_see_initiative(...) to those three (behavior-neutral
+-- for standard / null-initiative cases -- the helper returns true there), and hardens
+-- get_event_detail with the same gate PLUS an engaged-member bypass so members engaged in
+-- a CONFIDENTIAL initiative can open that committee's own meetings (incl. gp_only 1:1s).
+--
+-- See ADR-0105 (#785) + docs/reference/V4_AUTHORITY_MODEL.md (decision #5: any SECDEF read
+-- RPC over initiative-linked tables MUST apply the gate).
+--
+-- NOTE: function bodies below are byte-equivalent (modulo whitespace) to what was applied
+-- via apply_migration -- inline comments are intentionally omitted from the bodies because
+-- the Phase-C body-hash drift gate counts comments inside prosrc.
+
+CREATE OR REPLACE FUNCTION public.get_initiative_members(p_initiative_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $$
+DECLARE
+  v_result jsonb;
+BEGIN
+  IF NOT public.rls_can_see_initiative(p_initiative_id) THEN
+    RETURN '[]'::jsonb;
+  END IF;
+
+  SELECT coalesce(jsonb_agg(row_to_json(m) ORDER BY m.role_order, m.name), '[]'::jsonb)
+  INTO v_result
+  FROM (
+    SELECT
+      e.id as engagement_id,
+      e.kind,
+      e.role,
+      e.status,
+      e.start_date,
+      p.id as person_id,
+      COALESCE(p.name, mb.name) as name,
+      COALESCE(p.photo_url, mb.photo_url) as photo_url,
+      mb.id as member_id,
+      ek.display_name as kind_display,
+      CASE e.role
+        WHEN 'leader' THEN 0
+        WHEN 'coordinator' THEN 1
+        WHEN 'participant' THEN 2
+        WHEN 'observer' THEN 3
+        ELSE 4
+      END as role_order
+    FROM engagements e
+    JOIN persons p ON p.id = e.person_id
+    LEFT JOIN members mb ON mb.id = p.legacy_member_id
+    LEFT JOIN engagement_kinds ek ON ek.slug = e.kind
+    WHERE e.initiative_id = p_initiative_id
+      AND e.status = 'active'
+  ) m;
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_initiative_stats(p_initiative_id uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $$
+DECLARE
+  v_tribe_id int;
+BEGIN
+  IF NOT public.rls_can_see_initiative(p_initiative_id) THEN
+    RETURN json_build_object('error', 'Initiative not found');
+  END IF;
+
+  v_tribe_id := public.resolve_tribe_id(p_initiative_id);
+
+  IF v_tribe_id IS NOT NULL THEN
+    RETURN public.get_tribe_stats(v_tribe_id);
+  END IF;
+
+  RETURN (
+    WITH cycle AS (SELECT cycle_start FROM cycles WHERE is_current LIMIT 1),
+    init_members AS (
+      SELECT DISTINCT vir.member_id AS id, vir.name
+      FROM v_initiative_roster vir
+      WHERE vir.initiative_id = p_initiative_id AND vir.member_id IS NOT NULL
+    ),
+    init_events AS (
+      SELECT e.id, COALESCE(e.duration_actual, e.duration_minutes, 60) AS duration_minutes
+      FROM events e, cycle c
+      WHERE e.initiative_id = p_initiative_id AND e.date >= c.cycle_start AND e.date <= current_date
+    ),
+    att AS (
+      SELECT a.event_id, a.member_id FROM attendance a
+      JOIN init_events ie ON ie.id = a.event_id
+      WHERE a.present = true AND a.excused IS NOT TRUE
+    ),
+    init_boards AS (
+      SELECT bi.id, bi.status FROM board_items bi
+      JOIN project_boards pb ON pb.id = bi.board_id
+      WHERE pb.initiative_id = p_initiative_id
+    )
+    SELECT json_build_object(
+      'member_count', public.get_initiative_roster_count(p_initiative_id),
+      'events_held', (SELECT count(*) FROM init_events),
+      'attendance_rate', (SELECT round(
+        count(a.*)::numeric / NULLIF((SELECT count(*) FROM init_members) * (SELECT count(*) FROM init_events), 0) * 100, 0
+      ) FROM att a),
+      'impact_hours', (SELECT coalesce(round(sum(ie.duration_minutes * sub.c)::numeric / 60, 1), 0)
+        FROM init_events ie JOIN (SELECT event_id, count(*) c FROM att GROUP BY event_id) sub ON sub.event_id = ie.id),
+      'cards_backlog', (SELECT count(*) FROM init_boards WHERE status = 'backlog'),
+      'cards_in_progress', (SELECT count(*) FROM init_boards WHERE status = 'in_progress'),
+      'cards_review', (SELECT count(*) FROM init_boards WHERE status = 'review'),
+      'cards_done', (SELECT count(*) FROM init_boards WHERE status = 'done'),
+      'top_contributors', (SELECT coalesce(json_agg(row_to_json(r) ORDER BY r.att_count DESC), '[]')
+        FROM (
+          SELECT im.name, count(a2.event_id) as att_count,
+            round(count(a2.event_id)::numeric / NULLIF((SELECT count(*) FROM init_events), 0) * 100, 0) as rate
+          FROM init_members im
+          LEFT JOIN att a2 ON a2.member_id = im.id
+          GROUP BY im.name
+        ) r
+      )
+    )
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_initiative_events_timeline(p_initiative_id uuid, p_upcoming_limit integer DEFAULT 5, p_past_limit integer DEFAULT 10)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $$
+DECLARE
+  v_caller record;
+  v_upcoming jsonb;
+  v_past jsonb;
+  v_today date := (NOW() AT TIME ZONE 'America/Sao_Paulo')::date;
+  v_eligible int;
+BEGIN
+  SELECT * INTO v_caller FROM members WHERE auth_id = auth.uid();
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  IF NOT public.rls_can_see_initiative(p_initiative_id) THEN
+    RETURN jsonb_build_object('upcoming', '[]'::jsonb, 'past', '[]'::jsonb);
+  END IF;
+
+  SELECT count(*) INTO v_eligible
+  FROM engagements
+  WHERE initiative_id = p_initiative_id AND status = 'active';
+
+  SELECT COALESCE(jsonb_agg(row_data ORDER BY row_data->>'date'), '[]'::jsonb)
+  INTO v_upcoming
+  FROM (
+    SELECT jsonb_build_object(
+      'id', e.id,
+      'title', e.title,
+      'title_i18n', e.title_i18n,
+      'date', e.date,
+      'time_start', e.time_start,
+      'type', e.type,
+      'duration_minutes', COALESCE(e.duration_minutes, 60),
+      'meeting_link', e.meeting_link,
+      'agenda_text', e.agenda_text
+    ) as row_data
+    FROM events e
+    WHERE e.initiative_id = p_initiative_id
+      AND e.date >= v_today
+    ORDER BY e.date ASC
+    LIMIT p_upcoming_limit
+  ) sub;
+
+  SELECT COALESCE(jsonb_agg(row_data ORDER BY (row_data->>'date') DESC), '[]'::jsonb)
+  INTO v_past
+  FROM (
+    SELECT jsonb_build_object(
+      'id', e.id,
+      'title', e.title,
+      'title_i18n', e.title_i18n,
+      'date', e.date,
+      'time_start', e.time_start,
+      'type', e.type,
+      'duration_minutes', COALESCE(e.duration_actual, e.duration_minutes, 60),
+      'recording_url', e.recording_url,
+      'youtube_url', e.youtube_url,
+      'has_recording', (e.youtube_url IS NOT NULL OR e.recording_url IS NOT NULL),
+      'minutes_text', e.minutes_text,
+      'has_minutes', (e.minutes_text IS NOT NULL AND e.minutes_text != ''),
+      'agenda_text', e.agenda_text,
+      'attendee_count', (SELECT count(*) FROM attendance a WHERE a.event_id = e.id AND a.present = true),
+      'eligible_count', v_eligible
+    ) as row_data
+    FROM events e
+    WHERE e.initiative_id = p_initiative_id
+      AND e.date < v_today
+    ORDER BY e.date DESC
+    LIMIT p_past_limit
+  ) sub;
+
+  RETURN jsonb_build_object(
+    'upcoming', v_upcoming,
+    'past', v_past
+  );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_event_detail(p_event_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_caller record;
+  v_event record;
+  v_event_tribe_id int;
+  v_engaged_confidential boolean;
+  v_result jsonb;
+BEGIN
+  SELECT * INTO v_caller FROM members WHERE auth_id = auth.uid();
+  IF NOT FOUND THEN RETURN jsonb_build_object('error', 'Unauthorized'); END IF;
+
+  SELECT * INTO v_event FROM events WHERE id = p_event_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('error', 'Event not found'); END IF;
+
+  IF NOT public.rls_can_see_initiative(v_event.initiative_id) THEN
+    RETURN jsonb_build_object('error', 'Event not found');
+  END IF;
+
+  v_engaged_confidential := (v_event.initiative_id IS NOT NULL AND EXISTS (
+    SELECT 1 FROM public.initiatives i
+    JOIN public.auth_engagements ae ON ae.initiative_id = i.id
+    WHERE i.id = v_event.initiative_id
+      AND i.visibility = 'confidential'
+      AND ae.auth_id = auth.uid()
+      AND ae.is_authoritative = true
+  ));
+
+  IF v_event.visibility = 'gp_only'
+     AND NOT public.can_by_member(v_caller.id, 'manage_platform')
+     AND NOT v_engaged_confidential THEN
+    RETURN jsonb_build_object('error', 'Restricted content');
+  END IF;
+  IF v_event.visibility = 'leadership'
+     AND NOT public.can_by_member(v_caller.id, 'manage_event')
+     AND NOT v_engaged_confidential THEN
+    RETURN jsonb_build_object('error', 'Restricted content');
+  END IF;
+
+  v_event_tribe_id := public.resolve_tribe_id(v_event.initiative_id);
+
+  SELECT jsonb_build_object(
+    'event', jsonb_build_object(
+      'id', v_event.id, 'title', v_event.title, 'date', v_event.date,
+      'type', v_event.type, 'tribe_id', v_event_tribe_id,
+      'duration_minutes', v_event.duration_minutes, 'duration_actual', v_event.duration_actual,
+      'meeting_link', v_event.meeting_link, 'is_recorded', v_event.is_recorded,
+      'youtube_url', v_event.youtube_url, 'recording_url', v_event.recording_url,
+      'recording_type', v_event.recording_type, 'visibility', v_event.visibility
+    ),
+    'agenda', jsonb_build_object(
+      'text', v_event.agenda_text, 'url', v_event.agenda_url,
+      'posted_at', v_event.agenda_posted_at,
+      'posted_by', (SELECT m.name FROM members m WHERE m.id = v_event.agenda_posted_by)
+    ),
+    'minutes', jsonb_build_object(
+      'text', v_event.minutes_text, 'url', v_event.minutes_url,
+      'posted_at', v_event.minutes_posted_at,
+      'posted_by', (SELECT m.name FROM members m WHERE m.id = v_event.minutes_posted_by)
+    ),
+    'action_items', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', ai.id, 'description', ai.description, 'assignee_id', ai.assignee_id,
+        'assignee_name', COALESCE(ai.assignee_name, am.name),
+        'due_date', ai.due_date, 'status', ai.status,
+        'carried_to_event_id', ai.carried_to_event_id
+      ) ORDER BY ai.created_at), '[]'::jsonb)
+      FROM meeting_action_items ai
+      LEFT JOIN members am ON am.id = ai.assignee_id
+      WHERE ai.event_id = p_event_id AND ai.status != 'cancelled'
+    ),
+    'attendance', jsonb_build_object(
+      'present_count', (SELECT COUNT(*) FROM attendance WHERE event_id = p_event_id),
+      'members', (
+        SELECT COALESCE(jsonb_agg(jsonb_build_object(
+          'id', a.member_id, 'name', m.name, 'present', true,
+          'excused', COALESCE(a.excused, false)
+        )), '[]'::jsonb)
+        FROM attendance a JOIN members m ON m.id = a.member_id
+        WHERE a.event_id = p_event_id
+      )
+    ),
+    'showcases', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', es.id, 'member_id', es.member_id, 'member_name', m.name,
+        'showcase_type', es.showcase_type, 'title', es.title, 'duration_min', es.duration_min
+      ) ORDER BY es.created_at), '[]'::jsonb)
+      FROM event_showcases es JOIN members m ON m.id = es.member_id
+      WHERE es.event_id = p_event_id
+    )
+  ) INTO v_result;
+  RETURN v_result;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260805000237_p785_gate_event_read_rpcs_confidential_part2.sql
+++ b/supabase/migrations/20260805000237_p785_gate_event_read_rpcs_confidential_part2.sql
@@ -1,0 +1,269 @@
+-- #785 follow-up (part 2) -- close the remaining confidential-initiative gate gaps on
+-- member-callable event-read RPCs surfaced by the sweep (verified live, non-engaged identity):
+--   * get_meeting_preparation(event_id)        -> leaked the prep pack (title/agenda/attendees/cards)
+--   * get_events_with_attendance(limit,offset)  -> leaked confidential rows (minutes/notes/visibility)
+--   * list_meetings_with_notes(...)             -> leaked confidential meetings with notes
+--
+-- Each now applies public.rls_can_see_initiative(...) -- behavior-neutral for standard / null
+-- initiatives (helper returns true there), tightening only the confidential case. Part 1 lives
+-- in 20260805000236. (Already-gated peers: get_event_detail, get_agenda_smart, get_meeting_detail,
+-- get_near_events, get_recent_events. Admin-only peers raise before any read: get_event_attendance_health.)
+--
+-- NOTE: these RPCs do NOT enforce the gp_only/leadership visibility TIER on null-initiative
+-- standalone events (a separate, pre-existing concern, orthogonal to the confidential-initiative
+-- gate). Tracked as a follow-up; out of scope for this PR.
+--
+-- get_events_with_attendance is an admin/analytics source (the /attendance page; granted to
+-- authenticated + service_role, NOT anon). Its gate is OR'd with `auth.uid() IS NULL` so trusted
+-- server contexts (service_role / cron / postgres) still see every event for reconciliation,
+-- while authenticated end-users are filtered to what they may see. anon cannot reach it (no grant).
+--
+-- Bodies are byte-equivalent (modulo whitespace) to what was applied via apply_migration;
+-- inline comments are omitted from the bodies (Phase-C drift gate counts comments in prosrc).
+
+CREATE OR REPLACE FUNCTION public.get_meeting_preparation(p_event_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_caller_id uuid;
+  v_event record;
+  v_initiative record;
+  v_result jsonb;
+BEGIN
+  IF auth.uid() IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN RAISE EXCEPTION 'Caller has no member record'; END IF;
+
+  SELECT e.id, e.title, e.date, e.type, e.duration_minutes, e.meeting_link,
+         e.initiative_id, e.agenda_text, e.agenda_url
+  INTO v_event FROM public.events e WHERE e.id = p_event_id;
+  IF v_event.id IS NULL THEN
+    RETURN jsonb_build_object('error', 'event_not_found');
+  END IF;
+
+  IF NOT public.rls_can_see_initiative(v_event.initiative_id) THEN
+    RETURN jsonb_build_object('error', 'event_not_found');
+  END IF;
+
+  IF v_event.initiative_id IS NOT NULL THEN
+    SELECT i.id, i.title, i.kind, i.legacy_tribe_id
+    INTO v_initiative FROM public.initiatives i WHERE i.id = v_event.initiative_id;
+  END IF;
+
+  v_result := jsonb_build_object(
+    'event', jsonb_build_object(
+      'id', v_event.id,
+      'title', v_event.title,
+      'date', v_event.date,
+      'type', v_event.type,
+      'duration_minutes', v_event.duration_minutes,
+      'meeting_link', v_event.meeting_link,
+      'agenda_text', v_event.agenda_text,
+      'agenda_url', v_event.agenda_url
+    ),
+    'initiative', CASE WHEN v_initiative.id IS NOT NULL THEN
+      jsonb_build_object('id', v_initiative.id, 'title', v_initiative.title,
+        'kind', v_initiative.kind, 'legacy_tribe_id', v_initiative.legacy_tribe_id)
+    ELSE NULL END,
+    'expected_attendees', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'member_id', m.id,
+        'name', m.name,
+        'operational_role', m.operational_role,
+        'engagement_kind', ae.kind,
+        'engagement_role', ae.role,
+        'photo_url', m.photo_url
+      ) ORDER BY m.name)
+      FROM public.members m
+      JOIN public.persons p ON p.legacy_member_id = m.id
+      JOIN public.auth_engagements ae ON ae.person_id = p.id
+      WHERE m.is_active = true
+        AND ae.is_authoritative = true
+        AND ae.initiative_id = v_event.initiative_id
+        AND v_event.initiative_id IS NOT NULL
+    ), '[]'::jsonb),
+    'pending_action_items', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'id', mai.id,
+        'event_id', mai.event_id,
+        'event_title', e2.title,
+        'event_date', e2.date,
+        'description', mai.description,
+        'kind', mai.kind,
+        'assignee_name', mai.assignee_name,
+        'assignee_id', mai.assignee_id,
+        'due_date', mai.due_date,
+        'days_open', GREATEST(0, EXTRACT(DAY FROM (now() - mai.created_at))::int)
+      ) ORDER BY mai.due_date NULLS LAST, mai.created_at DESC)
+      FROM public.meeting_action_items mai
+      JOIN public.events e2 ON e2.id = mai.event_id
+      WHERE mai.resolved_at IS NULL
+        AND e2.initiative_id = v_event.initiative_id
+        AND v_event.initiative_id IS NOT NULL
+        AND e2.id <> p_event_id
+        AND e2.date < v_event.date
+        AND mai.created_at >= (now() - interval '90 days')
+    ), '[]'::jsonb),
+    'open_cards', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'id', bi.id,
+        'title', bi.title,
+        'status', bi.status,
+        'curation_status', bi.curation_status,
+        'assignee_id', bi.assignee_id,
+        'assignee_name', am.name,
+        'due_date', bi.due_date,
+        'forecast_date', bi.forecast_date,
+        'baseline_date', bi.baseline_date,
+        'days_since_update', GREATEST(0, EXTRACT(DAY FROM (now() - bi.updated_at))::int),
+        'tags', bi.tags,
+        'is_at_risk', (
+          (bi.forecast_date IS NOT NULL AND bi.baseline_date IS NOT NULL
+            AND bi.forecast_date > bi.baseline_date + INTERVAL '7 days')
+          OR (bi.updated_at < now() - interval '14 days' AND bi.status NOT IN ('done', 'archived'))
+        )
+      ) ORDER BY
+        CASE WHEN bi.status NOT IN ('done', 'archived') THEN 0 ELSE 1 END,
+        bi.due_date NULLS LAST, bi.updated_at DESC)
+      FROM public.board_items bi
+      JOIN public.project_boards pb ON pb.id = bi.board_id
+      LEFT JOIN public.members am ON am.id = bi.assignee_id
+      WHERE pb.initiative_id = v_event.initiative_id
+        AND v_event.initiative_id IS NOT NULL
+        AND pb.is_active = true
+        AND bi.status NOT IN ('archived')
+      LIMIT 50
+    ), '[]'::jsonb),
+    'recent_meetings', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'id', e3.id,
+        'title', e3.title,
+        'date', e3.date,
+        'type', e3.type,
+        'has_minutes', e3.minutes_text IS NOT NULL,
+        'attendance_count', (SELECT COUNT(*) FROM public.attendance a WHERE a.event_id = e3.id),
+        'open_actions_count', (
+          SELECT COUNT(*) FROM public.meeting_action_items
+          WHERE event_id = e3.id AND resolved_at IS NULL
+        )
+      ) ORDER BY e3.date DESC)
+      FROM public.events e3
+      WHERE e3.initiative_id = v_event.initiative_id
+        AND v_event.initiative_id IS NOT NULL
+        AND e3.id <> p_event_id
+        AND e3.date < v_event.date
+        AND e3.date >= (v_event.date - interval '60 days')
+      LIMIT 5
+    ), '[]'::jsonb),
+    'generated_at', now()
+  );
+
+  RETURN v_result;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_events_with_attendance(p_limit integer DEFAULT 500, p_offset integer DEFAULT 0)
+ RETURNS TABLE(id uuid, title text, date date, type text, nature text, duration_minutes integer, time_start time without time zone, timezone text, meeting_link text, youtube_url text, is_recorded boolean, audience_level text, tribe_id integer, attendee_count bigint, agenda_text text, agenda_url text, minutes_text text, minutes_url text, recording_url text, recording_type text, notes text, visibility text, external_attendees text[], recurrence_group uuid, initiative_id uuid, initiative_name text, status text, cancelled_at timestamp with time zone, cancellation_reason text)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $$
+  SELECT
+    e.id, e.title, e.date, e.type, e.nature,
+    e.duration_minutes, e.time_start, e.timezone, e.meeting_link,
+    e.youtube_url, e.is_recorded, e.audience_level,
+    i.legacy_tribe_id AS tribe_id,
+    (SELECT count(*) FROM public.attendance a WHERE a.event_id = e.id AND a.present = true) AS attendee_count,
+    e.agenda_text, e.agenda_url,
+    e.minutes_text, e.minutes_url,
+    e.recording_url, e.recording_type,
+    e.notes, e.visibility,
+    e.external_attendees, e.recurrence_group,
+    e.initiative_id,
+    i.title AS initiative_name,
+    e.status, e.cancelled_at, e.cancellation_reason
+  FROM public.events e
+  LEFT JOIN public.initiatives i ON i.id = e.initiative_id
+  WHERE (public.rls_can_see_initiative(e.initiative_id) OR auth.uid() IS NULL)
+  ORDER BY e.date DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_meetings_with_notes(p_tribe_id integer DEFAULT NULL::integer, p_type text DEFAULT NULL::text, p_search text DEFAULT NULL::text, p_include_empty boolean DEFAULT false, p_limit integer DEFAULT 100, p_offset integer DEFAULT 0)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_caller_id uuid;
+  v_total int;
+  v_rows jsonb;
+BEGIN
+  SELECT id INTO v_caller_id FROM members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Not authenticated');
+  END IF;
+
+  SELECT count(*) INTO v_total
+  FROM events e
+  LEFT JOIN initiatives i ON i.id = e.initiative_id
+  WHERE (p_tribe_id IS NULL OR i.legacy_tribe_id = p_tribe_id)
+    AND public.rls_can_see_initiative(e.initiative_id)
+    AND (p_type IS NULL OR e.type = p_type)
+    AND (p_include_empty OR (e.minutes_text IS NOT NULL AND length(trim(e.minutes_text)) >= 20))
+    AND (
+      p_search IS NULL OR p_search = ''
+      OR to_tsvector('portuguese',
+           coalesce(e.title, '') || ' ' ||
+           coalesce(e.minutes_text, '') || ' ' ||
+           coalesce(e.agenda_text, '')
+         ) @@ plainto_tsquery('portuguese', p_search)
+    );
+
+  SELECT COALESCE(jsonb_agg(row_to_json(sub) ORDER BY sub.date DESC), '[]'::jsonb)
+  INTO v_rows
+  FROM (
+    SELECT
+      e.id, e.title, e.date, e.type, i.legacy_tribe_id AS tribe_id,
+      i.title AS tribe_name,
+      e.initiative_id,
+      i.title AS initiative_name,
+      e.youtube_url, e.recording_url,
+      e.minutes_text IS NOT NULL AND length(trim(e.minutes_text)) >= 20 AS has_minutes,
+      length(COALESCE(e.minutes_text, '')) AS minutes_length,
+      e.agenda_text IS NOT NULL AS has_agenda,
+      (SELECT count(*) FROM attendance a WHERE a.event_id = e.id AND a.present = true) AS attendee_count
+    FROM events e
+    LEFT JOIN initiatives i ON i.id = e.initiative_id
+    WHERE (p_tribe_id IS NULL OR i.legacy_tribe_id = p_tribe_id)
+      AND public.rls_can_see_initiative(e.initiative_id)
+      AND (p_type IS NULL OR e.type = p_type)
+      AND (p_include_empty OR (e.minutes_text IS NOT NULL AND length(trim(e.minutes_text)) >= 20))
+      AND (
+        p_search IS NULL OR p_search = ''
+        OR to_tsvector('portuguese',
+             coalesce(e.title, '') || ' ' ||
+             coalesce(e.minutes_text, '') || ' ' ||
+             coalesce(e.agenda_text, '')
+           ) @@ plainto_tsquery('portuguese', p_search)
+      )
+    ORDER BY e.date DESC
+    LIMIT p_limit
+    OFFSET p_offset
+  ) sub;
+
+  RETURN jsonb_build_object(
+    'meetings', v_rows,
+    'total', v_total,
+    'limit', p_limit,
+    'offset', p_offset
+  );
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/785-followup-event-read-gate.test.mjs
+++ b/tests/contracts/785-followup-event-read-gate.test.mjs
@@ -1,0 +1,73 @@
+/**
+ * #785 follow-up — confidential gate on the event / roster / stats read RPCs that
+ * PR-3 (20260805000233) missed. A non-engaged member could read a confidential
+ * initiative's roster (get_initiative_members), stats (get_initiative_stats),
+ * meetings (get_initiative_events_timeline / get_meeting_preparation /
+ * get_events_with_attendance / list_meetings_with_notes) and event detail
+ * (get_event_detail). Each now calls public.rls_can_see_initiative(...).
+ *
+ * Static (offline) assertions: every targeted RPC's CREATE block in the two
+ * follow-up migrations applies the gate. The 4-identity behavioural proof
+ * (non-engaged blocked everywhere; engaged committee leaders + GP keep access;
+ * standard initiatives unchanged) was validated live in ROLLBACK transactions
+ * during development; it is not replayed here because the harness has no
+ * per-user JWT path (service_role sets auth.uid() = NULL).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const MIG1 = readFileSync(
+  resolve(process.cwd(), 'supabase/migrations/20260805000236_p785_gate_event_read_rpcs_confidential.sql'),
+  'utf8',
+);
+const MIG2 = readFileSync(
+  resolve(process.cwd(), 'supabase/migrations/20260805000237_p785_gate_event_read_rpcs_confidential_part2.sql'),
+  'utf8',
+);
+
+/** Slice the CREATE OR REPLACE block for a given function out of the migration text. */
+function fnBlock(sql, name) {
+  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION public.${name}(`);
+  if (start === -1) return null;
+  const next = sql.indexOf('CREATE OR REPLACE FUNCTION public.', start + 1);
+  return sql.slice(start, next === -1 ? undefined : next);
+}
+
+const PART1 = ['get_initiative_members', 'get_initiative_stats', 'get_initiative_events_timeline', 'get_event_detail'];
+const PART2 = ['get_meeting_preparation', 'get_events_with_attendance', 'list_meetings_with_notes'];
+
+for (const name of PART1) {
+  test(`#785 follow-up: ${name} applies rls_can_see_initiative (mig 236)`, () => {
+    const block = fnBlock(MIG1, name);
+    assert.ok(block, `${name} must be CREATE OR REPLACE'd in migration 236`);
+    assert.ok(
+      block.includes('rls_can_see_initiative'),
+      `${name} must call rls_can_see_initiative (confidential gate)`,
+    );
+  });
+}
+
+for (const name of PART2) {
+  test(`#785 follow-up: ${name} applies rls_can_see_initiative (mig 237)`, () => {
+    const block = fnBlock(MIG2, name);
+    assert.ok(block, `${name} must be CREATE OR REPLACE'd in migration 237`);
+    assert.ok(
+      block.includes('rls_can_see_initiative'),
+      `${name} must call rls_can_see_initiative (confidential gate)`,
+    );
+  });
+}
+
+test('#785 follow-up: get_event_detail keeps the engaged-confidential bypass for gp_only/leadership', () => {
+  const block = fnBlock(MIG1, 'get_event_detail');
+  assert.ok(block.includes('v_engaged_confidential'), 'must compute engaged-confidential membership');
+  assert.ok(block.includes("i.visibility = 'confidential'"), 'bypass must be scoped to confidential initiatives');
+  assert.ok(block.includes('gp_only') && block.includes('leadership'), 'both visibility tiers must honour the bypass');
+});
+
+test('#785 follow-up: both migrations reload the PostgREST schema cache', () => {
+  assert.ok(/NOTIFY pgrst/.test(MIG1), 'mig 236 must NOTIFY pgrst');
+  assert.ok(/NOTIFY pgrst/.test(MIG2), 'mig 237 must NOTIFY pgrst');
+});


### PR DESCRIPTION
## Contexto

Trabalho operacional (adicionar membros + migrar reuniões recorrentes ao comitê confidencial **GP × Presidência — Governança do Núcleo**, #785) revelou **lacunas pré-existentes no gate de confidencialidade do #785**: o PR-3 (#838, mig 233) gateou as RPCs de iniciativa/board/artifact, mas várias RPCs **SECDEF de leitura de evento/roster/stats** não aplicavam `rls_can_see_initiative()` e vazavam dados de uma iniciativa confidencial para **qualquer membro autenticado**.

Provado ao vivo com a identidade de um membro comum **não-engajado**:

| RPC | Antes | Depois |
|---|---|---|
| `get_initiative_members` | vazava roster (nomes+fotos) | gated |
| `get_initiative_stats` | vazava contadores+contribuidores | gated |
| `get_initiative_events_timeline` | vazava reuniões | gated |
| `get_meeting_preparation` | vazava prep pack | gated |
| `get_events_with_attendance` | vazava minutas/notas | gated (+ bypass service_role) |
| `list_meetings_with_notes` | vazava reuniões c/ atas | gated |
| `get_event_detail` | gp_only→GP apenas | gated + bypass p/ engajado confidencial |

## Mudança

- Cada RPC passa a chamar `public.rls_can_see_initiative(...)` — **behavior-neutral** para iniciativas standard/null (o helper retorna `true`), estreitando só o caso confidencial.
- `get_event_detail`: gate + bypass para membro engajado em iniciativa **confidencial** → abre as reuniões do próprio comitê (incl. `gp_only`), sem expor a outros líderes.
- `get_events_with_attendance` (fonte admin/analytics da página `/attendance`, grant só p/ `authenticated`/`service_role`, **não** `anon`): gate OR'd com `auth.uid() IS NULL` para contextos server-side confiáveis (service_role/cron) seguirem vendo tudo na reconciliação de presença.

## Verificação ao vivo (transações ROLLBACK, 4 identidades)

- **Não-engajado (Andre):** `0` em todas as superfícies (roster/stats/timeline/detail/prep/events_with_attendance/list_meetings).
- **Engajados (Ivan/Fabricio) + GP:** acesso completo (10 reuniões, roster, abrem detalhe).
- **Iniciativa standard (tribo):** inalterada (Andre segue vendo dados públicos da tribo).

## QA

- `astro build` ✅
- contract suite **4318/4320** — as 2 falhas são pré-existentes e não relacionadas (flake `p276 leaderboard`, `resolve_default_gates executive_summary`)
- Phase-C body-hash drift **= 0**; ADR-0097 missing-file/orphan/empty-statements **= 0**
- novo teste `tests/contracts/785-followup-event-read-gate.test.mjs` (9 asserções estáticas do gate por função)

## Estado de produção

⚠️ A DDL (migs 236+237) **já foi aplicada ao DB compartilhado** via `apply_migration` (padrão #785) — o gate de confidencialidade **já está vigente em produção** e as 10 reuniões recorrentes GP×Presidência já estão re-migradas ao comitê. Este PR carrega os arquivos de migração + teste para o repo. **Não mergear sem o seu "vai".**

## Fora de escopo (follow-up sugerido)

`get_events_with_attendance` / `list_meetings_with_notes` **não** aplicam o tier de visibilidade `gp_only`/`leadership` em **eventos avulsos** (`initiative_id = NULL`, ex.: o 1:1 "GP + Presidente — Walkthrough"). Concern ortogonal ao gate de confidencialidade do #785 e pré-existente — recomendo issue separada.

Closes parcial #785 (downstream de governança).