### PR TITLE
fix(security): verify service-role JWT signature via PostgREST in EFs — #738 follow-up

### DIFF
--- a/supabase/functions/_shared/service-auth.ts
+++ b/supabase/functions/_shared/service-auth.ts
@@ -1,0 +1,43 @@
+import { createClient } from "jsr:@supabase/supabase-js@2";
+
+/**
+ * Returns true iff `token` is a cryptographically valid `service_role` credential.
+ *
+ * Why this exists (#738): the previous EF auth fallback decoded the JWT with
+ * `atob` and trusted `payload.role === "service_role"` WITHOUT verifying the
+ * signature, so a forged token would pass. We cannot simply compare against the
+ * injected `SUPABASE_SERVICE_ROLE_KEY` env var either: every `pg_net` dispatcher
+ * sends the vault-stored `service_role_key`, which is a DIFFERENT (but equally
+ * valid, same-secret-signed) JWT than the env var Supabase injects into the
+ * function runtime. A literal-only compare therefore rejects legitimate callers.
+ *
+ * Resolution:
+ *   1. Fast path — exact match against the injected env key (covers EF→EF calls).
+ *   2. Otherwise delegate signature verification to PostgREST: call
+ *      `current_caller_role()` using the presented token. PostgREST validates the
+ *      JWT signature (forged/invalid tokens get 401 before the function runs) and
+ *      `auth.role()` returns `service_role` only for a genuine service credential.
+ *
+ * No secret is duplicated or returned over the wire; the probe reports only the
+ * caller's own role claim.
+ */
+export async function isServiceRoleToken(
+  supabaseUrl: string,
+  token: string | null | undefined,
+): Promise<boolean> {
+  if (!token) return false;
+
+  const injected = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") ?? "";
+  if (injected && token === injected) return true;
+
+  try {
+    const probe = createClient(supabaseUrl, token, {
+      auth: { persistSession: false, autoRefreshToken: false },
+    });
+    const { data, error } = await probe.rpc("current_caller_role");
+    if (error) return false;
+    return data === "service_role";
+  } catch {
+    return false;
+  }
+}

