### PR TITLE
fix(comms): drop escapable iframe sandbox on the calendar embed (#886b)

### DIFF
--- a/src/pages/admin/comms.astro
+++ b/src/pages/admin/comms.astro
@@ -201,10 +201,15 @@ const COMMS_I18N = {
             <p class="text-[var(--text-muted)] max-w-lg mx-auto">Pra exibir o calendário editorial: (1) tornar o Google Calendar institucional <code class="text-[.7rem] bg-[var(--surface-hover)] px-1 rounded">público</code> ou <code class="text-[.7rem] bg-[var(--surface-hover)] px-1 rounded">shared via link</code>, (2) copiar URL de "Integrar agenda" → "URL pública neste calendário", (3) update <code class="text-[.7rem] bg-[var(--surface-hover)] px-1 rounded">site_config.comms_calendar_embed_url</code> via SQL ou tool admin.</p>
             <p class="text-[10px] text-[var(--text-muted)] mt-3">Mantém workflow Comms team em GCal (source of truth); este painel é só visualização.</p>
           </div>
-          <!-- #886: sandbox is defense-in-depth — this PR is what first enables the iframe to load
-               (CSP frame-src 'none' -> calendar.google.com). allow-scripts+allow-same-origin render
-               the public Google Calendar embed; allow-popups opens event links in a new tab. -->
-          <iframe id="comms-calendar-iframe" class="hidden w-full" style="height: 500px; border: 0;" loading="lazy" sandbox="allow-scripts allow-same-origin allow-popups" title="Calendário Editorial Comms"></iframe>
+          <!-- #886b: deliberately NO sandbox. A public Google Calendar embed needs BOTH allow-scripts
+               AND allow-same-origin to render, and that exact pair is an ESCAPABLE sandbox — browsers
+               warn it "can escape its sandboxing", i.e. it gives false assurance plus console noise
+               while not actually isolating anything. The real, sufficient controls are:
+               CSP `frame-src https://calendar.google.com` (only Google Calendar can EVER be framed),
+               `frame-ancestors 'none'`, and the embed URL being superadmin-write-only (site_config RLS).
+               Do NOT re-add an allow-scripts+allow-same-origin sandbox here (re-introduces the warning
+               for zero security gain). -->
+          <iframe id="comms-calendar-iframe" class="hidden w-full" style="height: 500px; border: 0;" loading="lazy" title="Calendário Editorial Comms"></iframe>
         </div>
       </section>
 


### PR DESCRIPTION
Follow-up imediato do #886 (PR #887), levantado pelo PM no console de prod.

## Problema
`sandbox="allow-scripts allow-same-origin allow-popups"` (adicionado no #886) dispara o aviso do browser: *"An iframe which has both allow-scripts and allow-same-origin for its sandbox attribute can escape its sandboxing."* Um embed público do Google Calendar precisa dos **dois** tokens para renderizar → o sandbox era **autodestrutivo**: escapável (sem isolamento real) **e** barulhento no console.

## Correção
Remover o atributo `sandbox`. Os controles reais (suficientes p/ embed first-party confiável) ficam:
- CSP `frame-src https://calendar.google.com` — só o Google Calendar pode ser embedado;
- `frame-ancestors 'none'` + `X-Frame-Options: DENY` — guard de clickjacking;
- `src` do embed é **superadmin-write-only** (RLS `site_config`).

Comentário no código instrui a **não re-adicionar** o sandbox escapável.

## Contexto da validação ao vivo do #886
- ✅ Thumbnails do **YouTube** (`i.ytimg.com`) renderizando.
- As do **Instagram** ("Top Content") são **outra questão**, não regressão de CSP: 22/31 itens têm `thumbnail_url` NULL (Graph API só dá p/ vídeo) → placeholder; 9 usam URLs `cdninstagram` assinadas/expiráveis. Rastreado em **#889** (cachear no sync).

Refs #886, #889