### PR TITLE
chore(#816): public-repo hygiene — forward-protection .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ Sensitive/
 sensitive/
 docs/project-governance/DATA_INGESTION_POLICY.md
 
+# Diagnosis screenshots: scraped from prod UI, contain member PII (names/photos:
+# CPMAI mural, team gallery, tribe leaders). NEVER commit to the PUBLIC repo. See #816.
+docs/strategy/diagnosis/screenshots/
+
 # Data Science: local-only analysis scripts and sensitive inputs
 scripts/data_science/
 
@@ -76,3 +80,44 @@ REPO_INVENTORY.md
 *.rpm
 *.AppImage
 tmp/
+
+# === #816 — Public-repo governance: keep internal / PII / legal-draft / partner docs out of the PUBLIC tree ===
+# This repo is PUBLIC. Sensitive material lives in the private org wiki (nucleo-ia-gp/wiki) + Sensitive/ + data/.
+# NOTE: .gitignore only blocks FUTURE untracked adds. Already-tracked sensitive files are purged separately
+#       (see #816 — history rewrite). Signed/public-final versions can be force-added with `git add -f`.
+# NOTE: docs/legal/ is intentionally KEPT public — compliance/transparency SSOT under contract tests
+#       (638 runbook, 641 annex, 642 DPA sub-processor inventory, RoPA). Do NOT add it here.
+
+# Internal meetings, agendas, briefings (named people + strategy)
+docs/**/ATA_*
+docs/**/PAUTA_*
+docs/**/BRIEFING_*
+docs/**/DEMO_SCRIPT_*
+docs/**/*briefing_reuniao*
+
+# Unsigned legal / IP instrument drafts + legal opinions (pareceres) — NOT the docs/legal/ compliance SSOT
+docs/instrumentos-ip/
+docs/council/cr-050-*-source/
+docs/council/**/*legal-counsel*
+docs/**/*_DRAFT.html
+docs/drafts/*termo_voluntario*
+docs/drafts/*ip_policy*
+docs/drafts/p148_external_reviewer_agreement*
+docs/drafts/r3c3-clause*
+docs/drafts/v2.7_*
+docs/drafts/p269_*
+
+# Partner dossiers, commercial pitch decks, BSP/commercial outreach, multi-client/whitelabel + directorate intel
+docs/strategy/partnerships/
+docs/strategy/deck/
+docs/strategy/whatsapp_bsp_*
+docs/strategy/*_multi_client_gaps.md
+docs/strategy/*_directorate_mapping.md
+
+# Applicant / member PII audits, extractions, peer-review briefings
+docs/**/*GMAIL_DATA*
+docs/**/*VIDEO_SCREENING*
+docs/**/*selection-journey-audit*
+docs/**/*peer_review_briefing*
+docs/**/*WHATSAPP_CROSS_GROUP*
+docs/drafts/p131_email_*


### PR DESCRIPTION
## Contexto

`docs/` deste repo **PÚBLICO** carrega material interno tracked. Auditoria completa do #816 (533 arquivos `docs/` + `*.md` da raiz, varredura por padrão 100% + confirmação 1-a-1 do núcleo sensível) classificou **70 arquivos** como move-private:

- **PII de membro/candidato** (ex.: auditoria de jornada de seleção com 27 emails de candidatos, extração Gmail, peer-review, auditorias de ciclo, briefing de incidente de auth nomeado)
- **Reuniões/briefings internos** com pessoas nomeadas + estratégia (atas/pautas, briefings de liderança, KPI agreement)
- **Instrumentos legais/IP em rascunho não-assinado** (`instrumentos-ip/`, `cr-050-*-source/`, drafts de termo/política IP)
- **Pareceres jurídicos** (work-product) + **parceiro-confidencial/comercial** (dossiê de parceiro, pitch decks, BSP outreach, mapa de diretorias, gaps de whitelabel)

## O que ESTE PR faz (e o que NÃO faz)

✅ **Só proteção pra frente:** bloco de governança no `.gitignore` para que docs internos/PII/legal-draft/parceiro não voltem a ser adicionados ao tree público. Corrige o placeholder do bloco de screenshots (`#<audit-issue>` → `#816`).

❌ **NÃO remove** os 70 arquivos já tracked. Um PR de `git rm --cached` exibiria o conteúdo removido no diff (permanente e público no GitHub) — re-expondo a PII que se quer apagar. A remoção é feita por uma **reescrita de histórico autorizada** (`git filter-repo`), que purga de todo o histórico sem diff revelador. Repo tem **0 forks/0 network**, então a reescrita é viável e de baixo custo.

## Carve-outs (mantidos públicos de propósito)

`docs/legal/` é **SSOT de compliance/transparência sob contract tests** (638 runbook, 641 annex, 642 inventário de subprocessadores DPA, RoPA com contato `dpo@` oficial) — **não** entra no gitignore nem na remoção.

`docs/audit/lgpd-art11-remediation/notification_eduardo_luz` é carve-out para **follow-up dedicado**: a PII do candidato está espalhada em doc + migration aplicada + EF + 2 testes — exige sanitização cross-file, não untrack simples (que quebraria CI).

## Validação

- Os 70 paths são todos cross-ref em comentário em `tests/`/`src/` — **0 leituras** (`readFileSync`), nada quebra no CI.
- O bloco não ignora por engano nenhum arquivo KEEP (legal/ compliance + blog outline verificados).

Refs #816. **Não mergear sem "vai" do PM.**

🤖 Auditoria assistida por Claude Code