### PR TITLE
fix(security): bare /admin index also gets no-store + noindex (#855 follow-up)

### DIFF
--- a/src/lib/securityHeaders.ts
+++ b/src/lib/securityHeaders.ts
@@ -134,15 +134,22 @@ export function applySecurityHeaders(
   return target;
 }
 
+// A `/foo/` prefix also matches the BARE `/foo` (no trailing slash). Without this,
+// the index route `/admin` escaped `/admin/` and shipped without no-store/noindex
+// (caught in live validation of #855) while `/admin/members` was covered.
+function prefixMatches(pathname: string, prefix: string): boolean {
+  return pathname === prefix.slice(0, -1) || pathname.startsWith(prefix);
+}
+
 /** True when `pathname` must be served with a no-store Cache-Control. */
 export function isNoStorePath(pathname: string): boolean {
   return (
     NO_STORE_EXACT.includes(pathname) ||
-    NO_STORE_PREFIXES.some((p) => pathname.startsWith(p))
+    NO_STORE_PREFIXES.some((p) => prefixMatches(pathname, p))
   );
 }
 
 /** True when `pathname` must carry X-Robots-Tag: noindex, nofollow. */
 export function isNoIndexPath(pathname: string): boolean {
-  return NOINDEX_PREFIXES.some((p) => pathname.startsWith(p));
+  return NOINDEX_PREFIXES.some((p) => prefixMatches(pathname, p));
 }

--- a/tests/contracts/855-ssr-security-headers-parity.test.mjs
+++ b/tests/contracts/855-ssr-security-headers-parity.test.mjs
@@ -27,6 +27,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { isNoStorePath, isNoIndexPath } from '../../src/lib/securityHeaders.ts';
 
 const ROOT = process.cwd();
 const read = (p) => readFileSync(resolve(ROOT, p), 'utf8');
@@ -125,4 +126,18 @@ test('parity: no-store + noindex per-route policy matches _headers', () => {
     .filter(([, h]) => /noindex/.test(h['X-Robots-Tag'] || '')).map(([p]) => p);
   assert.deepEqual(noindexPaths, ['/admin/*'], 'noindex is admin-only in _headers');
   assert.match(SSOT, /NOINDEX_PREFIXES[\s\S]*?["']\/admin\/["']/, 'SSOT noindex = /admin/');
+});
+
+test('per-route matchers: a /foo/ prefix also covers the BARE /foo index route', () => {
+  // Regression guard: live #855 validation found bare `/admin` shipped without
+  // no-store/noindex because it did not match the `/admin/` prefix.
+  assert.equal(isNoIndexPath('/admin'), true, 'bare /admin is noindex');
+  assert.equal(isNoStorePath('/admin'), true, 'bare /admin is no-store');
+  assert.equal(isNoIndexPath('/admin/members'), true, '/admin subpath is noindex');
+  assert.equal(isNoStorePath('/admin/members'), true, '/admin subpath is no-store');
+  assert.equal(isNoStorePath('/workspace'), true, 'exact /workspace is no-store');
+  // The public home must NOT be no-store/noindex.
+  assert.equal(isNoStorePath('/'), false, 'home is not no-store');
+  assert.equal(isNoIndexPath('/'), false, 'home is not noindex');
+  assert.equal(isNoIndexPath('/about'), false, 'public /about is not noindex');
 });


### PR DESCRIPTION
Follow-up to #855 (PR #857), found by live post-deploy validation.

## Gap
After #857 shipped, `curl -I` confirmed SSR headers are live — but the **exact** path `/admin` got CSP + X-Frame-Options yet **no** `X-Robots-Tag: noindex` and **no** `Cache-Control: no-store`, because `/admin` does not match the `/admin/` prefix. Subpaths (`/admin/members`) were correct.

```
/admin          → CSP+XFO, but MISSING noindex + no-store   ❌
/admin/members  → CSP+XFO + noindex + no-store              ✅
/workspace /profile → no-store                              ✅
```

## Fix
`prefixMatches()`: a `/foo/` prefix now also matches the bare `/foo`. Closes the gap for `/admin` (and uniformly for `/en`,`/es` locale roots). Locked with a functional test importing the SSOT helpers (`isNoStorePath`/`isNoIndexPath`), asserting bare `/admin` is covered while the public home (`/`,`/about`) is not.

Local: build ✅ · 855 test 8/8 ✅.