### PR TITLE
fix(security): enforce gp_only/leadership event visibility tier in read RPCs — #847

### DIFF
--- a/supabase/migrations/20260805000238_847_event_visibility_tier_gate.sql
+++ b/supabase/migrations/20260805000238_847_event_visibility_tier_gate.sql
@@ -1,0 +1,154 @@
+-- #847 — enforce the gp_only/leadership event VISIBILITY TIER in the two read RPCs
+-- that #846 only gated for initiative CONFIDENTIALITY (rls_can_see_initiative).
+--
+-- Gap (pre-existing, orthogonal to #785/#846): standalone events (initiative_id IS NULL)
+-- carry a visibility tier ('all' | 'leadership' | 'gp_only') that get_events_with_attendance
+-- and list_meetings_with_notes never applied. A regular authenticated member therefore
+-- received every gp_only/leadership standalone event — including minutes_text/agenda_text —
+-- over the wire (proven live with a non-leader identity). /attendance hid them client-side
+-- (cosmetic, not a boundary); /meetings rendered them directly (no client filter).
+--
+-- Fix: a new helper public.rls_can_see_event_tier(visibility, initiative_id) that mirrors
+-- the per-event tier gate already shipped in get_event_detail (#846):
+--   * visibility = 'gp_only'    -> requires can_by_member(caller, 'manage_platform')
+--   * visibility = 'leadership' -> requires can_by_member(caller, 'manage_event')
+--   * a member engaged in the event's CONFIDENTIAL initiative bypasses the tier
+--     (sees all of that committee's events, matching get_event_detail)
+--   * service_role / cron (auth.uid() IS NULL) bypasses for analytics (invariant m3a D12)
+-- Both RPCs AND this helper next to the existing rls_can_see_initiative gate. The tier
+-- gate mirrors get_event_detail exactly (no participant override), so the list stays
+-- coherent with the detail RPC and /attendance is behaviour-neutral.
+
+CREATE OR REPLACE FUNCTION public.rls_can_see_event_tier(p_visibility text, p_initiative_id uuid)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    auth.uid() IS NULL
+    OR p_visibility IS NULL
+    OR p_visibility NOT IN ('gp_only', 'leadership')
+    OR (p_visibility = 'leadership'
+        AND public.can_by_member((SELECT m.id FROM public.members m WHERE m.auth_id = auth.uid()), 'manage_event'))
+    OR (p_visibility = 'gp_only'
+        AND public.can_by_member((SELECT m.id FROM public.members m WHERE m.auth_id = auth.uid()), 'manage_platform'))
+    OR (p_initiative_id IS NOT NULL AND EXISTS (
+          SELECT 1 FROM public.initiatives i
+          JOIN public.auth_engagements ae ON ae.initiative_id = i.id
+          WHERE i.id = p_initiative_id
+            AND i.visibility = 'confidential'
+            AND ae.auth_id = auth.uid()
+            AND ae.is_authoritative = true
+       ));
+$function$;
+
+REVOKE ALL ON FUNCTION public.rls_can_see_event_tier(text, uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.rls_can_see_event_tier(text, uuid) TO authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.get_events_with_attendance(p_limit integer DEFAULT 500, p_offset integer DEFAULT 0)
+ RETURNS TABLE(id uuid, title text, date date, type text, nature text, duration_minutes integer, time_start time without time zone, timezone text, meeting_link text, youtube_url text, is_recorded boolean, audience_level text, tribe_id integer, attendee_count bigint, agenda_text text, agenda_url text, minutes_text text, minutes_url text, recording_url text, recording_type text, notes text, visibility text, external_attendees text[], recurrence_group uuid, initiative_id uuid, initiative_name text, status text, cancelled_at timestamp with time zone, cancellation_reason text)
+ LANGUAGE sql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  SELECT
+    e.id, e.title, e.date, e.type, e.nature,
+    e.duration_minutes, e.time_start, e.timezone, e.meeting_link,
+    e.youtube_url, e.is_recorded, e.audience_level,
+    i.legacy_tribe_id AS tribe_id,
+    (SELECT count(*) FROM public.attendance a WHERE a.event_id = e.id AND a.present = true) AS attendee_count,
+    e.agenda_text, e.agenda_url,
+    e.minutes_text, e.minutes_url,
+    e.recording_url, e.recording_type,
+    e.notes, e.visibility,
+    e.external_attendees, e.recurrence_group,
+    e.initiative_id,
+    i.title AS initiative_name,
+    e.status, e.cancelled_at, e.cancellation_reason
+  FROM public.events e
+  LEFT JOIN public.initiatives i ON i.id = e.initiative_id
+  WHERE (public.rls_can_see_initiative(e.initiative_id) OR auth.uid() IS NULL)
+    AND public.rls_can_see_event_tier(e.visibility, e.initiative_id)
+  ORDER BY e.date DESC
+  LIMIT p_limit
+  OFFSET p_offset;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.list_meetings_with_notes(p_tribe_id integer DEFAULT NULL::integer, p_type text DEFAULT NULL::text, p_search text DEFAULT NULL::text, p_include_empty boolean DEFAULT false, p_limit integer DEFAULT 100, p_offset integer DEFAULT 0)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_total int;
+  v_rows jsonb;
+BEGIN
+  SELECT id INTO v_caller_id FROM members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Not authenticated');
+  END IF;
+
+  SELECT count(*) INTO v_total
+  FROM events e
+  LEFT JOIN initiatives i ON i.id = e.initiative_id
+  WHERE (p_tribe_id IS NULL OR i.legacy_tribe_id = p_tribe_id)
+    AND public.rls_can_see_initiative(e.initiative_id)
+    AND public.rls_can_see_event_tier(e.visibility, e.initiative_id)
+    AND (p_type IS NULL OR e.type = p_type)
+    AND (p_include_empty OR (e.minutes_text IS NOT NULL AND length(trim(e.minutes_text)) >= 20))
+    AND (
+      p_search IS NULL OR p_search = ''
+      OR to_tsvector('portuguese',
+           coalesce(e.title, '') || ' ' ||
+           coalesce(e.minutes_text, '') || ' ' ||
+           coalesce(e.agenda_text, '')
+         ) @@ plainto_tsquery('portuguese', p_search)
+    );
+
+  SELECT COALESCE(jsonb_agg(row_to_json(sub) ORDER BY sub.date DESC), '[]'::jsonb)
+  INTO v_rows
+  FROM (
+    SELECT
+      e.id, e.title, e.date, e.type, i.legacy_tribe_id AS tribe_id,
+      i.title AS tribe_name,
+      e.initiative_id,
+      i.title AS initiative_name,
+      e.youtube_url, e.recording_url,
+      e.minutes_text IS NOT NULL AND length(trim(e.minutes_text)) >= 20 AS has_minutes,
+      length(COALESCE(e.minutes_text, '')) AS minutes_length,
+      e.agenda_text IS NOT NULL AS has_agenda,
+      (SELECT count(*) FROM attendance a WHERE a.event_id = e.id AND a.present = true) AS attendee_count
+    FROM events e
+    LEFT JOIN initiatives i ON i.id = e.initiative_id
+    WHERE (p_tribe_id IS NULL OR i.legacy_tribe_id = p_tribe_id)
+      AND public.rls_can_see_initiative(e.initiative_id)
+      AND public.rls_can_see_event_tier(e.visibility, e.initiative_id)
+      AND (p_type IS NULL OR e.type = p_type)
+      AND (p_include_empty OR (e.minutes_text IS NOT NULL AND length(trim(e.minutes_text)) >= 20))
+      AND (
+        p_search IS NULL OR p_search = ''
+        OR to_tsvector('portuguese',
+             coalesce(e.title, '') || ' ' ||
+             coalesce(e.minutes_text, '') || ' ' ||
+             coalesce(e.agenda_text, '')
+           ) @@ plainto_tsquery('portuguese', p_search)
+      )
+    ORDER BY e.date DESC
+    LIMIT p_limit
+    OFFSET p_offset
+  ) sub;
+
+  RETURN jsonb_build_object(
+    'meetings', v_rows,
+    'total', v_total,
+    'limit', p_limit,
+    'offset', p_offset
+  );
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/847-event-visibility-tier-gate.test.mjs
+++ b/tests/contracts/847-event-visibility-tier-gate.test.mjs
@@ -1,0 +1,87 @@
+/**
+ * #847 — gp_only/leadership event VISIBILITY TIER must be enforced server-side in the
+ * two read RPCs that #846 only gated for initiative CONFIDENTIALITY.
+ *
+ * Before this migration, get_events_with_attendance and list_meetings_with_notes returned
+ * every gp_only/leadership standalone event (initiative_id IS NULL) — including
+ * minutes_text/agenda_text — to any authenticated member over the wire. /attendance hid
+ * them client-side (cosmetic); /meetings rendered them directly (no client filter).
+ *
+ * Fix (mig 20260805000238): a new helper public.rls_can_see_event_tier(visibility,
+ * initiative_id) mirroring the per-event tier gate already shipped in get_event_detail
+ * (#846): gp_only -> manage_platform, leadership -> manage_event, confidential-initiative
+ * engaged members bypass the tier, and service_role/cron (auth.uid() IS NULL) bypasses for
+ * analytics (invariant m3a D12). Both RPCs AND the helper next to rls_can_see_initiative.
+ *
+ * The 4-identity behavioural proof (regular member sees 0 restricted; tribe leader sees
+ * leadership but not gp_only; GP sees all; service_role sees all) was validated live in
+ * ROLLBACK transactions during development. The harness has no per-user JWT path
+ * (service_role sets auth.uid() = NULL), so only the service_role analytics-bypass leg is
+ * replayed here as a DB-gated regression lock.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+
+const MIG_PATH = resolve(process.cwd(), 'supabase/migrations/20260805000238_847_event_visibility_tier_gate.sql');
+const MIG = existsSync(MIG_PATH) ? readFileSync(MIG_PATH, 'utf8') : '';
+
+/** Slice the CREATE OR REPLACE block for a given function out of the migration text. */
+function fnBlock(sql, name) {
+  const start = sql.indexOf(`CREATE OR REPLACE FUNCTION public.${name}(`);
+  if (start === -1) return null;
+  const next = sql.indexOf('CREATE OR REPLACE FUNCTION public.', start + 1);
+  return sql.slice(start, next === -1 ? undefined : next);
+}
+
+// ── Static (offline) assertions ─────────────────────────────────────────────
+test('#847: migration 20260805000238 exists', () => {
+  assert.ok(MIG.length > 0, 'migration file must exist');
+});
+
+test('#847: rls_can_see_event_tier helper maps tiers to capabilities', () => {
+  const block = fnBlock(MIG, 'rls_can_see_event_tier');
+  assert.ok(block, 'rls_can_see_event_tier must be CREATE OR REPLACE\'d');
+  assert.match(block, /auth\.uid\(\)\s+IS\s+NULL/i, 'service_role/cron bypass present');
+  assert.match(block, /'leadership'[\s\S]*can_by_member\([\s\S]*'manage_event'\)/i, 'leadership -> manage_event');
+  assert.match(block, /'gp_only'[\s\S]*can_by_member\([\s\S]*'manage_platform'\)/i, 'gp_only -> manage_platform');
+  assert.match(block, /visibility\s*=\s*'confidential'/i, 'confidential-initiative engaged bypass present');
+  assert.match(block, /SECURITY DEFINER/i);
+});
+
+for (const name of ['get_events_with_attendance', 'list_meetings_with_notes']) {
+  test(`#847: ${name} applies rls_can_see_event_tier`, () => {
+    const block = fnBlock(MIG, name);
+    assert.ok(block, `${name} must be CREATE OR REPLACE'd in migration 238`);
+    assert.match(block, /rls_can_see_event_tier\(\s*e\.visibility\s*,\s*e\.initiative_id\s*\)/i,
+      `${name} must AND the tier gate`);
+    // the confidential gate from #846 must NOT be dropped
+    assert.ok(block.includes('rls_can_see_initiative'), `${name} must keep the #846 confidential gate`);
+  });
+}
+
+test('#847: get_events_with_attendance keeps the service_role confidential bypass', () => {
+  const block = fnBlock(MIG, 'get_events_with_attendance');
+  assert.match(block, /rls_can_see_initiative\(e\.initiative_id\)\s+OR\s+auth\.uid\(\)\s+IS\s+NULL/i,
+    'analytics path (m3a D12) must survive the confidential gate');
+});
+
+// ── DB-gated: service_role analytics bypass must survive the tier gate ───────
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const dbGated = !!(SUPABASE_URL && SUPABASE_KEY);
+const skipMsg = 'Skipped: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required';
+
+test('#847 DB: service_role still sees gp_only + leadership events (analytics not broken)',
+  { skip: dbGated ? false : skipMsg }, async () => {
+    const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+    const { data, error } = await sb.rpc('get_events_with_attendance', { p_limit: 2000, p_offset: 0 });
+    assert.ifError(error);
+    assert.ok(Array.isArray(data) && data.length > 0, 'service_role must receive rows');
+    const gp = data.filter((e) => e.visibility === 'gp_only').length;
+    const lead = data.filter((e) => e.visibility === 'leadership').length;
+    assert.ok(gp > 0, 'service_role must still see gp_only events (tier bypass via auth.uid() IS NULL)');
+    assert.ok(lead > 0, 'service_role must still see leadership events');
+  });


### PR DESCRIPTION
Closes #847.

## Problema (vazamento provado ao vivo)
`get_events_with_attendance` e `list_meetings_with_notes` só aplicavam o gate de **confidencialidade de iniciativa** (`rls_can_see_initiative`, #846), nunca o **tier de visibilidade do evento** (`gp_only`/`leadership`). Eventos avulsos (`initiative_id IS NULL`) de tier restrito vazavam para qualquer membro autenticado **pela rede** — incluindo `minutes_text`/`agenda_text`:
- `/attendance` escondia client-side (cosmético, não é fronteira);
- `/meetings` renderizava direto (sem filtro client-side).

Medido ao vivo com identidade não-líder (Italo, researcher): `get_events_with_attendance` retornava **5 gp_only + 152 leadership** (139 standalone); `list_meetings_with_notes` retornava **14 reuniões restritas de 45**.

## Fix
Novo helper `public.rls_can_see_event_tier(visibility, initiative_id)` que **espelha exatamente** o gate por-evento já shipado em `get_event_detail` (#846):
- `gp_only` → `can_by_member(caller, 'manage_platform')`
- `leadership` → `can_by_member(caller, 'manage_event')`
- membro engajado na iniciativa **confidencial** do evento faz bypass do tier (vê todos os eventos do comitê)
- `service_role`/cron (`auth.uid() IS NULL`) faz bypass para analytics (invariante **m3a D12**)

Ambas as RPCs aplicam o helper ao lado do `rls_can_see_initiative` existente. Sem exceção de participante (decisão do PM) → a lista fica coerente com `get_event_detail`, e `/attendance` é behavior-neutral (o `isParticipant` lá já era dead code — `i_attended` nunca é populado).

## Prova ao vivo (4 identidades, ROLLBACK)
| Identidade | total | gp_only | leadership |
|---|---|---|---|
| researcher comum | 310 | **0** | **0** |
| tribe_leader (manage_event) | 462 | 0 | 152 |
| GP (manage_platform) | 477 | 15 | 152 |
| service_role (uid NULL) | 477 | 15 | 152 |

## QA
- `npx astro build` ✅
- Testes de contrato 847 (estáticos + DB-gated lock do bypass service_role) ✅ · 785-followup ✅ · m3a D6/D12 ✅ (21/21)
- `rpc-migration-coverage` + `rpc-body-drift` (Phase-C / ADR-0097) ✅ — `drifted_definite=0`, `orphan_true=0`, sem missing-file
- Helper não entra em `database.gen.ts` (mesmo padrão de `rls_can_see_initiative`) → sem regen

## Notas
- DDL já aplicado ao DB compartilhado via `apply_migration` (behavior-neutral; o gate só estreita). `schema_migrations` reconciliado por nome → `20260805000238`.
- `list_meetings_with_notes` mantém o grant histórico a `anon` (inofensivo: retorna `'Not authenticated'` cedo); fora de escopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)