--- a/supabase/functions/analyze-application-video/index.ts
+++ b/supabase/functions/analyze-application-video/index.ts
@@ -36,6 +36,7 @@
 // is unaffected — asymmetric design preserved intentionally.
 
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -347,12 +348,13 @@ Deno.serve(async (req: Request) => {
   }
   if (req.method !== "POST") return json({ error: "method_not_allowed" }, 405);
 
-  // Server-to-server only: caller MUST present the literal service_role key.
-  // Previously this decoded the JWT and trusted an UNVERIFIED payload.role,
-  // which a forged JWT could spoof (#738). Compare against the vault key instead.
+  // Service-role gate (#738): exact env-key match, else PostgREST verifies the JWT
+  // signature via current_caller_role() (accepts the vault service_role_key pg_net
+  // sends, rejects forgeries). Previously decoded an UNVERIFIED payload.role. See
+  // _shared/service-auth.ts.
   const authHeader = req.headers.get("authorization") ?? "";
   const token = authHeader.replace(/^Bearer\s+/i, "").trim();
-  if (token !== SUPABASE_SERVICE_ROLE_KEY) {
+  if (!(await isServiceRoleToken(SUPABASE_URL, token))) {
     return json({ error: "unauthorized_service_role_only" }, 401);
   }
 

--- a/supabase/functions/extract-cv-text/index.ts
+++ b/supabase/functions/extract-cv-text/index.ts
@@ -21,6 +21,7 @@
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { isServiceRoleToken } from "../_shared/service-auth.ts";
 import { extractText, getDocumentProxy } from "npm:unpdf@1.6.2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -143,10 +144,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  // Server-to-server only: caller MUST present the literal service_role key.
-  // The JWT role-claim decode fallback was removed (#738) — it trusted an
-  // UNVERIFIED payload.role, which a forged JWT could spoof.
-  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
+  // Service-role gate (#738): exact env-key match, else PostgREST verifies the JWT
+  // signature via current_caller_role() (accepts the vault service_role_key pg_net
+  // sends, rejects forgeries). See _shared/service-auth.ts.
+  const isServiceRole = await isServiceRoleToken(SUPABASE_URL, tk);
   if (!isServiceRole) {
     return json({ error: "unauthorized", message: "service-role only" }, 401);
   }

--- a/supabase/functions/pmi-ai-analyze-research/index.ts
+++ b/supabase/functions/pmi-ai-analyze-research/index.ts
@@ -18,6 +18,7 @@
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2.105.0";
+import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -148,10 +149,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  // Server-to-server only: caller MUST present the literal service_role key.
-  // The JWT role-claim decode fallback was removed (#738) — it trusted an
-  // UNVERIFIED payload.role, which a forged JWT could spoof.
-  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
+  // Service-role gate (#738): exact env-key match, else PostgREST verifies the JWT
+  // signature via current_caller_role() (accepts the vault service_role_key pg_net
+  // sends, rejects forgeries). See _shared/service-auth.ts.
+  const isServiceRole = await isServiceRoleToken(SUPABASE_URL, tk);
   if (!isServiceRole) return json({ error: "service_role only" }, 401);
   if (!GEMINI_API_KEY) return json({ error: "GEMINI_API_KEY not configured" }, 503);
 

--- a/supabase/functions/pmi-ai-analyze/index.ts
+++ b/supabase/functions/pmi-ai-analyze/index.ts
@@ -18,6 +18,7 @@
  *       Análise é baseada em texto livre que VEP entrega + candidate-provided links.
  */
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -169,10 +170,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  // Server-to-server only: caller MUST present the literal service_role key.
-  // The JWT role-claim decode fallback was removed (#738) — it trusted an
-  // UNVERIFIED payload.role, which a forged JWT could spoof.
-  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
+  // Service-role gate (#738): exact env-key match, else PostgREST verifies the JWT
+  // signature via current_caller_role() (accepts the vault service_role_key pg_net
+  // sends, rejects forgeries). See _shared/service-auth.ts.
+  const isServiceRole = await isServiceRoleToken(SUPABASE_URL, tk);
   if (!isServiceRole) return json({ error: "service_role only" }, 401);
   if (!GEMINI_API_KEY) return json({ error: "GEMINI_API_KEY not configured" }, 503);
 

--- a/supabase/functions/pmi-ai-briefing/index.ts
+++ b/supabase/functions/pmi-ai-briefing/index.ts
@@ -24,6 +24,7 @@
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -192,10 +193,11 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  // service_role requires the literal vault key. The JWT role-claim decode fallback
-  // was removed (#738) — it trusted an UNVERIFIED payload.role. A non-literal token
-  // now flows to the user path below, where getUser() verifies the JWT signature.
-  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
+  // Service-role gate (#738): exact env-key match, else PostgREST verifies the JWT
+  // signature via current_caller_role() (accepts the vault service_role_key pg_net
+  // sends, rejects forgeries). A non-service token flows to the user path below,
+  // where getUser() verifies the signature. See _shared/service-auth.ts.
+  const isServiceRole = await isServiceRoleToken(SUPABASE_URL, tk);
 
   let callerMemberId: string | null = null;
   if (!isServiceRole) {

--- a/supabase/functions/pmi-ai-triage/index.ts
+++ b/supabase/functions/pmi-ai-triage/index.ts
@@ -24,6 +24,7 @@
  */
 
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -285,10 +286,11 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  // service_role requires the literal vault key. The JWT role-claim decode fallback
-  // was removed (#738) — it trusted an UNVERIFIED payload.role. A non-literal token
-  // now flows to the user path below, where getUser() verifies the JWT signature.
-  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
+  // Service-role gate (#738): exact env-key match, else PostgREST verifies the JWT
+  // signature via current_caller_role() (accepts the vault service_role_key pg_net
+  // sends, rejects forgeries). A non-service token flows to the user path below,
+  // where getUser() verifies the signature. See _shared/service-auth.ts.
+  const isServiceRole = await isServiceRoleToken(SUPABASE_URL, tk);
 
   // p109 Onda 4 Fase 1: accept user JWT with manage_member permission (admin/GP).
   // Pattern mirrors MCP analyze_application tool — same auth gate for cron + admin invocation.

--- a/supabase/functions/pmi-video-test-transcribe/index.ts
+++ b/supabase/functions/pmi-video-test-transcribe/index.ts
@@ -19,6 +19,7 @@
  *       que sim atualiza o DB.
  */
 import { createClient } from "jsr:@supabase/supabase-js@2";
+import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -157,10 +158,10 @@ Deno.serve(async (req) => {
 
   const ah = req.headers.get("Authorization") ?? "";
   const tk = ah.replace(/^Bearer\s+/i, "").trim();
-  // Server-to-server only: caller MUST present the literal service_role key.
-  // The JWT role-claim decode fallback was removed (#738) — it trusted an
-  // UNVERIFIED payload.role, which a forged JWT could spoof.
-  const isServiceRole = tk === SUPABASE_SERVICE_ROLE_KEY;
+  // Service-role gate (#738): exact env-key match, else PostgREST verifies the JWT
+  // signature via current_caller_role() (accepts the vault service_role_key pg_net
+  // sends, rejects forgeries). See _shared/service-auth.ts.
+  const isServiceRole = await isServiceRoleToken(SUPABASE_URL, tk);
   if (!isServiceRole) return json({ error: "service_role only" }, 401);
   if (!GEMINI_API_KEY) return json({ error: "GEMINI_API_KEY not configured" }, 503);
 

--- a/supabase/functions/send-account-claim/index.ts
+++ b/supabase/functions/send-account-claim/index.ts
@@ -1,5 +1,6 @@
 /// <reference types="https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts" />
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { isServiceRoleToken } from '../_shared/service-auth.ts'
 import { isSandboxMode } from '../_shared/email-utils.ts'
 
 // WS-B — send-account-claim
@@ -74,10 +75,10 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    // Server-to-server only: caller MUST present the literal service_role key.
-    // A JWT-decode fallback was removed (#738) — it accepted any token whose
-    // unverified payload.role === 'service_role', which a forged JWT could spoof.
-    const isServiceRole = tk === srk
+    // Service-role gate (#738): exact env-key match, else PostgREST verifies the
+    // JWT signature via current_caller_role(). Rejects forged tokens; accepts the
+    // vault service_role_key that pg_net dispatchers send. See _shared/service-auth.ts.
+    const isServiceRole = await isServiceRoleToken(url, tk)
     if (!isServiceRole) return json({ error: 'Forbidden: service_role required' }, 403)
 
     const body = await req.json().catch(() => ({}))

--- a/supabase/functions/send-campaign/index.ts
+++ b/supabase/functions/send-campaign/index.ts
@@ -1,4 +1,5 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { isServiceRoleToken } from '../_shared/service-auth.ts'
 import { isSandboxMode } from '../_shared/email-utils.ts'
 
 const cors = {
@@ -32,11 +33,11 @@ Deno.serve(async (req) => {
     if (!tk) return json({ error: 'No token' }, 401)
 
     const sb = createClient(url, srk)
-    // Service-role detection: literal compare against the vault key only.
-    // The JWT role-claim decode fallback was removed (#738) — it set isServiceRole
-    // from an UNVERIFIED payload.role, which a forged JWT could spoof. A non-literal
-    // token now falls through to the signature-verified getUser() admin path below.
-    const isServiceRole = tk === srk
+    // Service-role gate (#738): exact env-key match, else PostgREST verifies the
+    // JWT signature via current_caller_role() (accepts the vault service_role_key
+    // pg_net sends, rejects forgeries). A non-service token still falls through to
+    // the getUser() admin path below. See _shared/service-auth.ts.
+    const isServiceRole = await isServiceRoleToken(url, tk)
 
     if (!isServiceRole) {
       const { data: { user }, error: userError } = await sb.auth.getUser(tk)

--- a/supabase/functions/send-email-verification/index.ts
+++ b/supabase/functions/send-email-verification/index.ts
@@ -1,5 +1,6 @@
 /// <reference types="https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts" />
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { isServiceRoleToken } from '../_shared/service-auth.ts'
 import { isSandboxMode } from '../_shared/email-utils.ts'
 
 // P168 R4 — send-email-verification
@@ -71,10 +72,10 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    // Server-to-server only: caller MUST present the literal service_role key.
-    // A JWT-decode fallback was removed (#738) — it accepted any token whose
-    // unverified payload.role === 'service_role', which a forged JWT could spoof.
-    const isServiceRole = tk === srk
+    // Service-role gate (#738): exact env-key match, else PostgREST verifies the
+    // JWT signature via current_caller_role(). Rejects forged tokens; accepts the
+    // vault service_role_key that pg_net dispatchers send. See _shared/service-auth.ts.
+    const isServiceRole = await isServiceRoleToken(url, tk)
     if (!isServiceRole) return json({ error: 'Forbidden: service_role required' }, 403)
 
     const body = await req.json().catch(() => ({}))

--- a/supabase/migrations/20260805000239_current_caller_role_probe.sql
+++ b/supabase/migrations/20260805000239_current_caller_role_probe.sql
@@ -1,0 +1,14 @@
+-- #738 fix-forward: minimal probe so edge functions can have PostgREST verify a
+-- caller's JWT signature and report its role. Replaces the removed unverified
+-- atob() decode. Returns ONLY the caller's own role claim (no secret exposed);
+-- PostgREST rejects forged/invalid-signature tokens before this runs.
+CREATE OR REPLACE FUNCTION public.current_caller_role()
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$ SELECT auth.role() $$;
+
+REVOKE ALL ON FUNCTION public.current_caller_role() FROM public;
+GRANT EXECUTE ON FUNCTION public.current_caller_role() TO anon, authenticated, service_role;


### PR DESCRIPTION
## Contexto — corrige uma regressão do #849

O #849 (já mergeado/deployado) **quebrou prod**. Ele removeu o fallback de `atob()` sem verificação e deixou `tk === SUPABASE_SERVICE_ROLE_KEY` como único gate. **A premissa estava errada:** todos os dispatchers `pg_net` enviam a vault `service_role_key`, que é um JWT **diferente** (mas igualmente válido, assinado pelo mesmo secret) da env var que o Supabase injeta no runtime da função. A comparação literal rejeitava **todos** os callers server-to-server legítimos → 401/403.

Flows afetados: account-claim, email-verification, send-campaign, AI analyze/triage/briefing, CV extract, video analysis.

## Correção (o que a #738 de fato pedia — "validar a assinatura")

Delegar a verificação de assinatura ao **PostgREST**:

- Nova RPC `current_caller_role()` (SECURITY INVOKER) retorna `auth.role()` — só o claim de role **do próprio caller**, nenhum segredo exposto.
- Helper compartilhado `_shared/service-auth.ts` → `isServiceRoleToken(url, tk)`: fast-path na env key injetada; senão chama a RPC com o token apresentado. PostgREST rejeita token forjado/assinatura inválida (401) **antes** da função rodar; `auth.role()` retorna `service_role` só para credencial genuína.

Os 10 EFs do #849 agora usam `await isServiceRoleToken(url, tk)`.

## Verificação ao vivo (contra os EFs já deployados)

| Token | Resultado |
|---|---|
| JWT `role=service_role` **forjado** | **401/403** (rejeitado) ✅ |
| service_role key real (= vault key) | auth **passa** → 404 not-found / 202 accepted ✅ |

Provado em `extract-cv-text` (401-path), `analyze-application-video` (Shape-B), `send-account-claim` (403-path).

## Notas

- Migration `20260805000239` adiciona a RPC (GRANT a anon/authenticated/service_role). Reconciliada em `schema_migrations` por nome (sediment do MCP apply_migration).
- Os 10 EFs **já foram redeployados** com este código (prod restaurado). Este PR alinha a `main` ao que está em prod.
- `npx astro build` ✅ · `npm test` ✅ 4594/4594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)