### PR TITLE
feat(curation)(#190): surface Drive grant state in curation queue envelope

### DIFF
--- a/src/lib/mcp-manifest.json
+++ b/src/lib/mcp-manifest.json
@@ -935,7 +935,7 @@
     },
     {
       "name": "get_curation_queue_state",
-      "description": "Returns the curation queue with normalized per-item state: curation_status, SLA, review round/count, per-caller eligible_actions, and a caller capability block. Read access requires curate_content, write_board, or participate_in_governance_review.",
+      "description": "Returns the curation queue with normalized per-item state: curation_status, SLA, review round/count, per-caller eligible_actions, and a caller capability block. For curate_content/manage_platform callers each item also carries Drive grant state (drive_permission_status, drive_grant_role, drive_grant_errors, missing_drive_access, temporary_access_expires_or_revokes_on). Read access requires curate_content, write_board, or participate_in_governance_review.",
       "domain": "board",
       "permission": "read",
       "is_sensitive": false

--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -547,7 +547,7 @@ O Núcleo de IA Aplicada à Gestão de Projetos é uma iniciativa de pesquisa do
 | 74 | get_wiki_health | — | — | Relatório de saúde da wiki |
 | 75 | list_initiatives | kind?, status? | — | Lista iniciativas (filtro por tipo/status) |
 | 76 | manage_initiative_engagement | initiative_id, person_id, kind, role?, action | manage_member | Add/remove/update membro em iniciativa |
-| 77 | get_curation_queue_state | status? | curate_content \\| write_board \\| participate_in_governance_review | Fila de curadoria normalizada (#190): estado FSM, SLA, eligible_actions por chamador |
+| 77 | get_curation_queue_state | status? | curate_content \\| write_board \\| participate_in_governance_review | Fila de curadoria normalizada (#190): estado FSM, SLA, eligible_actions por chamador + estado de grant de Drive por item (gated curate\\|manage) |
 | 78 | submit_curation_review | item_id, decision, criteria_scores?, feedback_notes? | participate_in_governance_review | Submeter revisão estruturada (aprovar/devolver/rejeitar; auto-publica no N-ésimo OK) |
 | 79 | assign_curation_reviewer | item_id, reviewer_id, round | participate_in_governance_review | Designar revisor (curate_content/co_gp) para uma rodada de curadoria |
 
@@ -1615,7 +1615,9 @@ function registerTools(mcp: McpServer, sb: ReturnType<typeof createClient>) {
   // TOOL: get_curation_queue_state — Curators / board writers / governance reviewers.
   // Wraps the #190 normalized envelope: per-item curation FSM state, SLA, review round/count,
   // per-caller eligible_actions, and a caller capability block. The stable envelope #188 exposes.
-  mcp.tool("get_curation_queue_state", "Returns the curation queue with normalized per-item state: curation_status, SLA, review round/count, per-caller eligible_actions, and a caller capability block. Read access requires curate_content, write_board, or participate_in_governance_review.", {
+  // Drive layer (#190/#301): per-item drive_permission_status + grant role/errors/expiry are
+  // populated only for curate_content/manage_platform callers (null otherwise); caller.can_see_drive flags it.
+  mcp.tool("get_curation_queue_state", "Returns the curation queue with normalized per-item state: curation_status, SLA, review round/count, per-caller eligible_actions, and a caller capability block. For curate_content/manage_platform callers each item also carries Drive grant state (drive_permission_status missing|pending|error|ready, drive_grant_role, drive_grant_errors, missing_drive_access, temporary_access_expires_or_revokes_on). Read access requires curate_content, write_board, or participate_in_governance_review.", {
     status: z.string().optional().describe("Filter by curation_status: 'peer_review' | 'leader_review' | 'curation_pending'. Omit for the full active queue.")
   }, async (params: { status?: string }) => {
     const start = Date.now();

--- a/supabase/migrations/20260805000272_190_curation_queue_state_drive_access.sql
+++ b/supabase/migrations/20260805000272_190_curation_queue_state_drive_access.sql
@@ -1,0 +1,187 @@
+-- #190 (Drive layer) — surface curation Drive grant state in the queue envelope.
+--
+-- Post-#301 (ADR-0108): drive_curation_grants tracks temporary governed Drive
+-- access for curation. get_curation_queue_state is the normalized envelope the
+-- curator MCP tools wrap. This adds, per item, an item-level rollup of Drive
+-- access state so a curator/governance reviewer sees grant readiness alongside
+-- SLA/review state — mirroring get_board_item_drive_access's per-file→overall
+-- derivation exactly so the queue chip and the modal badge always agree.
+--
+-- New per-item fields:
+--   drive_permission_status                 missing | pending | error | ready
+--   drive_grant_role                        'commenter' when files exist, else null
+--   drive_grant_errors                      jsonb[] of distinct API error messages
+--   missing_drive_access                    bool (0 non-deleted board_item_files)
+--   temporary_access_expires_or_revokes_on  = curation_due_at (= item-RPC expires_or_revokes_on)
+--
+-- GATE (PM-ratified): the Drive fields are populated ONLY for callers with
+-- curate_content OR manage_platform — consistent with the read gate of
+-- get_board_item_drive_access. write_board-only / govern-only callers (who can
+-- read the queue but cannot open the item-RPC) get NULL Drive fields. This
+-- avoids opening a second, broader read surface over grant state.
+--
+-- Behavior-neutral at ship: 0 grants, 0 queue items with board_item_files ->
+-- every item resolves to missing_drive_access=true / drive_permission_status='missing'.
+--
+-- Same signature -> CREATE OR REPLACE. Rollback: re-apply 20260805000121.
+
+CREATE OR REPLACE FUNCTION public.get_curation_queue_state(p_status text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_can_curate boolean;
+  v_can_write_board boolean;
+  v_can_govern boolean;
+  v_can_manage boolean;
+  v_drive_visible boolean;
+  v_result jsonb;
+BEGIN
+  SELECT id INTO v_member_id FROM public.members WHERE auth_id = auth.uid() LIMIT 1;
+  IF v_member_id IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+  v_can_curate := public.can_by_member(v_member_id, 'curate_content');
+  v_can_write_board := public.can_by_member(v_member_id, 'write_board');
+  v_can_govern := public.can_by_member(v_member_id, 'participate_in_governance_review');
+  IF NOT (v_can_curate OR v_can_write_board OR v_can_govern) THEN
+    RAISE EXCEPTION 'Curatorship access required';
+  END IF;
+  -- Drive grant state mirrors the get_board_item_drive_access read gate.
+  v_can_manage := public.can_by_member(v_member_id, 'manage_platform');
+  v_drive_visible := (v_can_curate OR v_can_manage);
+
+  WITH q AS (
+    SELECT bi.id, bi.title, bi.curation_status, bi.curation_due_at, bi.board_id,
+           bi.reviewer_id, bi.leader_reviewer_id, bi.created_by, bi.created_at,
+           bi.peer_review_completed_at, bi.peer_review_waived,
+           bi.leader_review_completed_at, bi.leader_review_decision,
+           pb.board_name, i.legacy_tribe_id AS tribe_id, i.title AS tribe_name,
+           COALESCE(sc.reviewers_required, 2) AS reviewers_required,
+           (SELECT COALESCE(max(ble.review_round), 1) FROM public.board_lifecycle_events ble
+              WHERE ble.item_id = bi.id AND ble.action = 'reviewer_assigned') AS current_round
+    FROM public.board_items bi
+    JOIN public.project_boards pb ON pb.id = bi.board_id
+    LEFT JOIN public.initiatives i ON i.id = pb.initiative_id
+    LEFT JOIN public.board_sla_config sc ON sc.board_id = bi.board_id
+    WHERE bi.status <> 'archived' AND pb.is_active = true
+      AND bi.curation_status IN ('peer_review', 'leader_review', 'curation_pending')
+      AND (p_status IS NULL OR bi.curation_status = p_status)
+  ),
+  -- Per-file Drive status (mirrors get_board_item_drive_access's per-file CASE):
+  --   error  = any failed|revoke_failed grant for the file
+  --   pending= any pending_grant grant
+  --   ready  = any granted grant
+  --   else   = 'pending' (file with no resolvable active grant)
+  -- Only computed when the caller may see Drive state (avoids needless work).
+  dfile AS (
+    SELECT bif.board_item_id, bif.drive_file_id,
+      CASE
+        WHEN count(*) FILTER (WHERE g.status IN ('failed','revoke_failed')) > 0 THEN 'error'
+        WHEN count(*) FILTER (WHERE g.status = 'pending_grant') > 0           THEN 'pending'
+        WHEN count(*) FILTER (WHERE g.status = 'granted') > 0                 THEN 'ready'
+        ELSE 'pending'
+      END AS file_status
+    FROM public.board_item_files bif
+    LEFT JOIN public.drive_curation_grants g
+      ON g.drive_file_id = bif.drive_file_id AND g.board_item_id = bif.board_item_id
+    WHERE v_drive_visible
+      AND bif.deleted_at IS NULL
+      AND bif.board_item_id IN (SELECT id FROM q)
+    GROUP BY bif.board_item_id, bif.drive_file_id
+  ),
+  -- Item-level rollup (error > pending > ready > pending) + distinct error messages.
+  drive AS (
+    SELECT
+      f.board_item_id,
+      count(*) AS file_count,
+      CASE
+        WHEN bool_or(f.file_status = 'error')   THEN 'error'
+        WHEN bool_or(f.file_status = 'pending') THEN 'pending'
+        WHEN bool_or(f.file_status = 'ready')   THEN 'ready'
+        ELSE 'pending'
+      END AS overall_when_files,
+      (SELECT COALESCE(jsonb_agg(DISTINCT (g2.api_error->>'message'))
+                FILTER (WHERE g2.api_error IS NOT NULL), '[]'::jsonb)
+         FROM public.drive_curation_grants g2
+        WHERE g2.board_item_id = f.board_item_id
+          AND g2.status IN ('failed','revoke_failed')
+          AND EXISTS (SELECT 1 FROM public.board_item_files bif2
+                       WHERE bif2.board_item_id = f.board_item_id
+                         AND bif2.drive_file_id = g2.drive_file_id
+                         AND bif2.deleted_at IS NULL)) AS errors
+    FROM dfile f
+    GROUP BY f.board_item_id
+  )
+  SELECT jsonb_build_object(
+    'items', COALESCE((
+      SELECT jsonb_agg(jsonb_build_object(
+        'origin_type', 'board_item',
+        'origin_id', q.id,
+        'id', q.id, 'title', q.title,
+        'curation_status', q.curation_status,
+        'board_id', q.board_id, 'board_name', q.board_name,
+        'tribe_id', q.tribe_id, 'tribe_name', q.tribe_name,
+        'reviewer_id', q.reviewer_id, 'reviewer_name', rm.name,
+        'leader_reviewer_id', q.leader_reviewer_id,
+        'review_round', q.current_round,
+        'review_count', (SELECT count(*) FROM public.curation_review_log crl WHERE crl.board_item_id = q.id AND crl.review_round = q.current_round),
+        'reviews_approved', (SELECT count(DISTINCT crl.curator_id) FROM public.curation_review_log crl WHERE crl.board_item_id = q.id AND crl.decision = 'approved' AND crl.review_round = q.current_round),
+        'reviewers_required', q.reviewers_required,
+        'peer_review_completed_at', q.peer_review_completed_at,
+        'leader_review_completed_at', q.leader_review_completed_at,
+        'due_at', q.curation_due_at,
+        'sla_status', CASE
+          WHEN q.curation_due_at IS NULL THEN 'no_sla'
+          WHEN q.curation_due_at < now() THEN 'overdue'
+          WHEN q.curation_due_at < now() + interval '2 days' THEN 'warning'
+          ELSE 'on_time' END,
+        'caller_reviewed_this_round', EXISTS (SELECT 1 FROM public.curation_review_log crl WHERE crl.board_item_id = q.id AND crl.curator_id = v_member_id AND crl.review_round = q.current_round),
+        -- #190 Drive layer (gated to curate_content OR manage_platform; null otherwise).
+        'drive_permission_status', CASE WHEN v_drive_visible
+          THEN (CASE WHEN dr.board_item_id IS NULL THEN 'missing' ELSE dr.overall_when_files END)
+          ELSE NULL END,
+        'drive_grant_role', CASE WHEN v_drive_visible AND dr.board_item_id IS NOT NULL THEN 'commenter' ELSE NULL END,
+        'drive_grant_errors', CASE WHEN v_drive_visible THEN COALESCE(dr.errors, '[]'::jsonb) ELSE NULL END,
+        'missing_drive_access', CASE WHEN v_drive_visible THEN (dr.board_item_id IS NULL) ELSE NULL END,
+        'temporary_access_expires_or_revokes_on', CASE WHEN v_drive_visible THEN q.curation_due_at ELSE NULL END,
+        'eligible_actions', (
+          SELECT COALESCE(jsonb_agg(a.act), '[]'::jsonb) FROM (
+            SELECT 'submit_review'::text AS act
+              WHERE v_can_govern
+                AND q.curation_status = 'curation_pending'
+                AND NOT EXISTS (SELECT 1 FROM public.curation_review_log crl WHERE crl.board_item_id = q.id AND crl.curator_id = v_member_id AND crl.review_round = q.current_round)
+            UNION ALL SELECT 'assign_reviewer' WHERE v_can_govern
+            UNION ALL SELECT 'publish' WHERE q.curation_status = 'curation_pending' AND v_can_govern
+          ) a
+        )
+      ) ORDER BY
+        CASE
+          WHEN q.curation_due_at IS NOT NULL AND q.curation_due_at < now() THEN 0
+          WHEN q.curation_due_at IS NOT NULL AND q.curation_due_at < now() + interval '2 days' THEN 1
+          ELSE 2 END,
+        q.curation_due_at ASC NULLS LAST)
+      FROM q
+      LEFT JOIN public.members rm ON rm.id = q.reviewer_id
+      LEFT JOIN drive dr ON dr.board_item_id = q.id
+    ), '[]'::jsonb),
+    'summary', jsonb_build_object(
+      'total', (SELECT count(*) FROM q),
+      'by_status', (SELECT COALESCE(jsonb_object_agg(s.curation_status, s.c), '{}'::jsonb) FROM (SELECT curation_status, count(*) c FROM q GROUP BY curation_status) s),
+      'overdue', (SELECT count(*) FROM q WHERE curation_due_at < now())
+    ),
+    'caller', jsonb_build_object(
+      'member_id', v_member_id,
+      'can_curate', v_can_curate,
+      'can_write_board', v_can_write_board,
+      'can_govern', v_can_govern,
+      'can_see_drive', v_drive_visible
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.get_curation_queue_state(text) TO authenticated;

--- a/tests/contracts/190-curation-queue-state.test.mjs
+++ b/tests/contracts/190-curation-queue-state.test.mjs
@@ -26,6 +26,13 @@ const MIG = readFileSync(
   'utf8',
 );
 
+// Drive layer (#190 + #301): the queue envelope surfaces per-item Drive grant
+// state, computed only for curate_content/manage_platform callers.
+const MIG_DRIVE = readFileSync(
+  join(resolve(process.cwd(), 'supabase/migrations'), '20260805000272_190_curation_queue_state_drive_access.sql'),
+  'utf8',
+);
+
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const dbGated = !!(SUPABASE_URL && SUPABASE_KEY);
@@ -57,6 +64,47 @@ test('#190: normalized envelope — origin_type + eligible_actions + actionable-
 
 test('#190: caller capability block is returned', () => {
   assert.match(MIG, /'caller', jsonb_build_object\([\s\S]*?'can_curate', v_can_curate[\s\S]*?'can_govern', v_can_govern/);
+});
+
+// ── (C) Drive layer (#190 + #301) — static asserts over the Drive-access migration ──
+test('#190 drive: re-declares get_curation_queue_state(p_status) (same signature, CREATE OR REPLACE)', () => {
+  assert.match(MIG_DRIVE, /CREATE OR REPLACE FUNCTION public\.get_curation_queue_state\(p_status text/);
+  assert.match(MIG_DRIVE, /SECURITY DEFINER/);
+});
+
+test('#190 drive: Drive visibility gate is curate_content OR manage_platform (mirrors get_board_item_drive_access)', () => {
+  assert.match(MIG_DRIVE, /v_can_manage\s*:=\s*public\.can_by_member\(v_member_id, 'manage_platform'\)/);
+  assert.match(MIG_DRIVE, /v_drive_visible\s*:=\s*\(v_can_curate OR v_can_manage\)/);
+  // the original read gate (curate|write_board|govern) must remain intact
+  assert.match(MIG_DRIVE, /IF NOT \(v_can_curate OR v_can_write_board OR v_can_govern\) THEN/);
+});
+
+test('#190 drive: each item carries the 5 Drive fields, all gated on v_drive_visible', () => {
+  for (const key of [
+    'drive_permission_status',
+    'drive_grant_role',
+    'drive_grant_errors',
+    'missing_drive_access',
+    'temporary_access_expires_or_revokes_on',
+  ]) {
+    assert.match(MIG_DRIVE, new RegExp(`'${key}',\\s*CASE WHEN v_drive_visible`), `${key} present + gated`);
+  }
+  // expiry mirrors the item-RPC's expires_or_revokes_on (= curation_due_at)
+  assert.match(MIG_DRIVE, /'temporary_access_expires_or_revokes_on', CASE WHEN v_drive_visible THEN q\.curation_due_at ELSE NULL END/);
+});
+
+test('#190 drive: per-file status bucketing mirrors the item-RPC (error>pending>ready)', () => {
+  assert.match(MIG_DRIVE, /FILTER \(WHERE g\.status IN \('failed','revoke_failed'\)\)[\s\S]*?THEN 'error'/);
+  assert.match(MIG_DRIVE, /FILTER \(WHERE g\.status = 'pending_grant'\)[\s\S]*?THEN 'pending'/);
+  assert.match(MIG_DRIVE, /FILTER \(WHERE g\.status = 'granted'\)[\s\S]*?THEN 'ready'/);
+  // item-level rollup keeps the same precedence
+  assert.match(MIG_DRIVE, /bool_or\(f\.file_status = 'error'\)\s*THEN 'error'/);
+  // 0 files -> 'missing'
+  assert.match(MIG_DRIVE, /WHEN dr\.board_item_id IS NULL THEN 'missing'/);
+});
+
+test('#190 drive: caller block exposes can_see_drive', () => {
+  assert.match(MIG_DRIVE, /'can_see_drive', v_drive_visible/);
 });
 
 // ── (B) DB-gated: the RPC exists and fail-closes for an unauthenticated caller ──


### PR DESCRIPTION
## #190 — Drive grant state in the curation queue envelope

Surfaces, per queue item, an item-level rollup of the temporary governed Drive grant state introduced by #301 (ADR-0108), so the curator MCP tools (and any envelope consumer) can show grant readiness alongside SLA / review state.

### New per-item fields (in `get_curation_queue_state`)
- `drive_permission_status` — `missing | pending | error | ready`
- `drive_grant_role` — `'commenter'` when the item has files, else `null`
- `drive_grant_errors` — distinct Drive API error messages
- `missing_drive_access` — bool (0 non-deleted `board_item_files`)
- `temporary_access_expires_or_revokes_on` — `= curation_due_at` (matches the item-RPC's `expires_or_revokes_on`)

The rollup **mirrors `get_board_item_drive_access`'s per-file→overall derivation exactly** (error > pending > ready; `missing` when 0 files) so the queue indicator and the curation-modal badge (#201) always agree.

### Authority
Drive fields are **gated to `curate_content | manage_platform`** callers (null otherwise) — consistent with the read gate of `get_board_item_drive_access`. The broader queue read gate (`curate_content | write_board | participate_in_governance_review`) is unchanged; `caller.can_see_drive` flags visibility.

### Surface
- `supabase/migrations/20260805000272_190_curation_queue_state_drive_access.sql` — `CREATE OR REPLACE` (same signature). Already applied to prod via `apply_migration` + GC-097 tracking sync.
- MCP: tool description + `mcp-manifest.json` note the new fields. **Passthrough — no new tool** (tool count unchanged).
- `tests/contracts/190-curation-queue-state.test.mjs` — extended with the Drive-layer asserts.

### Verification (live)
- **Behavior-neutral at ship:** 0 grants in `drive_curation_grants`, 0 queue items with `board_item_files` → every item resolves to `missing_drive_access=true` / `drive_permission_status='missing'`.
- **Both sides of the gate proven under impersonation:** a `curate_content`/`manage_platform` caller sees the fields; a `write_board`-only caller sees the queue but `null` Drive fields.
- `npx astro build` clean; `npm test` 4709/4709 pass (DB-gated contract tests run with secrets).

Pairs with #201 (curation-modal per-file Drive badge), shipping as a separate PR.
