### PR TITLE
fix(#867): pré-onboarding guests reach the pre-term journey (nav minTier flip) — DO NOT MERGE w/o PM vai

### DIFF
--- a/src/lib/navigation.config.ts
+++ b/src/lib/navigation.config.ts
@@ -63,11 +63,11 @@ export const NAV_ITEMS: NavItem[] = [
   { key: 'team',           labelKey: 'nav.team',          href: '/#team',           minTier: 'visitor', requiresAuth: false, section: 'main', group: 'home-anchors', navSlot: 'home-sections-dropdown' },
 
   // ─── Workspace ───
-  { key: 'workspace', labelKey: 'nav.workspace', href: '/workspace', minTier: 'member', requiresAuth: true, section: 'both', group: 'member', navSlot: 'primary', drawerSection: 'meu-espaco' },
+  { key: 'workspace', labelKey: 'nav.workspace', href: '/workspace', minTier: 'visitor', requiresAuth: true, section: 'both', group: 'member', navSlot: 'primary', drawerSection: 'meu-espaco' }, // #867 pre-term journey — guest-reachable (page self-gates own data; RLS/SECDEF is the boundary, not nav)
 
   // ─── Tool pages (public) ───
   { key: 'library',      labelKey: 'nav.library',      href: '/library',      minTier: 'visitor', requiresAuth: false, section: 'both', group: 'tools', navSlot: 'none', drawerSection: 'explorar' },
-  { key: 'onboarding',   labelKey: 'nav.onboarding',   href: '/workspace',   minTier: 'member',  requiresAuth: true,  section: 'main', group: 'profile', navSlot: 'none' },
+  { key: 'onboarding',   labelKey: 'nav.onboarding',   href: '/workspace',   minTier: 'visitor', requiresAuth: true,  section: 'main', group: 'profile', navSlot: 'none' }, // #867 pre-term journey — guest-reachable
   { key: 'gamification', labelKey: 'nav.gamification',  href: '/gamification', minTier: 'visitor', requiresAuth: false, section: 'both', group: 'tools', navSlot: 'none', drawerSection: 'explorar' },
   // #701 Agenda Viva — public General Meetings agenda (anon-OK; reservation gated in-page).
   { key: 'reunioes-gerais', labelKey: 'nav.reunioesGerais', href: '/reunioes-gerais', minTier: 'visitor', requiresAuth: false, section: 'both', group: 'tools', navSlot: 'none', drawerSection: 'explorar' },
@@ -86,7 +86,7 @@ export const NAV_ITEMS: NavItem[] = [
   { key: 'blog',         labelKey: 'nav.blog',         href: '/blog',          minTier: 'visitor', requiresAuth: false, section: 'main',   group: 'tools', navSlot: 'primary' },
 
   // ─── Profile drawer only ───
-  { key: 'profile', labelKey: 'nav.profile', href: '/profile', minTier: 'member', requiresAuth: true, section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' },
+  { key: 'profile', labelKey: 'nav.profile', href: '/profile', minTier: 'visitor', requiresAuth: true, section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' }, // #867 pre-term journey — guest-reachable (profile.astro self-gates via isRegisteredMember; own-row SECDEF)
 
   // ─── Admin area ───
   { key: 'admin',           labelKey: 'nav.admin',          href: '/admin',           minTier: 'observer', requiresAuth: true, section: 'both',   group: 'admin', badge: 'purple', drawerSection: 'admin', navSlot: 'primary' },
@@ -119,8 +119,8 @@ export const NAV_ITEMS: NavItem[] = [
   { key: 'help',            labelKey: 'nav.adminHelp',     href: '/help',           minTier: 'visitor',  requiresAuth: false, section: 'both', group: 'member', navSlot: 'none', drawerSection: 'meu-espaco' },
 
   // ─── Drawer-only secondary links (R4) ───
-  { key: 'certificates',        labelKey: 'nav.certificates',  href: '/certificates',        minTier: 'member',  requiresAuth: true,  section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' },
-  { key: 'volunteer-agreement', labelKey: 'nav.volunteer',     href: '/volunteer-agreement', minTier: 'member',  requiresAuth: true,  section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' },
+  { key: 'certificates',        labelKey: 'nav.certificates',  href: '/certificates',        minTier: 'visitor', requiresAuth: true,  section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' }, // #867 pre-term journey — guest-reachable (own-scope SECDEF)
+  { key: 'volunteer-agreement', labelKey: 'nav.volunteer',     href: '/volunteer-agreement', minTier: 'visitor', requiresAuth: true,  section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' }, // #867 pre-term journey — guest-reachable (signing surface; term body gated in-page)
   { key: 'changelog',           labelKey: 'nav.changelog',     href: '/changelog',           minTier: 'visitor', requiresAuth: false, section: 'drawer', group: 'tools',   drawerSection: 'explorar' },
   { key: 'my-pending',          labelKey: 'nav.myPending',     href: '/governance/my-pending', minTier: 'member', requiresAuth: true,  section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' },
 ];

--- a/tests/contracts/navigation-visibility.test.mjs
+++ b/tests/contracts/navigation-visibility.test.mjs
@@ -88,7 +88,57 @@ const PROFILES = {
   comms_member: { tier: 'member', isLoggedIn: true, designations: ['comms_member'], operationalRole: 'researcher' },
   curator: { tier: 'observer', isLoggedIn: true, designations: ['curator'], operationalRole: 'researcher' },
   co_gp: { tier: 'observer', isLoggedIn: true, designations: ['co_gp'], operationalRole: 'researcher' },
+  // #867: pre-onboarding guest — logged in, unsigned volunteer term → operational_role='guest' collapses to AccessTier 'visitor' (rank 0).
+  preonboardingGuest: { tier: 'visitor', isLoggedIn: true, designations: [], operationalRole: 'guest' },
 };
+
+// ─── #867: pre-term journey is guest-reachable; member-only + admin stay locked ───
+//
+// The nav gate is cosmetic (ADR-0106: the real data boundary is RLS + SECURITY DEFINER + canFor()).
+// This asserts the *reachability* contract: a logged-in guest can open the pre-term journey, and
+// nothing member-only or admin/LGPD-sensitive is opened by the same change.
+
+const PRETERM_GUEST_ITEMS = ['workspace', 'onboarding', 'profile', 'certificates', 'volunteer-agreement'];
+const MEMBER_ONLY_LOCKED_FOR_GUEST = [
+  'attendance', 'meetings', 'my-initiatives', 'my-tribe', 'boards',
+  'presentations', 'notifications', 'my-pending', 'stakeholder-dashboard',
+];
+
+test('#867 pre-term journey items are visible AND enabled for a pre-onboarding guest', () => {
+  const g = PROFILES.preonboardingGuest;
+  for (const key of PRETERM_GUEST_ITEMS) {
+    const item = parseNavItem(key);
+    assert.equal(item.minTier, 'visitor', `${key} must be minTier:'visitor' for the pre-term journey`);
+    assert.equal(item.requiresAuth, true, `${key} must keep requiresAuth:true (invisible to anon)`);
+    const result = getItemAccessibility(item, g.tier, g.designations, g.isLoggedIn, g.operationalRole);
+    assert.ok(result.visible && result.enabled, `${key} must be reachable (visible+enabled) for a pre-onboarding guest`);
+    // still invisible to anonymous (requiresAuth gate)
+    const anon = getItemAccessibility(item, 'visitor', [], false, '');
+    assert.equal(anon.visible, false, `${key} must stay invisible to anonymous visitors`);
+  }
+});
+
+test('#867 regression: member-only items stay LOCKED for a pre-onboarding guest', () => {
+  const g = PROFILES.preonboardingGuest;
+  for (const key of MEMBER_ONLY_LOCKED_FOR_GUEST) {
+    const item = parseNavItem(key);
+    const result = getItemAccessibility(item, g.tier, g.designations, g.isLoggedIn, g.operationalRole);
+    assert.equal(result.enabled, false, `${key} must remain disabled for a pre-onboarding guest (not opened by #867)`);
+  }
+});
+
+test('#867 regression: admin + LGPD-sensitive items stay closed to a pre-onboarding guest', () => {
+  const g = PROFILES.preonboardingGuest;
+  for (const key of navItemKeys) {
+    const item = parseNavItem(key);
+    if (!item.href.startsWith('/admin') && !item.lgpdSensitive) continue;
+    const result = getItemAccessibility(item, g.tier, g.designations, g.isLoggedIn, g.operationalRole);
+    assert.equal(result.enabled, false, `admin/lgpd item ${key} must stay disabled for a pre-onboarding guest`);
+    if (item.lgpdSensitive) {
+      assert.equal(result.visible, false, `lgpdSensitive item ${key} must stay invisible to a pre-onboarding guest`);
+    }
+  }
+});
 
 // ─── LGPD items must be invisible to visitor, researcher, tribe_leader ───
 


### PR DESCRIPTION
## #867 — pré-onboarding "Visitante" travado

Voluntários recém-aprovados (Ciclo 4) aparecem como **Visitante** com o menu inteiro cadeado.

### Causa-raiz (verificada — código + DB ao vivo)
Termo de voluntário não assinado → `auth_engagements.is_authoritative=false` → `sync_operational_role_cache` deriva `operational_role='guest'` → AccessTier colapsa para `visitor` (rank 0) → todo item de nav `minTier:'member'` renderiza **cadeado**. É **cosmético** (ADR-0106: sem gate SSR; a fronteira real é RLS + SECURITY DEFINER + `canFor()`).

### Reenquadramento
O Termo está **intencionalmente retido** (novo template pendente). O fix **não** destrava o termo — destrava a **jornada PRÉ-termo** que deve ser alcançável pelo tier guest: perfil, workspace (checklist de pré-onboarding + Credly), certificados, link do termo, alias de onboarding.

### Mudança (mínima, 1 arquivo)
Flip `minTier: 'member' → 'visitor'` em **exatamente 5** itens em `src/lib/navigation.config.ts` (`workspace`, `onboarding`, `profile`, `certificates`, `volunteer-agreement`), mantendo `requiresAuth:true` (continua invisível p/ anônimo).

`permissions.ts` **não** é tocado de propósito — adicionar chave `guest`/`visitor` em `TIER_PERMISSIONS` concederia capacidades silenciosamente via `hasPermission`/`getEffectivePermissions`. Cada página aberta já auto-gateia o próprio dado sob o JWT do guest.

### Teste
`tests/contracts/navigation-visibility.test.mjs` — perfil `preonboardingGuest` novo assegura (a) os 5 itens pré-termo visíveis+habilitados, (b) itens member-only continuam travados, (c) admin + LGPD-sensitive continuam fechados. `astro build` OK; suites de nav + paridade tier/rota verdes.

### Coorte (ao vivo nesta sessão)
30 membros ativos `operational_role='guest'`.

### Follow-ups (separados, fora deste PR)
- Banner "0/0 passos" + reconciliação de templates de onboarding (código+dado).
- ⚠️ Endurecimento de RLS de leitura (alta prioridade) — **sequenciar antes do merge deste PR** (rastreado em canal privado).

---
⛔ **NÃO mergear sem "vai" do PM** — `main` auto-deploya em produção.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
