### PR TITLE
fix(map): get_public_state_reach_v2 no longer throws on BR 2-letter UF codes

### DIFF
--- a/supabase/migrations/20260805000250_fix_state_reach_v2_br_lookup_collision.sql
+++ b/supabase/migrations/20260805000250_fix_state_reach_v2_br_lookup_collision.sql
@@ -1,0 +1,72 @@
+-- Fix: get_public_state_reach_v2() throws "more than one row returned by a subquery"
+-- when a consented member's members.state is a 2-letter UF code (e.g. 'go','ce') that
+-- collides with br_lookup's duplicate-code aliases (accented + unaccented names share a
+-- code: 'goiás'/'goias' both 'GO', 'ceará'/'ceara' both 'CE', etc. — 11 such codes).
+-- The scalar subquery WHERE l.code = upper(st_raw) then matches 2 rows and the whole
+-- function aborts, silently collapsing the ENTIRE state layer (incl. unrelated US states
+-- like VA that have >=3 opt-ins and should render). The ChaptersSection.astro fail-soft
+-- swallows the RPC error → stateReachV2=[] → no orange state pins at all.
+-- Guard each lookup with LIMIT 1: the code column is constant across the matched alias
+-- rows, so LIMIT 1 is deterministic and correct. Signature unchanged → CREATE OR REPLACE.
+-- Behavior-neutral for all other inputs (full state names, US codes — unique anyway).
+CREATE OR REPLACE FUNCTION public.get_public_state_reach_v2(p_min_k integer DEFAULT 3)
+ RETURNS TABLE(country_code text, region_code text, member_count bigint)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  WITH us_lookup(nm, code) AS (VALUES
+    ('alabama','AL'),('alaska','AK'),('arizona','AZ'),('arkansas','AR'),('california','CA'),
+    ('colorado','CO'),('connecticut','CT'),('delaware','DE'),('florida','FL'),('georgia','GA'),
+    ('hawaii','HI'),('idaho','ID'),('illinois','IL'),('indiana','IN'),('iowa','IA'),
+    ('kansas','KS'),('kentucky','KY'),('louisiana','LA'),('maine','ME'),('maryland','MD'),
+    ('massachusetts','MA'),('michigan','MI'),('minnesota','MN'),('mississippi','MS'),('missouri','MO'),
+    ('montana','MT'),('nebraska','NE'),('nevada','NV'),('new hampshire','NH'),('new jersey','NJ'),
+    ('new mexico','NM'),('new york','NY'),('north carolina','NC'),('north dakota','ND'),('ohio','OH'),
+    ('oklahoma','OK'),('oregon','OR'),('pennsylvania','PA'),('rhode island','RI'),('south carolina','SC'),
+    ('south dakota','SD'),('tennessee','TN'),('texas','TX'),('utah','UT'),('vermont','VT'),
+    ('virginia','VA'),('washington','WA'),('west virginia','WV'),('wisconsin','WI'),('wyoming','WY'),
+    ('district of columbia','DC')
+  ),
+  br_lookup(nm, code) AS (VALUES
+    ('acre','AC'),('alagoas','AL'),('amapá','AP'),('amapa','AP'),('amazonas','AM'),('bahia','BA'),
+    ('ceará','CE'),('ceara','CE'),('distrito federal','DF'),('espírito santo','ES'),('espirito santo','ES'),
+    ('goiás','GO'),('goias','GO'),('maranhão','MA'),('maranhao','MA'),('mato grosso','MT'),
+    ('mato grosso do sul','MS'),('minas gerais','MG'),('pará','PA'),('para','PA'),('paraíba','PB'),
+    ('paraiba','PB'),('paraná','PR'),('parana','PR'),('pernambuco','PE'),('piauí','PI'),('piaui','PI'),
+    ('rio de janeiro','RJ'),('rio grande do norte','RN'),('rio grande do sul','RS'),('rondônia','RO'),
+    ('rondonia','RO'),('roraima','RR'),('santa catarina','SC'),('são paulo','SP'),('sao paulo','SP'),
+    ('sergipe','SE'),('tocantins','TO')
+  ),
+  pop AS (
+    SELECT
+      CASE
+        WHEN lower(trim(m.country)) ~ 'bras|brazil' OR lower(trim(m.country)) = 'br' THEN 'BR'
+        WHEN lower(trim(m.country)) ~ 'estados unidos|united states|usa' OR lower(trim(m.country)) IN ('us','eua') THEN 'US'
+        ELSE NULL
+      END AS cc,
+      lower(btrim(m.state)) AS st_raw
+    FROM public.members m
+    WHERE m.is_active
+      AND m.current_cycle_active
+      AND NOT public.member_is_pre_onboarding(m.person_id, m.member_status)
+      AND m.allow_state_in_public_map
+  ),
+  resolved AS (
+    SELECT cc AS country_code,
+      CASE cc
+        WHEN 'US' THEN COALESCE((SELECT l.code FROM us_lookup l WHERE l.nm = pop.st_raw LIMIT 1),
+                                (SELECT l.code FROM us_lookup l WHERE l.code = upper(pop.st_raw) LIMIT 1))
+        WHEN 'BR' THEN COALESCE((SELECT l.code FROM br_lookup l WHERE l.nm = pop.st_raw LIMIT 1),
+                                (SELECT l.code FROM br_lookup l WHERE l.code = upper(pop.st_raw) LIMIT 1))
+      END AS region_code
+    FROM pop
+    WHERE cc IS NOT NULL
+  )
+  SELECT country_code, region_code, count(*)::bigint AS member_count
+  FROM resolved
+  WHERE region_code IS NOT NULL
+  GROUP BY country_code, region_code
+  HAVING count(*) >= GREATEST(p_min_k, 3)
+  ORDER BY member_count DESC, country_code, region_code;
+$function$;


