### PR TITLE
fix(security): allowlist PostHog ingest host + Cloudflare beacon in CSP (#865)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -9,7 +9,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://us.posthog.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://ldrfrvwhxsmgaabwmaik.supabase.co https://*.googleusercontent.com; connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us-assets.i.posthog.com https://*.sentry.io; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://us.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://ldrfrvwhxsmgaabwmaik.supabase.co https://*.googleusercontent.com; connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://cloudflareinsights.com; frame-src 'none'; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
 
 # SSR pages — no caching
 /tribe/*

--- a/src/lib/securityHeaders.ts
+++ b/src/lib/securityHeaders.ts
@@ -35,11 +35,11 @@
  */
 export const CSP =
   "default-src 'self'; " +
-  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://us.posthog.com; " +
+  "script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://us.posthog.com https://static.cloudflareinsights.com; " +
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
   "font-src 'self' https://fonts.gstatic.com; " +
   "img-src 'self' data: blob: https://ldrfrvwhxsmgaabwmaik.supabase.co https://*.googleusercontent.com; " +
-  "connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us-assets.i.posthog.com https://*.sentry.io; " +
+  "connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://cloudflareinsights.com; " +
   "frame-src 'none'; " +
   "object-src 'none'; " +
   "frame-ancestors 'none'; " +


### PR DESCRIPTION
Closes #865. Regressão do #855.

## Problema (validado ao vivo, prod)
- CSP servido em `/` e `/profile`: `connect-src` tinha `https://us.posthog.com` mas **faltava `https://us.i.posthog.com`** — para onde o posthog-js da nuvem US auto-roteia os POSTs de evento (`/e/`, `/i/v0/e/`). `api_host` baked em prod = `https://us.posthog.com` (confirmado no bundle `BaseLayout…index_2…js`), mas a ingestão runtime vai p/ o host `.i.` → bloqueada → telemetria morre silenciosamente em página logada.
- Beacon de Web Analytics da Cloudflare (`static.cloudflareinsights.com`, edge-injected, não está no nosso código) bloqueado por `script-src`; o POST do beacon (`cloudflareinsights.com`) não estava em `connect-src`.
- A auditoria CSP de 9 agentes do #855 testou só a HOME anon/cacheada → não exercita `capture`/beacon autenticado → buraco passou.

## Fix (aditivo, byte-equal nos dois arquivos)
- `src/lib/securityHeaders.ts` (SSOT) **e** `public/_headers /*` — guardados pelo contract test `855-ssr-security-headers-parity` (exige byte-equal):
  - `script-src` += `https://static.cloudflareinsights.com`
  - `connect-src` += `https://us.i.posthog.com` `https://cloudflareinsights.com`
- `frame-ancestors 'none'` e o restante da política intactos. Nada removido/afrouxado além do necessário.

## Validação local
- `855-…parity` contract test: 8/8 ✅
- `npx astro build`: ✅
- `npm test`: 4172 pass / 0 fail / 372 skip (DB-aware offline) ✅
- Byte-equality SSOT ↔ `_headers` confirmada programaticamente.

## Pós-merge (deploy auto em prod)
Validar ao vivo: `/profile` sem erros de CSP no console + evento chegando no projeto PostHog `ai-pm-hub` (334261) + beacon Cloudflare carrega.

## Fora de escopo (deixados p/ depois, por decisão do PM)
- Report Credly/`/profile` opções "desabilitadas" — provável bug independente (gate tier/RLS), não downstream deste CSP (`safePH` engole erros; bloqueio de CSP é assíncrono).
- Mapa-múndi: pins de estado sumiram + pedido pin-Europa (colide com k≥3 do parecer legal-counsel).