### PR TITLE
fix(security): remove unverified JWT role-claim auth fallback from EFs — #738

### DIFF
--- a/supabase/functions/analyze-application-video/index.ts
+++ b/supabase/functions/analyze-application-video/index.ts
@@ -347,15 +347,13 @@ Deno.serve(async (req: Request) => {
   }
   if (req.method !== "POST") return json({ error: "method_not_allowed" }, 405);
 
+  // Server-to-server only: caller MUST present the literal service_role key.
+  // Previously this decoded the JWT and trusted an UNVERIFIED payload.role,
+  // which a forged JWT could spoof (#738). Compare against the vault key instead.
   const authHeader = req.headers.get("authorization") ?? "";
-  const token = authHeader.replace(/^Bearer\s+/i, "");
-  try {
-    const payload = JSON.parse(atob(token.split(".")[1].replace(/-/g, "+").replace(/_/g, "/")));
-    if (payload.role !== "service_role") {
-      return json({ error: "unauthorized_service_role_only", got: payload.role ?? "no_role" }, 401);
-    }
-  } catch (_) {
-    return json({ error: "invalid_jwt" }, 401);
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (token !== SUPABASE_SERVICE_ROLE_KEY) {
+    return json({ error: "unauthorized_service_role_only" }, 401);
   }
 
   const body = await req.json().catch(() => ({}));

--- a/supabase/functions/extract-cv-text/index.ts
+++ b/supabase/functions/extract-cv-text/index.ts
@@ -143,20 +143,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  // Accept either exact env key match OR a JWT whose payload.role === 'service_role'.
-  // Vault-stored service_role_key may differ from injected SUPABASE_SERVICE_ROLE_KEY
-  // env var (e.g., post-rotation skew); JWT decode is the canonical check.
-  // Pattern mirrors pmi-ai-triage auth gate.
-  let isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
-  if (!isServiceRole && tk.length > 0) {
-    try {
-      const parts = tk.split(".");
-      if (parts.length === 3) {
-        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
-        if (payload.role === "service_role") isServiceRole = true;
-      }
-    } catch { /* not a JWT */ }
-  }
+  // Server-to-server only: caller MUST present the literal service_role key.
+  // The JWT role-claim decode fallback was removed (#738) — it trusted an
+  // UNVERIFIED payload.role, which a forged JWT could spoof.
+  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
   if (!isServiceRole) {
     return json({ error: "unauthorized", message: "service-role only" }, 401);
   }

--- a/supabase/functions/pmi-ai-analyze-research/index.ts
+++ b/supabase/functions/pmi-ai-analyze-research/index.ts
@@ -148,16 +148,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  let isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
-  if (!isServiceRole) {
-    try {
-      const parts = tk.split(".");
-      if (parts.length === 3) {
-        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
-        if (payload.role === "service_role") isServiceRole = true;
-      }
-    } catch { /* not JWT */ }
-  }
+  // Server-to-server only: caller MUST present the literal service_role key.
+  // The JWT role-claim decode fallback was removed (#738) — it trusted an
+  // UNVERIFIED payload.role, which a forged JWT could spoof.
+  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
   if (!isServiceRole) return json({ error: "service_role only" }, 401);
   if (!GEMINI_API_KEY) return json({ error: "GEMINI_API_KEY not configured" }, 503);
 

--- a/supabase/functions/pmi-ai-analyze/index.ts
+++ b/supabase/functions/pmi-ai-analyze/index.ts
@@ -169,16 +169,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  let isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
-  if (!isServiceRole) {
-    try {
-      const parts = tk.split(".");
-      if (parts.length === 3) {
-        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
-        if (payload.role === "service_role") isServiceRole = true;
-      }
-    } catch { /* not JWT */ }
-  }
+  // Server-to-server only: caller MUST present the literal service_role key.
+  // The JWT role-claim decode fallback was removed (#738) — it trusted an
+  // UNVERIFIED payload.role, which a forged JWT could spoof.
+  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
   if (!isServiceRole) return json({ error: "service_role only" }, 401);
   if (!GEMINI_API_KEY) return json({ error: "GEMINI_API_KEY not configured" }, 503);
 

--- a/supabase/functions/pmi-ai-briefing/index.ts
+++ b/supabase/functions/pmi-ai-briefing/index.ts
@@ -192,16 +192,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  let isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
-  if (!isServiceRole) {
-    try {
-      const parts = tk.split(".");
-      if (parts.length === 3) {
-        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
-        if (payload.role === "service_role") isServiceRole = true;
-      }
-    } catch { /* not JWT */ }
-  }
+  // service_role requires the literal vault key. The JWT role-claim decode fallback
+  // was removed (#738) — it trusted an UNVERIFIED payload.role. A non-literal token
+  // now flows to the user path below, where getUser() verifies the JWT signature.
+  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
 
   let callerMemberId: string | null = null;
   if (!isServiceRole) {

--- a/supabase/functions/pmi-ai-triage/index.ts
+++ b/supabase/functions/pmi-ai-triage/index.ts
@@ -285,16 +285,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  let isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
-  if (!isServiceRole) {
-    try {
-      const parts = tk.split(".");
-      if (parts.length === 3) {
-        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
-        if (payload.role === "service_role") isServiceRole = true;
-      }
-    } catch { /* not JWT */ }
-  }
+  // service_role requires the literal vault key. The JWT role-claim decode fallback
+  // was removed (#738) — it trusted an UNVERIFIED payload.role. A non-literal token
+  // now flows to the user path below, where getUser() verifies the JWT signature.
+  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
 
   // p109 Onda 4 Fase 1: accept user JWT with manage_member permission (admin/GP).
   // Pattern mirrors MCP analyze_application tool — same auth gate for cron + admin invocation.

--- a/supabase/functions/pmi-video-test-transcribe/index.ts
+++ b/supabase/functions/pmi-video-test-transcribe/index.ts
@@ -157,16 +157,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  let isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
-  if (!isServiceRole) {
-    try {
-      const parts = tk.split(".");
-      if (parts.length === 3) {
-        const payload = JSON.parse(atob(parts[1].replace(/-/g, "+").replace(/_/g, "/")));
-        if (payload.role === "service_role") isServiceRole = true;
-      }
-    } catch { /* not JWT */ }
-  }
+  // Server-to-server only: caller MUST present the literal service_role key.
+  // The JWT role-claim decode fallback was removed (#738) — it trusted an
+  // UNVERIFIED payload.role, which a forged JWT could spoof.
+  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
   if (!isServiceRole) return json({ error: "service_role only" }, 401);
   if (!GEMINI_API_KEY) return json({ error: "GEMINI_API_KEY not configured" }, 503);
 

--- a/supabase/functions/send-account-claim/index.ts
+++ b/supabase/functions/send-account-claim/index.ts
@@ -74,17 +74,10 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    let isServiceRole = tk === srk
-    if (!isServiceRole) {
-      try {
-        const parts = tk.split('.')
-        if (parts.length === 3) {
-          const payloadJson = atob(parts[1].replace(/-/g, '+').replace(/_/g, '/'))
-          const payload = JSON.parse(payloadJson)
-          if (payload.role === 'service_role') isServiceRole = true
-        }
-      } catch { /* not JWT */ }
-    }
+    // Server-to-server only: caller MUST present the literal service_role key.
+    // A JWT-decode fallback was removed (#738) — it accepted any token whose
+    // unverified payload.role === 'service_role', which a forged JWT could spoof.
+    const isServiceRole = tk === srk
     if (!isServiceRole) return json({ error: 'Forbidden: service_role required' }, 403)
 
     const body = await req.json().catch(() => ({}))

--- a/supabase/functions/send-campaign/index.ts
+++ b/supabase/functions/send-campaign/index.ts
@@ -32,19 +32,11 @@ Deno.serve(async (req) => {
     if (!tk) return json({ error: 'No token' }, 401)
 
     const sb = createClient(url, srk)
-    // Service-role detection: literal compare first (fast path), fallback to JWT
-    // role claim decode (resilient to env↔vault key rotation drift).
-    let isServiceRole = tk === srk
-    if (!isServiceRole) {
-      try {
-        const parts = tk.split('.')
-        if (parts.length === 3) {
-          const payloadJson = atob(parts[1].replace(/-/g, '+').replace(/_/g, '/'))
-          const payload = JSON.parse(payloadJson)
-          if (payload.role === 'service_role') isServiceRole = true
-        }
-      } catch { /* not a parseable JWT, fall through */ }
-    }
+    // Service-role detection: literal compare against the vault key only.
+    // The JWT role-claim decode fallback was removed (#738) — it set isServiceRole
+    // from an UNVERIFIED payload.role, which a forged JWT could spoof. A non-literal
+    // token now falls through to the signature-verified getUser() admin path below.
+    const isServiceRole = tk === srk
 
     if (!isServiceRole) {
       const { data: { user }, error: userError } = await sb.auth.getUser(tk)

--- a/supabase/functions/send-email-verification/index.ts
+++ b/supabase/functions/send-email-verification/index.ts
@@ -71,17 +71,10 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    let isServiceRole = tk === srk
-    if (!isServiceRole) {
-      try {
-        const parts = tk.split('.')
-        if (parts.length === 3) {
-          const payloadJson = atob(parts[1].replace(/-/g, '+').replace(/_/g, '/'))
-          const payload = JSON.parse(payloadJson)
-          if (payload.role === 'service_role') isServiceRole = true
-        }
-      } catch { /* not JWT */ }
-    }
+    // Server-to-server only: caller MUST present the literal service_role key.
+    // A JWT-decode fallback was removed (#738) — it accepted any token whose
+    // unverified payload.role === 'service_role', which a forged JWT could spoof.
+    const isServiceRole = tk === srk
     if (!isServiceRole) return json({ error: 'Forbidden: service_role required' }, 403)
 
     const body = await req.json().catch(() => ({}))


### PR DESCRIPTION
## O quê

Remove o fallback de autenticação que aceitava um caller como `service_role` quando um **JWT decodificado sem verificação de assinatura** (`atob`, sem checar assinatura) tinha `payload.role === 'service_role'`. Um JWT forjado com esse claim passaria.

Fecha #738 (P3, security-engineer WS-B / PR #735 L-1).

## Por que é seguro (grounding)

O fallback era **dead code na prática**: todo caller legítimo apresenta a service_role key **literal**, e o caminho primário `tk === SUPABASE_SERVICE_ROLE_KEY` já os resolve.

Validei a premissa de risco antes de remover (o comentário antigo em `extract-cv-text` alegava que o decode era "the canonical check" por causa de "post-rotation skew" entre vault e env):

- A `vault.decrypted_secrets.service_role_key` usada pelos dispatches `pg_net` é **byte-idêntica** à `SUPABASE_SERVICE_ROLE_KEY` injetada nas EFs (md5 igual, len 219). **Não há skew** — a comparação literal resolve para 100% dos callers.

## Mudança por EF (10 arquivos)

- **6 service-role-only** (`send-account-claim`, `send-email-verification`, `pmi-ai-analyze`, `pmi-ai-analyze-research`, `pmi-video-test-transcribe`, `extract-cv-text`): removido o bloco de decode; a comparação literal vira o único gate de service_role.
- **3 com caminho de usuário** (`pmi-ai-briefing`, `pmi-ai-triage`, `send-campaign`): removido o bloco de decode; tokens não-literais seguem para o caminho de usuário verificado por assinatura (`getUser()`, inalterado).
- **`analyze-application-video`** (era decode-only, **sem** comparação literal): substituído o decode por comparação literal contra a vault key.

Callers internos confirmados passando a key literal: dispatches `pg_net` (vault key) + fetch inline `pmi-ai-triage → extract-cv-text` (`SUPABASE_SERVICE_ROLE_KEY`).

## Efeito

Zero mudança de comportamento para callers legítimos. JWTs `service_role` forjados agora recebem 401/403 em vez de serem aceitos.

## Verificação

- `npx astro build` ✅ (EFs Deno não entram no build, mas roda limpo)
- `npm test` ✅ 4593/4594 (o único fail é o flake conhecido `p277/#419` live-data 76≠75 — passa 6/6 isolado; não tocado por mudança em Deno EF)
- `grep` confirma: 0 `payload.role`/`atob` perigoso restante nos 10 EFs (só comentários)

🤖 Generated with [Claude Code](https://claude.com/claude-code)