### PR TITLE
test(flake): harden p276 leaderboard pool check against two-round-trip race (#875)

### DIFF
--- a/tests/contracts/p276-bucket-a-lgpd-auth-hardening.test.mjs
+++ b/tests/contracts/p276-bucket-a-lgpd-auth-hardening.test.mjs
@@ -180,13 +180,23 @@ test('p276 DB: get_member_cycle_xp raises without auth', { skip: dbGated ? false
 
 test('p276 DB: get_public_leaderboard pool == active members with opt_out=false', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
-  const { data, error } = await sb.rpc('get_public_leaderboard', { p_limit: 1000 });
-  assert.ok(!error, `rpc should not error: ${error?.message}`);
-  const { count } = await sb
-    .from('members')
-    .select('id', { count: 'exact', head: true })
-    .eq('is_active', true)
-    .eq('current_cycle_active', true)
-    .eq('gamification_opt_out', false);
-  assert.equal((data || []).length, count, 'leaderboard must equal the opt-out-respecting active pool');
+  // get_public_leaderboard filters on (is_active AND current_cycle_active AND NOT gamification_opt_out),
+  // byte-identical to the pool query below. The leaderboard and the count are two separate round-trips,
+  // so a concurrent member mutation landing between them yields a transient ±1 — a real filter
+  // divergence persists, a race resolves. Retry to read both against a stable snapshot before asserting.
+  let lbLen = -1, count = -2;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const { data, error } = await sb.rpc('get_public_leaderboard', { p_limit: 1000 });
+    assert.ok(!error, `rpc should not error: ${error?.message}`);
+    const res = await sb
+      .from('members')
+      .select('id', { count: 'exact', head: true })
+      .eq('is_active', true)
+      .eq('current_cycle_active', true)
+      .eq('gamification_opt_out', false);
+    lbLen = (data || []).length;
+    count = res.count;
+    if (lbLen === count) break;
+  }
+  assert.equal(lbLen, count, 'leaderboard must equal the opt-out-respecting active pool');
 });


### PR DESCRIPTION
Closes #875. Test-only; no production change.

`get_public_leaderboard` already filters on `is_active AND current_cycle_active AND NOT gamification_opt_out` — byte-identical to the test's pool query (verified atomically in one query: leaderboard=77, pool=77, diff=0). The test's two reads are separate round-trips, so a concurrent member mutation between them yields a transient ±1 (observed 78 vs 77 in a local run; CI stays green as the race rarely hits).

Fix: retry the paired read up to 3×, break on agreement, then assert. A real filter divergence persists and still fails; a race resolves. Surfaced during #872 (handoff pt.20).