### PR TITLE
feat(map): UI for unified precise-location geo opt-in (PR-2/3)

### DIFF
--- a/src/components/sections/ChaptersSection.astro
+++ b/src/components/sections/ChaptersSection.astro
@@ -2,6 +2,7 @@
 import { t, type Lang } from '../../i18n/utils';
 import { createClient } from '@supabase/supabase-js';
 import { loadChapters } from '../../lib/chapters';
+import { CONTINENT_NAMES } from '../../lib/worldMap';
 import WorldReachMap from './WorldReachMap.astro';
 
 interface Props { lang?: Lang; }
@@ -17,33 +18,51 @@ const chapters = await loadChapters(sbAnon);
 // carregados ao vivo — nada hardcoded (fallback de chapters.ts cobre RPC indisponível).
 const activeCount = chapters.length;
 
-// R6 — Alcance internacional (legenda nomeada por país, ao vivo). get_public_country_reach()
-// agrega members.country (ISO-2) sobre a MESMA população de active_members ("pesquisadores
-// ativos"), então a soma das contagens bate com o denominador canônico. Zero-PII.
+// R6 — Alcance internacional + camadas do opt-in unificado de localização (parecer legal-counsel
+// 2026-06-25). get_public_country_reach() agrega members.country (ISO-2) k>=3; precise_country_reach
+// un-bucketiza quem consentiu exibição precisa (k=1); continent_reach decompõe o residual em
+// continentes (k>=3) + 'ZZ' (Internacional). Tudo zero-PII, MESMA população canônica de active_members.
 type CountryReach = { country_code: string; member_count: number };
+type StateReach = { country_code: string; region_code: string; member_count: number };
+type ContinentReach = { continent_code: string; member_count: number };
+
 let countryReach: CountryReach[] = [];
 try {
   const { data, error } = await sbAnon.rpc('get_public_country_reach');
   if (!error && Array.isArray(data)) countryReach = data as CountryReach[];
 } catch { /* legenda some se a RPC falhar — banda de capítulos segue íntegra */ }
 
-// Países NOMEADOS p/ a contagem "N países" — exclui o bucket k-anon 'ZZ'/'XX' ("Internacional"),
-// que não é um país e não deve inflar o número (ele aparece como chip 🌎 separado abaixo).
-const namedReach = countryReach.filter((c) => c.country_code !== 'ZZ' && c.country_code !== 'XX');
+// Países do opt-in PRECISO (k=1): non-BR/US que consentiram aparecer mesmo como único membro.
+let preciseCountryReach: CountryReach[] = [];
+try {
+  const { data, error } = await sbAnon.rpc('get_public_precise_country_reach');
+  if (!error && Array.isArray(data)) preciseCountryReach = data as CountryReach[];
+} catch { /* camada precise some se a RPC falhar */ }
+
+// Países NOMEADOS p/ a contagem "N países" — k>=3 nomeados (BR/US/…) + países do opt-in preciso (k=1).
+// Exclui 'ZZ'/'XX' ("Internacional"); o residual aparece como chips de continente abaixo.
+const namedReach = [
+  ...countryReach.filter((c) => c.country_code !== 'ZZ' && c.country_code !== 'XX'),
+  ...preciseCountryReach.filter((c) => c.country_code !== 'ZZ' && c.country_code !== 'XX'),
+];
 const reachCountries = namedReach.length;
 const reachMembers = namedReach.reduce((sum, c) => sum + Number(c.member_count || 0), 0);
 
-// PD-MAP-WORLD — pins por ESTADO (BR UFs + US states) de membros que autorizaram a exibição
-// (get_public_state_reach_v2: opt-in allow_state_in_public_map + supressão k>=3, parecer
-// legal-counsel 2026-06-23). Camada de detalhe sobre os pins de país; some sozinha enquanto
-// nenhum estado tem >=3 opt-ins. Zero-PII, mesma população canônica do country reach.
-type StateReachV2 = { country_code: string; region_code: string; member_count: number };
-let stateReachV2: StateReachV2[] = [];
+// PD-MAP-WORLD — pins por ESTADO (BR/US) via get_public_state_reach_v3: dual-população (k=1 preciso
+// + k>=3 agregado legado), nunca somadas abaixo de k (parecer 2026-06-25). Some sozinha enquanto vazia.
+let stateReach: StateReach[] = [];
 try {
-  const { data, error } = await sbAnon.rpc('get_public_state_reach_v2');
-  if (!error && Array.isArray(data)) stateReachV2 = data as StateReachV2[];
+  const { data, error } = await sbAnon.rpc('get_public_state_reach_v3');
+  if (!error && Array.isArray(data)) stateReach = data as StateReach[];
 } catch { /* a camada de estado some se a RPC falhar — os pins de país seguem íntegros */ }
