### PR TITLE
fix(map): continent_reach keeps unmapped-country (XX) members in the residual (#897)

### DIFF
--- a/docs/audit/LGPD_ROPA_PUBLIC_SURFACES.md
+++ b/docs/audit/LGPD_ROPA_PUBLIC_SURFACES.md
@@ -452,13 +452,13 @@ individual por consentimento explícito.
 | **Base legal** | **Art. 7, IX (legítimo interesse)** — **sem novo consentimento**: agrega o residual com piso de anonimato (mesma base de H.1). |
 | **Teste de balanceamento (Art. 10, §2º)** | Idêntico a H.1: interesse legítimo em comunicar o alcance continental; impacto mínimo (output agregado k≥3, sem singularização); **o interesse prevalece**. |
 | **Finalidade** | Pin de continente (navy, no centroide) + chip de legenda para o residual; bucket `ZZ` (Internacional) para o resto. |
-| **Output** | `(continent_code, member_count)` agrupado por continente quando ≥3, senão colapsado em `ZZ`. **Exclui**: BR/US (pin nomeado), países com total ≥3 (pin nomeado), e precise-consententes (já exibidos em H.3) — **sem double-count**. |
-| **k-anonimato** | **k≥3 por continente**; abaixo disso → `ZZ`. `ZZ` é chip de legenda, nunca pin. |
+| **Output** | `(continent_code, member_count)` agrupado por continente quando ≥3, senão colapsado em `ZZ`. **Exclui**: BR/US (pin nomeado) e, **entre os países reconhecidos**, os com total ≥3 (pin nomeado) e os precise-consententes (já exibidos em H.3) — **sem double-count**. O bucket sintético `XX` (países não-mapeados) **nunca** é excluído — não vira pin nomeado nem preciso (sem centroide), então todo membro `XX` permanece no residual → `ZZ` (fix #897, mig `…253`). |
+| **k-anonimato** | **k≥3 por continente nomeado** (EU/SA/NA); abaixo disso → `ZZ`. O bucket residual `ZZ` (Internacional) **não tem piso próprio** — é o catch-all de todo membro cujo continente não atingiu k=3 **ou** cujo país é não-mapeado (`XX`); pode portanto exibir `count` < 3 (já era assim em H.1 antes do mapa). Não singulariza país nem indivíduo: revela só "existem ≥N membros fora dos pins nomeados". `ZZ` é chip de legenda, nunca pin. |
 | **Titulares** | Membros ativos (processados; output sem localização individual — apenas agregado continental k≥3). |
 | **Transferência internacional** | Igual a H.1. |
 | **Retenção** | N/A (derivado ao vivo de `members`). |
-| **Medidas técnicas (Art. 46)** | SECURITY DEFINER, STABLE, `search_path=''`; exclui precise-consententes para não double-contar; k≥3 por continente. ACL REVOKE-PUBLIC alinhada (mig `…252`, PR-3). |
-| **Migration** | `20260805000251` |
+| **Medidas técnicas (Art. 46)** | SECURITY DEFINER, STABLE, `search_path=''`; exclui precise-consententes **de países reconhecidos** para não double-contar; **`XX` (não-mapeado) sempre mantido no residual** (#897, mig `…253`); k≥3 por continente. ACL REVOKE-PUBLIC alinhada (mig `…252`, PR-3). |
+| **Migration** | `20260805000251` (criação) · `20260805000253` (fix #897 — `XX` sempre no residual) |
 
 ### H.5 `get_public_state_reach_v2(p_min_k)` + `get_public_state_reach()` — legados (deprecados)
 
@@ -510,16 +510,23 @@ individual por consentimento explícito.
   PR-3** via `REVOKE ALL ... FROM PUBLIC` + `GRANT EXECUTE` só a
   anon/authenticated/service_role (mig `…252`) — verificado ao vivo (antes:
   `=X/postgres` presente; depois: ausente).
-- **Bug latente (0 consenters hoje) — precise-consenter em país não-suportado some
-  do mapa**: `get_public_precise_country_reach` reconhece só 8 países (PT, IT, ES,
-  AR, GB, CA, FR, DE); um membro com `allow_precise=true` em país fora dessa lista
-  (a) não recebe pin preciso (H.3, `ELSE NULL`) **e** (b) é excluído do residual de
-  continente (H.4, `AND NOT n.is_precise`) ⇒ desaparece das duas camadas. Hoje é
-  **behavior-neutral** (0 precise-consenters), mas viola a expectativa do
-  consentimento. O texto de `/privacy` foi redigido para **não** prometer cobertura
-  universal ("para os países suportados pela plataforma"). **Follow-up (#897):**
-  ampliar a lista de países OU não excluir do residual o precise-consenter de país
-  não-reconhecido.
+- **precise-consenter em país não-suportado some do mapa — ✅ RESOLVIDO (#897, mig
+  `…253`, 2026-06-26)**: `get_public_precise_country_reach` reconhece só 8 países
+  (PT, IT, ES, AR, GB, CA, FR, DE); um membro com `allow_precise=true` em país fora
+  dessa lista não recebe pin preciso (H.3, `ELSE NULL`). O bug: `get_public_continent_reach`
+  o excluía **também** do residual (`AND NOT n.is_precise`) ⇒ sumia das duas camadas
+  — pior que não consentir (um não-consenter no mesmo país ainda cairia no `ZZ`).
+  **Buraco-irmão descoberto no fix:** o filtro `ct.total<3` também era aplicado ao
+  bucket sintético `XX`, derrubando **qualquer** conjunto de ≥3 membros espalhados
+  por países não-mapeados (mesmo não-precise), já que `XX` nunca vira pin nomeado
+  (`get_public_country_reach` sempre dobra `XX`→`ZZ`). **Fix:** `XX` bypassa **ambos**
+  os filtros e permanece sempre no residual → chip `ZZ` (mesma exposição agregada
+  Art. 7,IX que um não-consenter já tem; **menos** do que o precise-consenter
+  autorizou). Behavior-neutral hoje (0 precise / 0 `XX`); provado por simulação no
+  engine PG (predicado antigo: `ZZ`=1, 5 membros sumindo; predicado novo: `ZZ`=6,
+  todos presentes). **Opção 1** (pin preciso para países arbitrários — exige
+  centroides novos em `worldMap.ts` + asset) fica como enhancement separado, fora
+  deste fix. Guard em `cycle4-coverage-map.test.mjs`.
 
 ---
 
@@ -587,6 +594,7 @@ documentando:
 - `20260805000250_fix_state_reach_v2_br_lookup_collision.sql` — fix `LIMIT 1` da colisão `br_lookup` (#893; reaproveitado pela v3)
 - `20260805000251_precise_location_optin_backend.sql` — coluna `allow_precise_location_in_public_map` + `get_public_state_reach_v3` (dual-população) + `get_public_precise_country_reach` + `get_public_continent_reach` (seções H.2/H.3/H.4; PR #894)
 - `20260805000252_revoke_public_precise_reach_funcs.sql` — alinha ACL das 3 funções novas (H.2/H.3/H.4) ao padrão `REVOKE ALL FROM PUBLIC` + `GRANT EXECUTE` a anon/authenticated/service_role; corrige o cross-ref do COMMENT da coluna (`RoPA H.4` → `H.2/H.3`); PR-3
+- `20260805000253_fix_continent_reach_unmapped_country_vanish_897.sql` — `get_public_continent_reach` (H.4): `XX` (países não-mapeados) sempre mantido no residual → não some do mapa; fecha #897 (precise-consenter em país não-suportado) + o buraco-irmão `XX`≥3; behavior-neutral (0 precise/0 `XX` hoje)
 
 **Trilha imutável**: GitHub commits assinados (`2ff39e8`, `ca072c8`; mapa precise: `d6dfe5c0`, `0c6404a6`).
 

--- a/supabase/migrations/20260805000253_fix_continent_reach_unmapped_country_vanish_897.sql
+++ b/supabase/migrations/20260805000253_fix_continent_reach_unmapped_country_vanish_897.sql
@@ -1,0 +1,85 @@
+-- #897 fix — get_public_continent_reach: keep every unmapped-country (XX) member in the residual.
+-- continent_reach is the SOLE source of the ZZ "Internacional" chip on the public home map
+-- (get_public_country_reach's own ZZ is filtered out client-side; namedReach drops ZZ/XX).
+-- The old residual filter (ct.total<3 AND NOT is_precise) was written for RECOGNIZED countries
+-- (PT/IT/...) — which DO become named pins at >=3 or precise pins when consented — but it was also
+-- applied to the synthetic XX bucket. XX is never a named pin (country_reach always folds XX->ZZ)
+-- and never a precise pin (no centroid), so any XX member caught by those filters vanished from the
+-- map entirely. Two latent cases (both behavior-neutral today: 0 XX, 0 precise members live):
+--   (a) #897: a precise-consenter in an unsupported country (NOT is_precise dropped them, and the
+--       precise-country layer maps them to NULL -> no pin);
+--   (b) >=3 members spread across unmapped countries (ct.total<3 false -> the whole XX bucket dropped).
+-- Fix: XX bypasses BOTH filters and always stays in the residual -> lands in the ZZ chip, the same
+-- aggregate (Art. 7,IX) exposure a non-consenter already gets. Recognized-country behavior unchanged.
+-- Option 1 (precise pins for arbitrary countries) needs new centroids in src/lib/worldMap.ts and stays
+-- a separate enhancement. RoPA H.4 (residual continent layer).
+CREATE OR REPLACE FUNCTION public.get_public_continent_reach()
+ RETURNS TABLE(continent_code text, member_count bigint)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+  WITH normalized AS (
+    SELECT
+      m.allow_precise_location_in_public_map AS is_precise,
+      CASE
+        WHEN lower(trim(m.country)) ~ 'bras|brazil'                     OR lower(trim(m.country)) = 'br'         THEN 'BR'
+        WHEN lower(trim(m.country)) ~ 'portug'                          OR lower(trim(m.country)) = 'pt'         THEN 'PT'
+        WHEN lower(trim(m.country)) ~ 'estados unidos|united states|usa' OR lower(trim(m.country)) IN ('us','eua') THEN 'US'
+        WHEN lower(trim(m.country)) ~ 'ital'                           OR lower(trim(m.country)) = 'it'         THEN 'IT'
+        WHEN lower(trim(m.country)) ~ 'espanha|spain|espana'           OR lower(trim(m.country)) = 'es'         THEN 'ES'
+        WHEN lower(trim(m.country)) ~ 'argentin'                       OR lower(trim(m.country)) = 'ar'         THEN 'AR'
+        WHEN lower(trim(m.country)) ~ 'reino unido|united kingdom'     OR lower(trim(m.country)) IN ('uk','gb') THEN 'GB'
+        WHEN lower(trim(m.country)) ~ 'canad'                          OR lower(trim(m.country)) = 'ca'         THEN 'CA'
+        WHEN lower(trim(m.country)) ~ 'fran'                           OR lower(trim(m.country)) = 'fr'         THEN 'FR'
+        WHEN lower(trim(m.country)) ~ 'aleman|german|deutsch'          OR lower(trim(m.country)) = 'de'         THEN 'DE'
+        WHEN m.country IS NULL OR trim(m.country) = ''                                                          THEN NULL
+        ELSE 'XX'
+      END AS code
+    FROM public.members m
+    WHERE m.is_active
+      AND m.current_cycle_active
+      AND NOT public.member_is_pre_onboarding(m.person_id, m.member_status)
+  ),
+  country_totals AS (
+    SELECT code, count(*) AS total FROM normalized WHERE code IS NOT NULL GROUP BY code
+  ),
+  residual AS (
+    SELECT
+      CASE n.code
+        WHEN 'PT' THEN 'EU' WHEN 'IT' THEN 'EU' WHEN 'ES' THEN 'EU'
+        WHEN 'GB' THEN 'EU' WHEN 'FR' THEN 'EU' WHEN 'DE' THEN 'EU'
+        WHEN 'AR' THEN 'SA'
+        WHEN 'CA' THEN 'NA'
+        ELSE 'ZZ'  -- XX / unmapped -> Internacional
+      END AS continent
+    FROM normalized n
+    JOIN country_totals ct ON ct.code = n.code
+    WHERE n.code NOT IN ('BR','US')   -- always-named country pins (or the BR/US state-pin layer)
+      AND (
+        n.code = 'XX'                 -- #897: XX is the catch-all for unmapped countries and is NEVER a
+                                      -- named pin (country_reach folds XX->ZZ) nor a precise pin (no
+                                      -- centroid) -> every XX member must stay in the residual (-> ZZ),
+                                      -- else it vanishes from the map. Replaces the old, too-greedy
+                                      -- `ct.total<3 AND NOT is_precise` for the XX case.
+        OR (ct.total < 3 AND NOT n.is_precise)  -- recognized small countries not already shown as a
+                                                -- named (>=3) or precise country pin
+      )
+  ),
+  grouped AS (
+    SELECT continent, count(*)::bigint AS n FROM residual GROUP BY continent
+  )
+  SELECT
+    CASE WHEN n >= 3 AND continent <> 'ZZ' THEN continent ELSE 'ZZ' END AS continent_code,
+    sum(n)::bigint AS member_count
+  FROM grouped
+  GROUP BY CASE WHEN n >= 3 AND continent <> 'ZZ' THEN continent ELSE 'ZZ' END
+  ORDER BY member_count DESC, continent_code;
+$function$;
+
+-- ACL: this zero-PII public surface is REVOKE-PUBLIC + granted only to the three roles (RoPA pattern,
+-- mig `…242`/`…252`). CREATE OR REPLACE above preserves existing grants, so this is a no-op against a DB
+-- that already ran `…252` (verified live 2026-06-26: PUBLIC has no EXECUTE) — restated here only so this
+-- migration reproduces the hardened end-state on a from-baseline apply, instead of depending on `…252`.
+REVOKE ALL ON FUNCTION public.get_public_continent_reach() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_public_continent_reach() TO anon, authenticated, service_role;

--- a/tests/contracts/cycle4-coverage-map.test.mjs
+++ b/tests/contracts/cycle4-coverage-map.test.mjs
@@ -24,6 +24,7 @@ const SECTION = 'src/components/sections/ChaptersSection.astro';
 const ASSET = 'public/assets/maps/world-equirect.svg';
 const MIG_COL = 'supabase/migrations/20260805000226_pd_map_2_allow_state_column.sql';
 const MIG_V2 = 'supabase/migrations/20260805000241_pd_map_world_state_reach_v2.sql';
+const MIG_CONT_897 = 'supabase/migrations/20260805000253_fix_continent_reach_unmapped_country_vanish_897.sql';
 
 test('PD-MAP-WORLD: the Brazil-only choropleth was retired (no BrazilMap import remains)', () => {
   assert.ok(!existsSync('src/components/sections/BrazilMap.astro'), 'BrazilMap.astro removed');
@@ -111,6 +112,29 @@ test('PD-MAP-WORLD: state-reach v2 migration carries the LGPD gates (opt-in + k�
   assert.match(rpc, /SECURITY DEFINER/, 'RPC is SECURITY DEFINER (zero-PII public surface)');
   assert.match(rpc, /REVOKE ALL ON FUNCTION public\.get_public_state_reach_v2/, 'PUBLIC execute revoked');
   assert.match(rpc, /GRANT EXECUTE ON FUNCTION public\.get_public_state_reach_v2\(integer\) TO anon, authenticated, service_role/, 'granted to the three roles');
+});
+
+test('PD-MAP-WORLD (#897): continent-reach keeps every unmapped-country (XX) member in the residual', () => {
+  // continent_reach is the SOLE source of the ZZ "Internacional" chip (country_reach's own ZZ is
+  // filtered out client-side). The old residual filter (ct.total<3 AND NOT is_precise) was written
+  // for RECOGNIZED countries but also hit the synthetic XX bucket — which is never a named pin
+  // (country_reach folds XX->ZZ) nor a precise pin (no centroid). That silently dropped (a) a
+  // precise-consenter in an unsupported country (#897) and (b) >=3 members spread across unmapped
+  // countries (XX bucket >=3). The fix: XX bypasses BOTH filters and always stays in the residual.
+  const rpc = read(MIG_CONT_897);
+  assert.ok(rpc, '#897 continent-reach fix migration present');
+  assert.match(rpc, /CREATE OR REPLACE FUNCTION public\.get_public_continent_reach\(\)/, 'redefines continent_reach');
+  // the XX-bypass branch keeps unmapped-country members in the residual
+  assert.match(rpc, /n\.code = 'XX'/, "XX bucket bypasses the recognized-country exclusions (stays in residual)");
+  // the recognized-small-country gate is preserved (so named/precise pins are still deduped out)
+  assert.match(rpc, /OR \(ct\.total < 3 AND NOT n\.is_precise\)/, 'recognized small countries still gated by total<3 + not-precise');
+  // the buggy form had `ct.total<3` and `NOT is_precise` as standalone TOP-LEVEL ANDs (which also
+  // gated the XX bucket). The fix nests them inside `OR (...)`, so the standalone `AND ct.total < 3`
+  // must be gone — that's the #897 root cause that dropped XX members.
+  assert.doesNotMatch(rpc, /AND\s+ct\.total\s*<\s*3/, 'no standalone top-level total<3 filter (the #897 root cause; now nested in the OR)');
+  assert.match(rpc, /SECURITY DEFINER/, 'stays SECURITY DEFINER (zero-PII public surface)');
+  // ZZ stays an aggregate chip, never a placeable pin (k-anon preserved)
+  assert.match(rpc, /ELSE 'ZZ'/, 'unmapped -> ZZ Internacional bucket');
 });
 
 test('PD-MAP-WORLD: coverage-map i18n keys exist in all 3 dictionaries', () => {


### PR DESCRIPTION
Closes #897.

## What
`get_public_continent_reach()` is the **sole** source of the `ZZ` (Internacional) chip on the public home "world reach" map (`get_public_country_reach`'s own `ZZ` is filtered out client-side in `ChaptersSection`'s `namedReach`). Its residual filter `ct.total<3 AND NOT is_precise` was written for **recognized** countries but was also applied to the synthetic `XX` bucket — which is **never** a named pin (`country_reach` folds `XX`→`ZZ`) nor a precise pin (no centroid). So an `XX` member could vanish from the map entirely in two latent cases:

- **(a) #897** — a precise-consenter in an unsupported country: dropped by `NOT is_precise`, and the precise-country layer maps unrecognized → `NULL` (no pin).
- **(b) sibling bug** — ≥3 members spread across unmapped countries (`XX` bucket total ≥3): dropped by `ct.total<3`. The originally-recommended "Option 2" missed this, and even missed (a) once the `XX` bucket reached ≥3.

**Fix:** `XX` bypasses **both** filters and always stays in the residual → lands in the `ZZ` chip (the same Art. 7,IX aggregate a non-consenter already gets; strictly **less** than a precise-consenter authorized). Recognized-country behavior unchanged.

```sql
-      WHERE n.code NOT IN ('BR','US') AND ct.total < 3 AND NOT n.is_precise
+      WHERE n.code NOT IN ('BR','US')
+        AND ( n.code = 'XX' OR (ct.total < 3 AND NOT n.is_precise) )
```

## Behavior-neutral today
Live (grounded this session): **0** members with `allow_precise_location_in_public_map`, **0** members resolving to `XX` → `continent_reach` returns `ZZ:1` before and after. Purely latent fix.

## Proof
- **Predicate (real PG engine, synthetic matrix):** the 5 synthetic `XX` members go `covered_current=false → covered_proposed=true`; recognized (BR/US/PT incl. precise) covered in both.
- **Full-pipeline output (synthetic):** old predicate → `ZZ=1` (5 members vanish); new → `ZZ=6` (all present, the precise PT member correctly stays a precise pin).
- **Deployed body verified:** `has_xx_bypass=true`, recognized gate preserved, bare exclusion gone.
- **ACL verified live:** REVOKE-PUBLIC from mig `…252` preserved by `CREATE OR REPLACE` (no PUBLIC execute). Idempotent REVOKE/GRANT restated in the migration for from-baseline self-containment.
- **Build** `Complete!` · **`npm test` 4635 pass / 0 fail / 0 skipped** (DB-aware incl. `rpc-migration-coverage` + body-drift ran).
- **Adversarial 2-lens review** (legal-counsel LGPD + code-reviewer correctness): both **ship-with-nits, 0 blockers**. The 3 actionable nits are applied (test regex robustness, RoPA `ZZ` no-floor clarification, migration ACL self-containment).

## Migration ritual (GC-097)
`apply_migration` (DDL) → reconcile auto tracking row to convention `20260805000253` → `NOTIFY pgrst` → local file written (matches applied SQL). Head was `…252`.

## Files
- `supabase/migrations/20260805000253_…` — redefine `get_public_continent_reach` (+ idempotent REVOKE/GRANT)
- `docs/audit/LGPD_ROPA_PUBLIC_SURFACES.md` — H.4 + Riscos residuais: #897 resolved; `ZZ` no-floor clarified
- `tests/contracts/cycle4-coverage-map.test.mjs` — static guard for the XX-bypass residual predicate

## Out of scope / follow-ups (PM decision)
- **`privacy.s3map.revoke` text** says "mínimo de 3 membros" for all aggregates, but the `ZZ` chip has no floor — a **pre-existing** transparency wording gap from PR-3 (#898), *not* introduced or aggravated here (this fix makes `ZZ=1` less likely). Legal lens suggests fixing it in the next `/privacy` quarterly review (target **2026-07-26**), no re-consent needed.
- **Option 1** (precise pins for arbitrary countries) needs new centroids in `src/lib/worldMap.ts` + asset — separate enhancement. Legal lens also flagged a future UX note in `/profile` ("your country isn't supported for a precise pin → you'll appear in the Internacional group") to pre-empt Art. 18 questions; tie to that work.

⚠️ `main` auto-deploys on merge — **do not merge without explicit PM go.**