### PR TITLE
feat(map): always-show map legend note explaining all location levels

### DIFF
--- a/src/components/sections/ChaptersSection.astro
+++ b/src/components/sections/ChaptersSection.astro
@@ -110,11 +110,12 @@ function flagEmoji(code: string): string {
           </span>
         )}
       </div>
-      {hasStatePins && (
-        <p class="text-[.7rem] text-[var(--text-muted)] mt-2 max-w-[520px] mx-auto">
-          {t('chapters.mapStateNote', lang)}
-        </p>
-      )}
+      {/* Always-shown note: explains all map levels (country aggregate · state/country by opt-in,
+          aggregate min-3 OR precise k=1 · continent residual) so the model is discoverable even
+          when the precise/continent layers currently have no data. */}
+      <p class="text-[.7rem] text-[var(--text-muted)] mt-2 max-w-[520px] mx-auto">
+        {t('chapters.mapNote', lang)}
+      </p>
     </div>
 
     <div class="flex flex-wrap justify-center gap-4 mb-8">

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -742,7 +742,7 @@ const enUS: Record<string, string> = {
   'chapters.mapLegendCountry': 'Researchers by country',
   'chapters.mapLegendContinent': 'Continents (grouped)',
   'chapters.mapLegendState': 'States with members who opted in',
-  'chapters.mapStateNote': 'States with 3+ members who authorized displaying their state of residence (aggregate, never individual · LGPD). Already counted in the country total.',
+  'chapters.mapNote': 'The map shows where the Núcleo is present, by country (aggregate count, min. 3 members). Each member may authorize displaying their state (Brazil/USA) or country of residence — aggregated (min. 3) or precise, even as the only one in their location — under Settings → Profile. The rest is grouped by continent. No individual location appears without authorization (LGPD).',
   'chapters.activeLabel': 'active partners',
   'chapters.onboardingLabel': 'onboarding',
   'chapters.goal': 'Union announced at CBGPL 2026 — PMI Brazil chapters in progressive integration',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -742,7 +742,7 @@ const esLATAM: Record<string, string> = {
   'chapters.mapLegendCountry': 'Investigadores por país',
   'chapters.mapLegendContinent': 'Continentes (agrupado)',
   'chapters.mapLegendState': 'Estados con miembros que autorizaron mostrarlo',
-  'chapters.mapStateNote': 'Estados con 3+ miembros que autorizaron mostrar su estado de residencia (agregado, nunca individual · LGPD). Ya contabilizados en el total del país.',
+  'chapters.mapNote': 'El mapa muestra la presencia de Núcleo por país (conteo agregado, mín. 3 miembros). Cada miembro puede autorizar mostrar su estado (Brasil/EUA) o país de residencia — de forma agregada (mín. 3) o precisa, incluso siendo el único de su ubicación — en Configuración → Perfil. El resto se agrupa por continente. Ninguna ubicación individual aparece sin autorización (LGPD).',
   'chapters.activeLabel': 'socios activos',
   'chapters.onboardingLabel': 'en integración',
   'chapters.goal': 'Unión anunciada en CBGPL 2026 — capítulos PMI Brasil en integración progresiva',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -742,7 +742,7 @@ const ptBR: Record<string, string> = {
   'chapters.mapLegendCountry': 'Pesquisadores por país',
   'chapters.mapLegendContinent': 'Continentes (agrupado)',
   'chapters.mapLegendState': 'Estados com membros que autorizaram exibição',
-  'chapters.mapStateNote': 'Estados com 3+ membros que autorizaram a exibição do seu estado de residência (agregado, nunca individual · LGPD). Já contabilizados no total do país.',
+  'chapters.mapNote': 'O mapa mostra a presença do Núcleo por país (contagem agregada, mín. 3 membros). Cada membro pode autorizar exibir seu estado (Brasil/EUA) ou país de residência — de forma agregada (mín. 3) ou precisa, mesmo sendo o único da sua localização — em Configurações → Perfil. O restante é agrupado por continente. Nenhuma localização individual aparece sem autorização (LGPD).',
   'chapters.activeLabel': 'parceiros ativos',
   'chapters.onboardingLabel': 'em integração',
   'chapters.goal': 'União anunciada no CBGPL 2026 — capítulos PMI Brasil em integração progressiva',

--- a/tests/contracts/cycle4-coverage-map.test.mjs
+++ b/tests/contracts/cycle4-coverage-map.test.mjs
@@ -114,7 +114,7 @@ test('PD-MAP-WORLD: state-reach v2 migration carries the LGPD gates (opt-in + kâ
 });
 
 test('PD-MAP-WORLD: coverage-map i18n keys exist in all 3 dictionaries', () => {
-  const keys = ['chapters.worldMapAria', 'chapters.mapLegendCountry', 'chapters.mapLegendState', 'chapters.mapStateNote'];
+  const keys = ['chapters.worldMapAria', 'chapters.mapLegendCountry', 'chapters.mapLegendState', 'chapters.mapLegendContinent', 'chapters.mapNote'];
   for (const dict of ['pt-BR', 'en-US', 'es-LATAM']) {
     const body = read(`src/i18n/${dict}.ts`);
     assert.ok(body, `${dict} dictionary present`);


### PR DESCRIPTION
Follow-up to PR-3 (#898). The homepage map note was gated on `hasStatePins` and described only the legacy aggregate state layer. Now always visible and rewritten to explain the full model — country aggregate (min 3) · state/country by member opt-in (aggregate min-3 **or** precise k=1) · continent grouping — so the precise-location capability is discoverable even while those layers have no data yet (0 precise opt-ins today).

- `chapters.mapStateNote` → `chapters.mapNote` (3 dicts) + ungated the `<p>` in ChaptersSection.
- Updated `cycle4-coverage-map` contract to the new key + added `chapters.mapLegendContinent`.

Cosmetic/copy only; no RPC or data change. `astro build` green; `npm test` 4200 pass / 0 fail.