### PR TITLE
fix(comms): LinkedIn org-stats fetcher → /rest/ + Linkedin-Version (#859 Fase 1)

### DIFF
--- a/supabase/functions/sync-comms-metrics/index.ts
+++ b/supabase/functions/sync-comms-metrics/index.ts
@@ -291,10 +291,11 @@ async function fetchLinkedInMetrics(cfg: ChannelConfig): Promise<NormalizedMetri
     // The /rest/ organizationalEntityFollowerStatistics endpoint no longer
     // returns total follower counts (only demographic facets), so the total
     // comes from the dedicated networkSizes endpoint. The org URN is a path
-    // key here; the gateway accepts the literal colon form documented by LinkedIn.
+    // key here and MUST be URL-encoded — the raw colon form returns
+    // 400 ILLEGAL_ARGUMENT "Syntax exception in path variables".
     let followers: number | null = null
     const networkResp = await fetchWithRetry(
-      `https://api.linkedin.com/rest/networkSizes/${orgUrn}?edgeType=COMPANY_FOLLOWED_BY_MEMBER`,
+      `https://api.linkedin.com/rest/networkSizes/${encodeURIComponent(orgUrn)}?edgeType=COMPANY_FOLLOWED_BY_MEMBER`,
       { headers: liHeaders }
     )
     if (networkResp.ok) {

--- a/supabase/functions/sync-comms-metrics/index.ts
+++ b/supabase/functions/sync-comms-metrics/index.ts
@@ -50,6 +50,12 @@ type ChannelConfig = {
 const RUN_KEY_PREFIX = 'comms_metrics'
 const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000
 
+// LinkedIn Community Management API version (YYYYMM). The legacy /v2/ endpoints
+// were sunset; current org-statistics live under /rest/ and REQUIRE this header
+// alongside X-Restli-Protocol-Version: 2.0.0. Keep current — stale monikers 410.
+// Docs: learn.microsoft.com/linkedin/marketing/community-management/organizations
+const LINKEDIN_VERSION = '202606'
+
 function parseInteger(value: unknown): number | null {
   if (value === null || value === undefined || value === '') return null
   if (typeof value === 'number' && Number.isFinite(value)) return Math.trunc(value)
@@ -272,42 +278,66 @@ async function fetchLinkedInMetrics(cfg: ChannelConfig): Promise<NormalizedMetri
   const today = new Date().toISOString().slice(0, 10)
   const metrics: NormalizedMetric[] = []
 
-  try {
-    // Fetch follower count
-    const followersResp = await fetchWithRetry(
-      `https://api.linkedin.com/v2/organizationalEntityFollowerStatistics?q=organizationalEntity&organizationalEntity=${encodeURIComponent(orgUrn)}`,
-      { headers: { 'Authorization': `Bearer ${token}`, 'X-Restli-Protocol-Version': '2.0.0' } }
-    )
+  // Versioned Community Management API headers. /rest/ requires BOTH the
+  // LinkedIn-Version moniker and the Rest.li 2.0.0 protocol header.
+  const liHeaders = {
+    'Authorization': `Bearer ${token}`,
+    'LinkedIn-Version': LINKEDIN_VERSION,
+    'X-Restli-Protocol-Version': '2.0.0',
+  }
 
+  try {
+    // ── Follower count ──
+    // The /rest/ organizationalEntityFollowerStatistics endpoint no longer
+    // returns total follower counts (only demographic facets), so the total
+    // comes from the dedicated networkSizes endpoint. The org URN is a path
+    // key here; the gateway accepts the literal colon form documented by LinkedIn.
     let followers: number | null = null
-    if (followersResp.ok) {
-      const followersData = await followersResp.json()
-      const element = followersData?.elements?.[0]
-      if (element) {
-        followers = parseInteger(
-          (element.followerCounts?.organicFollowerCount || 0) +
-          (element.followerCounts?.paidFollowerCount || 0)
-        )
-      }
+    const networkResp = await fetchWithRetry(
+      `https://api.linkedin.com/rest/networkSizes/${orgUrn}?edgeType=COMPANY_FOLLOWED_BY_MEMBER`,
+      { headers: liHeaders }
+    )
+    if (networkResp.ok) {
+      const networkData = await networkResp.json()
+      followers = parseInteger(networkData?.firstDegreeSize)
+    } else {
+      console.warn(`LinkedIn networkSizes ${networkResp.status}: ${(await networkResp.text()).slice(0, 300)}`)
     }
 
-    // Fetch share statistics
+    // ── Lifetime share statistics (impressions, clicks, engagement) ──
     const shareResp = await fetchWithRetry(
-      `https://api.linkedin.com/v2/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=${encodeURIComponent(orgUrn)}`,
-      { headers: { 'Authorization': `Bearer ${token}`, 'X-Restli-Protocol-Version': '2.0.0' } }
+      `https://api.linkedin.com/rest/organizationalEntityShareStatistics?q=organizationalEntity&organizationalEntity=${encodeURIComponent(orgUrn)}`,
+      { headers: liHeaders }
     )
 
     let reach: number | null = null
     let engagement: number | null = null
+    let shareExtras: Record<string, unknown> = {}
     if (shareResp.ok) {
       const shareData = await shareResp.json()
       const totals = shareData?.elements?.[0]?.totalShareStatistics
       if (totals) {
         reach = parseInteger(totals.impressionCount)
-        const clicks = totals.clickCount || 0
-        const impressions = totals.impressionCount || 1
-        engagement = parseEngagement(clicks / impressions)
+        // LinkedIn supplies an official org engagement rate
+        // ((clicks+likes+comments+shares)/impressions). Use it when present,
+        // else fall back to clicks/impressions.
+        if (typeof totals.engagement === 'number') {
+          engagement = parseEngagement(totals.engagement)
+        } else {
+          const clicks = totals.clickCount || 0
+          const impressions = totals.impressionCount || 1
+          engagement = parseEngagement(clicks / impressions)
+        }
+        shareExtras = {
+          unique_impressions: parseInteger(totals.uniqueImpressionsCount),
+          clicks: parseInteger(totals.clickCount),
+          likes: parseInteger(totals.likeCount),
+          comments: parseInteger(totals.commentCount),
+          shares: parseInteger(totals.shareCount),
+        }
       }
+    } else {
+      console.warn(`LinkedIn shareStatistics ${shareResp.status}: ${(await shareResp.text()).slice(0, 300)}`)
     }
 
     metrics.push({
@@ -318,7 +348,12 @@ async function fetchLinkedInMetrics(cfg: ChannelConfig): Promise<NormalizedMetri
       engagement_rate: engagement,
       leads: null,
       source: 'api',
-      payload: { api: 'linkedin_org_stats' },
+      payload: {
+        api: 'linkedin_org_stats',
+        version: LINKEDIN_VERSION,
+        followers_source: 'networkSizes',
+        ...shareExtras,
+      },
     })
   } catch (e) {
     console.error('LinkedIn fetch error:', e)


### PR DESCRIPTION
Closes #859 (Fase 1 — analytics da página-organização). Fase 2 (publicar como org) registrada em #880.

## Contexto
A integração LinkedIn do `/admin/comms` **já estava codada e ligada** (EF `sync-comms-metrics` + cron diário `sync-comms-metrics-daily` 06:00 UTC + card no FE + storage RPC `admin_manage_comms_channel`). O bloqueio nunca foi build — era **credencial** (acesso Community Management API só aprovado 2026-06-24) **+ um bug de versão de endpoint** que este PR corrige.

## O bug corrigido
`fetchLinkedInMetrics()` chamava os endpoints **legados `/v2/...Statistics`** com `X-Restli-Protocol-Version: 2.0.0`. Pesquisa nos docs LinkedIn (2026, citada abaixo) confirma:
- Os `/v2/` foram **sunset**; a Community Management API atual serve sob **`/rest/`** e **exige** o header `Linkedin-Version` (YYYYMM) além do `X-Restli-Protocol-Version: 2.0.0`.
- `organizationalEntityFollowerStatistics` em `/rest/` **não retorna mais o total de followers** (só facetas demográficas) — o código lia exatamente `followerCounts.organicFollowerCount`, que viria nulo. O total agora vem do endpoint dedicado **`networkSizes`** (`firstDegreeSize`).

## Mudanças
- Constante `LINKEDIN_VERSION = '202606'`.
- **Followers** via `GET /rest/networkSizes/{orgUrn}?edgeType=COMPANY_FOLLOWED_BY_MEMBER`.
- **Reach + engagement** via `GET /rest/organizationalEntityShareStatistics` — usa o campo oficial `engagement` do LinkedIn (fallback `clicks/impressions`); guarda likes/comments/shares/clicks/unique_impressions no `payload`.
- Log dos corpos não-2xx para facilitar a verificação ao vivo via `get_logs`.

## Segurança / OAuth
3-legged é **obrigatório** (2-legged não existe para Marketing APIs; `rw_organization_admin` exige o membro ser ADMINISTRATOR da página). Token (60d) + `organization_urn` ficam em `comms_channel_config` (tabela RLS admin-only, mesmo padrão do Instagram). **Nenhum segredo neste PR/repo** (repo é público).

## Behavior-neutral até provisionar credencial
O fetcher retorna `[]` enquanto não houver `oauth_token` + `config.organization_urn` na linha `linkedin` de `comms_channel_config`. Logo, mergear este código sozinho **não muda comportamento em prod**.

## ⛔ Gate de merge (combinado com PM)
Merge **só após verificação ao vivo dos 2 lados** (lição #849): com o token real provisionado, a API `/rest/` retorna número correto de followers/reach **E** a linha `linkedin` aparece em `comms_metrics_daily` e renderiza no card. Provisionar config + deploy do EF + verificação acontecem ANTES do merge.

## Teste
- `npx astro build` ✓ (EF não é bundlado pelo Astro; build confirma o resto intacto)
- `node --test` nos 2 testes que tocam o EF (`ef-contracts`, `security-lgpd`): 155/155 ✓ (mantém `fetchWithRetry`+backoff, tabelas, import de cors, sem secrets hardcoded)

## Fontes (LinkedIn / Microsoft Learn, fetched 2026-06-24)
- follower-statistics / share-statistics / organization-lookup-api / networkSizes (community-management/organizations, view li-lms-2026-06)
- authorization-code-flow + client-credentials-flow (shared/authentication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
