### PR TITLE
fix(selection): interview_stuck respects grace window (was flagging in-progress interviews "expirada")

### DIFF
--- a/supabase/migrations/20260805000240_fix_interview_stuck_grace_window.sql
+++ b/supabase/migrations/20260805000240_fix_interview_stuck_grace_window.sql
@@ -1,0 +1,324 @@
+-- Fix — interview_stuck respects a grace window (was firing the instant the START time passed)
+--
+-- WHAT: Change ONE line inside the per-app `meta.interview_stuck` flag of
+--       public.get_selection_dashboard. Old: `si.scheduled_at < now()`.
+--       New: `si.scheduled_at < now() - COALESCE(<sla 'stuck_scheduled_grace'>, 48h)`.
+--
+-- WHY: meta.interview_stuck drives the rose "⚠ Entrevista agendada expirada"
+--      banner (selection.astro), the "Stuck scheduled" filter chip, the
+--      quick-stat, and the GP "Entrevista vencida" action card. It was true the
+--      MOMENT the scheduled start passed — so an interview literally IN PROGRESS
+--      (e.g. Hanae Monma, 18:00–18:30 EDT, flagged "expirada" at 18:01) showed the
+--      rescue banner whose "Reenviar" button CANCELS the live booking. The two
+--      crons that act on the same concept already use a grace:
+--      _selection_stuck_scheduled_rescue_cron reads sla_policies
+--      'stuck_scheduled_grace' (default 48h); _selection_interview_overdue_cron
+--      reads 'interview_overdue_grace' (24h). Only the UI flag had no grace. This
+--      aligns the flag with the rescue cron exactly, so the banner appears
+--      precisely when the automated rescue would actually act — not during the
+--      interview.
+--
+-- SCOPE: Read-side only — no writes, no signature change, single-line predicate
+--      change. Validated live (read-only) pre-apply: an interview started 1h ago
+--      → OLD=true / NEW=false; started 3 days ago & not conducted → NEW=true.
+--
+-- PHASE-C: body below = migration-189 (Wave 3a-0) body verbatim — md5 of the live
+--      prosrc confirmed == file 189 before edit (69b2911176770ce934adf7da63de4e22)
+--      — with the single interview_stuck predicate line changed. New md5 recorded
+--      post-apply.
+--
+-- ROLLBACK: re-issue CREATE OR REPLACE FUNCTION public.get_selection_dashboard(text)
+--      with the migration-189 body (the `si.scheduled_at < now()` predicate). The
+--      only effect is the banner reverting to the no-grace (over-eager) behavior.
+
+CREATE OR REPLACE FUNCTION public.get_selection_dashboard(p_cycle_code text DEFAULT NULL)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $$
+DECLARE
+  v_caller_id uuid;
+  v_cycle_id uuid;
+  v_result jsonb;
+  v_stats_a jsonb;
+  v_stats_b jsonb;
+BEGIN
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF p_cycle_code IS NOT NULL THEN
+    SELECT id INTO v_cycle_id FROM public.selection_cycles WHERE cycle_code = p_cycle_code;
+  ELSE
+    SELECT id INTO v_cycle_id FROM public.selection_cycles ORDER BY created_at DESC LIMIT 1;
+  END IF;
+  IF v_cycle_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'No cycle found', 'cycle', null, 'applications', '[]'::jsonb, 'stats', jsonb_build_object('total', 0));
+  END IF;
+
+  v_stats_a := jsonb_build_object(
+    'total', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id),
+    'approved', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('approved', 'converted')),
+    'rejected', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('rejected', 'objective_cutoff')),
+    'pending', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('submitted', 'screening', 'objective_eval', 'interview_pending', 'interview_scheduled', 'interview_done', 'final_eval')),
+    'cancelled', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('cancelled', 'withdrawn')),
+    'waitlist', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status = 'waitlist'),
+    'leader_ranked', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND rank_leader IS NOT NULL),
+    'researcher_ranked', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND rank_researcher IS NOT NULL),
+    'ai_analysis_done_count', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_at IS NOT NULL AND ai_analysis IS NOT NULL),
+    'consent_ai_pending', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_at IS NULL),
+    'consent_ai_consented', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_at IS NOT NULL AND consent_ai_analysis_revoked_at IS NULL),
+    'consent_ai_revoked', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_revoked_at IS NOT NULL)
+  );
+
+  v_stats_b := jsonb_build_object(
+    'with_peer_evals_2plus', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND (SELECT count(DISTINCT e.evaluator_id) FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluation_type = 'objective' AND e.submitted_at IS NOT NULL) >= 2),
+    'with_interview_scheduled', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.selection_interviews si WHERE si.application_id = a.id AND si.status IN ('scheduled','completed','rescheduled'))),
+    'with_interview_today', (
+      SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id
+        AND EXISTS (SELECT 1 FROM public.selection_interviews si WHERE si.application_id = a.id
+          AND si.status = 'scheduled'
+          AND (si.scheduled_at AT TIME ZONE 'America/Sao_Paulo')::date = (now() AT TIME ZONE 'America/Sao_Paulo')::date)
+    ),
+    'with_video_uploaded', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded','transcribing','transcribed'))),
+    'with_video_opted_out', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id) AND NOT EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded','transcribing','transcribed'))),
+    'with_pmi_member_active', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND pmi_id IS NOT NULL AND pmi_id <> '' AND service_latest_end_date >= CURRENT_DATE),
+    'with_chapter_canonical', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND service_history_chapters IS NOT NULL AND service_history_chapters <> '' AND service_history_chapters <> 'PMI Global'),
+    'with_re_applicants', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND COALESCE(application_count, 1) > 1),
+    'with_briefing_generated', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND last_briefing_at IS NOT NULL),
+    'shadow_vep_count', (
+      SELECT count(*) FROM public.selection_applications a
+      WHERE a.cycle_id = v_cycle_id
+        AND a.status IN ('approved', 'converted', 'cancelled', 'rejected', 'withdrawn')
+        AND EXISTS (
+          SELECT 1 FROM public.members m
+          WHERE m.is_active = true
+            AND lower(m.email) = lower(a.email)
+            AND m.created_at < a.created_at
+        )
+    ),
+    'my_evals_submitted', (SELECT count(*) FROM public.selection_evaluations e JOIN public.selection_applications a ON a.id = e.application_id WHERE a.cycle_id = v_cycle_id AND e.evaluator_id = v_caller_id AND e.submitted_at IS NOT NULL),
+    'my_evals_pending', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.notifications n WHERE n.type = 'peer_review_requested' AND n.source_id = a.id AND n.recipient_id = v_caller_id) AND NOT EXISTS (SELECT 1 FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluator_id = v_caller_id))
+  );
+
+  SELECT jsonb_build_object(
+    'cycle', (SELECT jsonb_build_object(
+      'id', c.id, 'cycle_code', c.cycle_code, 'title', c.title, 'status', c.status,
+      'interview_booking_url', c.interview_booking_url,
+      'interview_questions', COALESCE(c.interview_questions, '[]'::jsonb),
+      'pert_cutoff', (SELECT jsonb_build_object(
+        'target_score', MAX(pert_target_score),
+        'band_lower', MAX(pert_band_lower),
+        'band_upper', MAX(pert_band_upper),
+        'cohort_n', MAX(pert_cohort_n),
+        'method', MAX(pert_cutoff_method),
+        'calc_at', MAX(pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE pert_target_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id),
+      'leader_extra_cutoff', (SELECT jsonb_build_object(
+        'target_score', MAX(leader_extra_pert_target),
+        'band_lower', MAX(leader_extra_pert_band_lower),
+        'band_upper', MAX(leader_extra_pert_band_upper),
+        'cohort_n', MAX(leader_extra_pert_cohort_n),
+        'method', MAX(leader_extra_pert_cutoff_method),
+        'calc_at', MAX(leader_extra_pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE leader_extra_pert_target IS NOT NULL),
+        'apps_with_score', COUNT(*) FILTER (WHERE leader_extra_pert_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id),
+      'final_score_cutoff_researcher', (SELECT jsonb_build_object(
+        'target_score', MAX(final_score_pert_target),
+        'band_lower', MAX(final_score_pert_band_lower),
+        'band_upper', MAX(final_score_pert_band_upper),
+        'cohort_n', MAX(final_score_pert_cohort_n),
+        'method', MAX(final_score_pert_cutoff_method),
+        'calc_at', MAX(final_score_pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE final_score_pert_target IS NOT NULL),
+        'apps_with_score', COUNT(*) FILTER (WHERE final_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND role_applied = 'researcher'),
+      'final_score_cutoff_leader', (SELECT jsonb_build_object(
+        'target_score', MAX(final_score_pert_target),
+        'band_lower', MAX(final_score_pert_band_lower),
+        'band_upper', MAX(final_score_pert_band_upper),
+        'cohort_n', MAX(final_score_pert_cohort_n),
+        'method', MAX(final_score_pert_cutoff_method),
+        'calc_at', MAX(final_score_pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE final_score_pert_target IS NOT NULL),
+        'apps_with_score', COUNT(*) FILTER (WHERE final_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND role_applied = 'leader')
+    ) FROM public.selection_cycles c WHERE c.id = v_cycle_id),
+    'applications', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', a.id, 'applicant_name', a.applicant_name, 'email', a.email,
+          'phone', a.phone,
+          'role_applied', a.role_applied, 'chapter', a.chapter, 'status', a.status,
+          'objective_score', a.objective_score_avg, 'final_score', a.final_score,
+          'research_score', a.research_score, 'leader_score', a.leader_score,
+          'rank_researcher', a.rank_researcher, 'rank_leader', a.rank_leader,
+          'promotion_path', a.promotion_path, 'linked_application_id', a.linked_application_id,
+          'rank_chapter', a.rank_chapter, 'rank_overall', a.rank_overall,
+          'objective_rank', a.objective_rank,
+          'linkedin_url', a.linkedin_url, 'resume_url', a.resume_url,
+          'resume_storage_path', a.resume_storage_path,
+          'resume_synced_at', a.resume_synced_at,
+          'tags', a.tags, 'feedback', a.feedback,
+          'motivation', a.motivation_letter, 'experience_years', a.seniority_years,
+          'membership_status', a.membership_status, 'certifications', a.certifications,
+          'is_returning_member', a.is_returning_member, 'application_date', a.application_date,
+          'academic_background', a.academic_background, 'areas_of_interest', a.areas_of_interest,
+          'availability_declared', a.availability_declared, 'non_pmi_experience', a.non_pmi_experience,
+          'proposed_theme', a.proposed_theme, 'leadership_experience', a.leadership_experience,
+          'created_at', a.created_at, 'interview_status', a.interview_status,
+          'interview_reschedule_reason', a.interview_reschedule_reason,
+          'interview_reschedule_requested_at', a.interview_reschedule_requested_at,
+          'consent_ai_status', CASE
+            WHEN a.consent_ai_analysis_revoked_at IS NOT NULL THEN 'revoked'
+            WHEN a.consent_ai_analysis_at IS NOT NULL THEN 'consented'
+            ELSE 'pending'
+          END,
+          'consent_ai_at', a.consent_ai_analysis_at,
+          'consent_ai_revoked_at', a.consent_ai_analysis_revoked_at,
+          'member_credly_url', (SELECT m.credly_url FROM public.members m WHERE lower(m.email) = lower(a.email) LIMIT 1),
+          'member_photo_url', (SELECT m.photo_url FROM public.members m WHERE lower(m.email) = lower(a.email) LIMIT 1),
+          'leader_extra_pert_score', a.leader_extra_pert_score
+        ) || jsonb_build_object(
+          'interview_score', a.interview_score,
+          'cutoff_approved_email_sent_at', a.cutoff_approved_email_sent_at,
+          'final_score_pert_target', a.final_score_pert_target,
+          'final_score_pert_band_lower', a.final_score_pert_band_lower,
+          'final_score_pert_band_upper', a.final_score_pert_band_upper,
+          'final_score_pert_cutoff_method', a.final_score_pert_cutoff_method,
+          'final_score_pert_cohort_n', a.final_score_pert_cohort_n,
+          'final_score_pert_calc_at', a.final_score_pert_calc_at,
+          'peer_eval_count', (
+            SELECT count(*)::int FROM public.selection_evaluations e
+            WHERE e.application_id = a.id AND e.evaluation_type = 'objective' AND e.submitted_at IS NOT NULL
+          ),
+          'peer_extra', jsonb_build_object(
+            'distinct_evaluators', (
+              SELECT count(DISTINCT e.evaluator_id)::int FROM public.selection_evaluations e
+              WHERE e.application_id = a.id AND e.evaluation_type = 'objective' AND e.submitted_at IS NOT NULL
+            ),
+            'invites_pending', (
+              SELECT count(*)::int FROM public.notifications n
+              WHERE n.type = 'peer_review_requested' AND n.source_id = a.id
+                AND NOT EXISTS (SELECT 1 FROM public.selection_evaluations e2 WHERE e2.application_id = a.id AND e2.evaluator_id = n.recipient_id)
+            )
+          ),
+          'meta', jsonb_build_object(
+            'ai_analysis_done', (a.consent_ai_analysis_at IS NOT NULL AND a.ai_analysis IS NOT NULL),
+            'interview_scheduled', EXISTS (SELECT 1 FROM public.selection_interviews si WHERE si.application_id = a.id AND si.status IN ('scheduled', 'completed', 'rescheduled')),
+            'interview_next_at', (
+              SELECT MIN(si.scheduled_at) FROM public.selection_interviews si
+              WHERE si.application_id = a.id
+                AND si.status = 'scheduled'
+                AND si.scheduled_at >= now() - interval '12 hours'
+            ),
+            'has_interview_today', EXISTS (
+              SELECT 1 FROM public.selection_interviews si
+              WHERE si.application_id = a.id
+                AND si.status = 'scheduled'
+                AND (si.scheduled_at AT TIME ZONE 'America/Sao_Paulo')::date = (now() AT TIME ZONE 'America/Sao_Paulo')::date
+            ),
+            'token_consumed', EXISTS (SELECT 1 FROM public.onboarding_tokens t WHERE t.source_id = a.id AND t.source_type = 'pmi_application' AND COALESCE(t.access_count, 0) > 0),
+            'video_screening_done', EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded', 'transcribing', 'transcribed', 'opted_out')),
+            'interview_stuck', (
+              a.status = 'interview_scheduled'
+              AND EXISTS (
+                SELECT 1 FROM public.selection_interviews si
+                WHERE si.application_id = a.id
+                  AND si.status = 'scheduled'
+                  AND si.conducted_at IS NULL
+                  AND si.scheduled_at IS NOT NULL
+                  AND si.scheduled_at < now() - COALESCE(
+                        (SELECT value_interval FROM public.sla_policies WHERE policy_key = 'stuck_scheduled_grace'),
+                        interval '48 hours')
+              )
+            )
+          ),
+          'video_agg', jsonb_build_object(
+            'status_agg', (SELECT CASE WHEN count(*) = 0 THEN 'none' WHEN count(*) FILTER (WHERE v.status IN ('uploaded','transcribing','transcribed')) > 0 THEN 'uploaded' WHEN count(*) FILTER (WHERE v.status = 'opted_out') = count(*) THEN 'opted_out' ELSE 'partial' END FROM public.pmi_video_screenings v WHERE v.application_id = a.id),
+            'uploaded_count', (SELECT count(*)::int FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded','transcribing','transcribed')),
+            'total_rows', (SELECT count(*)::int FROM public.pmi_video_screenings v WHERE v.application_id = a.id)
+          ),
+          'pmi_canonical', jsonb_build_object(
+            'chapter_canonical', (
+              SELECT trim(c) FROM unnest(string_to_array(COALESCE(a.service_history_chapters, ''), ';')) AS c
+              WHERE trim(c) <> '' AND trim(c) <> 'PMI Global' LIMIT 1
+            ),
+            'pmi_memberships', COALESCE(a.pmi_memberships, '[]'::jsonb),
+            'is_pmi_member', (a.pmi_id IS NOT NULL AND a.pmi_id <> ''),
+            'member_status', CASE
+              WHEN a.pmi_id IS NULL OR a.pmi_id = '' THEN 'unknown'
+              WHEN a.service_latest_end_date IS NULL THEN 'unknown'
+              WHEN a.service_latest_end_date >= CURRENT_DATE THEN 'active'
+              ELSE 'past'
+            END,
+            'member_since', a.service_first_start_date,
+            'member_until', a.service_latest_end_date,
+            'service_history_count', COALESCE(a.service_history_count, 0),
+            'phase_b_fetched_at', a.pmi_data_fetched_at,
+            'pmi_id', a.pmi_id
+          ),
+          'extra_flags', jsonb_build_object(
+            'application_count', COALESCE(a.application_count, 1),
+            'has_briefing', (a.last_briefing_at IS NOT NULL),
+            'briefing_at', a.last_briefing_at,
+            'briefing_model', a.last_briefing_model,
+            'ai_triage_score', a.ai_triage_score,
+            'ai_triage_confidence', a.ai_triage_confidence,
+            'is_shadow_vep', (
+              a.status IN ('approved', 'converted', 'cancelled', 'rejected', 'withdrawn')
+              AND EXISTS (
+                SELECT 1 FROM public.members m
+                WHERE m.is_active = true
+                  AND lower(m.email) = lower(a.email)
+                  AND m.created_at < a.created_at
+              )
+            ),
+            'pdf_likely_invalid', EXISTS (
+              SELECT 1 FROM storage.objects so
+              WHERE so.bucket_id = 'selection-resumes'
+                AND so.name = a.resume_storage_path
+                AND (so.metadata->>'size')::int < 1000
+            )
+          ),
+          'vep_recon', jsonb_build_object(
+            'status_raw', a.vep_status_raw,
+            'last_seen_at', a.vep_last_seen_at,
+            'reconciled_at', a.vep_reconciled_at
+          ),
+          'my_eval_status', COALESCE(
+            (SELECT CASE WHEN e.submitted_at IS NOT NULL THEN 'submitted' ELSE 'draft' END
+              FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluator_id = v_caller_id LIMIT 1),
+            CASE WHEN EXISTS (SELECT 1 FROM public.notifications n WHERE n.type = 'peer_review_requested' AND n.source_id = a.id AND n.recipient_id = v_caller_id) THEN 'invited' ELSE 'not_invited' END
+          ),
+          'my_eval_score', (SELECT e.weighted_subtotal FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluator_id = v_caller_id AND e.submitted_at IS NOT NULL LIMIT 1)
+        )
+      ORDER BY COALESCE(a.leader_score, a.research_score, a.final_score) DESC NULLS LAST)
+      FROM (
+        SELECT
+          sa.*,
+          ROW_NUMBER() OVER (
+            PARTITION BY sa.role_applied
+            ORDER BY sa.objective_score_avg DESC NULLS LAST, sa.id ASC
+          )::int AS objective_rank
+        FROM public.selection_applications sa
+        WHERE sa.cycle_id = v_cycle_id
+      ) a
+    ), '[]'::jsonb),
+    'stats', v_stats_a || v_stats_b
+  ) INTO v_result;
+  RETURN v_result;
+END;
+$$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Bug

`get_selection_dashboard.meta.interview_stuck` was `true` the **instant the scheduled START time passed** (`si.scheduled_at < now()`), with zero grace. So an interview **literally in progress** showed the rose **"⚠ Entrevista agendada expirada"** banner — whose **"🔄 Reenviar"** button **cancels the live booking** and re-invites the candidate.

Hit live during **Hanae Monma's interview** (18:00–18:30 EDT) — flagged "expirada" at ~18:01, mid-interview.

## Root cause

The flag had **no grace window**. The two crons that act on the same concept already use one:
- `_selection_stuck_scheduled_rescue_cron` → `sla_policies 'stuck_scheduled_grace'` (default **48h**)
- `_selection_interview_overdue_cron` → `'interview_overdue_grace'` (24h)

Only the UI flag (`meta.interview_stuck`) was missing it — so the UI screamed "expired" 48h before the automated rescue would actually act.

## Fix

Single-line predicate change inside `get_selection_dashboard`:

```diff
-                  AND si.scheduled_at < now()
+                  AND si.scheduled_at < now() - COALESCE(
+                        (SELECT value_interval FROM public.sla_policies WHERE policy_key = 'stuck_scheduled_grace'),
+                        interval '48 hours')
```

Mirrors the rescue cron **exactly**, so the banner now appears precisely when the automated rescue would act — not during the interview. Fixes all four consumers of the flag: the modal banner, the "Stuck scheduled" filter chip, the quick-stat, and the GP "Entrevista vencida" action card.

## Safety / validation

- **Read-side only** — no writes, no signature change, single predicate line.
- Migration body = file `...189` (Wave 3a-0) **verbatim**; live `prosrc` md5 confirmed `== file 189` pre-edit (`69b2911…`) and `== file 240` post-apply (`da0864…`) → **Phase-C parity**.
- Validated **live (read-only)** before apply:
  - interview started 1h ago → **OLD=true / NEW=false** ✅
  - started 3 days ago & not conducted → **NEW=true** ✅ (still flagged for rescue)
- `npx astro build` ✓. Offline contract gates ✓ (DB-gated checks run in CI).

## Apply status

DDL **already applied to remote DB** via MCP `apply_migration` (the canonical DDL path here); `schema_migrations` row reconciled to `20260805000240`; `NOTIFY pgrst` issued. This PR captures the migration file. **Awaiting "vai" to merge.**

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>