-const hasStatePins = stateReachV2.length > 0;
+const hasStatePins = stateReach.length > 0;
+
+// Continente — residual não-consentido agrupado (k>=3) + 'ZZ' (Internacional). Substitui o chip ZZ plano.
+let continentReach: ContinentReach[] = [];
+try {
+  const { data, error } = await sbAnon.rpc('get_public_continent_reach');
+  if (!error && Array.isArray(data)) continentReach = data as ContinentReach[];
+} catch { /* camada de continente some se a RPC falhar */ }
 
 // Bandeira emoji a partir do ISO-3166-1 alpha-2 (regional indicator symbols).
 function flagEmoji(code: string): string {
@@ -67,7 +86,9 @@ function flagEmoji(code: string): string {
     <div class="mb-10">
       <WorldReachMap
         countryReach={countryReach}
-        stateReach={stateReachV2}
+        stateReach={stateReach}
+        preciseCountryReach={preciseCountryReach}
+        continentReach={continentReach}
         lang={lang}
         ariaLabel={t('chapters.worldMapAria', lang)}
       />
@@ -76,6 +97,12 @@ function flagEmoji(code: string): string {
           <span class="inline-block w-3 h-3 rounded-full" style="background:var(--color-teal)"></span>
           {t('chapters.mapLegendCountry', lang)}
         </span>
+        {continentReach.some((c) => c.continent_code !== 'ZZ' && c.continent_code !== 'XX') && (
+          <span class="inline-flex items-center gap-2">
+            <span class="inline-block w-3 h-3 rounded-full" style="background:var(--color-navy)"></span>
+            {t('chapters.mapLegendContinent', lang)}
+          </span>
+        )}
         {hasStatePins && (
           <span class="inline-flex items-center gap-2">
             <span class="inline-block w-3 h-3 rounded-full" style="background:var(--color-orange)"></span>
@@ -116,10 +143,17 @@ function flagEmoji(code: string): string {
           {' · '}{reachMembers} {t('chapters.reachMembersSuffix', lang)}
         </p>
         <div class="flex flex-wrap justify-center gap-3">
-          {countryReach.map((c) => (
+          {namedReach.map((c) => (
             <div class="bg-[var(--surface-card)] border border-[var(--border-subtle)] rounded-full pl-3 pr-4 py-1.5 flex items-center gap-2">
               <span class="text-lg leading-none" aria-hidden="true">{flagEmoji(c.country_code)}</span>
               <span class="text-sm font-bold text-[var(--text-primary)]">{t(`country.${c.country_code}`, lang)}</span>
+              <span class="text-sm font-semibold text-teal tabular-nums">{c.member_count}</span>
+            </div>
+          ))}
+          {continentReach.map((c) => (
+            <div class="bg-[var(--surface-card)] border border-[var(--border-subtle)] rounded-full pl-3 pr-4 py-1.5 flex items-center gap-2">
+              <span class="text-lg leading-none" aria-hidden="true">{c.continent_code === 'ZZ' || c.continent_code === 'XX' ? '🌎' : '🌍'}</span>
+              <span class="text-sm font-bold text-[var(--text-primary)]">{c.continent_code === 'ZZ' || c.continent_code === 'XX' ? t(`country.${c.continent_code}`, lang) : (CONTINENT_NAMES[c.continent_code] || c.continent_code)}</span>
               <span class="text-sm font-semibold text-teal tabular-nums">{c.member_count}</span>
             </div>
           ))}

--- a/src/components/sections/WorldReachMap.astro
+++ b/src/components/sections/WorldReachMap.astro
@@ -10,22 +10,26 @@ import { buildGeoPins, pinDiameter } from '../../lib/worldMap';
 interface Props {
   countryReach: Array<{ country_code: string; member_count: number | string }>;
   stateReach: Array<{ country_code: string; region_code: string; member_count: number | string }>;
+  preciseCountryReach?: Array<{ country_code: string; member_count: number | string }>;
+  continentReach?: Array<{ continent_code: string; member_count: number | string }>;
   lang: Lang;
   ariaLabel: string;
   class?: string;
 }
-const { countryReach, stateReach, lang, ariaLabel, class: className = '' } = Astro.props;
+const { countryReach, stateReach, preciseCountryReach = [], continentReach = [], lang, ariaLabel, class: className = '' } = Astro.props;
 
-const { pins } = buildGeoPins(countryReach ?? [], stateReach ?? []);
-// Larger country pins first (painted under), then smaller; state pins last so they sit on top.
+const { pins } = buildGeoPins(countryReach ?? [], stateReach ?? [], preciseCountryReach ?? [], continentReach ?? []);
+// Paint order (bottom → top): country, continent, then state on top. Larger pins first within a
+// kind so smaller ones sit on top and stay clickable.
+const paintOrder: Record<string, number> = { country: 0, continent: 1, state: 2 };
 const ordered = [...pins].sort((a, b) =>
-  a.kind === b.kind ? b.count - a.count : a.kind === 'country' ? -1 : 1,
+  paintOrder[a.kind] !== paintOrder[b.kind] ? paintOrder[a.kind] - paintOrder[b.kind] : b.count - a.count,
 );
 const countryName = (code: string) => t(`country.${code}`, lang);
 const pinLabel = (p: (typeof ordered)[number]) =>
-  p.kind === 'country'
-    ? `${countryName(p.countryCode)} · ${p.count}`
-    : `${p.regionName}, ${countryName(p.countryCode)} · ${p.count}`;
+  p.kind === 'country' ? `${countryName(p.countryCode)} · ${p.count}`
+  : p.kind === 'continent' ? `${p.regionName} · ${p.count}`
+  : `${p.regionName}, ${countryName(p.countryCode)} · ${p.count}`;
 ---
 
 <div class={`nia-worldmap ${className}`} role="img" aria-label={ariaLabel}>
@@ -97,6 +101,10 @@ const pinLabel = (p: (typeof ordered)[number]) =>
   }
   .nia-pin--country {
     background-color: var(--color-teal, #00799e);
+    z-index: 1;
+  }
+  .nia-pin--continent {
+    background-color: var(--color-navy, #1b3a5b);
     z-index: 1;
   }
   .nia-pin--state {

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -573,6 +573,8 @@ const enUS: Record<string, string> = {
   'profile.statePlaceholder': 'Select your state',
   'profile.countryPlaceholder': 'Select your country',
   'profile.allowStateMapLabel': 'I authorize including my state of residence in geographic distribution maps shown publicly on the Núcleo IA & GP platform. The data appears only in aggregate form (never individually). You may revoke this at any time.',
+  'profile.allowPreciseLocationMapLabel': 'I authorize the inclusion of my geographic location — state of residence (for members in Brazil and the United States) or country of residence (for members elsewhere) — in geographic distribution maps shown publicly on the Núcleo IA & GP platform. I understand that my state or country may be displayed even if I am the only member of this platform in that location, making my geographic origin identifiable within this community. I may revoke this authorization at any time in my profile settings.',
+  'profile.legacyStateMapNote': 'You authorized aggregate display of your state (minimum of 3 members). To appear even as the only member of your location, check the option above.',
   'profile.privacyDisclaimer': 'Address and phone are always used in the Volunteer Agreement. These options control only whether other members can see them on your public profile.',
   'profile.readPrivacyPolicy': 'Read Privacy Policy',
   'profile.gpManagedFields': '🔒 Email, chapter, role, and tribe are managed by GP.',
@@ -738,6 +740,7 @@ const enUS: Record<string, string> = {
   // World map (PD-MAP-WORLD — country pins + BR/US state pins for opted-in members)
   'chapters.worldMapAria': 'World map of active Núcleo researchers by country and state',
   'chapters.mapLegendCountry': 'Researchers by country',
+  'chapters.mapLegendContinent': 'Continents (grouped)',
   'chapters.mapLegendState': 'States with members who opted in',
   'chapters.mapStateNote': 'States with 3+ members who authorized displaying their state of residence (aggregate, never individual · LGPD). Already counted in the country total.',
   'chapters.activeLabel': 'active partners',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -573,6 +573,8 @@ const esLATAM: Record<string, string> = {
   'profile.statePlaceholder': 'Selecciona tu estado',
   'profile.countryPlaceholder': 'Selecciona tu país',
   'profile.allowStateMapLabel': 'Autorizo la inclusión de mi estado de residencia en mapas de distribución geográfica exhibidos públicamente en la plataforma Núcleo IA & GP. El dato aparecerá solo de forma agregada (nunca individual). Puedes revocar en cualquier momento.',
+  'profile.allowPreciseLocationMapLabel': 'Autorizo la inclusión de mi ubicación geográfica — estado de residencia (para miembros de Brasil y Estados Unidos) o país de residencia (para miembros de otros países) — en mapas de distribución geográfica exhibidos públicamente en la plataforma Núcleo IA & GP. Soy consciente de que mi estado o país podrá aparecer incluso si soy el único miembro de esta plataforma en esa ubicación, haciendo identificable mi origen geográfico en el contexto de esta comunidad. Puedo revocar esta autorización en cualquier momento en la configuración de mi perfil.',
+  'profile.legacyStateMapNote': 'Autorizaste la exhibición agregada de tu estado (mínimo de 3 miembros). Para aparecer incluso como único miembro de tu ubicación, marca la opción de arriba.',
   'profile.privacyDisclaimer': 'Dirección y teléfono se usan siempre en el Acuerdo de Voluntariado. Estas opciones controlan solo si otros miembros pueden verlos en tu perfil público.',
   'profile.readPrivacyPolicy': 'Leer Política de Privacidad',
   'profile.gpManagedFields': '🔒 Email, capítulo, rol y tribu son gestionados por el GP.',
@@ -738,6 +740,7 @@ const esLATAM: Record<string, string> = {
   // Mapa mundial (PD-MAP-WORLD — pines por país + estados BR/EUA de quien consintió)
   'chapters.worldMapAria': 'Mapa mundial de investigadores activos del Núcleo por país y estado',
   'chapters.mapLegendCountry': 'Investigadores por país',
+  'chapters.mapLegendContinent': 'Continentes (agrupado)',
   'chapters.mapLegendState': 'Estados con miembros que autorizaron mostrarlo',
   'chapters.mapStateNote': 'Estados con 3+ miembros que autorizaron mostrar su estado de residencia (agregado, nunca individual · LGPD). Ya contabilizados en el total del país.',
   'chapters.activeLabel': 'socios activos',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -573,6 +573,8 @@ const ptBR: Record<string, string> = {
   'profile.statePlaceholder': 'Selecione o estado',
   'profile.countryPlaceholder': 'Selecione o país',
   'profile.allowStateMapLabel': 'Autorizo a inclusão do meu estado de residência em mapas de distribuição geográfica exibidos publicamente na plataforma Núcleo IA & GP. O dado aparecerá apenas de forma agregada (nunca individual). Você pode revogar a qualquer momento.',
+  'profile.allowPreciseLocationMapLabel': 'Autorizo a inclusão da minha localização geográfica — estado de residência (para membros do Brasil e dos Estados Unidos) ou país de residência (para membros de outros países) — em mapas de distribuição geográfica exibidos publicamente na plataforma Núcleo IA & GP. Estou ciente de que meu estado ou país poderá aparecer mesmo que eu seja o único membro desta plataforma naquela localização, tornando minha origem geográfica identificável no contexto desta comunidade. Posso revogar esta autorização a qualquer momento nas configurações do meu perfil.',
+  'profile.legacyStateMapNote': 'Você autorizou a exibição agregada do seu estado (mínimo de 3 membros). Para aparecer mesmo como único membro da sua localização, marque a opção acima.',
   'profile.privacyDisclaimer': 'Endereço e telefone são sempre usados no Termo de Voluntariado. Essas opções controlam apenas se outros membros podem ver no seu perfil público.',
   'profile.readPrivacyPolicy': 'Ler Política de Privacidade',
   'profile.gpManagedFields': '🔒 Email, capítulo, papel e tribo são geridos pelo GP.',
@@ -738,6 +740,7 @@ const ptBR: Record<string, string> = {
   // Mapa-múndi (PD-MAP-WORLD — pins por país + estados BR/EUA de quem consentiu)
   'chapters.worldMapAria': 'Mapa-múndi com pesquisadores ativos do Núcleo por país e estado',
   'chapters.mapLegendCountry': 'Pesquisadores por país',
+  'chapters.mapLegendContinent': 'Continentes (agrupado)',
   'chapters.mapLegendState': 'Estados com membros que autorizaram exibição',
   'chapters.mapStateNote': 'Estados com 3+ membros que autorizaram a exibição do seu estado de residência (agregado, nunca individual · LGPD). Já contabilizados no total do país.',
   'chapters.activeLabel': 'parceiros ativos',

--- a/src/lib/worldMap.ts
+++ b/src/lib/worldMap.ts
@@ -78,11 +78,27 @@ export const REGION_NAMES: Record<string, string> = {
   _AL: 'Alagoas',
 };
 
+// Continent centroids (lat, lon) for the residual continent pins (k>=3 per continent, from
+// get_public_continent_reach). 'ZZ' (Internacional) has no single location → legend chip only,
+// never a pin. Codes match the SQL continent mapping (EU/SA/NA + AF reserved for the future).
+export const CONTINENT_CENTROIDS: Record<string, [number, number]> = {
+  EU: [50.0, 10.0],   // central Europe
+  SA: [-15.0, -60.0], // central South America
+  NA: [58.0, -100.0], // central Canada (residual NA is non-US/BR → sits north of the US country pin)
+  AF: [2.0, 20.0],    // central Africa (reserved)
+};
+
+// Continent display names (pt-BR proper nouns; recognizable across locales), mirroring REGION_NAMES.
+// Kept out of the i18n dicts. 'ZZ' = the Internacional bucket label for the legend chip.
+export const CONTINENT_NAMES: Record<string, string> = {
+  EU: 'Europa', SA: 'América do Sul', NA: 'América do Norte', AF: 'África', ZZ: 'Internacional',
+};
+
 export interface GeoPin {
-  kind: 'country' | 'state';
-  code: string;            // 'BR' / 'US-VA' / 'BR-SP'
-  countryCode: string;     // 'BR' / 'US'
-  regionName?: string;     // 'Virgínia' (state pins only)
+  kind: 'country' | 'state' | 'continent';
+  code: string;            // 'BR' / 'US-VA' / 'BR-SP' / 'EU'
+  countryCode: string;     // 'BR' / 'US' (continent pins: the continent code)
+  regionName?: string;     // 'Virgínia' (state pins) / 'Europa' (continent pins)
   count: number;
   leftPct: number;
   topPct: number;
@@ -96,27 +112,47 @@ function regionName(countryCode: string, region: string): string {
 }
 
 /**
- * Build the placeable pin list from the two zero-PII RPC payloads. Country pins come from
- * get_public_country_reach (k-anon, ZZ excluded → legend), state pins from
- * get_public_state_reach_v2 (consented + k≥3). Off-window or unknown-centroid rows are returned as
- * pins-skipped (skippedCountries/skippedStates); a skipped STATE's members still count in that
- * country's pin (country layer covers all active members), so no member is dropped from a total.
+ * Build the placeable pin list from the zero-PII RPC payloads (unified geo opt-in model,
+ * legal-counsel parecer 2026-06-25). Four layers, painted in order:
+ *  - countryReach (get_public_country_reach): named countries k>=3 (BR/US + any >=3) → country pins;
+ *    'ZZ'/'XX' excluded (the Internacional bucket is a legend chip, surfaced via continentReach).
+ *  - preciseCountryReach (get_public_precise_country_reach): non-BR/US countries with >=1 member who
+ *    consented to precise (k=1) display → country pins; deduped against named countries.
+ *  - stateReach (get_public_state_reach_v3): BR/US states, dual-population (k=1 precise + k>=3 aggregate).
+ *  - continentReach (get_public_continent_reach): the residual grouped by continent (k>=3) → continent
+ *    pins; the 'ZZ' row carries no centroid and is returned to the caller as the Internacional chip.
+ * Off-window or unknown-centroid rows are returned as pins-skipped; their members still count in a
+ * coarser layer, so no member is dropped from a total.
  */
 export function buildGeoPins(
   countryReach: Array<{ country_code: string; member_count: number | string }>,
   stateReach: Array<{ country_code: string; region_code: string; member_count: number | string }>,
-): { pins: GeoPin[]; skippedCountries: string[]; skippedStates: string[] } {
+  preciseCountryReach: Array<{ country_code: string; member_count: number | string }> = [],
+  continentReach: Array<{ continent_code: string; member_count: number | string }> = [],
+): { pins: GeoPin[]; skippedCountries: string[]; skippedStates: string[]; skippedContinents: string[] } {
   const pins: GeoPin[] = [];
   const skippedCountries: string[] = [];
   const skippedStates: string[] = [];
+  const skippedContinents: string[] = [];
+  const seenCountry = new Set<string>();
+
+  const pushCountry = (code: string, count: number) => {
+    if (seenCountry.has(code)) return;
+    const centroid = COUNTRY_CENTROIDS[code];
+    if (!centroid || !isInWindow(centroid[0], centroid[1])) { skippedCountries.push(code); return; }
+    const { leftPct, topPct } = projectToWindow(centroid[0], centroid[1]);
+    pins.push({ kind: 'country', code, countryCode: code, count, leftPct, topPct });
+    seenCountry.add(code);
+  };
 
   for (const c of countryReach) {
-    const code = c.country_code;
-    if (code === 'ZZ' || code === 'XX') continue; // intl bucket → legend chip, not a pin
-    const centroid = COUNTRY_CENTROIDS[code];
-    if (!centroid || !isInWindow(centroid[0], centroid[1])) { skippedCountries.push(code); continue; }
-    const { leftPct, topPct } = projectToWindow(centroid[0], centroid[1]);
-    pins.push({ kind: 'country', code, countryCode: code, count: Number(c.member_count || 0), leftPct, topPct });
+    if (c.country_code === 'ZZ' || c.country_code === 'XX') continue; // intl bucket → continentReach/chip
+    pushCountry(c.country_code, Number(c.member_count || 0));
+  }
+  // Precise (k=1) consented countries — un-bucket the member from ZZ into a named country pin.
+  for (const c of preciseCountryReach) {
+    if (c.country_code === 'ZZ' || c.country_code === 'XX') continue;
+    pushCountry(c.country_code, Number(c.member_count || 0));
   }
 
   for (const s of stateReach) {
@@ -128,12 +164,25 @@ export function buildGeoPins(
       regionName: regionName(s.country_code, s.region_code), count: Number(s.member_count || 0), leftPct, topPct,
     });
   }
-  return { pins, skippedCountries, skippedStates };
+
+  for (const ct of continentReach) {
+    const code = ct.continent_code;
+    if (code === 'ZZ' || code === 'XX') continue; // Internacional → legend chip, not a pin
+    const centroid = CONTINENT_CENTROIDS[code];
+    if (!centroid || !isInWindow(centroid[0], centroid[1])) { skippedContinents.push(code); continue; }
+    const { leftPct, topPct } = projectToWindow(centroid[0], centroid[1]);
+    pins.push({
+      kind: 'continent', code, countryCode: code,
+      regionName: CONTINENT_NAMES[code] || code, count: Number(ct.member_count || 0), leftPct, topPct,
+    });
+  }
+
+  return { pins, skippedCountries, skippedStates, skippedContinents };
 }
 
-/** Pin diameter in px from member count (sqrt scale; country pins larger than state pins). */
-export function pinDiameter(kind: 'country' | 'state', count: number): number {
-  const base = kind === 'country' ? 20 : 15;
-  const k = kind === 'country' ? 4.2 : 2.6;
+/** Pin diameter in px from member count (sqrt scale; country/continent pins larger than state pins). */
+export function pinDiameter(kind: 'country' | 'state' | 'continent', count: number): number {
+  const base = kind === 'state' ? 15 : 20;
+  const k = kind === 'state' ? 2.6 : 4.2;
   return Math.round(base + k * Math.sqrt(Math.max(count, 1)));
 }

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -212,6 +212,8 @@ const PROFILE_I18N = {
   statePlaceholder: t('profile.statePlaceholder', lang),
   countryPlaceholder: t('profile.countryPlaceholder', lang),
   allowStateMapLabel: t('profile.allowStateMapLabel', lang),
+  allowPreciseLocationMapLabel: t('profile.allowPreciseLocationMapLabel', lang),
+  legacyStateMapNote: t('profile.legacyStateMapNote', lang),
   privacyDisclaimer: t('profile.privacyDisclaimer', lang),
   readPrivacyPolicy: t('profile.readPrivacyPolicy', lang),
   gpManagedFields: t('profile.gpManagedFields', lang),
@@ -1829,9 +1831,16 @@ const PROFILE_I18N = {
               <span class="text-[.78rem] text-[var(--text-primary)]">${PROFILE_I18N.shareBirthDateLabel}</span>
             </label>
             <label class="flex items-start gap-2 cursor-pointer">
-              <input type="checkbox" id="self-allow-state-map" class="mt-0.5" ${m.allow_state_in_public_map ? 'checked' : ''}>
+              <input type="checkbox" id="self-allow-precise-map" class="mt-0.5" ${m.allow_precise_location_in_public_map ? 'checked' : ''}>
+              <span class="text-[.78rem] text-[var(--text-primary)]">${PROFILE_I18N.allowPreciseLocationMapLabel}</span>
+            </label>
+            ${m.allow_state_in_public_map ? `
+            <label class="flex items-start gap-2 cursor-pointer">
+              <input type="checkbox" id="self-allow-state-map" class="mt-0.5" checked>
               <span class="text-[.78rem] text-[var(--text-primary)]">${PROFILE_I18N.allowStateMapLabel}</span>
             </label>
+            ${!m.allow_precise_location_in_public_map ? `<p class="text-[.65rem] text-[var(--text-muted)] pl-6 -mt-1">${PROFILE_I18N.legacyStateMapNote}</p>` : ''}
+            ` : ''}
           </div>
           <p class="text-[.65rem] text-[var(--text-muted)] mt-3">
             ${PROFILE_I18N.privacyDisclaimer}
@@ -2229,9 +2238,13 @@ const PROFILE_I18N = {
     if (shareAddress !== (currentMember.share_address ?? false)) fields.share_address = shareAddress;
     const shareBirthDate = (document.getElementById('self-share-birth-date') as HTMLInputElement)?.checked ?? false;
     if (shareBirthDate !== (currentMember.share_birth_date ?? false)) fields.share_birth_date = shareBirthDate;
-    // PD-MAP: consentimento p/ heatmap público por estado (opt-in, revogável)
+    // PD-MAP: consentimento legado p/ heatmap público por estado agregado (k>=3, opt-in, revogável).
+    // Checkbox só renderiza para quem já o tem (os grandfathered); novos membros usam o toggle preciso abaixo.
     const allowStateMap = (document.getElementById('self-allow-state-map') as HTMLInputElement)?.checked ?? false;
     if (allowStateMap !== (currentMember.allow_state_in_public_map ?? false)) fields.allow_state_in_public_map = allowStateMap;
+    // PD-MAP unified opt-in: localização precisa (estado BR/US ou país) mesmo a k=1 (parecer 2026-06-25).
+    const allowPreciseMap = (document.getElementById('self-allow-precise-map') as HTMLInputElement)?.checked ?? false;
+    if (allowPreciseMap !== (currentMember.allow_precise_location_in_public_map ?? false)) fields.allow_precise_location_in_public_map = allowPreciseMap;
 
     let data: any;
     if (Object.keys(fields).length > 0) {

--- a/tests/contracts/cycle4-coverage-map.test.mjs
+++ b/tests/contracts/cycle4-coverage-map.test.mjs
@@ -81,11 +81,15 @@ test('PD-MAP-WORLD: ChaptersSection feeds the map LIVE from both RPCs (anti-hard
   assert.ok(body, 'ChaptersSection.astro present');
   assert.match(body, /import WorldReachMap/, 'mounts the WorldReachMap');
   assert.match(body, /get_public_country_reach/, 'fetches the country-reach RPC');
-  assert.match(body, /get_public_state_reach_v2/, 'fetches the state-reach v2 RPC');
+  assert.match(body, /get_public_state_reach_v3/, 'fetches the state-reach v3 RPC (dual-population)');
+  assert.match(body, /get_public_precise_country_reach/, 'fetches the precise (k=1) country-reach RPC');
+  assert.match(body, /get_public_continent_reach/, 'fetches the continent-reach RPC (residual)');
   assert.match(body, /countryReach=\{countryReach\}/, 'passes country reach to the map');
-  assert.match(body, /stateReach=\{stateReachV2\}/, 'passes state reach to the map');
+  assert.match(body, /stateReach=\{stateReach\}/, 'passes state reach to the map');
+  assert.match(body, /preciseCountryReach=\{preciseCountryReach\}/, 'passes precise country reach to the map');
+  assert.match(body, /continentReach=\{continentReach\}/, 'passes continent reach to the map');
   // no hardcoded UF/country→count literal feeding the map
-  assert.doesNotMatch(body, /stateReachV2\s*=\s*\[\s*\{/, 'stateReachV2 is not a hardcoded literal');
+  assert.doesNotMatch(body, /stateReach\s*=\s*\[\s*\{/, 'stateReach is not a hardcoded literal');
 });
 
 test('PD-MAP-WORLD: the land asset exists, is CC0-noted, and keeps the Atlantic crop viewBox', () => {


### PR DESCRIPTION
PR-2 de 3 (backend #894 ✅ → **UI (este)** → governança). Liga as RPCs do PR-1 ao mapa público + perfil. **Behavior-neutral hoje** (0 consentidores precise: `state_v3==v2`, precise vazio, continente == ZZ plano); as camadas novas acendem conforme membros consentem.

## Perfil (`/profile`)
- **Novo toggle** `allow_precise_location_in_public_map` com o texto aprovado pelo legal-counsel (3 idiomas): estado (BR/US) **ou** país (demais) exibido **mesmo a k=1** ("mesmo que eu seja o único"). Persistido via `update_my_profile`.
- O checkbox legado `allow_state_in_public_map` agora **só renderiza para quem já o tem** (os 7 grandfathered) — para poderem **revogar** (LGPD Art. 18) — + uma **nota** apontando o toggle novo pra fazer upgrade. Novos membros veem só o toggle novo.

## Mapa (home — `ChaptersSection` / `WorldReachMap` / `worldMap.ts`)
- Estado v2 → **v3** (dual-população) + 2 camadas novas: **pins de país preciso** (k=1, não-BR/US consentidos) + **pins de continente** (residual, k≥3), com a linha `'ZZ'` seguindo como chip "Internacional".
- Continentes como **pin (navy, no centroide) E chip** (escolha do PM). `buildGeoPins` ganha `preciseCountryReach` + `continentReach` + a kind `'continent'`; dedup precise vs nomeado.
- Contador "N países" agora inclui países do opt-in preciso.
- i18n novo (3 dicts): `profile.allowPreciseLocationMapLabel`, `profile.legacyStateMapNote`, `chapters.mapLegendContinent`. Nomes de continente em `worldMap.ts` (`CONTINENT_NAMES`, espelha o padrão REGION_NAMES fora do i18n).

## Verificação
- `astro build` limpo · `cycle4-coverage-map` **8/8** (atualizado pros novos RPCs/props, segue anti-hardcode) · i18n **29/29** · 3 chaves novas presentes nos 3 dicts.
- Branch da **main limpa** (pós #893/#894). Sem merge sem teu "vai".

## Falta (PR-3)
RoPA seção **H.2** (atualizar população dupla) + **H.4** (nova, Art. 7,I) + 1 parágrafo no `/privacy` (até 26/jul).