### PR TITLE
fix(authority): sponsor role precedence + full-read sponsor designation (Wave 1 — Ivan/LIM)

### DIFF
--- a/src/lib/permissions.ts
+++ b/src/lib/permissions.ts
@@ -32,6 +32,7 @@ export type OperationalTier =
 
 export type Designation =
   | 'deputy_manager'
+  | 'sponsor'
   | 'curator'
   | 'comms_leader'
   | 'comms_member'
@@ -212,6 +213,26 @@ export const TIER_PERMISSIONS: Record<OperationalTier, Permission[]> = {
 // ==========================================
 
 export const DESIGNATION_PERMISSIONS: Record<Designation, Permission[]> = {
+  // Patrocinador (Wave 1 — Ivan / LATAM LIM). The `sponsor` designation previously granted NOTHING
+  // here, so a sponsor saw no admin panels even though RLS already lets any authoritative (non-guest)
+  // member READ all boards/initiatives (minus confidential #785) and the member directory. This grants
+  // the FULL READ surface (admin read panels + board/initiative read-all + member directory + analytics);
+  // NO write/manage (server RPCs remain the write boundary). Wave 2 decides chapter-layer restrictions
+  // for chapter sponsors/directors.
+  sponsor: [
+    'admin.access', 'admin.members.view',
+    'admin.analytics', 'admin.analytics.chapter',
+    'admin.curation', 'admin.governance.view',
+    'admin.sustainability', 'admin.portfolio', 'admin.partners',
+    'admin.gamification', 'admin.publications',
+    'admin.filiacao', 'admin.voluntarios', 'admin.certificacao',
+    'board.view_all', 'board.view_global',
+    'event.view_all',
+    'gamification.view_ranking',
+    'content.view_publications',
+    'data.view_members', 'data.view_analytics',
+    'workspace.access',
+  ],
   deputy_manager: [
     'admin.access', 'admin.members.view', 'admin.members.manage',
     'admin.events.manage', 'admin.campaigns', 'admin.analytics',
@@ -301,6 +322,7 @@ export const TIER_LABELS: Record<OperationalTier, { pt: string; en: string; es: 
 
 export const DESIGNATION_LABELS: Record<Designation, { pt: string; en: string; es: string }> = {
   deputy_manager: { pt: 'Vice-Gerente',         en: 'Deputy Manager',    es: 'Vice-Gerente' },
+  sponsor:        { pt: 'Patrocinador',         en: 'Sponsor',           es: 'Patrocinador' },
   curator:        { pt: 'Curador',              en: 'Curator',           es: 'Curador' },
   comms_leader:   { pt: 'Líder de Comunicação', en: 'Comms Leader',     es: 'Líder de Comunicación' },
   comms_member:   { pt: 'Time de Comunicação',  en: 'Comms Member',     es: 'Equipo de Comunicación' },

--- a/supabase/migrations/20260805000282_ivan_sponsor_role_precedence.sql
+++ b/supabase/migrations/20260805000282_ivan_sponsor_role_precedence.sql
@@ -1,0 +1,60 @@
+-- Wave 1 (Ivan / LATAM LIM) — sponsor must outrank researcher in the operational_role derivation.
+--
+-- Problem: sync_operational_role_cache derives operational_role from auth_engagements with a CASE
+-- precedence where the `researcher` branch (which also catches committee_member / workgroup roles)
+-- is checked BEFORE `sponsor`. Ivan Lourenço (host-chapter PMI-GO sponsor, LATAM LIM presenter) is
+-- also LEADER of the "GP × Presidência — Governança do Núcleo" committee → he matched `researcher`
+-- and derived operational_role='researcher' → badge "Pesquisador" + the researcher tier (no admin.*).
+--
+-- Blast radius (grounded 2026-06-28): of the 5 members with an authoritative sponsor engagement,
+-- 4 (PMI-MG/CE/RS/DF chapter sponsors) already derive 'sponsor' (no committee engagement). ONLY Ivan
+-- derived 'researcher'. Moving the `sponsor` branch above `researcher` flips ONLY Ivan; zero collateral.
+-- Kept BELOW manager/deputy_manager/tribe_leader so an operational leader who also sponsors stays a leader.
+--
+-- (Wave 2 — separate — will handle chapter_board→chapter_liaison precedence for all sede/chapter
+-- directors + the access-restriction decision per directorate/chapter layer.)
+
+CREATE OR REPLACE FUNCTION public.sync_operational_role_cache()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_new_role text;
+BEGIN
+  SELECT id INTO v_member_id FROM public.members WHERE person_id = COALESCE(NEW.person_id, OLD.person_id);
+  IF v_member_id IS NULL THEN RETURN COALESCE(NEW, OLD); END IF;
+
+  SELECT CASE
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'co_gp')          THEN 'manager'
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'deputy_manager') THEN 'deputy_manager'
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+      -- Wave 1 fix: sponsor outranks researcher (committee/workgroup) so a sponsor who also sits on a
+      -- committee (e.g. the governance committee) shows as a sponsor, not a researcher.
+      WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+      WHEN bool_or(
+        (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+        OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+            AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+        OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+            AND ae.role IN ('leader','co_leader','owner','coordinator'))
+      ) THEN 'researcher'
+      WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+      WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+      WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+      WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+      WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+      ELSE 'guest'
+    END INTO v_new_role
+  FROM public.auth_engagements ae
+  WHERE ae.person_id = COALESCE(NEW.person_id, OLD.person_id) AND ae.is_authoritative = true;
+
+  UPDATE public.members SET operational_role = COALESCE(v_new_role, 'guest'), updated_at = now()
+    WHERE id = v_member_id AND operational_role IS DISTINCT FROM COALESCE(v_new_role, 'guest');
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$function$;

--- a/supabase/migrations/20260805000283_a3_invariant_sponsor_precedence_parity.sql
+++ b/supabase/migrations/20260805000283_a3_invariant_sponsor_precedence_parity.sql
@@ -1,0 +1,699 @@
+-- Wave 1 (Ivan) parity: mirror the sponsor>researcher precedence into the A3 invariant ladder.
+--
+-- ADR-0023 (role-ladder-parity.test.mjs) requires the CASE ladder in sync_operational_role_cache()
+-- to match the A3 expected_role ladder in check_schema_invariants() byte-for-byte (same conditions,
+-- same order). Migration 20260805000282 moved `sponsor` above `researcher` in the trigger; this moves
+-- the matching A3 branch so the drift detector expects the same derivation (else Ivan, now correctly
+-- 'sponsor', would be reported as A3 drift). ONLY the A3 ladder's sponsor branch position changes; every
+-- other invariant is reproduced verbatim from the live body.
+
+CREATE OR REPLACE FUNCTION public.check_schema_invariants()
+ RETURNS TABLE(invariant_name text, description text, severity text, violation_count integer, sample_ids uuid[])
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL
+     AND current_setting('role', true) NOT IN ('service_role', 'postgres')
+     AND current_user NOT IN ('postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'Unauthorized: check_schema_invariants requires authentication';
+  END IF;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'alumni' AND operational_role IS DISTINCT FROM 'alumni'
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A1_alumni_role_consistency'::text,
+         'member_status=alumni must coerce operational_role=alumni (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'observer' AND operational_role NOT IN ('observer','guest','none')
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A2_observer_role_consistency'::text,
+         'member_status=observer must coerce operational_role IN (observer,guest,none) (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH computed AS (
+    SELECT m.id AS member_id,
+      CASE
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'co_gp')          THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'deputy_manager') THEN 'deputy_manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+        -- Wave 1 fix: sponsor outranks researcher (committee/workgroup) so a sponsor who also sits on a
+        -- committee (e.g. the governance committee) shows as a sponsor, not a researcher.
+        WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+        WHEN bool_or(
+          (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+          OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+              AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+          OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+              AND ae.role IN ('leader','co_leader','owner','coordinator'))
+        ) THEN 'researcher'
+        WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+        WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+        WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+        WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+        WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+        ELSE 'guest'
+      END AS expected_role
+    FROM public.members m
+    LEFT JOIN public.auth_engagements ae ON ae.person_id = m.person_id AND ae.is_authoritative = true
+    WHERE m.member_status='active' AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT c.member_id FROM computed c
+    JOIN public.members m ON m.id = c.member_id
+    WHERE m.operational_role IS DISTINCT FROM c.expected_role
+  )
+  SELECT 'A3_active_role_engagement_derivation'::text,
+         'active member operational_role must equal priority-ladder derivation from active engagements (cache trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE ((member_status='active' AND is_active=false) OR (member_status IN ('observer','alumni','inactive') AND is_active=true))
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B_is_active_status_mismatch'::text,
+         'members.is_active must match member_status mapping (active=true, terminal=false)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND designations IS NOT NULL AND array_length(designations,1)>0
+  )
+  SELECT 'C_designations_in_terminal_status'::text,
+         'members.designations must be empty when member_status is observer/alumni/inactive'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    JOIN public.persons p ON p.id = m.person_id
+    WHERE m.auth_id IS NOT NULL AND p.auth_id IS NOT NULL AND m.auth_id IS DISTINCT FROM p.auth_id
+  )
+  SELECT 'D_auth_id_mismatch_person_member'::text,
+         'persons.auth_id and members.auth_id must agree when both are set (ghost resolution sync)'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ae.engagement_id AS e_id FROM public.auth_engagements ae
+    JOIN public.members m ON m.person_id = ae.person_id
+    WHERE ae.status='active' AND m.member_status IN ('observer','alumni','inactive')
+      AND ae.kind NOT IN ('observer','alumni','external_signer','sponsor','chapter_board','partner_contact')
+  )
+  SELECT 'E_engagement_active_with_terminal_member'::text,
+         'engagement.status=active is inconsistent with member.member_status in (observer/alumni/inactive) unless kind matches'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(e_id ORDER BY e_id) FROM (SELECT e_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT i.id AS initiative_id FROM public.initiatives i
+    WHERE i.legacy_tribe_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.tribes t WHERE t.id = i.legacy_tribe_id)
+  )
+  SELECT 'F_initiative_legacy_tribe_orphan'::text,
+         'initiatives.legacy_tribe_id must point to an existing tribe (bridge integrity)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(initiative_id ORDER BY initiative_id) FROM (SELECT initiative_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    LEFT JOIN public.document_versions dv ON dv.id = gd.current_version_id
+    WHERE gd.current_version_id IS NOT NULL
+      AND (dv.id IS NULL OR dv.locked_at IS NULL)
+      AND NOT EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status IN ('review','approved','activated')
+          AND ac.closed_at IS NULL
+      )
+  )
+  SELECT 'J_current_version_published'::text,
+         'governance_documents.current_version_id must point to a document_versions row with locked_at IS NOT NULL — unless an open approval_chain (review/approved/activated, closed_at NULL) is in flight that will lock the version on close (Phase IP-1, chain-aware).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.operational_role='external_signer'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.auth_engagements ae
+        WHERE ae.person_id=m.person_id AND ae.kind='external_signer' AND ae.status='active' AND ae.is_authoritative=true
+      )
+  )
+  SELECT 'K_external_signer_integrity'::text,
+         'members.operational_role=external_signer must have an active auth_engagements row with kind=external_signer (Phase IP-1).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.member_status IN ('alumni','observer','inactive') AND m.anonymized_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM public.member_offboarding_records r WHERE r.member_id=m.id)
+  )
+  SELECT 'L_offboarding_record_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have a member_offboarding_records row (#91 G3 trigger).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH expected AS (
+    SELECT a.id AS application_id, a.research_score AS cached,
+      CASE
+        WHEN e.obj_avg IS NOT NULL AND e.int_avg IS NOT NULL THEN round(e.obj_avg + e.int_avg, 2)
+        WHEN e.obj_avg IS NOT NULL THEN round(e.obj_avg, 2)
+        ELSE NULL
+      END AS expected
+    FROM public.selection_applications a
+    CROSS JOIN LATERAL (
+      SELECT AVG(weighted_subtotal) FILTER (WHERE evaluation_type='objective' AND submitted_at IS NOT NULL) AS obj_avg,
+        AVG(weighted_subtotal) FILTER (WHERE evaluation_type='interview' AND submitted_at IS NOT NULL) AS int_avg
+      FROM public.selection_evaluations WHERE application_id=a.id
+    ) e
+  ),
+  drift AS (
+    SELECT application_id FROM expected
+    WHERE (cached IS NULL) IS DISTINCT FROM (expected IS NULL)
+       OR (cached IS NOT NULL AND expected IS NOT NULL AND ABS(cached - expected) > 0.01)
+  )
+  SELECT 'M_application_score_consistency'::text,
+         'selection_applications.research_score must equal compute_application_scores(application_id) derivation (sync trigger trg_recompute_application_scores).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive')
+      AND offboarded_at IS NULL AND anonymized_at IS NULL
+      AND name <> 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'N_terminal_status_offboarded_at_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have offboarded_at NOT NULL (ARM-9 G6 defense-in-depth complement to L).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ma.id AS artifact_id FROM public.meeting_artifacts ma
+    WHERE ma.event_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.id = ma.event_id)
+  )
+  SELECT 'O_meeting_artifact_event_orphan'::text,
+         'meeting_artifacts.event_id must point to an existing event when not NULL (FK defense).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(artifact_id ORDER BY artifact_id) FROM (SELECT artifact_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  SELECT 'P_tribe_initiative_bridge_complete'::text,
+         'tribes.is_active=true must have at least one initiative.legacy_tribe_id pointing to it (V3-V4 bridge; cron leader digest depends).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM public.tribes t
+          WHERE t.is_active = true
+            AND NOT EXISTS (SELECT 1 FROM public.initiatives i WHERE i.legacy_tribe_id = t.id)),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS engagement_id FROM public.engagements
+    WHERE status = 'expired' AND end_date > CURRENT_DATE
+  )
+  SELECT 'Q_expired_engagement_end_date'::text,
+         'engagements.status=expired requires end_date <= CURRENT_DATE (impossible to be expired in the future; VEP service_latest_end_date is source of truth).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT a.id AS application_id
+    FROM public.selection_applications a
+    WHERE a.status = 'approved'
+      AND a.email IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.members m WHERE lower(m.email) = lower(a.email)
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM public.member_emails me WHERE lower(me.email) = lower(a.email)
+      )
+  )
+  SELECT 'R_approved_application_has_member'::text,
+         'selection_applications.status=approved must have a matching members row by lower(email). Bypass of approve_selection_application() canonical RPC creates this drift (Issue #180).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT DISTINCT m.id AS member_id
+    FROM public.selection_applications a
+    JOIN public.members m ON lower(m.email) = lower(a.email)
+    WHERE a.status = 'approved' AND m.person_id IS NULL
+  )
+  SELECT 'S_approved_member_has_person_id'::text,
+         'members tied to an approved selection_applications row must have person_id NOT NULL (V4 graph anchor for engagements). Issue #180.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH primary_email_counts AS (
+    SELECT m.id AS member_id,
+           COUNT(me.id) FILTER (WHERE me.is_primary = true) AS primary_count
+    FROM public.members m
+    LEFT JOIN public.member_emails me ON me.member_id = m.id
+    WHERE m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT member_id FROM primary_email_counts
+    WHERE primary_count <> 1
+  )
+  SELECT 'T_member_has_exactly_one_primary_email'::text,
+         'Every member must have exactly one primary email in member_emails (Issue #205).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status = 'pending_proposer_consent'
+      AND EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status NOT IN ('withdrawn','superseded')
+      )
+  )
+  SELECT 'V_prime_pending_proposer_consent_no_open_chain'::text,
+         'status=pending_proposer_consent must not have non-cancelled approval_chains rows (#315 P0-Q7 + Amendment A2 — pending_proposer_consent precedes any chain).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status IN ('approved','active')
+      AND gd.current_ratified_chain_id IS NULL
+  )
+  SELECT 'V_status_chain_coherence'::text,
+         'governance_documents with status approved/active must have current_ratified_chain_id NOT NULL (#315 P0-Q6 + #367 Wave 1b first leaf). NO carve-out: 7 legacy pre-chain docs backfilled with PM-designated synthetic chains via migration 20260805000038 (acknowledge signoffs, metadata.legacy_migration=true, role=migration_attestation).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT cp.id AS product_id
+    FROM public.content_products cp
+    WHERE
+      CASE cp.source_kind
+        WHEN 'governance_document_version' THEN
+          NOT (cp.source_document_version_id IS NOT NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'board_item' THEN
+          NOT (cp.source_board_item_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'publication_idea' THEN
+          NOT (cp.source_publication_idea_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'external' THEN
+          NOT (cp.source_external_uri IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL)
+        WHEN 'none' THEN
+          NOT (cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        ELSE TRUE
+      END
+  )
+  SELECT 'W_content_product_source_integrity'::text,
+         'content_products row must satisfy chk_content_products_source_integrity CHECK semantics (exactly one source FK populated per source_kind; ADR-0099 §2.2 + §6 step 9). Defense-in-depth complement to the CHECK constraint; mirrors V/V''/T pattern.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(product_id ORDER BY product_id) FROM (SELECT product_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT p.id AS parecer_id
+    FROM public.blind_review_pareceres p
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.blind_review_assignments a
+      WHERE a.session_id = p.session_id
+        AND a.reviewer_member_id = p.reviewer_member_id
+        AND a.status = 'active'
+    )
+  )
+  SELECT 'X_blind_review_pareceres_session_product_match'::text,
+         'blind_review_pareceres.reviewer_member_id must have an active blind_review_assignments row in the same session (assignment-parecer integrity; ADR-0099 §2.7 + §7 step 11). Defense-in-depth complement to FK constraints; catches drift if assignment is withdrawn while parecer remains. #382 PR-B.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(parecer_id ORDER BY parecer_id) FROM (SELECT parecer_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH pe AS (
+    SELECT name AS k FROM public.partner_entities
+    WHERE entity_type = 'pmi_chapter' AND status = 'active' AND NOT COALESCE(is_international, false)
+  ),
+  ch AS (
+    SELECT 'PMI-' || code AS k FROM public.chapters WHERE status = 'active'
+  ),
+  drift AS (
+    SELECT k FROM pe WHERE k NOT IN (SELECT k FROM ch)
+    UNION ALL
+    SELECT k FROM ch WHERE k NOT IN (SELECT k FROM pe)
+  )
+  SELECT 'Y_chapter_pipeline_parity'::text,
+         'every active domestic pmi_chapter in partner_entities must have a matching active chapters row (by name = ''PMI-'' || chapters.code) and vice-versa — MEMBERSHIP parity (not just count), so it catches single-table inserts/archives even when row counts coincide. Drift = get_chapter_metrics()->>signed forks from the V4 chapters table (#481).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM drift),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS webinar_id FROM public.webinars
+    WHERE status IS NULL OR status NOT IN ('planned','confirmed','completed','cancelled')
+  )
+  SELECT 'Z_webinar_status_domain'::text,
+         'webinars.status must be within planned|confirmed|completed|cancelled (the realized=completed canonical definition depends on it; defense-in-depth complement to webinars_status_check — #479/#481).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(webinar_id ORDER BY webinar_id) FROM (SELECT webinar_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND current_cycle_active = true
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B2_current_cycle_active_terminal_status'::text,
+         'members in observer/alumni/inactive must have current_cycle_active=false (#483 sync_member_status_consistency B-trigger; CCA gates the get_gamification_leaderboard/get_public_leaderboard cohort).'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id
+    FROM public.members m
+    WHERE m.member_status = 'active'
+      AND m.person_id IS NOT NULL
+      AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND m.name NOT LIKE '%_synthetic%'
+      AND replace(m.chapter, 'PMI-', '') IN (SELECT chapter_code FROM public.chapter_registry)
+      AND NOT (m.operational_role = 'guest' AND m.entry_chapter_code IS NULL)
+      AND (SELECT COUNT(*) FROM public.member_chapter_affiliations a
+            WHERE a.person_id = m.person_id AND a.is_primary) <> 1
+  )
+  SELECT 'U_active_person_has_primary_chapter_affiliation'::text,
+         'every active registry-chaptered member''s person_id must have exactly one is_primary=true member_chapter_affiliations row, else the members.chapter COALESCE(entry, primary, legacy) derivation breaks silently (ADR-0104 Wave 3b-ii). Excluded: operational_role=''guest'' AND entry_chapter_code IS NULL (pre-onboarding, entry-chapter choice not yet made — affiliation is seeded by set_my_entry_chapter, Wave 3b-i; until then the COALESCE falls through to the legacy default). Non-registry chapters (Outro/Externo) excluded — legitimately unaffiliated.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT op.member_id
+    FROM public.onboarding_progress op
+    WHERE op.step_key = 'volunteer_term'
+      AND op.status <> 'completed'
+      AND op.member_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM public.certificates c
+        WHERE c.member_id = op.member_id
+          AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+      )
+  )
+  SELECT 'AA_volunteer_term_complete_when_cert_issued'::text,
+         'a member holding an issued volunteer_agreement certificate must have their volunteer_term onboarding_progress step at status=completed. Guaranteed by the cert-side AFTER trigger (_trg_complete_volunteer_term_on_cert on certificates) plus the seed-side BEFORE guard (_trg_complete_volunteer_term_on_seed on onboarding_progress), p233 / issue #766. A non-completed step alongside an issued cert means a trigger was bypassed (service_role direct INSERT, or a cert backfill that did not fire the AFTER trigger). Directional: a member with no volunteer_term row, or a completed step without an issued cert (all certs rejected or superseded), is NOT a violation.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'term_signed'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.certificates c
+        WHERE c.member_id = mm.member_id
+          AND c.type = 'volunteer_agreement'
+      )
+  )
+  SELECT 'AB_term_signed_milestone_has_cert_ancestry'::text,
+         'a term_signed member_milestone must have at least one volunteer_agreement certificate of any status (issued/rejected/superseded) for the same member. Wave 3c reject/reissue is valid ancestry — the milestone persists after a cert is rejected or superseded because the member did sign once. A milestone with NO cert in any state indicates fabrication or a bad backfill (service_role direct INSERT into member_milestones; source_id is informational-only without FK). #766 PR2, mig 20260805000202. Directional complement to AA.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'first_attendance'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.attendance a
+        WHERE a.member_id = mm.member_id
+          AND a.present = true
+      )
+  )
+  SELECT 'AC_first_attendance_milestone_has_attendance'::text,
+         'a first_attendance member_milestone must have at least one present=true attendance row for the same member. source_id is informational-only (no FK), so a milestone with no present attendance indicates fabrication or a bad backfill (service_role direct INSERT into member_milestones). #766 PR3, mig 20260805000203. Directional, mirrors AA/AB.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'first_deliverable'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.tribe_deliverables td
+        WHERE td.assigned_member_id = mm.member_id
+          AND td.status = 'completed'
+      )
+  )
+  SELECT 'AD_first_deliverable_milestone_has_completed_deliverable'::text,
+         'a first_deliverable member_milestone must have at least one tribe_deliverable with status=''completed'' assigned to the same member. Keyed on status=''completed'' (same signal as the trigger and the XP sibling trg_tribe_deliverable_completed_xp; NOT completed_at, a derived audit column). A milestone with no completed deliverable indicates fabrication, a bad backfill, or a status reverted via service_role after the milestone fired. #766 PR3, mig 20260805000203. Directional, mirrors AA/AB.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'profile_complete'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.members m
+        WHERE m.id = mm.member_id
+          AND m.profile_completed_at IS NOT NULL
+      )
+  )
+  SELECT 'AE_profile_complete_milestone_has_profile_completed_at'::text,
+         'a profile_complete member_milestone must have members.profile_completed_at set. The column is monotonic — only update_my_profile writes it (NULL -> now() once, never cleared) — so this directional check is false-positive-free, unlike promotion whose mutable operational_role cache demotes routinely (hence PR4 added no invariant). A milestone with a NULL profile_completed_at indicates fabrication, a bad backfill (service_role direct INSERT into member_milestones; source_id is informational-only without FK), or the column cleared via a manual UPDATE after the milestone fired. #766 PR5, mig 20260805000205. Directional, mirrors AA/AB/AC/AD.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT si.id AS interview_id
+    FROM public.selection_interviews si
+    WHERE si.status IN ('scheduled','rescheduled')
+      AND EXISTS (
+        SELECT 1 FROM public.selection_interviews si2
+        WHERE si2.application_id = si.application_id
+          AND si2.created_at > si.created_at
+      )
+  )
+  SELECT 'AF_open_interview_is_newest_row'::text,
+         'a selection_interviews row in an open status (scheduled/rescheduled) must be the most-recently-created interview row for its application. An open row older than another interview row of the same application indicates a reschedule/re-booking that did not close the prior open row (bypass of the AFTER INSERT trigger trg_supersede_prior_open_interviews, or pre-fix legacy drift). Root cause: sync_calendar_booking_to_interview / schedule_interview INSERTing a new scheduled row without superseding the prior open one (D4/D5, mig 20260805000210). KNOWN directional gap (defense-in-depth): a TERMINAL row inserted newer than an open row (only import_historical_interviews) is not superseded by the trigger and would surface here; the live path reaches completed via UPDATE in-place, so it is covered.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(interview_id ORDER BY interview_id) FROM (SELECT interview_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT e.id AS engagement_id
+    FROM public.engagements e
+    JOIN public.initiatives i ON i.id = e.initiative_id AND i.kind = 'research_tribe'
+    JOIN public.members m ON m.person_id = e.person_id
+    WHERE e.kind = 'volunteer' AND e.status = 'active'
+      AND m.tribe_id IS DISTINCT FROM i.legacy_tribe_id
+  )
+  SELECT 'AG_tribe_engagement_has_tribe_id'::text,
+         'every active volunteer engagement in a research_tribe initiative must have member.tribe_id = initiative.legacy_tribe_id (the correctness contract of the bridge trigger trg_sync_tribe_id_from_engagement; count_tribe_slots reads members.tribe_id, so a divergence corrupts the slot count). A violation means the bridge was bypassed (service_role direct INSERT into engagements) or a stale legacy tribe_id conflicts with the engagement. Tribe Selection Híbrida PR1, mig 20260805000216. Baseline 0.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT e.person_id
+    FROM public.engagements e
+    JOIN public.initiatives i ON i.id = e.initiative_id AND i.kind = 'research_tribe'
+    WHERE e.kind = 'volunteer' AND e.status = 'active'
+    GROUP BY e.person_id
+    HAVING COUNT(*) > 1
+  )
+  SELECT 'AH_research_tribe_single_active_engagement'::text,
+         'a person must have at most one active volunteer engagement across research_tribe initiatives. members.tribe_id is a single scalar and the bridge trigger trg_sync_tribe_id_from_engagement (admission + demotion branch) assumes a single active tribe engagement; two make tribe_id ambiguous and can leave a stale tribe_id after one is demoted. Supersedes the SPEC''s I_research_tribe_no_dual_pending (which false-positives on a legitimate tribe-move and whose committed-divergence sibling is already non-zero from frozen legacy tribe_selections staleness, below the bridge since AG=0). Tribe Selection Híbrida PR1, mig 20260805000216. Baseline 0.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(person_id ORDER BY person_id) FROM (SELECT person_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id FROM public.selection_applications WHERE interview_auto_rescue_count > 1
+  )
+  SELECT 'AI_unbooked_rescue_cap_respected'::text,
+         'selection_applications with interview_auto_rescue_count > 1 (above cap=1). _selection_unbooked_rescue_cron + selection_rescue_unbooked_invite enforce the cap via a RAISE guard at count>=1; a value >1 means a re-entry bug or a service_role direct UPDATE bypassed the guard. D3 auto-rescue, mig 20260805000219. Baseline 0.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(id ORDER BY id) FROM (SELECT id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH expected(tbl) AS (
+    VALUES ('initiatives'),('events'),('project_boards'),('board_items'),
+           ('meeting_artifacts'),('tribe_deliverables'),('recurring_meeting_rules'),('governance_documents')
+  ),
+  drift AS (
+    SELECT e.tbl FROM expected e
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_policies p
+      WHERE p.schemaname = 'public'
+        AND p.tablename = e.tbl
+        AND p.permissive = 'RESTRICTIVE'
+        AND p.cmd IN ('SELECT','ALL')
+        AND p.qual ILIKE '%rls_can_see_%'
+    )
+  )
+  SELECT 'AJ_confidential_visibility_gate_present'::text,
+         'each of the 8 initiative-dependent tables (initiatives/events/project_boards/board_items/meeting_artifacts/tribe_deliverables/recurring_meeting_rules/governance_documents) must carry a RESTRICTIVE SELECT policy whose USING calls a rls_can_see_* helper — the confidential-initiative visibility gate (#785 PR-2, mig 20260805000232). A missing policy means the gate was dropped and a confidential initiative''s rows leak to non-engaged members. Structural catalog check (pg_policies); baseline 0.'::text,
+         'high'::text,
+         (SELECT COUNT(*)::integer FROM drift),
+         NULL::uuid[];
+
+
+  -- #333 (Wave 4, #221/#218): voice-biometric consent enforcement — periodic detector that
+  -- complements the write-time trigger trg_pmi_video_screening_voice_consent.
+  RETURN QUERY
+  WITH ack AS (
+    -- Applications with a documented LGPD Art.18 retroactive-notification retention basis
+    -- (the #332 acknowledged pre-block row). The application id is parsed from the pii_access_log
+    -- audit record so NO candidate identifier is hardcoded in this migration; the exclusion IS the
+    -- documented retention, and it self-heals to nothing if the row is eventually deleted.
+    SELECT (substring(pal.reason FROM 'application_id=([0-9a-fA-F-]+)'))::uuid AS application_id
+    FROM public.pii_access_log pal
+    WHERE pal.context = 'lgpd_art_18_retroactive_notification'
+      AND pal.reason ~ 'application_id='
+  ),
+  drift AS (
+    SELECT vs.id
+    FROM public.pmi_video_screenings vs
+    WHERE vs.transcription IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.selection_applications sa
+        WHERE sa.id = vs.application_id
+          AND sa.consent_voice_biometric_at IS NOT NULL
+          AND sa.consent_voice_biometric_revoked_at IS NULL
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM ack WHERE ack.application_id = vs.application_id
+      )
+  )
+  SELECT 'AK_voice_biometric_consent_enforcement'::text,
+         'every pmi_video_screenings row with transcription IS NOT NULL must have a matching selection_applications row where consent_voice_biometric_at IS NOT NULL AND consent_voice_biometric_revoked_at IS NULL (voice-biometric consent, LGPD Art.11), UNLESS its application has a documented Art.18 retroactive-notification retention basis logged in pii_access_log. The BEFORE INSERT/UPDATE trigger trg_pmi_video_screening_voice_consent is the write-time moat; this invariant is the periodic detector for any NEW drift (trigger disabled, consent revoked without deleting the row, raw SQL bypass). #333/#221/#218 Wave 4. The 1 acknowledged pre-block row (#332, tacit Art.18 retention; PM path (b) 2026-06-27) is EXCLUDED via its retention record, so baseline is 0; a new non-consented transcription with no retention basis is flagged. Named AK because the U_ code is already held by U_active_person_has_primary_chapter_affiliation.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(id ORDER BY id) FROM (SELECT id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- #209 / ADR-0107: Drive offboarding revocation queue state-machine integrity.
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS audit_id FROM public.drive_offboarding_audit
+    WHERE
+      (status = 'revoked' AND (approved_by IS NULL OR revoked_at IS NULL))
+      OR (status IN ('pending_revoke','approved') AND EXISTS (
+            SELECT 1 FROM public.members m
+            WHERE m.id = drive_offboarding_audit.member_id
+              AND (m.member_status = 'active' OR m.offboarded_at IS NULL)))
+  )
+  SELECT 'AL_drive_revocation_terminal_consistency'::text,
+         'drive_offboarding_audit (#209/ADR-0107): a revoked row must carry approved_by AND revoked_at (proof it went through the approve_drive_revocation + mark_drive_revocation_done RPC path), and no OPEN row (pending_revoke/approved) may reference a member who is active / not offboarded — a reversed offboarding must clear the revocation queue. A violation means a service_role direct write bypassed the RPC path, or an offboarding was reversed without clearing pending grants. Baseline 0.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(audit_id ORDER BY audit_id) FROM (SELECT audit_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- #301 / ADR-0108: curation temporary Drive grant state-machine integrity.
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS grant_id FROM public.drive_curation_grants
+    WHERE (status = 'granted' AND (permission_id IS NULL OR granted_at IS NULL))
+       OR (status = 'granted' AND revoked_at IS NOT NULL)
+       OR (status = 'revoked' AND revoked_at IS NULL)
+  )
+  SELECT 'AM_drive_curation_grant_terminal_consistency'::text,
+         'drive_curation_grants (#301/ADR-0108): a granted row must carry permission_id AND granted_at (proof the Drive POST succeeded) and must NOT carry revoked_at; a revoked row must carry revoked_at. The grant/revoke EF mark RPCs (mark_curation_grant_done/mark_curation_grant_revoked) are the only legitimate writers of these terminal states; a violation means a service_role direct write bypassed them. Named AM (AL is the #209 sibling). Baseline 0.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(grant_id ORDER BY grant_id) FROM (SELECT grant_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+END;
+$function$;

