### PR TITLE
chore(#816): forward-protect docs/drafts/p277_* in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,4 @@ docs/**/*selection-journey-audit*
 docs/**/*peer_review_briefing*
 docs/**/*WHATSAPP_CROSS_GROUP*
 docs/drafts/p131_email_*
+docs/drafts/p277_*


### PR DESCRIPTION
## What
One-line forward-protection guard: `docs/drafts/p277_*` added to `.gitignore`
(PII section). The `p269_*` sibling is already covered (lines 96 + 108).

## Why glob-only / why no git-rm
- The filename itself leaks two first names — so the guard uses the **session-number
  glob**, never the full name.
- **No `git rm`**: on a public repo a deletion commit re-exposes the content in the
  PR diff and in `refs/pull/*` (which `filter-repo` does not purge) — the exact trap
  #816 is unwinding. The still-tracked copy is removed by the **deferred history-rewrite
  round** (the refs/pull GitHub-Support ticket), not by this PR.

Forward-protection only. Does not close #816 — the rewrite + refs/pull cleanup remain.

Refs #816