### PR TITLE
fix(onboarding): pré-onboarding "0/0 passos" banner counts canonical progress + purge ghost step-keys (#872)

### DIFF
--- a/src/components/onboarding/OnboardingCockpitNudge.tsx
+++ b/src/components/onboarding/OnboardingCockpitNudge.tsx
@@ -55,8 +55,13 @@ export default function OnboardingCockpitNudge({ lang = 'pt-BR' }: Props) {
     // Best-effort progress for the banner (non-blocking; banner shows regardless).
     const sb = getSb();
     sb?.rpc('get_candidate_onboarding_progress').then((res: any) => {
-      const p = res?.data?.pre_onboarding;
-      if (p && typeof p.total === 'number') setProgress({ completed: p.completed || 0, total: p.total });
+      // #872: read the member's own CANONICAL onboarding progress. The legacy `pre_onboarding`
+      // (phase-based) aggregate has been dead since p155 (2026-05-13) consolidated onto the
+      // canonical onboarding_steps catalog, so it always returned 0 → the "0/0 passos" symptom.
+      // `onboarding.total` is 0 for cohorts with no canonical rows (e.g. external reviewers) →
+      // the count is omitted rather than rendered as a misleading 0/0.
+      const p = res?.data?.onboarding;
+      if (p && typeof p.total === 'number' && p.total > 0) setProgress({ completed: p.completed ?? 0, total: p.total });
     }).catch(() => { /* ignore */ });
   }, [getSb, workspaceUrl]);
 