### PR DESCRIPTION
## Bug (camada de estado do mapa-múndi público sumindo)

A camada laranja de pins por **estado** (BR UFs + US states) do mapa da home sumia inteira. Causa-raiz aterrada em produção:

`get_public_state_reach_v2()` **estourava** com `ERROR: more than one row returned by a subquery used as an expression` sempre que um membro consentido tinha `members.state` como **sigla de 2 letras** (hoje `go` e `ce`). O `br_lookup` tem **11 códigos com 2 aliases** (nome acentuado + sem acento compartilham o mesmo código: `goiás`/`goias`→GO, `ceará`/`ceara`→CE, …), então o subquery escalar `WHERE l.code = upper(st_raw)` casava **2 linhas** e a função inteira abortava.

O `ChaptersSection.astro` trata o erro da RPC como *fail-soft* silencioso (`stateReachV2=[]`), então **toda** a camada de estado desaparecia — inclusive **US-VA, que tem 3 opt-ins e deveria renderizar** (nada a ver com BR).

## Fix

Guarda cada subquery de lookup com `LIMIT 1`. A coluna `code` é constante entre as linhas-alias casadas, então `LIMIT 1` é determinístico e correto. Assinatura inalterada → `CREATE OR REPLACE`. Comportamento-neutro para nomes completos de estado e códigos US (já únicos).

## Verificação (ao vivo, produção)

- **Antes:** `get_public_state_reach_v2(3)` → throw (camada some).
- **Depois:** `get_public_state_reach_v2(3)` → `US / VA / 3` sem erro. ✅
- k-anon (`k≥3` via `GREATEST`) + gate opt-in (`allow_state_in_public_map`) + `SECURITY DEFINER` **preservados**.
- `rpc-migration-coverage` (Track Q-C + Phase C body-hash + ADR-0097) **todos ✔**
- `cycle4-coverage-map` (8 testes, incl. gate LGPD da migration) **todos ✔**
- `npx astro build` **limpo**

## Escopo

- **DB-only**: a DDL já foi aplicada ao DB remoto via `apply_migration` — **o fix já está LIVE em prod** (próxima renderização da home mostra a Virgínia). Nenhum frontend tocado.
- Este PR carrega só o **arquivo de migration** (`20260805000250`) para histórico/CI. Mergear é **comportamento-neutro** (o DB já está corrigido).
- Auto-row de apply-time (`20260626014349`) limpa do `schema_migrations`; linha de convenção `20260805000250` registrada com `has_body=true`.

## Notas (fora de escopo deste PR)

- **BR ainda não "desce"** mesmo pós-fix: cada estado BR consentido tem só **1** opt-in (`ce`/`rj`/`go`/`ms`), abaixo do piso `k≥3`. Não é bug — é k-anon + dado esparso. Para um estado BR aparecer precisa de ≥3 consentindo no mesmo estado.
- Bucket **"Internacional"** (PT=1 em ZZ): decisão de design/LGPD à parte — parecer do legal-counsel já levantado (Opção A continente k≥3 = CONFORME-COM-CONDIÇÕES; Opção B "Portugal: 1" = NÃO-CONFORME sob o consentimento atual). Tratado separadamente.