--- a/supabase/migrations/20260805000284_trail_ranking_cohort_exclude_sponsor_roles.sql
+++ b/supabase/migrations/20260805000284_trail_ranking_cohort_exclude_sponsor_roles.sql
@@ -1,0 +1,69 @@
+-- Wave 1 follow-through (Ivan): align get_public_trail_ranking's cohort to calc_trail_completion_pct.
+--
+-- M6 (ADR-0100) contract: the public trail ranking and the home calc_trail_completion_pct must share
+-- ONE cohort (tested by p277-419-m6 "home == ranking"). calc excludes operational_role IN
+-- ('sponsor','chapter_liaison','observer','candidate','visitor','guest'); the ranking did NOT — it
+-- admitted anyone with a tribe OR an active leader/coordinator/manager/participant engagement. Those
+-- two definitions coincided until Ivan Lourenço became a sponsor (mig …282): he is also the governance-
+-- committee LEADER, so calc now drops him (sponsor) while the ranking still admitted him (engagement
+-- role='leader') → the home==ranking invariant diverged.
+--
+-- Fix: apply the SAME operational_role exclusion in the ranking. A sponsor / chapter focal point /
+-- observer is not a CPMAI-trail participant, so this is the correct cohort for a trail ranking — and it
+-- restores the single-cohort M6 contract. Behaviour: removes Ivan (and any future sponsor/liaison with a
+-- qualifying engagement) from the public trail ranking; researchers/leaders/managers are unaffected.
+
+CREATE OR REPLACE FUNCTION public.get_public_trail_ranking()
+ RETURNS TABLE(member_name text, photo_url text, completed integer, in_progress integer, pct integer)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH trail_courses AS (
+    SELECT id FROM courses WHERE is_trail = true
+  ),
+  trail_total AS (
+    SELECT count(*)::int AS cnt FROM trail_courses
+  ),
+  eligible_members AS (
+    SELECT DISTINCT m.id, m.name, m.photo_url
+    FROM members m
+    WHERE m.is_active AND m.current_cycle_active
+      AND m.gamification_opt_out = false
+      AND NOT public.member_is_pre_onboarding(m.person_id, m.member_status)
+      -- M6 single-cohort parity with calc_trail_completion_pct (#419 / ADR-0100): exclude the same
+      -- non-trail operational roles (sponsor/chapter_liaison/observer/candidate/visitor/guest).
+      AND m.operational_role NOT IN ('sponsor', 'chapter_liaison', 'observer', 'candidate', 'visitor', 'guest')
+      AND (
+        m.tribe_id IS NOT NULL
+        OR EXISTS(
+          SELECT 1 FROM engagements e
+          WHERE e.person_id = m.person_id AND e.status = 'active'
+            AND e.role IN ('leader', 'coordinator', 'manager', 'participant')
+        )
+      )
+  ),
+  progress AS (
+    SELECT cp.member_id, cp.status
+    FROM course_progress cp
+    JOIN trail_courses tc ON tc.id = cp.course_id
+  ),
+  member_stats AS (
+    SELECT
+      p.member_id,
+      COUNT(*) FILTER (WHERE p.status = 'completed') AS completed,
+      COUNT(*) FILTER (WHERE p.status = 'in_progress') AS in_progress
+    FROM progress p
+    GROUP BY p.member_id
+  )
+  SELECT
+    em.name,
+    em.photo_url,
+    COALESCE(ms.completed, 0)::int,
+    COALESCE(ms.in_progress, 0)::int,
+    CASE WHEN tt.cnt > 0 THEN ROUND(COALESCE(ms.completed, 0)::numeric / tt.cnt * 100)::int ELSE 0 END
+  FROM eligible_members em
+  CROSS JOIN trail_total tt
+  LEFT JOIN member_stats ms ON ms.member_id = em.id
+  ORDER BY COALESCE(ms.completed, 0) DESC, COALESCE(ms.in_progress, 0) DESC, em.name;
+$function$;

--- a/tests/permissions.test.mjs
+++ b/tests/permissions.test.mjs
@@ -19,8 +19,23 @@ describe('permissions types', () => {
     assert.equal(Object.keys(TIER_PERMISSIONS).length, 11);
   });
 
-  it('all 12 designations defined', () => {
-    assert.equal(Object.keys(DESIGNATION_PERMISSIONS).length, 12);
+  it('all 13 designations defined', () => {
+    assert.equal(Object.keys(DESIGNATION_PERMISSIONS).length, 13);
+  });
+
+  it('sponsor designation grants full read (no write) — Wave 1 Ivan/LIM', () => {
+    const perms = DESIGNATION_PERMISSIONS.sponsor;
+    // read surface present
+    for (const p of ['admin.access', 'admin.members.view', 'admin.portfolio', 'admin.partners',
+                     'admin.governance.view', 'board.view_all', 'board.view_global',
+                     'data.view_members', 'event.view_all']) {
+      assert.ok(perms.includes(p), `sponsor read perm missing: ${p}`);
+    }
+    // never any write/manage
+    for (const p of perms) {
+      assert.ok(!/\.(manage|create|edit|delete|anonymize)$/.test(p) && p !== 'admin.campaigns',
+        `sponsor must be read-only, found write perm: ${p}`);
+    }
   });
 
   it('tier labels cover all tiers', () => {


### PR DESCRIPTION
Wave 1 of the sponsor-access audit. **Priority** — Ivan presents the LATAM LIM.

## Problem
Ivan Lourenço (host-chapter PMI-GO sponsor) logged in as **"PESQUISADOR"** and could not reach the admin menus / executive report. Two root causes:

1. **Badge** — `sync_operational_role_cache` derives `operational_role` from engagements with the `researcher` branch (catches committee/workgroup) ranked **above** `sponsor`. Ivan also leads the *GP × Presidência — Governança do Núcleo* committee → derived `researcher`. → badge "Pesquisador" + researcher tier (no `admin.*`).
2. **Access** — the `sponsor` designation granted **zero** client capabilities (it wasn't even in `DESIGNATION_PERMISSIONS` / the `Designation` type).

## Fix (Ivan-scoped, durable)
1. Moved `sponsor` above `researcher` in the derivation (kept below manager/deputy/tribe_leader). **Blast radius = 1**: of the 5 sponsor-designated members, only Ivan flipped (the 4 chapter sponsors PMI-MG/CE/RS/DF already derived `sponsor`). Mirrored into the `check_schema_invariants` A3 ladder (ADR-0023 byte-for-byte parity — else Ivan would be flagged as drift).
2. Added `DESIGNATION_PERMISSIONS['sponsor']` = the full **READ** surface (admin read panels + `board.view_all/view_global` + `data.view_members` + analytics); **no write/manage**. RLS already lets any authoritative non-guest member read all boards (minus confidential #785) + the member directory, so this only **surfaces the read menus** — no data-access expansion. Server RPCs stay the write boundary.

## Validation (live)
- Ivan now `operational_role='sponsor'` (badge **"Patrocinador"** 🏛️); the 4 chapter sponsors unchanged.
- `check_schema_invariants` A3 = **0 violations** (no drift); function reproduces cleanly (all invariants 0).
- Tests **87/87** (permissions + role-ladder-parity + schema-invariants + rpc-migration-coverage); `astro build` clean. Migrations `…282` + `…283` applied to prod; phantom rows reverted.

## Wave 2 (separate, deeper)
Governance for all sede + associated-chapter directors: `chapter_board`→`chapter_liaison` precedence, and the decision on access restrictions per directorate / chapter layer (e.g. should chapter sponsors be scoped to their own chapter; the host volunteers-director seeing all volunteers).