--- a/supabase/migrations/20260805000244_onboarding_canonical_count_and_purge_ghost_steps.sql
+++ b/supabase/migrations/20260805000244_onboarding_canonical_count_and_purge_ghost_steps.sql
@@ -1,0 +1,95 @@
+-- #872 (#867 follow-up): pre-onboarding "0/0 passos" banner + purge ghost legacy step-keys
+--
+-- (1) get_candidate_onboarding_progress: add an `onboarding` aggregate that counts the member's
+--     OWN canonical rows (step_key IN onboarding_steps), treating completed+skipped as done — mirrors
+--     get_my_onboarding's completion semantics. The cockpit banner (OnboardingCockpitNudge) reads this
+--     instead of `pre_onboarding`, whose phase='pre_onboarding' path has been dead since p155 F2
+--     (2026-05-13) consolidated onboarding onto the canonical 7-step catalog → it always returns 0,
+--     hence the "0/0 passos" symptom for the whole guest cohort.
+--     This aggregate subquery is read-only (no auto-insert); the function's existing
+--     check_pre_onboarding_auto_steps() side-effect (UPDATE pending→completed) is preserved unchanged.
+--     `onboarding.total` is 0 for cohorts with no canonical rows (e.g. external_reviewer guests) → the
+--     banner shows no count (not a misleading 0/0). `pre_onboarding` is kept intact (not removed) so the
+--     deferred gamified-journey revival (#873) is not broken.
+--
+-- (2) Purge 5 off-catalog ghost step-keys (accept_terms, profile_complete, platform_access,
+--     join_whatsapp, kick_off) — Cycle-3 w124/w130 seed residue. Footprint at apply: 31 members × 5 =
+--     155 rows, ALL status='pending' (0 completed/0 skipped), outside onboarding_steps, with NO live
+--     function dependency (references to "profile_complete" in check_schema_invariants / update_my_profile
+--     / _trg_record_profile_complete_milestone are to the member_milestones milestone_key, not this step).
+--     Current seeders only emit canonical steps, so these do not regenerate.
+
+CREATE OR REPLACE FUNCTION public.get_candidate_onboarding_progress(p_member_id uuid DEFAULT NULL::uuid)
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_mid uuid;
+  v_result json;
+BEGIN
+  -- Use provided member_id or resolve from auth
+  v_mid := p_member_id;
+  IF v_mid IS NULL THEN
+    SELECT id INTO v_mid FROM members WHERE auth_id = auth.uid();
+  END IF;
+
+  IF v_mid IS NULL THEN
+    RETURN json_build_object('error', 'Not authenticated');
+  END IF;
+
+  -- First run auto-detection
+  PERFORM check_pre_onboarding_auto_steps(v_mid);
+
+  SELECT json_build_object(
+    'member_id', v_mid,
+    'steps', coalesce((
+      SELECT json_agg(json_build_object(
+        'step_key', op.step_key,
+        'status', op.status,
+        'completed_at', op.completed_at,
+        'sla_deadline', op.sla_deadline,
+        'xp', coalesce((op.metadata->>'xp')::int, 0),
+        'phase', coalesce(op.metadata->>'phase', 'onboarding')
+      ) ORDER BY
+        CASE op.step_key
+          WHEN 'create_account' THEN 1
+          WHEN 'complete_profile' THEN 2
+          WHEN 'setup_credly' THEN 3
+          WHEN 'explore_platform' THEN 4
+          WHEN 'read_blog' THEN 5
+          WHEN 'start_pmi_certs' THEN 6
+          WHEN 'code_of_conduct' THEN 7
+          WHEN 'volunteer_term' THEN 8
+          WHEN 'vep_acceptance' THEN 9
+          WHEN 'first_meeting' THEN 10
+          WHEN 'meet_tribe' THEN 11
+          WHEN 'start_trail' THEN 12
+          ELSE 99
+        END
+      )
+      FROM onboarding_progress op
+      WHERE op.member_id = v_mid
+    ), '[]'::json),
+    'pre_onboarding', json_build_object(
+      'total', (SELECT count(*) FROM onboarding_progress WHERE member_id = v_mid AND metadata->>'phase' = 'pre_onboarding'),
+      'completed', (SELECT count(*) FROM onboarding_progress WHERE member_id = v_mid AND metadata->>'phase' = 'pre_onboarding' AND status = 'completed'),
+      'xp_earned', coalesce((SELECT sum((metadata->>'xp')::int) FROM onboarding_progress WHERE member_id = v_mid AND metadata->>'phase' = 'pre_onboarding' AND status = 'completed'), 0),
+      'xp_total', coalesce((SELECT sum((metadata->>'xp')::int) FROM onboarding_progress WHERE member_id = v_mid AND metadata->>'phase' = 'pre_onboarding'), 0)
+    ),
+    'onboarding', json_build_object(
+      'total', (SELECT count(*) FROM onboarding_progress WHERE member_id = v_mid AND step_key IN (SELECT id FROM onboarding_steps)),
+      'completed', (SELECT count(*) FROM onboarding_progress WHERE member_id = v_mid AND step_key IN (SELECT id FROM onboarding_steps) AND status IN ('completed', 'skipped'))
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- (2) purge ghost legacy step-keys (see header)
+DELETE FROM public.onboarding_progress
+WHERE step_key IN ('accept_terms', 'profile_complete', 'platform_access', 'join_whatsapp', 'kick_off');
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
Closes #872. Secondary follow-up of #867. Deferred gamified-journey revival → #873.

## Problem
The pre-onboarding cockpit banner (`OnboardingCockpitNudge`, shown only to `operational_role='guest'`) rendered **"· 0/0 passos"** for the whole guest cohort. It read `get_candidate_onboarding_progress().pre_onboarding`, whose count is `metadata->>'phase'='pre_onboarding'`-based. That gamified path has been dead since **p155 F2 (2026-05-13)** consolidated onboarding onto the canonical `onboarding_steps` catalog — no current member carries a `phase='pre_onboarding'` row → `total` always 0.

## Changes
**`migration 20260805000244`**
- `get_candidate_onboarding_progress` gains an `onboarding` aggregate = the member's **own** canonical rows (`step_key IN onboarding_steps`), counting `completed+skipped` as done (mirrors `get_my_onboarding`). Read-only subquery (no auto-insert); `pre_onboarding` kept intact so the deferred #873 revival is unbroken.
- Purges 5 off-catalog ghost step-keys (`accept_terms, profile_complete, platform_access, join_whatsapp, kick_off`) — Cycle-3 w124/w130 seed residue. Footprint at apply: 31 members × 5 = **155 rows, all pending (0 completed/skipped)**, no live function dependency, do not regenerate.

**`OnboardingCockpitNudge.tsx`** — reads `data.onboarding` with a `total>0` guard. A volunteer guest now sees the real canonical count (e.g. **1/7**); an external-reviewer guest with no canonical rows (total 0) shows **no count** rather than a misleading 0/0.

## Live antes → depois (sample guest `31e3fdea`)
- `pre_onboarding {total:0}` → `onboarding {total:7, completed:1}`
- steps array: **12 → 7** (ghosts gone)
- ghost rows: **155 → 0**
- external reviewer (`f05570d1`) `onboarding {total:0}` → banner omits count

## Validation
- `npx astro build` clean. `rpc-migration-coverage` (Phase C body-drift) 22/22 — live body byte-matches the captured migration; stray apply-time auto-row removed (GC-097 ritual, ADR-0097).
- Full suite: only the **pre-existing, unrelated** `p276` LGPD leaderboard pool drift (78 vs 77) fails — `onboarding_progress` DELETE fires no triggers (all INSERT/UPDATE-only) and the leaderboard reads members/gamification, not onboarding. Flagged separately.

## Notes for review
- Migration is **already applied to prod** (apply via MCP; deploy.yml does not auto-apply migrations). This PR captures it for the record + ships the component read.
- The 2 zero-row guests are `external_reviewer` (cohort #300), **not** seeded with member onboarding (would be wrong for that cohort).
- code-reviewer pass: 0 blockers. Flagged a **pre-existing** IDOR on the `p_member_id` param path of this RPC (not introduced here; mitigated by the MCP EF gate) — raised to PM for separate, deliberate handling (public repo → no pre-fix exploit disclosure).