### PR TITLE
feat(selection): surface VEP application/offer deadlines + approved-then-expired state (#902)

### DIFF
--- a/cloudflare-workers/pmi-vep-sync/src/db.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/db.ts
@@ -412,7 +412,9 @@ export async function upsertSelectionApplication(
     .from('selection_applications')
     // email + vep_reconciled_at → #444 reconciled-email freeze;
     // status → #472 corr.#2 re-import status freeze (both applied below).
-    .select('id, cycle_id, email, status, vep_reconciled_at, consent_ai_analysis_at, consent_ai_analysis_revoked_at')
+    // #902: cutoff_approved_email_sent_at → distinguishes a VEP expiry AFTER cutoff
+    // approval from a plain evaluation rejection in the audit trail (auditVepTerminalClobber).
+    .select('id, cycle_id, email, status, vep_reconciled_at, consent_ai_analysis_at, consent_ai_analysis_revoked_at, cutoff_approved_email_sent_at')
     .eq('vep_application_id', payload.vep_application_id)
     .eq('vep_opportunity_id', payload.vep_opportunity_id)
     .maybeSingle();
@@ -474,6 +476,12 @@ export async function upsertSelectionApplication(
       // Worker reported success but vep_status_raw stayed NULL in all 97 apps.
       vep_status_raw: payload.vep_status_raw,
       vep_last_seen_at: payload.vep_last_seen_at,
+      // #902 — persist the captured VEP deadline + expiry on every refresh (they were
+      // mapped p902 but, like vep_status_raw pre-hotfix6, must reach the UPDATE SET or
+      // they silently stay NULL). Included in commonRefresh so cross-cycle partial
+      // refresh also keeps the deadline current.
+      vep_offer_expires_at: payload.vep_offer_expires_at ?? null,
+      vep_expired_at: payload.vep_expired_at ?? null,
       updated_at: new Date().toISOString()
     };
 
@@ -500,6 +508,12 @@ export async function upsertSelectionApplication(
     }
 
     // Same-cycle full update — decision-history fields also overwritten.
+    // #902 — resolve the status up front so a VEP-driven terminal flip can be audited
+    // (auditVepTerminalClobber below): the worker writes status directly via PostgREST,
+    // bypassing the audited DB-side reconcile_vep_terminal_status, so without this the
+    // approved→rejected clobber on a VEP expiry leaves NO admin_audit_log trail.
+    const newStatus = resolveReimportStatus(existing.status, payload.status, payload.vep_status_raw);
+
     const { error } = await db
       .from('selection_applications')
       .update({
@@ -527,12 +541,15 @@ export async function upsertSelectionApplication(
         // #693 defect 1 — pass vep_status_raw so a HARD terminal VEP decision
         // (OfferNotExtended/Withdrawn/Expired/OfferExpired) terminalizes an
         // in-flight candidate instead of being frozen by the #472 mid-pipeline rule.
-        status: resolveReimportStatus(existing.status, payload.status, payload.vep_status_raw),
+        status: newStatus,
         imported_at: payload.imported_at,
       })
       .eq('id', existing.id);
 
     if (error) throw new Error(`update selection_applications: ${error.message}`);
+
+    // #902 — best-effort audit of a VEP-driven terminal clobber (never blocks ingest).
+    await auditVepTerminalClobber(db, existing, newStatus, payload);
 
     return {
       id: existing.id,
@@ -553,6 +570,57 @@ export async function upsertSelectionApplication(
       was_new: true,
       consent_active: false
     };
+  }
+}
+
+/**
+ * #902 — audit a VEP-driven terminal status clobber.
+ *
+ * The worker writes selection_applications.status DIRECTLY via PostgREST (see
+ * resolveReimportStatus, applied in the same-cycle UPDATE above). That bypasses the
+ * audited DB-side heal `reconcile_vep_terminal_status` (which writes admin_audit_log),
+ * so a candidate flipped approved→rejected because their VEP application/offer expired
+ * left NO audit trail and the resulting 'rejected' was indistinguishable from an
+ * evaluation rejection (the #902 root cause). This restores a trail and tags the
+ * specific "expired after cutoff approval" case via metadata.reason.
+ *
+ * Fires ONLY when the resolved status is a NEW terminal value AND it was driven by a
+ * HARD-terminal VEP decision (mirrors the resolveReimportStatus #693 branch) — a normal
+ * forward-pipeline move is never audited here. Best-effort: an audit-write failure is
+ * logged but never thrown, so it cannot fail the candidate's ingest.
+ */
+async function auditVepTerminalClobber(
+  db: SupabaseClient,
+  existing: { id: string; status: string | null; cutoff_approved_email_sent_at?: string | null },
+  newStatus: string,
+  payload: SelectionApplicationUpsert
+): Promise<void> {
+  const vepRaw = (payload.vep_status_raw ?? '').toLowerCase();
+  const flippedToTerminal = newStatus !== existing.status && SELECTION_TERMINAL_STATUSES.has(newStatus);
+  const viaHardTerminal =
+    VEP_HARD_TERMINAL_STATUSES.has(vepRaw) && SELECTION_TERMINAL_STATUSES.has(payload.status);
+  if (!flippedToTerminal || !viaHardTerminal) return;
+
+  const afterCutoffApproval = existing.cutoff_approved_email_sent_at != null;
+  try {
+    const { error } = await db.from('admin_audit_log').insert({
+      actor_id: null,
+      action: 'selection.vep_terminal_clobber',
+      target_type: 'selection_application',
+      target_id: existing.id,
+      changes: { status: { from: existing.status, to: newStatus } },
+      metadata: {
+        source: 'pmi-vep-sync',
+        vep_status_raw: payload.vep_status_raw,
+        after_cutoff_approval: afterCutoffApproval,
+        reason: afterCutoffApproval ? 'vep_expired_after_cutoff_approval' : 'vep_terminal',
+      },
+    });
+    if (error) {
+      console.warn(`[pmi-vep-sync] audit vep_terminal_clobber failed for ${existing.id}: ${error.message}`);
+    }
+  } catch (e) {
+    console.warn(`[pmi-vep-sync] audit vep_terminal_clobber threw for ${existing.id}: ${String(e)}`);
   }
 }
 

--- a/cloudflare-workers/pmi-vep-sync/src/mapper.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/mapper.ts
@@ -11,6 +11,7 @@ import type {
   VepOpportunityRow,
   SelectionApplicationUpsert
 } from './types';
+import { safeTimestamp } from './script-mapper';
 
 const ORG_ID_DEFAULT = '2b4f58ab-7c45-4170-8718-b77ee69ff906';
 
@@ -63,6 +64,12 @@ export function mapPmiToNucleo(
       ?? detail.coverLetterInfo?.coverLetter
       ?? null,
     application_date: detail.applicationDate ?? null,
+    // #902 parity (server-to-server API path; currently dormant — see file header).
+    // VepApplicationDetail carries no forward-looking expiryDate, only the actual
+    // expiry timestamps, so only vep_expired_at is populated here. safeTimestamp
+    // normalizes + guards malformed dates to null (same as the active script path),
+    // so a bad PMI date can never throw and fail the upsert.
+    vep_expired_at: safeTimestamp(detail.offerExpiredDateUtc ?? detail.applicationExpiredDateUtc),
 
     status: mapPmiStatusToNucleo(detail.status),
     imported_at: new Date().toISOString(),

--- a/cloudflare-workers/pmi-vep-sync/src/script-mapper.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/script-mapper.ts
@@ -161,6 +161,14 @@ export function mapScriptToNucleo(
     // (Núcleo-side) to flag divergence.
     vep_status_raw: app.status ?? null,
     vep_last_seen_at: new Date().toISOString(),
+    // #902 — capture the VEP application/offer deadline + actual expiry that were
+    // previously dropped on the floor. expiryDateUtc is the forward-looking deadline
+    // (drives the admin/selection "expira em N dias" countdown); offer/application
+    // ExpiredDateUtc is the actual expiry date (drives the "aprovado → oferta VEP
+    // expirada DD/MM" badge). Normalized to ISO; malformed/absent → null (never throw,
+    // so a bad PMI date can't fail the whole upsert).
+    vep_offer_expires_at: safeTimestamp(app.expiryDateUtc),
+    vep_expired_at: safeTimestamp(app.offerExpiredDateUtc ?? app.applicationExpiredDateUtc),
     // Wave 3 synth fix (S-CONV-3 — 2 agents): null-semantic consistency vs empty string
     certifications: phaseBCertsString ?? null,
     role_applied: opp.role_default,
@@ -282,6 +290,19 @@ export function mapServiceHistory(
  * Already an array → return as-is (filtered for empty entries).
  * Anything else → null.
  */
+/**
+ * #902 — normalize a PMI lifecycle date string (e.g. expiryDateUtc,
+ * offerExpiredDateUtc) to an ISO timestamp for a timestamptz column. Returns null
+ * for absent / non-string / unparseable input so a malformed source date degrades
+ * gracefully (the field stays NULL) instead of throwing and failing the whole
+ * selection_applications upsert.
+ */
+export function safeTimestamp(value: string | null | undefined): string | null {
+  if (!value || typeof value !== 'string') return null;
+  const t = Date.parse(value.trim());
+  return Number.isNaN(t) ? null : new Date(t).toISOString();
+}
+
 export function parseMaybeCsvArray(value: unknown): string[] | null {
   if (value == null) return null;
   if (Array.isArray(value)) {

--- a/cloudflare-workers/pmi-vep-sync/src/types.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/types.ts
@@ -169,6 +169,12 @@ export interface SelectionApplicationUpsert {
   // p150 P0 (2026-05-12) — VEP raw status capture for reconciliation report.
   vep_status_raw?: string | null;
   vep_last_seen_at?: string | null;
+  // #902 — VEP application/offer deadline + actual expiry, previously discarded by
+  // the mapper. vep_offer_expires_at = forward-looking deadline (PMI expiryDate →
+  // expiryDateUtc), used for the admin/selection countdown; vep_expired_at = actual
+  // expiry once terminal (offerExpiredDateUtc ?? applicationExpiredDateUtc).
+  vep_offer_expires_at?: string | null;
+  vep_expired_at?: string | null;
   profile_volunteer_interest?: string | null;
   profile_specialties?: string | null;
   profile_linkedin_url?: string | null;

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -6574,6 +6574,21 @@ const enUS: Record<string, string> = {
   // p153 GAP-152.5 — stale flag (row was not in the latest VEP Apply)
   'comp.vepBadge.off': 'VEP·OFF',
   'comp.vepBadge.offTooltip': 'Not in the latest VEP Apply — likely removed from the recruiter dashboard by PMI',
+  // #902 — VEP terminal-expiry statuses + distinct "approved→VEP offer expired" badge + offer-deadline countdown.
+  'comp.vepBadge.expired': 'VEP·Exp',
+  'comp.vepBadge.statusExpired': 'VEP application/offer expired',
+  'comp.vepBadge.offerExpired': 'VEP·OfExp',
+  'comp.vepBadge.statusOfferExpired': 'VEP offer expired',
+  'comp.vepBadge.offerExtended': 'VEP·Offer',
+  'comp.vepBadge.statusOfferExtended': 'Offer extended (awaiting acceptance)',
+  'comp.vepBadge.complete': 'VEP·Compl',
+  'comp.vepBadge.statusComplete': 'Completed',
+  'comp.vepBadge.approvedExpiredShort': 'Appr→VEP✗',
+  'comp.vepBadge.approvedExpiredTooltip': 'Approved at cutoff, but the VEP application/offer expired — candidate auto-removed from the funnel, NOT an evaluation rejection',
+  'comp.vepBadge.deadlineDays': 'VEP expires in',
+  'comp.vepBadge.deadlineToday': 'VEP expires today',
+  'comp.vepBadge.deadlineTomorrow': 'VEP expires tomorrow',
+  'comp.vepBadge.deadlineTooltip': 'PMI VEP application/offer deadline — after this date the candidate is auto-removed from the funnel',
   // ── Affiliation Queue — Diretoria de Filiação panel (#659) ──
   'comp.affiliationQueue.loading': 'Loading queue…',
   'comp.recurringAgenda.heading': 'Recurring agenda',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -6574,6 +6574,21 @@ const esLATAM: Record<string, string> = {
   // p153 GAP-152.5 — flag stale (no vino en el Apply VEP más reciente)
   'comp.vepBadge.off': 'VEP·OFF',
   'comp.vepBadge.offTooltip': 'No vino en el Apply VEP más reciente — probablemente removida del recruiter dashboard por PMI',
+  // #902 — estados terminales de expiración VEP + badge distinto "aprobado→oferta VEP expirada" + cuenta regresiva del plazo.
+  'comp.vepBadge.expired': 'VEP·Exp',
+  'comp.vepBadge.statusExpired': 'Solicitud/oferta VEP expirada',
+  'comp.vepBadge.offerExpired': 'VEP·OfExp',
+  'comp.vepBadge.statusOfferExpired': 'Oferta VEP expirada',
+  'comp.vepBadge.offerExtended': 'VEP·Ofert',
+  'comp.vepBadge.statusOfferExtended': 'Oferta extendida (esperando aceptación)',
+  'comp.vepBadge.complete': 'VEP·Compl',
+  'comp.vepBadge.statusComplete': 'Completado',
+  'comp.vepBadge.approvedExpiredShort': 'Aprob→VEP✗',
+  'comp.vepBadge.approvedExpiredTooltip': 'Aprobado en el corte, pero la solicitud/oferta VEP expiró — candidato retirado del embudo automáticamente, NO es un rechazo de evaluación',
+  'comp.vepBadge.deadlineDays': 'VEP expira en',
+  'comp.vepBadge.deadlineToday': 'VEP expira hoy',
+  'comp.vepBadge.deadlineTomorrow': 'VEP expira mañana',
+  'comp.vepBadge.deadlineTooltip': 'Plazo de la solicitud/oferta en PMI VEP — después de esta fecha el candidato se retira del embudo automáticamente',
   // ── Affiliation Queue — Dirección de Afiliación (#659) ──
   'comp.affiliationQueue.loading': 'Cargando cola…',
   'comp.recurringAgenda.heading': 'Agenda recurrente',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -6580,6 +6580,22 @@ const ptBR: Record<string, string> = {
   // p153 GAP-152.5 — stale flag (app não veio no Apply VEP mais recente)
   'comp.vepBadge.off': 'VEP·OFF',
   'comp.vepBadge.offTooltip': 'Não veio no Apply VEP mais recente — provavelmente removida do recruiter dashboard pela PMI',
+  // #902 — VEP terminal-expiry statuses (antes caíam no badge cinza "desconhecido"),
+  // badge distinto "aprovado→oferta VEP expirada" + countdown de prazo da oferta.
+  'comp.vepBadge.expired': 'VEP·Exp',
+  'comp.vepBadge.statusExpired': 'Oferta/aplicação VEP expirada',
+  'comp.vepBadge.offerExpired': 'VEP·OfExp',
+  'comp.vepBadge.statusOfferExpired': 'Oferta VEP expirada',
+  'comp.vepBadge.offerExtended': 'VEP·Ofert',
+  'comp.vepBadge.statusOfferExtended': 'Oferta estendida (aguardando aceite)',
+  'comp.vepBadge.complete': 'VEP·Compl',
+  'comp.vepBadge.statusComplete': 'Concluído',
+  'comp.vepBadge.approvedExpiredShort': 'Aprov→VEP✗',
+  'comp.vepBadge.approvedExpiredTooltip': 'Aprovado no cutoff, mas a oferta/aplicação VEP expirou — candidato saiu do funil automaticamente, NÃO é reprovação na avaliação',
+  'comp.vepBadge.deadlineDays': 'VEP expira em',
+  'comp.vepBadge.deadlineToday': 'VEP expira hoje',
+  'comp.vepBadge.deadlineTomorrow': 'VEP expira amanhã',
+  'comp.vepBadge.deadlineTooltip': 'Prazo da oferta/aplicação no PMI VEP — após esta data o candidato é removido do funil automaticamente',
   // ── Affiliation Queue — Pasta Diretoria de Filiação (#659) ──
   'comp.affiliationQueue.loading': 'Carregando fila…',
   'comp.recurringAgenda.heading': 'Agenda recorrente',

--- a/src/pages/admin/selection.astro
+++ b/src/pages/admin/selection.astro
@@ -247,6 +247,21 @@ const SEL_I18N = {
     // p153 GAP-152.5
     off: t('comp.vepBadge.off', lang),
     offTooltip: t('comp.vepBadge.offTooltip', lang),
+    // #902 — terminal-expiry statuses + approved→expired badge + deadline countdown
+    expired: t('comp.vepBadge.expired', lang),
+    statusExpired: t('comp.vepBadge.statusExpired', lang),
+    offerExpired: t('comp.vepBadge.offerExpired', lang),
+    statusOfferExpired: t('comp.vepBadge.statusOfferExpired', lang),
+    offerExtended: t('comp.vepBadge.offerExtended', lang),
+    statusOfferExtended: t('comp.vepBadge.statusOfferExtended', lang),
+    complete: t('comp.vepBadge.complete', lang),
+    statusComplete: t('comp.vepBadge.statusComplete', lang),
+    approvedExpiredShort: t('comp.vepBadge.approvedExpiredShort', lang),
+    approvedExpiredTooltip: t('comp.vepBadge.approvedExpiredTooltip', lang),
+    deadlineDays: t('comp.vepBadge.deadlineDays', lang),
+    deadlineToday: t('comp.vepBadge.deadlineToday', lang),
+    deadlineTomorrow: t('comp.vepBadge.deadlineTomorrow', lang),
+    deadlineTooltip: t('comp.vepBadge.deadlineTooltip', lang),
   },
   // #224 — admin JSON import observability labels (consumed by
   // renderJsonApplyResult + renderJsonDryRunPreview helpers).
@@ -780,6 +795,15 @@ const SEL_I18N = {
       statusOfferNotExtended: 'Ciclo encerrado sem oferta',
       lastSync: 'Última sync VEP', reconciled: 'Reconciliado em',
       off: 'VEP·OFF', offTooltip: 'Não veio no Apply VEP mais recente — provavelmente removida do recruiter dashboard pela PMI',
+      // #902
+      expired: 'VEP·Exp', statusExpired: 'Oferta/aplicação VEP expirada',
+      offerExpired: 'VEP·OfExp', statusOfferExpired: 'Oferta VEP expirada',
+      offerExtended: 'VEP·Ofert', statusOfferExtended: 'Oferta estendida (aguardando aceite)',
+      complete: 'VEP·Compl', statusComplete: 'Concluído',
+      approvedExpiredShort: 'Aprov→VEP✗',
+      approvedExpiredTooltip: 'Aprovado no cutoff, mas a oferta/aplicação VEP expirou — candidato saiu do funil automaticamente, NÃO é reprovação na avaliação',
+      deadlineDays: 'VEP expira em', deadlineToday: 'VEP expira hoje', deadlineTomorrow: 'VEP expira amanhã',
+      deadlineTooltip: 'Prazo da oferta/aplicação no PMI VEP — após esta data o candidato é removido do funil automaticamente',
     },
   };
 
@@ -1117,8 +1141,16 @@ const SEL_I18N = {
   function vepBadge(r: any): string {
     const status = r.vep_recon?.status_raw;
     const lastSeenAt = r.vep_recon?.last_seen_at;
+    const offerExpiresAt = r.vep_recon?.offer_expires_at;  // #902 forward-looking deadline (expiryDateUtc)
+    const expiredAt = r.vep_recon?.expired_at;             // #902 actual expiry (offer/applicationExpiredDateUtc)
     if (!status && !lastSeenAt) return '';
     const VB = T.vepBadge || {};
+    // #902 — VEP raw statuses for which a deadline countdown is meaningless: the
+    // candidate is OUT of the funnel (terminal-negative) OR the assignment is already
+    // done ('Complete', terminal-positive). Either way, suppress the countdown chip.
+    const VEP_TERMINAL = ['Withdrawn', 'Declined', 'OfferNotExtended', 'Expired', 'OfferExpired', 'Removed', 'Complete'];
+    const isVepTerminal = status ? VEP_TERMINAL.includes(status) : false;
+    const isExpiryFamily = status === 'Expired' || status === 'OfferExpired';
     let statusBadge = '';
     if (status) {
       const labelMap: Record<string, { short: string; long: string; cls: string }> = {
@@ -1127,6 +1159,11 @@ const SEL_I18N = {
         Withdrawn: { short: VB.withdrawn || 'VEP·Saiu', long: VB.statusWithdrawn || 'Desistiu', cls: 'bg-gray-100 text-gray-600' },
         Declined: { short: VB.declined || 'VEP·Recus', long: VB.statusDeclined || 'Recusado', cls: 'bg-rose-50 text-rose-700' },
         OfferNotExtended: { short: VB.offerNotExtended || 'VEP·SemOf', long: VB.statusOfferNotExtended || 'Sem oferta', cls: 'bg-amber-50 text-amber-700' },
+        // #902 — statuses that previously fell through to the gray "unknown" badge.
+        OfferExtended: { short: VB.offerExtended || 'VEP·Ofert', long: VB.statusOfferExtended || 'Oferta estendida (aguardando aceite)', cls: 'bg-cyan-50 text-cyan-700' },
+        Expired: { short: VB.expired || 'VEP·Exp', long: VB.statusExpired || 'Oferta/aplicação VEP expirada', cls: 'bg-rose-50 text-rose-700' },
+        OfferExpired: { short: VB.offerExpired || 'VEP·OfExp', long: VB.statusOfferExpired || 'Oferta VEP expirada', cls: 'bg-rose-50 text-rose-700' },
+        Complete: { short: VB.complete || 'VEP·Compl', long: VB.statusComplete || 'Concluído', cls: 'bg-emerald-50 text-emerald-700' },
       };
       const entry = labelMap[status] || { short: VB.unknown || 'VEP·?', long: status, cls: 'bg-slate-100 text-slate-600' };
       const lastSyncStr = lastSeenAt ? new Date(lastSeenAt).toLocaleDateString('pt-BR') : '—';
@@ -1135,6 +1172,46 @@ const SEL_I18N = {
       const tooltip = `${VB.tooltipPrefix || 'Status no PMI VEP'}: ${entry.long} · ${VB.lastSync || 'Última sync VEP'} ${lastSyncStr}${reconciledLine}`;
       statusBadge = ` <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full ${entry.cls}" title="${esc(tooltip)}">${esc(entry.short)}</span>`;
     }
+
+    // #902 — distinct "aprovado → oferta/aplicação VEP expirada (DD/MM)" badge. Fires
+    // when the candidate passed the cutoff (cutoff_approved_email_sent_at set) but the
+    // VEP application/offer then expired — i.e. the silent approved→rejected flip this
+    // issue surfaces. Keyed on the expiry family only (Expired/OfferExpired), so it
+    // does not duplicate the OfferNotExtended/Withdrawn terminal cases.
+    let approvedExpiredBadge = '';
+    if (r.cutoff_approved_email_sent_at && isExpiryFamily) {
+      const whenIso = expiredAt || lastSeenAt;
+      const whenStr = whenIso ? new Date(whenIso).toLocaleDateString('pt-BR') : '—';
+      const tip = `${VB.approvedExpiredTooltip || 'Aprovado no cutoff, mas a oferta/aplicação VEP expirou'}${whenStr !== '—' ? ` (${whenStr})` : ''}`;
+      approvedExpiredBadge = ` <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-red-100 text-red-700 border border-red-300" title="${esc(tip)}">${esc(VB.approvedExpiredShort || 'Aprov→VEP✗')}${whenStr !== '—' ? ` ${esc(whenStr)}` : ''}</span>`;
+    }
+
+    // #902 — proactive deadline countdown. When the VEP offer/application has a
+    // forward-looking deadline still in the future and the candidate is NOT already
+    // out (terminal), show "expira em N dias" so operators can act BEFORE the silent
+    // expiry. Amber when ≤ 7 days (mirrors the offer_accept_grace window); only shown
+    // within 30 days to avoid noise on far-future deadlines.
+    let deadlineChip = '';
+    if (offerExpiresAt && !isVepTerminal) {
+      const expMs = new Date(offerExpiresAt).getTime();
+      if (Number.isFinite(expMs)) {
+        const daysLeft = Math.ceil((expMs - Date.now()) / 86400000);
+        if (daysLeft >= 0 && daysLeft <= 30) {
+          const label = daysLeft === 0
+            ? (VB.deadlineToday || 'VEP expira hoje')
+            : daysLeft === 1
+            ? (VB.deadlineTomorrow || 'VEP expira amanhã')
+            : `${VB.deadlineDays || 'VEP expira em'} ${daysLeft}d`;
+          const cls = daysLeft <= 7
+            ? 'bg-amber-100 text-amber-800 border border-amber-300'
+            : 'bg-slate-50 text-slate-600 border border-slate-200';
+          const expStr = new Date(offerExpiresAt).toLocaleDateString('pt-BR');
+          const tip = `${VB.deadlineTooltip || 'Prazo da oferta/aplicação no PMI VEP'} (${expStr})`;
+          deadlineChip = ` <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full ${cls}" title="${esc(tip)}">⏳ ${esc(label)}</span>`;
+        }
+      }
+    }
+
     // GAP-152.5 stale flag — only render if lastSeenAt is meaningfully older than dataset max
     let staleBadge = '';
     if (lastSeenAt && latestVepSeenMs > 0) {
@@ -1145,7 +1222,7 @@ const SEL_I18N = {
         staleBadge = ` <span class="text-[9px] font-bold px-1.5 py-0.5 rounded-full bg-orange-50 text-orange-700 border border-orange-200" title="${esc(offTip)}">${esc(VB.off || 'VEP·OFF')}</span>`;
       }
     }
-    return `${statusBadge}${staleBadge}`;
+    return `${statusBadge}${approvedExpiredBadge}${deadlineChip}${staleBadge}`;
   }
 
   /* p150 PM feedback — PMI canonical chapter name → curto code mapping.

--- a/supabase/migrations/20260805000254_902_vep_offer_deadline_capture.sql
+++ b/supabase/migrations/20260805000254_902_vep_offer_deadline_capture.sql
@@ -1,0 +1,328 @@
+-- #902 sub-gap 1 (visibility) — capture the VEP application/offer DEADLINE that the
+-- pmi-vep-sync worker currently discards, so admin/selection can surface a countdown
+-- ("expira em N dias") BEFORE expiry and a distinct "aprovado → oferta VEP expirada
+-- (DD/MM)" state AFTER, instead of the silent approved→rejected flip.
+--
+-- Source provenance: the extract script (extract_pmi_volunteer.js) already emits
+--   expiryDateUtc            (PMI `expiryDate` — forward-looking deadline)
+--   offerExpiredDateUtc      (offer actually expired)
+--   applicationExpiredDateUtc(application actually expired)
+-- but script-mapper.ts only used applicationExpiredDateUtc as an application_date
+-- fallback and dropped the rest. This migration adds the columns; the worker change
+-- (same PR) populates them.
+--
+-- Both columns are additive + nullable → dormant until the worker ships (no behavior
+-- change at apply time; existing rows stay NULL).
+--
+-- Rollback (trivially reversible — no data written until the worker deploys):
+--   ALTER TABLE public.selection_applications
+--     DROP COLUMN IF EXISTS vep_offer_expires_at,
+--     DROP COLUMN IF EXISTS vep_expired_at;
+--   -- then re-apply the prior get_selection_dashboard body (vep_recon without the 2 keys).
+
+ALTER TABLE public.selection_applications
+  ADD COLUMN IF NOT EXISTS vep_offer_expires_at timestamptz,
+  ADD COLUMN IF NOT EXISTS vep_expired_at       timestamptz;
+
+COMMENT ON COLUMN public.selection_applications.vep_offer_expires_at IS
+  '#902 — forward-looking VEP application/offer deadline (PMI expiryDate, via extract script expiryDateUtc). Used by admin/selection to show "expira em N dias" before expiry. Written by pmi-vep-sync worker; NULL when the source carried no deadline.';
+COMMENT ON COLUMN public.selection_applications.vep_expired_at IS
+  '#902 — actual VEP expiry timestamp once terminal (offerExpiredDateUtc ?? applicationExpiredDateUtc). Used by the "aprovado → oferta VEP expirada (DD/MM)" badge. Written by pmi-vep-sync worker.';
+
+-- Extend get_selection_dashboard: surface the two deadline fields inside the existing
+-- vep_recon object (additive — existing consumers ignore the new keys). Full body
+-- reproduced from the live definition (the only change is the two added keys in
+-- vep_recon), per the apply_migration capture rule (database.md Track Q-C).
+CREATE OR REPLACE FUNCTION public.get_selection_dashboard(p_cycle_code text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_cycle_id uuid;
+  v_result jsonb;
+  v_stats_a jsonb;
+  v_stats_b jsonb;
+BEGIN
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF p_cycle_code IS NOT NULL THEN
+    SELECT id INTO v_cycle_id FROM public.selection_cycles WHERE cycle_code = p_cycle_code;
+  ELSE
+    SELECT id INTO v_cycle_id FROM public.selection_cycles ORDER BY created_at DESC LIMIT 1;
+  END IF;
+  IF v_cycle_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'No cycle found', 'cycle', null, 'applications', '[]'::jsonb, 'stats', jsonb_build_object('total', 0));
+  END IF;
+
+  v_stats_a := jsonb_build_object(
+    'total', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id),
+    'approved', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('approved', 'converted')),
+    'rejected', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('rejected', 'objective_cutoff')),
+    'pending', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('submitted', 'screening', 'objective_eval', 'interview_pending', 'interview_scheduled', 'interview_done', 'final_eval')),
+    'cancelled', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status IN ('cancelled', 'withdrawn')),
+    'waitlist', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND status = 'waitlist'),
+    'leader_ranked', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND rank_leader IS NOT NULL),
+    'researcher_ranked', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND rank_researcher IS NOT NULL),
+    'ai_analysis_done_count', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_at IS NOT NULL AND ai_analysis IS NOT NULL),
+    'consent_ai_pending', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_at IS NULL),
+    'consent_ai_consented', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_at IS NOT NULL AND consent_ai_analysis_revoked_at IS NULL),
+    'consent_ai_revoked', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND consent_ai_analysis_revoked_at IS NOT NULL)
+  );
+
+  v_stats_b := jsonb_build_object(
+    'with_peer_evals_2plus', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND (SELECT count(DISTINCT e.evaluator_id) FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluation_type = 'objective' AND e.submitted_at IS NOT NULL) >= 2),
+    'with_interview_scheduled', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.selection_interviews si WHERE si.application_id = a.id AND si.status IN ('scheduled','completed','rescheduled'))),
+    'with_interview_today', (
+      SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id
+        AND EXISTS (SELECT 1 FROM public.selection_interviews si WHERE si.application_id = a.id
+          AND si.status = 'scheduled'
+          AND (si.scheduled_at AT TIME ZONE 'America/Sao_Paulo')::date = (now() AT TIME ZONE 'America/Sao_Paulo')::date)
+    ),
+    'with_video_uploaded', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded','transcribing','transcribed'))),
+    'with_video_opted_out', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id) AND NOT EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded','transcribing','transcribed'))),
+    'with_pmi_member_active', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND pmi_id IS NOT NULL AND pmi_id <> '' AND service_latest_end_date >= CURRENT_DATE),
+    'with_chapter_canonical', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND service_history_chapters IS NOT NULL AND service_history_chapters <> '' AND service_history_chapters <> 'PMI Global'),
+    'with_re_applicants', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND COALESCE(application_count, 1) > 1),
+    'with_briefing_generated', (SELECT count(*) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND last_briefing_at IS NOT NULL),
+    'shadow_vep_count', (
+      SELECT count(*) FROM public.selection_applications a
+      WHERE a.cycle_id = v_cycle_id
+        AND a.status IN ('approved', 'converted', 'cancelled', 'rejected', 'withdrawn')
+        AND EXISTS (
+          SELECT 1 FROM public.members m
+          WHERE m.is_active = true
+            AND lower(m.email) = lower(a.email)
+            AND m.created_at < a.created_at
+        )
+    ),
+    'my_evals_submitted', (SELECT count(*) FROM public.selection_evaluations e JOIN public.selection_applications a ON a.id = e.application_id WHERE a.cycle_id = v_cycle_id AND e.evaluator_id = v_caller_id AND e.submitted_at IS NOT NULL),
+    'my_evals_pending', (SELECT count(*) FROM public.selection_applications a WHERE a.cycle_id = v_cycle_id AND EXISTS (SELECT 1 FROM public.notifications n WHERE n.type = 'peer_review_requested' AND n.source_id = a.id AND n.recipient_id = v_caller_id) AND NOT EXISTS (SELECT 1 FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluator_id = v_caller_id))
+  );
+
+  SELECT jsonb_build_object(
+    'cycle', (SELECT jsonb_build_object(
+      'id', c.id, 'cycle_code', c.cycle_code, 'title', c.title, 'status', c.status,
+      'interview_booking_url', c.interview_booking_url,
+      'interview_questions', COALESCE(c.interview_questions, '[]'::jsonb),
+      'pert_cutoff', (SELECT jsonb_build_object(
+        'target_score', MAX(pert_target_score),
+        'band_lower', MAX(pert_band_lower),
+        'band_upper', MAX(pert_band_upper),
+        'cohort_n', MAX(pert_cohort_n),
+        'method', MAX(pert_cutoff_method),
+        'calc_at', MAX(pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE pert_target_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id),
+      'leader_extra_cutoff', (SELECT jsonb_build_object(
+        'target_score', MAX(leader_extra_pert_target),
+        'band_lower', MAX(leader_extra_pert_band_lower),
+        'band_upper', MAX(leader_extra_pert_band_upper),
+        'cohort_n', MAX(leader_extra_pert_cohort_n),
+        'method', MAX(leader_extra_pert_cutoff_method),
+        'calc_at', MAX(leader_extra_pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE leader_extra_pert_target IS NOT NULL),
+        'apps_with_score', COUNT(*) FILTER (WHERE leader_extra_pert_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id),
+      'final_score_cutoff_researcher', (SELECT jsonb_build_object(
+        'target_score', MAX(final_score_pert_target),
+        'band_lower', MAX(final_score_pert_band_lower),
+        'band_upper', MAX(final_score_pert_band_upper),
+        'cohort_n', MAX(final_score_pert_cohort_n),
+        'method', MAX(final_score_pert_cutoff_method),
+        'calc_at', MAX(final_score_pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE final_score_pert_target IS NOT NULL),
+        'apps_with_score', COUNT(*) FILTER (WHERE final_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND role_applied = 'researcher'),
+      'final_score_cutoff_leader', (SELECT jsonb_build_object(
+        'target_score', MAX(final_score_pert_target),
+        'band_lower', MAX(final_score_pert_band_lower),
+        'band_upper', MAX(final_score_pert_band_upper),
+        'cohort_n', MAX(final_score_pert_cohort_n),
+        'method', MAX(final_score_pert_cutoff_method),
+        'calc_at', MAX(final_score_pert_calc_at),
+        'apps_with_pert', COUNT(*) FILTER (WHERE final_score_pert_target IS NOT NULL),
+        'apps_with_score', COUNT(*) FILTER (WHERE final_score IS NOT NULL),
+        'apps_total', COUNT(*)
+      ) FROM public.selection_applications WHERE cycle_id = v_cycle_id AND role_applied = 'leader')
+    ) FROM public.selection_cycles c WHERE c.id = v_cycle_id),
+    'applications', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', a.id, 'applicant_name', a.applicant_name, 'email', a.email,
+          'phone', a.phone,
+          'role_applied', a.role_applied, 'chapter', a.chapter, 'status', a.status,
+          'objective_score', a.objective_score_avg, 'final_score', a.final_score,
+          'research_score', a.research_score, 'leader_score', a.leader_score,
+          'rank_researcher', a.rank_researcher, 'rank_leader', a.rank_leader,
+          'promotion_path', a.promotion_path, 'linked_application_id', a.linked_application_id,
+          'rank_chapter', a.rank_chapter, 'rank_overall', a.rank_overall,
+          'objective_rank', a.objective_rank,
+          'linkedin_url', a.linkedin_url, 'resume_url', a.resume_url,
+          'resume_storage_path', a.resume_storage_path,
+          'resume_synced_at', a.resume_synced_at,
+          'tags', a.tags, 'feedback', a.feedback,
+          'motivation', a.motivation_letter, 'experience_years', a.seniority_years,
+          'membership_status', a.membership_status, 'certifications', a.certifications,
+          'is_returning_member', a.is_returning_member, 'application_date', a.application_date,
+          'academic_background', a.academic_background, 'areas_of_interest', a.areas_of_interest,
+          'availability_declared', a.availability_declared, 'non_pmi_experience', a.non_pmi_experience,
+          'proposed_theme', a.proposed_theme, 'leadership_experience', a.leadership_experience,
+          'created_at', a.created_at, 'interview_status', a.interview_status,
+          'interview_reschedule_reason', a.interview_reschedule_reason,
+          'interview_reschedule_requested_at', a.interview_reschedule_requested_at,
+          'consent_ai_status', CASE
+            WHEN a.consent_ai_analysis_revoked_at IS NOT NULL THEN 'revoked'
+            WHEN a.consent_ai_analysis_at IS NOT NULL THEN 'consented'
+            ELSE 'pending'
+          END,
+          'consent_ai_at', a.consent_ai_analysis_at,
+          'consent_ai_revoked_at', a.consent_ai_analysis_revoked_at,
+          'member_credly_url', (SELECT m.credly_url FROM public.members m WHERE lower(m.email) = lower(a.email) LIMIT 1),
+          'member_photo_url', (SELECT m.photo_url FROM public.members m WHERE lower(m.email) = lower(a.email) LIMIT 1),
+          'leader_extra_pert_score', a.leader_extra_pert_score
+        ) || jsonb_build_object(
+          'interview_score', a.interview_score,
+          'cutoff_approved_email_sent_at', a.cutoff_approved_email_sent_at,
+          'final_score_pert_target', a.final_score_pert_target,
+          'final_score_pert_band_lower', a.final_score_pert_band_lower,
+          'final_score_pert_band_upper', a.final_score_pert_band_upper,
+          'final_score_pert_cutoff_method', a.final_score_pert_cutoff_method,
+          'final_score_pert_cohort_n', a.final_score_pert_cohort_n,
+          'final_score_pert_calc_at', a.final_score_pert_calc_at,
+          'peer_eval_count', (
+            SELECT count(*)::int FROM public.selection_evaluations e
+            WHERE e.application_id = a.id AND e.evaluation_type = 'objective' AND e.submitted_at IS NOT NULL
+          ),
+          'peer_extra', jsonb_build_object(
+            'distinct_evaluators', (
+              SELECT count(DISTINCT e.evaluator_id)::int FROM public.selection_evaluations e
+              WHERE e.application_id = a.id AND e.evaluation_type = 'objective' AND e.submitted_at IS NOT NULL
+            ),
+            'invites_pending', (
+              SELECT count(*)::int FROM public.notifications n
+              WHERE n.type = 'peer_review_requested' AND n.source_id = a.id
+                AND NOT EXISTS (SELECT 1 FROM public.selection_evaluations e2 WHERE e2.application_id = a.id AND e2.evaluator_id = n.recipient_id)
+            )
+          ),
+          'meta', jsonb_build_object(
+            'ai_analysis_done', (a.consent_ai_analysis_at IS NOT NULL AND a.ai_analysis IS NOT NULL),
+            'interview_scheduled', EXISTS (SELECT 1 FROM public.selection_interviews si WHERE si.application_id = a.id AND si.status IN ('scheduled', 'completed', 'rescheduled')),
+            'interview_next_at', (
+              SELECT MIN(si.scheduled_at) FROM public.selection_interviews si
+              WHERE si.application_id = a.id
+                AND si.status = 'scheduled'
+                AND si.scheduled_at >= now() - interval '12 hours'
+            ),
+            'has_interview_today', EXISTS (
+              SELECT 1 FROM public.selection_interviews si
+              WHERE si.application_id = a.id
+                AND si.status = 'scheduled'
+                AND (si.scheduled_at AT TIME ZONE 'America/Sao_Paulo')::date = (now() AT TIME ZONE 'America/Sao_Paulo')::date
+            ),
+            'token_consumed', EXISTS (SELECT 1 FROM public.onboarding_tokens t WHERE t.source_id = a.id AND t.source_type = 'pmi_application' AND COALESCE(t.access_count, 0) > 0),
+            'video_screening_done', EXISTS (SELECT 1 FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded', 'transcribing', 'transcribed', 'opted_out')),
+            'interview_stuck', (
+              a.status = 'interview_scheduled'
+              AND EXISTS (
+                SELECT 1 FROM public.selection_interviews si
+                WHERE si.application_id = a.id
+                  AND si.status = 'scheduled'
+                  AND si.conducted_at IS NULL
+                  AND si.scheduled_at IS NOT NULL
+                  AND si.scheduled_at < now() - COALESCE(
+                        (SELECT value_interval FROM public.sla_policies WHERE policy_key = 'stuck_scheduled_grace'),
+                        interval '48 hours')
+              )
+            )
+          ),
+          'video_agg', jsonb_build_object(
+            'status_agg', (SELECT CASE WHEN count(*) = 0 THEN 'none' WHEN count(*) FILTER (WHERE v.status IN ('uploaded','transcribing','transcribed')) > 0 THEN 'uploaded' WHEN count(*) FILTER (WHERE v.status = 'opted_out') = count(*) THEN 'opted_out' ELSE 'partial' END FROM public.pmi_video_screenings v WHERE v.application_id = a.id),
+            'uploaded_count', (SELECT count(*)::int FROM public.pmi_video_screenings v WHERE v.application_id = a.id AND v.status IN ('uploaded','transcribing','transcribed')),
+            'total_rows', (SELECT count(*)::int FROM public.pmi_video_screenings v WHERE v.application_id = a.id)
+          ),
+          'pmi_canonical', jsonb_build_object(
+            'chapter_canonical', (
+              SELECT trim(c) FROM unnest(string_to_array(COALESCE(a.service_history_chapters, ''), ';')) AS c
+              WHERE trim(c) <> '' AND trim(c) <> 'PMI Global' LIMIT 1
+            ),
+            'pmi_memberships', COALESCE(a.pmi_memberships, '[]'::jsonb),
+            'is_pmi_member', (a.pmi_id IS NOT NULL AND a.pmi_id <> ''),
+            'member_status', CASE
+              WHEN a.pmi_id IS NULL OR a.pmi_id = '' THEN 'unknown'
+              WHEN a.service_latest_end_date IS NULL THEN 'unknown'
+              WHEN a.service_latest_end_date >= CURRENT_DATE THEN 'active'
+              ELSE 'past'
+            END,
+            'member_since', a.service_first_start_date,
+            'member_until', a.service_latest_end_date,
+            'service_history_count', COALESCE(a.service_history_count, 0),
+            'phase_b_fetched_at', a.pmi_data_fetched_at,
+            'pmi_id', a.pmi_id
+          ),
+          'extra_flags', jsonb_build_object(
+            'application_count', COALESCE(a.application_count, 1),
+            'has_briefing', (a.last_briefing_at IS NOT NULL),
+            'briefing_at', a.last_briefing_at,
+            'briefing_model', a.last_briefing_model,
+            'ai_triage_score', a.ai_triage_score,
+            'ai_triage_confidence', a.ai_triage_confidence,
+            'is_shadow_vep', (
+              a.status IN ('approved', 'converted', 'cancelled', 'rejected', 'withdrawn')
+              AND EXISTS (
+                SELECT 1 FROM public.members m
+                WHERE m.is_active = true
+                  AND lower(m.email) = lower(a.email)
+                  AND m.created_at < a.created_at
+              )
+            ),
+            'pdf_likely_invalid', EXISTS (
+              SELECT 1 FROM storage.objects so
+              WHERE so.bucket_id = 'selection-resumes'
+                AND so.name = a.resume_storage_path
+                AND (so.metadata->>'size')::int < 1000
+            )
+          ),
+          'vep_recon', jsonb_build_object(
+            'status_raw', a.vep_status_raw,
+            'last_seen_at', a.vep_last_seen_at,
+            'reconciled_at', a.vep_reconciled_at,
+            'offer_expires_at', a.vep_offer_expires_at,
+            'expired_at', a.vep_expired_at
+          ),
+          'my_eval_status', COALESCE(
+            (SELECT CASE WHEN e.submitted_at IS NOT NULL THEN 'submitted' ELSE 'draft' END
+              FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluator_id = v_caller_id LIMIT 1),
+            CASE WHEN EXISTS (SELECT 1 FROM public.notifications n WHERE n.type = 'peer_review_requested' AND n.source_id = a.id AND n.recipient_id = v_caller_id) THEN 'invited' ELSE 'not_invited' END
+          ),
+          'my_eval_score', (SELECT e.weighted_subtotal FROM public.selection_evaluations e WHERE e.application_id = a.id AND e.evaluator_id = v_caller_id AND e.submitted_at IS NOT NULL LIMIT 1)
+        )
+      ORDER BY COALESCE(a.leader_score, a.research_score, a.final_score) DESC NULLS LAST)
+      FROM (
+        SELECT
+          sa.*,
+          ROW_NUMBER() OVER (
+            PARTITION BY sa.role_applied
+            ORDER BY sa.objective_score_avg DESC NULLS LAST, sa.id ASC
+          )::int AS objective_rank
+        FROM public.selection_applications sa
+        WHERE sa.cycle_id = v_cycle_id
+      ) a
+    ), '[]'::jsonb),
+    'stats', v_stats_a || v_stats_b
+  ) INTO v_result;
+  RETURN v_result;
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/902-vep-deadline-capture.test.mjs
+++ b/tests/contracts/902-vep-deadline-capture.test.mjs
@@ -1,0 +1,96 @@
+/**
+ * #902 — VEP application/offer deadline capture + "approved-then-VEP-expired" surfacing.
+ *
+ * Guards the chain that lets admin/selection show a deadline countdown BEFORE a VEP
+ * expiry and a distinct "aprovado → oferta VEP expirada" state AFTER, instead of the
+ * silent approved→rejected flip (root cause: the extract script emits expiryDateUtc /
+ * offerExpiredDateUtc / applicationExpiredDateUtc but the worker dropped them, and no
+ * column stored a deadline).
+ *
+ * Static source-parse only (no DB / network) — safe to run anywhere; catches drift
+ * before deploy. Mirrors the worker-mapper-db-update-coverage approach.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const read = (p) => readFileSync(join(REPO_ROOT, p), 'utf8');
+
+test('script-mapper captures the deadline + expiry fields the extract script emits', () => {
+  const src = read('cloudflare-workers/pmi-vep-sync/src/script-mapper.ts');
+  // forward-looking deadline → vep_offer_expires_at
+  assert.match(src, /vep_offer_expires_at:\s*safeTimestamp\(app\.expiryDateUtc\)/,
+    'script-mapper must map app.expiryDateUtc → vep_offer_expires_at');
+  // actual expiry → vep_expired_at (offer first, then application)
+  assert.match(src, /vep_expired_at:\s*safeTimestamp\(app\.offerExpiredDateUtc\s*\?\?\s*app\.applicationExpiredDateUtc\)/,
+    'script-mapper must map offerExpiredDateUtc ?? applicationExpiredDateUtc → vep_expired_at');
+  // safeTimestamp must degrade malformed/absent dates to null (never throw → never fail the upsert)
+  assert.match(src, /export function safeTimestamp\b/, 'safeTimestamp helper must exist + be exported (testable)');
+  assert.match(src, /Number\.isNaN\([\s\S]*?\?\s*null/, 'safeTimestamp must return null for unparseable input');
+});
+
+test('worker db.ts persists the captured deadline fields on UPDATE (commonRefresh)', () => {
+  const src = read('cloudflare-workers/pmi-vep-sync/src/db.ts');
+  const cr = src.match(/const\s+commonRefresh\s*=\s*\{([\s\S]*?)\};/);
+  assert.ok(cr, 'commonRefresh block must exist');
+  assert.match(cr[1], /vep_offer_expires_at:/, 'commonRefresh must include vep_offer_expires_at (else silently dropped on re-ingest)');
+  assert.match(cr[1], /vep_expired_at:/, 'commonRefresh must include vep_expired_at');
+});
+
+test('worker db.ts audits the VEP-driven terminal clobber (no longer silent/untraced)', () => {
+  const src = read('cloudflare-workers/pmi-vep-sync/src/db.ts');
+  assert.match(src, /auditVepTerminalClobber/, 'audit helper must exist + be called');
+  assert.match(src, /action:\s*'selection\.vep_terminal_clobber'/, 'audit must write a distinct action');
+  assert.match(src, /vep_expired_after_cutoff_approval/,
+    'audit must tag the approved-then-expired case distinctly from a plain evaluation rejection');
+});
+
+test('SelectionApplicationUpsert type declares the deadline fields', () => {
+  const src = read('cloudflare-workers/pmi-vep-sync/src/types.ts');
+  assert.match(src, /vep_offer_expires_at\?:\s*string\s*\|\s*null/, 'type must declare vep_offer_expires_at');
+  assert.match(src, /vep_expired_at\?:\s*string\s*\|\s*null/, 'type must declare vep_expired_at');
+});
+
+test('migration adds the two columns + get_selection_dashboard surfaces them in vep_recon', () => {
+  const dir = join(REPO_ROOT, 'supabase/migrations');
+  const file = readdirSync(dir).find((f) => f.includes('902_vep_offer_deadline_capture'));
+  assert.ok(file, 'the #902 migration file must exist');
+  const sql = readFileSync(join(dir, file), 'utf8');
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS vep_offer_expires_at\s+timestamptz/i);
+  assert.match(sql, /ADD COLUMN IF NOT EXISTS vep_expired_at\s+timestamptz/i);
+  // the dashboard RPC must expose both inside vep_recon so the FE row can render them
+  assert.match(sql, /'offer_expires_at',\s*a\.vep_offer_expires_at/);
+  assert.match(sql, /'expired_at',\s*a\.vep_expired_at/);
+});
+
+test('admin/selection vepBadge covers the previously-unmapped statuses + the new badges', () => {
+  const src = read('src/pages/admin/selection.astro');
+  // statuses that previously fell through to the gray "unknown" badge
+  for (const status of ['OfferExtended', 'Expired', 'OfferExpired', 'Complete']) {
+    assert.match(src, new RegExp(`${status}:\\s*\\{ short:`), `vepBadge labelMap must cover ${status}`);
+  }
+  // distinct approved→expired badge + proactive countdown chip
+  assert.match(src, /cutoff_approved_email_sent_at && isExpiryFamily/, 'approved→expired badge must gate on cutoff approval + expiry family');
+  assert.match(src, /offer_expires_at/, 'vepBadge must read the forward-looking deadline');
+  assert.match(src, /deadlineToday|deadlineDays/, 'vepBadge must render a deadline countdown');
+});
+
+test('the new comp.vepBadge i18n keys exist with full 3-dictionary parity', () => {
+  const NEW_KEYS = [
+    'expired', 'statusExpired', 'offerExpired', 'statusOfferExpired',
+    'offerExtended', 'statusOfferExtended', 'complete', 'statusComplete',
+    'approvedExpiredShort', 'approvedExpiredTooltip',
+    'deadlineDays', 'deadlineToday', 'deadlineTomorrow', 'deadlineTooltip',
+  ];
+  for (const dict of ['pt-BR', 'en-US', 'es-LATAM']) {
+    const src = read(`src/i18n/${dict}.ts`);
+    for (const k of NEW_KEYS) {
+      assert.match(src, new RegExp(`'comp\\.vepBadge\\.${k}'\\s*:`), `${dict} missing comp.vepBadge.${k}`);
+    }
+  }
+});

--- a/tests/contracts/p472-vep-reimport-status-freeze.test.mjs
+++ b/tests/contracts/p472-vep-reimport-status-freeze.test.mjs
@@ -112,21 +112,32 @@ test('#472 — existing-row SELECT loads status (needed for the freeze)', () => 
 });
 
 test('#472 — same-cycle update uses resolveReimportStatus, NOT bare payload.status', () => {
-  const block = sameCycleUpdateBlock(readDb());
+  const dbSrc = readDb();
+  const block = sameCycleUpdateBlock(dbSrc);
   const statusLine = block.split('\n').find((l) => /^\s*status\s*:/.test(l));
   assert.ok(statusLine, 'same-cycle update must still declare a `status:` key (update-coverage test)');
-  // #693 — the call now threads a third arg (payload.vep_status_raw) so a HARD
-  // terminal VEP decision can override the mid-pipeline freeze. The first two
-  // args MUST stay (existing.status, payload.status); the third is required so
-  // the terminal-honoring path is wired.
+  // #693 — the resolver threads a third arg (payload.vep_status_raw) so a HARD terminal
+  // VEP decision can override the mid-pipeline freeze. The first two args MUST stay
+  // (existing.status, payload.status); the third is required so the terminal-honoring
+  // path is wired. #902 — the resolved value may be wired EITHER inline OR via a
+  // `const newStatus = resolveReimportStatus(...)` one line above the update (so the
+  // same value is reused for auditVepTerminalClobber). Accept both forms; either way the
+  // exact 3-arg call must be present AND the status field must be wired to its result.
+  const RESOLVER_3ARG = /resolveReimportStatus\(\s*existing\.status\s*,\s*payload\.status\s*,\s*payload\.vep_status_raw\s*\)/;
+  const trimmed = statusLine.trim();
+  const inlineForm = RESOLVER_3ARG.test(trimmed);
+  const constForm =
+    /^status\s*:\s*newStatus\s*,?$/.test(trimmed) &&
+    new RegExp('const\\s+newStatus\\s*=\\s*' + RESOLVER_3ARG.source).test(stripComments(dbSrc));
   assert.ok(
-    /resolveReimportStatus\(\s*existing\.status\s*,\s*payload\.status\s*,\s*payload\.vep_status_raw\s*\)/.test(statusLine),
-    `status must be set via resolveReimportStatus(existing.status, payload.status, payload.vep_status_raw) — got: "${statusLine.trim()}"`
+    inlineForm || constForm,
+    `status must be set via resolveReimportStatus(existing.status, payload.status, payload.vep_status_raw) ` +
+      `(inline, or via a \`const newStatus = …\` reused for the audit) — got: "${trimmed}"`
   );
   // Forward defense: the exact pre-fix clobber must not reappear in db.ts CODE
   // (comments documenting the anti-pattern are stripped first).
   assert.ok(
-    !/status\s*:\s*payload\.status/.test(stripComments(readDb())),
+    !/status\s*:\s*payload\.status/.test(stripComments(dbSrc)),
     'REGRESSION: db.ts reverted to the unconditional `status: payload.status` overwrite (#472 B2)'
   );
 });


### PR DESCRIPTION
## #902 sub-gap 1 — VEP deadline surfacing + "approved-then-VEP-expired" state

Closes the **visibility** half of #902. Sub-gap 2 (re-application auto-approve + score transfer) is **deferred to a spec + legal/governance review** per PM decision this session.

### Root cause (grounded against live prod this session)
The `pmi-vep-sync` worker writes `selection_applications.status` **directly via PostgREST** (`resolveReimportStatus`, `db.ts`), bypassing the audited DB-side `reconcile_vep_terminal_status`. When an approved candidate's VEP application/offer expires, the worker flips them `→ rejected` in the same PATCH that stamps `vep_status_raw`/`vep_last_seen_at` — **silent, late, and with zero `admin_audit_log` trail**, and the `rejected` is indistinguishable from an evaluation rejection.

The deadline data **exists at the source and was discarded**: the extract script emits `expiryDateUtc` (forward-looking deadline) + `offerExpiredDateUtc`/`applicationExpiredDateUtc`, but `script-mapper.ts` only used `applicationExpiredDateUtc` as an `application_date` fallback. No column stored a deadline.

**Live scale (cycle4):** 7 "approved-then-terminal" cases (2 `Expired`, 4 `OfferNotExtended`, 1 `Withdrawn`) — all already terminal. The value here is preventing the **next** silent expiry (cycle4 open until 30/06; 24 approved+Active / 3 approved+OfferExtended still in flight) and giving the reason distinction.

### What ships
| Layer | Change |
|---|---|
| **DB** (`migration …254`) | nullable `vep_offer_expires_at` + `vep_expired_at`; `get_selection_dashboard.vep_recon` exposes both (additive). **Already applied to remote** (additive/dormant). |
| **Worker** | `script-mapper` captures the 2 dates via `safeTimestamp` (malformed → null, never throws); `db.ts` persists them on UPDATE + `auditVepTerminalClobber()` writes `admin_audit_log` (`selection.vep_terminal_clobber`, reason `vep_expired_after_cutoff_approval`) on the terminal flip; `types.ts`/`mapper.ts` parity. |
| **UI** (`admin/selection`) | `vepBadge` covers `Expired`/`OfferExpired`/`OfferExtended`/`Complete` (were gray "unknown"); distinct **"aprovado → oferta VEP expirada (DD/MM)"** badge; proactive **deadline countdown** chip (amber ≤7d, ≤30d window). |
| **i18n** | 14 new `comp.vepBadge.*` keys in pt-BR/en-US/es-LATAM + inline `T.vepBadge` fallback. |
| **Tests** | new `902-vep-deadline-capture` contract test; `p472` status-line assertion made refactor-tolerant (keeps the anti-regression guard against bare `status: payload.status`). |

### Verification
- `npx astro build` ✓ · `npm test` → **4201 pass / 0 fail** (DB-aware tests skip locally w/o creds) · worker `tsc --noEmit` ✓
- Adversarial `code-reviewer` pass: **0 blockers**; its MEDIUM findings (#1 `Complete` missing from the countdown-suppress set; #2 `mapper.ts` raw date; #3 rollback comment) are **fixed** in this branch.
- Migration tracking re-verified: exactly one `schema_migrations` row at the convention version `20260805000254`, no apply-time orphan.

### Post-merge (NOT done — needs your go)
1. `cd cloudflare-workers/pmi-vep-sync && npx wrangler deploy` — the capture + audit live in the worker; they only take effect after this.
2. The deadline columns populate on the **next live ingest** (worker `/ingest`); whether PMI populates `expiryDate` for every in-flight app is a runtime fact to confirm on that first ingest (payloads aren't persisted, so it couldn't be proven from a stored value).

### Out of scope (sub-gap 2 — spec next)
Re-application path: auto-approve + prior-score transfer (no transfer exists today; scores derive from `selection_evaluations` per `application_id`) + start conditioned on membership currency. Touches member-lifecycle (GP-only, LGPD Art.18) → spec + legal-counsel review before any code.
