### PR TITLE
feat(onda2): ADR-0111 amendment — auditor aggregate surface 8→12 + k-anonymity small-cell suppression (#952)

### DIFF
--- a/docs/GOVERNANCE_CHANGELOG.md
+++ b/docs/GOVERNANCE_CHANGELOG.md
@@ -10,6 +10,22 @@ Referência normativa: Manual de Governança e Operações R2 (DocuSign B2AFB185
 
 ## Decisões Implementadas
 
+### GC-150 — Auditor Institucional: Superfície Agregada 8 → 12 RPCs + Supressão de Célula Pequena (k=5)
+**Data:** 2026-06-29 · **Autor:** Vitor Maia Rodovalho (GP) · **Status:** Implementado (técnico, behavior-neutral — tier dormante)
+
+**Decisão (PM via `AskUserQuestion`):** Estender a capacidade agregada do auditor institucional externo de **8 → 12 RPCs**, adicionando dashboards de capítulo (`exec_chapter_dashboard`, `exec_chapter_comparison`, `get_chapter_selection_summary`) + métricas de comms agregadas (`comms_metrics_latest_by_channel`), **construindo a supressão de célula pequena em código** em vez de diferi-la ao processo (mig `20260805000294`, emenda ADR-0111).
+
+**Por que não foi um grant repetido:** uma **revisão adversarial por-RPC** (8 sub-agentes auditor+cético consultando o DB ao vivo) pegou um problema **comportamental** de LGPD que a verificação de fidelidade (drift/Phase-C, byte-fiel a live) **não** pega: `exec_chapter_dashboard`/`exec_chapter_comparison` quebram membros por capítulo, e **ao vivo 3 capítulos têm 1 único membro ativo** (`members.chapter` é texto livre, sem CHECK). Para esses capítulos, o "agregado" entregue a um auditor **externo** É o registro de um indivíduo re-identificável — exatamente o risco que o RoPA/LIA do FU-4 condicionava à supressão de célula pequena, que estava como compromisso de processo, não código.
+
+**Implementação:**
+1. **Supressão k=5 (em código), só para o auditor externo** (predicado `view_aggregate_analytics AND NOT view_internal_analytics`): `exec_chapter_dashboard` retorna marcador suprimido p/ capítulo com `<5` ativos; `exec_chapter_comparison` colapsa capítulos `<5` ativos num bucket `"Outros (<5 ativos)"`. Controladores internos (GP/liaison) recebem detalhe **completo inalterado** (split IF/ELSE → zero regressão à UI admin).
+2. **`get_chapter_selection_summary`**: só `count(*)` + metadados de ciclo (sem quebra de membro → sem supressão).
+3. **`comms_metrics_latest_by_channel`**: gate `OR` **inline** (não modifica o helper compartilhado `can_view_comms_analytics`, que vazaria `comms_top_media`/`comms_channel_status` transitivamente); `payload` jsonb opaco **NULL no caminho do auditor** (forward-defense).
+
+**Justificativa:** "zero-PII por construção" do ADR-0111 exige que as RPCs sejam seguras **agora**, não pendentes de processo futuro. A supressão em código honra o compromisso do RoPA/LIA no próprio gate. Excluída deste PR: `get_chapter_dashboard` (roster com nomes/fotos — permanece negada); `comms_top_media` (lista de posts, fora do escopo agregado). Achado separado registrado: `get_comms_dashboard_metrics` é SECDEF **sem gate** (não relacionado ao auditor).
+
+**Impacto técnico:** Migration `20260805000294`; ADR-0111 (§ Amendment); `tests/contracts/institutional-auditor-aggregate-scope.test.mjs` (`SAFE_RPCS` 8→12 com split FU3/emenda + forward-defense da supressão); `PERMISSIONS_MATRIX.md` §2.1; `docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md` §2.1/§2.3; Anexo R3 #641 §5.3. Verificação ao vivo 2-lados (GP detalhe completo / auditor suprimido), `carriers == 12`, dormância `route_to_suppression=0`.
+
 ### GC-149 — Arquitetura de Permissionamento (Onda 2): Sponsor Read-Only de Fato, Auditor Institucional Agregado, Assimetria Sede/Parceiro/Externo, SLA de Reassignment Function-Anchored e `end_date` em Engagements Institucionais
 **Data:** 2026-06-29 · **Autor:** Vitor Maia Rodovalho (GP) · **Status:** Implementado (camada técnica) + RASCUNHO (camada processo — gate de provisionamento do auditor pendente de DPO/parceiros)
 

--- a/docs/PERMISSIONS_MATRIX.md
+++ b/docs/PERMISSIONS_MATRIX.md
@@ -24,7 +24,7 @@ herda todas as permissões dos tiers inferiores.
 
 > † A persona externa **`institutional_auditor`** (órgão da rede PMI, ex.: PMI LATAM) **exibe** como
 > observer (`getAccessTier → observer`) mas tem capability **estritamente mais estreita** — somente
-> `view_aggregate_analytics` (8 RPCs agregadas). Ver **§2.1** (ADR-0111 · GC-149).
+> `view_aggregate_analytics` (12 RPCs agregadas — 2 com supressão de célula pequena k=5). Ver **§2.1** (ADR-0111 · GC-149).
 
 **Implementação backend (V4 — ADR-0011)**: `can_by_member(member_id, action)` / `rls_can(action)` / `rls_is_superadmin()` são as gates canônicas. Helper `has_min_tier(integer)` foi DEPRECATED p181 e DROPPED p182 (2026-05-17) após todos 4 callers (3 RLS policies + `exec_cert_timeline`) migrarem para V4 native.
 **Implementação frontend**: `resolveTierFromMember(member)` → `hasMinimumTier(tier, required)` (UI gates) ou `canFor(member, action, scope)` (capability cache p163, ADR-0083).
@@ -62,7 +62,7 @@ do observer (`sponsor`/`curator`/`chapter_liaison`): somente `view_aggregate_ana
 | Atributo | Valor |
 |---|---|
 | **Badge** | "Auditor Institucional" 🔎 (display `getAccessTier → observer`, mas capability **estritamente mais estreita**) |
-| **Acesso** | Leitura **agregada** apenas — action dedicada `view_aggregate_analytics`, honrada por **8 RPCs** zero-PII/zero-escrita (allowlist por construção, ADR-0111) |
+| **Acesso** | Leitura **agregada** apenas — action dedicada `view_aggregate_analytics`, honrada por **12 RPCs** zero-PII/zero-escrita (allowlist por construção, ADR-0111 + emenda 2026-06-29; as 2 RPCs de quebra por capítulo aplicam supressão de célula pequena k=5 ao auditor externo) |
 | **Nunca tem** | `admin.access` amplo, diretório de membros, PII individual, dados de seleção, qualquer escrita ou `manage_*`. Carve-out RLS exclui o auditor de `rls_is_authoritative_member()` (não pega o diretório baseline) |
 | **Provisionamento** | **GP-only** (`manager`/`deputy_manager`); `end_date` **obrigatório** (CHECK no banco); **dormante** até o gate de governança (acordo + ciência dos parceiros + RoPA/LIA do DPO) |
 | **Referência** | ADR-0111 · GC-149 · `docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md` · Anexo R3 #641 §5.3 |

--- a/docs/adr/ADR-0111-institutional-auditor-aggregate-analytics.md
+++ b/docs/adr/ADR-0111-institutional-auditor-aggregate-analytics.md
@@ -58,3 +58,36 @@ Comportamento-neutro na população atual: **zero** membros `institutional_audit
 ## Invariantes respeitados
 
 function-anchored (papel, nunca indivíduo) · read ≠ write (action read-only; 37 RPCs de PII/escrita intocadas) · member-lifecycle = GP-only (LGPD Art. 18) · minimização LGPD (parceiro externo = só agregado) · confidenciais #785 (`get_portfolio_items` mantém `rls_can_see_initiative`) · **NÃO** seed-expandir actions destrutivas · ADR-0023 paridade A3 · DDL via `apply_migration` + sync de migration local + repair (database.md).
+
+---
+
+## Amendment (2026-06-29) — superfície agregada 8 → 12 + supressão de célula pequena (k=5)
+
+**Status:** Accepted · **Migration:** `20260805000294_onda2_adr0111_amend_aggregate_chapter_comms_rpcs.sql` · **#952.**
+
+A capacidade agregada do auditor foi estendida de **8 → 12 RPCs**, adicionando dashboards de capítulo + métricas de comms agregadas (decisão do PM via `AskUserQuestion`, 2026-06-29). As 4 novas: `exec_chapter_dashboard`, `exec_chapter_comparison`, `get_chapter_selection_summary`, `comms_metrics_latest_by_channel`.
+
+### Por que não foi um simples grant repetido
+
+Antes de aplicar, rodou-se uma **revisão adversarial por-RPC** (8 sub-agentes: auditor de fidelidade + cético de refutação por RPC, todos consultando o DB ao vivo). Ela pegou o que a verificação de fidelidade (leitura campo-a-campo) **não** pega — um problema **comportamental** de LGPD:
+
+- `exec_chapter_dashboard` e `exec_chapter_comparison` **quebram membros por capítulo**. Ao vivo, **3 capítulos têm 1 único membro ativo** (PMI-PR, PMI-SP, Outro) e `members.chapter` **não tem CHECK/enum** (texto livre). Para esses capítulos, o "agregado" entregue a um auditor **externo** É o registro de um indivíduo re-identificável (role/tribo/cert/horas) — exatamente o "risco de re-identificação reconhecido" que o RoPA/LIA do FU-4 condiciona à supressão de célula pequena (§2.3/§8 do doc de cooperação), que até então **não estava implementada**.
+
+### Decisão (PM, `AskUserQuestion`): construir a supressão em código, não diferir
+
+- **Predicado de auditor externo (inline, sem helper)**: `can_by_member(_, 'view_aggregate_analytics') AND NOT can_by_member(_, 'view_internal_analytics')`. Mantém o invariante elegante do teste (`carriers == SAFE_RPCS`); controladores internos nunca disparam supressão → **behavior-neutral** (ao vivo: 0 membros atuais alcançam o branch; tier dormante).
+- `exec_chapter_dashboard`: auditor externo + capítulo com `<5` ativos → marcador `{suppressed:true, reason:'small_cell_below_threshold', threshold:5}` (sem detalhe).
+- `exec_chapter_comparison`: auditor externo → capítulos `<5` ativos colapsam num único bucket `"Outros (<5 ativos)"` (counts somados). Caminho interno = query original **verbatim** (split IF/ELSE → zero regressão à UI admin ao vivo).
+- `get_chapter_selection_summary`: só `count(*)` + metadados de ciclo (sem quebra de membro) → sem supressão necessária.
+- `comms_metrics_latest_by_channel`: gate `OR` **inline** (não modifica o helper compartilhado `can_view_comms_analytics`, que vazaria `comms_top_media`/`comms_channel_status` transitivamente). O `payload` jsonb opaco (controlado por ingestão) é **NULL no caminho do auditor** (forward-defense do achado da revisão).
+
+### Verificação (ao vivo, 2026-06-29)
+
+- `carriers` da action = **exatamente 12** (8 + 4); teste de contrato verde (`deepEqual(carriers, SAFE_RPCS)`).
+- **2 lados:** GP (Vitor, via `request.jwt.claims`) → `exec_chapter_dashboard('PMI-SP')` retorna detalhe **completo** (não suprimido) e `exec_chapter_comparison()` lista **11 capítulos nomeados** (regressão zero). Auditor (branch standalone) → PMI-SP suprimido; capítulos `<5` colapsados em "Outros (<5 ativos)" (total 8 / ativos 7).
+- **Dormância:** `holders_of_action=0`, `route_to_suppression=0` (nenhum membro atual alcança a supressão).
+- Mecânica: DO-block `replace()` + asserção match-único no `exec_chapter_dashboard` (18KB, zero transcrição); CREATE OR REPLACE pleno nos 3 menores; arquivo `…294` = SSOT literal pós-apply (Phase-C file==live); phantom-row do apply renomeada para a version canônica.
+
+### Lição (cross-ref pt12 / [LL] #588)
+
+Revisão adversarial **comportamental** (lente de domínio: security/LGPD) e validação de **fidelidade** (drift/Phase-C) são **camadas ortogonais**: o gate estava byte-fiel a live E ainda assim entregaria PII por célula pequena. Ambas necessárias.

--- a/docs/legal/641_MANUAL_R3_DATA_PROTECTION_ANNEX_DRAFT.md
+++ b/docs/legal/641_MANUAL_R3_DATA_PROTECTION_ANNEX_DRAFT.md
@@ -140,11 +140,13 @@ Esse eixo e **distinto** do compartilhamento com capitulos parceiros e nao se co
 - o auditor institucional **nao e capitulo parceiro** — nao possui membros no Programa e nao e
   controlador de nenhum dado tratado aqui; e **destinatario** de agregados, nao agente de tratamento;
 - recebe **apenas indicadores agregados** program-wide, **sem dado pessoal individual por construcao**
-  (allowlist de 8 RPCs SECDEF zero-PII verificadas — ADR-0111), sem recorte nominal de capitulo, sem
-  dados de selecao, sem escrita. O PMI-GO adota supressao de celula pequena (k-anonimato) quando algum
-  subgrupo for identificavel, conforme protocolado em
-  `docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md` §2.3/§8 (garantia de processo, nao
-  de resultado absoluto enquanto a supressao nao estiver implementada);
+  (allowlist de 12 RPCs SECDEF zero-PII verificadas — ADR-0111 + emenda 2026-06-29), sem recorte nominal
+  de capitulo, sem dados de selecao, sem escrita. O PMI-GO adota supressao de celula pequena
+  (k-anonimato): para as 2 RPCs de quebra de membro por capitulo (`exec_chapter_dashboard`,
+  `exec_chapter_comparison`) a supressao esta **implementada em codigo (k=5)** para o auditor externo
+  (capitulos com <5 membros ativos sao suprimidos/bucketizados); para as demais RPCs agregadas que
+  cruzem subgrupos sensiveis identificaveis o endurecimento transversal segue como FU, conforme
+  `docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md` §2.3/§8;
 - o acesso e **GP-only para provisionar**, com **prazo (`end_date`) obrigatorio**, e **revogavel**;
 - esta sujeito a um **gate de governanca proprio** (acordo de cooperacao + ciencia dos capitulos
   parceiros + ratificacao RoPA/LIA do DPO) antes do primeiro provisionamento.

--- a/docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md
+++ b/docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md
@@ -54,7 +54,8 @@ governa o eixo sede↔parceiro) e está documentado à parte, com referência cr
 ### 2.1 Superfície concedida (allowlist por construção — ADR-0111)
 
 A action `view_aggregate_analytics` é seedada **apenas** ao par `institutional_auditor × auditor` e é
-honrada por **exatamente 8 RPCs**, todas verificadas ao vivo como **zero-PII / zero-escrita**:
+honrada por **exatamente 12 RPCs**, todas verificadas ao vivo como **zero-PII / zero-escrita** (8 do
+FU-3 original + 4 da emenda ADR-0111 de 2026-06-29, mig `20260805000294`):
 
 | RPC | Conteúdo (agregado) |
 |---|---|
@@ -66,12 +67,16 @@ honrada por **exatamente 8 RPCs**, todas verificadas ao vivo como **zero-PII / z
 | `get_in_dashboard` | Pipeline institucional de MOU/capítulos (dado institucional) |
 | `get_comms_to_adoption_funnel` | Alcance e funil de comunicação→adoção |
 | `exec_role_transitions` | Matriz role→role (transições, sem nomes) |
+| `exec_chapter_dashboard` | Saúde por capítulo (counts de membros/produção/engajamento/cert) — **supressão de célula pequena** p/ o auditor (capítulo com `<5` ativos → marcador suprimido) |
+| `exec_chapter_comparison` | Comparação cross-chapter (só counts) — **supressão de célula pequena** p/ o auditor (capítulos `<5` ativos colapsam em "Outros (<5 ativos)") |
+| `get_chapter_selection_summary` | Resumo de seleção do capítulo (`open_apps`=count + metadados de ciclo; sem quebra de membro) |
+| `comms_metrics_latest_by_channel` | Métricas por canal social (reach/engagement/leads); `payload` jsonb **NULL no caminho do auditor** (forward-defense) |
 
 > **Allowlist, não denylist.** Estender a superfície agregada do auditor exige **curadoria
 > explícita** (verificar a RPC candidata como zero-PII/zero-escrita ao vivo) **+ atualização deste
 > documento + da lista `SAFE_RPCS`** em `tests/contracts/institutional-auditor-aggregate-scope.test.mjs`.
 > Esse teste impõe um **bound verdadeiro**: nenhuma RPC fora da allowlist pode honrar
-> `view_aggregate_analytics` (uma 9ª RPC com a action em qualquer migration falha o teste). Nunca alargar
+> `view_aggregate_analytics` (uma 13ª RPC com a action em qualquer migration falha o teste). Nunca alargar
 > a action para reusar uma action ampla (`view_pii`, `view_internal_analytics`) — foi exatamente a
 > premissa falsa que o ADR-0111 derrubou.
 
@@ -91,9 +96,24 @@ com um único indivíduo num cruzamento gênero×região; `get_cycle_report` de 
 
 **Salvaguardas atuais:** o escopo do auditor é **program-wide** (não recorta capítulo nominalmente),
 o que dilui counts; o provisionamento exige acordo de finalidade restrita (§4).
-**Hardening recomendado (FU futuro, ver §8):** piso de **supressão de célula pequena** (k-anonimato —
-suprimir/mascarar subgrupos com count abaixo de um limiar) nas RPCs do auditor, caso alguma exponha
-counts identificáveis por subgrupo sensível.
+
+**Supressão de célula pequena — IMPLEMENTADA EM CÓDIGO (k=5)** para as RPCs de quebra de membro por
+capítulo, que foram o vetor de re-identificação concreto identificado na revisão adversarial por-RPC
+(2026-06-29; ao vivo, **3 capítulos têm 1 único membro ativo** e `members.chapter` não tem CHECK/enum):
+
+- `exec_chapter_dashboard`: para o **auditor externo** (holds `view_aggregate_analytics` AND NOT
+  `view_internal_analytics`), capítulo com `<5` membros ativos retorna um marcador suprimido
+  (`{suppressed:true, reason:'small_cell_below_threshold', threshold:5}`) em vez do detalhe.
+- `exec_chapter_comparison`: para o auditor externo, capítulos com `<5` ativos colapsam num único
+  bucket `"Outros (<5 ativos)"` (counts somados), nunca um registro de capítulo n=1.
+- Controladores internos (`view_internal_analytics`/`manage_platform`) recebem o detalhe completo
+  **inalterado** — a supressão é exclusiva do caminho do auditor externo (behavior-neutral; ao vivo,
+  0 membros atuais alcançam o branch de supressão pois o tier está dormante).
+
+**Hardening recomendado (FU futuro, ver §8):** estender a mesma supressão de célula pequena às demais
+RPCs agregadas que cruzem subgrupos sensíveis identificáveis (ex.: `get_diversity_dashboard`
+gênero×região), de forma transversal — fora do escopo desta emenda, que cobriu as RPCs de quebra por
+capítulo (o vetor concreto).
 
 ---
 
@@ -109,13 +129,13 @@ São **duas** operações distintas, com titulares e bases legais diferentes —
 |---|---|
 | **Operação** | Disponibilização de indicadores **agregados** do Programa Núcleo IA a um órgão institucional externo da rede PMI, para prestação de contas (accountability) institucional. |
 | **Agente que trata** | PMI-GO (controladora), por intermédio da plataforma (operadora). O auditor externo é **destinatário** de agregados — **não** agente de tratamento de dados individuais, **não** controlador, **não** operador. |
-| **Categorias de dado** | Agregados (counts, médias, taxas, funis). **Sem dado pessoal individual** por construção (§2 — allowlist de 8 RPCs zero-PII). |
+| **Categorias de dado** | Agregados (counts, médias, taxas, funis). **Sem dado pessoal individual** por construção (§2 — allowlist de 12 RPCs zero-PII). |
 | **Titulares** | Membros e pré-onboarding do Programa, **apenas refletidos em agregados**. |
 | **Finalidade** | Accountability/transparência institucional do Programa perante a rede PMI federada. |
 | **Base legal** | **Base operativa ATUAL = legítimo interesse do PMI-GO (Art. 7º, IX — LIA §3.2)**, enquanto a supressão de célula pequena (§2.3 / §8) não estiver implementada. Contagens/taxas/funis program-wide que **não identificam** qualquer pessoa natural não se enquadram, por construção, no conceito de dado pessoal (**Art. 5º, I**); a supressão de célula pequena (k-anonimato) tornará o Art. 5º, I / Art. 12 aplicável como proteção adicional às células suprimidas. (`engagement_kind.legal_basis = legitimate_interest`.) **Não** se invoca o Art. 12 como base primária enquanto houver risco residual de re-identificação reconhecido em §2.3. |
 | **Retenção** | Os agregados **não são persistidos** junto ao auditor pela plataforma (leitura sob demanda); o acesso cessa com a revogação do engagement (§4.3). |
 | **Destinatários** | O órgão externo nomeado no acordo de cooperação (§4 P1). Sem repasse a terceiros sem novo fundamento. |
-| **Medidas de segurança (Art. 46)** | RLS carve-out (auditor não pega o diretório) + 8 RPCs SECDEF allowlisted, com **bound verdadeiro** no teste de contrato `institutional-auditor-aggregate-scope` (nenhuma RPC fora da allowlist pode honrar a action) + `end_date` CHECK no banco + provisionamento GP-only. |
+| **Medidas de segurança (Art. 46)** | RLS carve-out (auditor não pega o diretório) + 12 RPCs SECDEF allowlisted (2 com supressão de célula pequena k=5), com **bound verdadeiro** no teste de contrato `institutional-auditor-aggregate-scope` (nenhuma RPC fora da allowlist pode honrar a action) + `end_date` CHECK no banco + provisionamento GP-only. |
 | **Transparência (Art. 9º / Art. 10, §2º)** | Esta entrada + GC-149 + ciência formal dos capítulos parceiros (§6). **Quanto aos titulares-membros:** a inclusão de cláusula no Termo de Voluntariado / notificação de onboarding informando o reporte de participação **agregada** à rede institucional PMI é **pré-condição de provisionamento** (§4.1 P5, §7). **Este rascunho NÃO afirma** que o Termo vigente já cobre este fluxo — a transparência ex-post (este doc + GC-149) não substitui a informação ao titular do Art. 9º. |
 
 #### Operação 2 — Registro do engagement do auditor (a pessoa indicada)
@@ -188,7 +208,7 @@ independente (impedimento do titular, §8).
    `start_date`, **`end_date` (obrigatório — o CHECK do banco recusa NULL)**, `status='active'`,
    via o fluxo GP de gestão de engagement.
 2. **Verificação ao vivo de 2 lados:** confirmar badge "Auditor Institucional" 🔎; confirmar que as
-   **8 RPCs** agregadas retornam e que **qualquer RPC de PII/diretório nega** (ex.: `admin_list_members`,
+   **12 RPCs** agregadas retornam e que **qualquer RPC de PII/diretório nega** (ex.: `admin_list_members`,
    `get_member_detail`, `get_selection_dashboard`).
 3. **Registrar no `GOVERNANCE_CHANGELOG`**: quem provisionou, qual órgão, prazo, instrumento (P1).
 
@@ -278,7 +298,7 @@ alinhado ao mandato/acordo. Para `institutional_auditor` é **CHECK no banco** (
 - [ ] **P4** — `end_date` (≤ 365d) e pessoa do órgão definidos.
 - [ ] **P5** — Transparência ao titular-membro (Art. 9º): cláusula no Termo/onboarding incluída e vigente, **ou** confirmação documentada do DPO com citação de versão/cláusula (§4.1 P5).
 - [ ] **Mecanismo de revogação verificado (não-opcional, §4.3):** ou `auto_expire_behavior='revoke'` implementado (opção A), ou notificação `notify_only` confirmada como alcançando um humano nomeado com lead time + auto-certificação de término no acordo (opção B). **Não** provisionar com caminho de notificação não verificado.
-- [ ] Verificação ao vivo de 2 lados (§4.2 passo 2): 8 RPCs retornam, RPCs de PII negam.
+- [ ] Verificação ao vivo de 2 lados (§4.2 passo 2): 12 RPCs retornam (com supressão de célula pequena ativa p/ as 2 de quebra por capítulo), RPCs de PII negam.
 - [ ] Entrada no `GOVERNANCE_CHANGELOG` registrando o provisionamento.
 - [ ] Dono nomeado da revogação (§4.3): issue recorrente trimestral atribuída ao **cargo GP** + engagements institucionais ativos marcados como item de handoff na transição de GP; lembrete T-7 e tolerância máxima D+1 do `end_date`.
 

--- a/supabase/migrations/20260805000294_onda2_adr0111_amend_aggregate_chapter_comms_rpcs.sql
+++ b/supabase/migrations/20260805000294_onda2_adr0111_amend_aggregate_chapter_comms_rpcs.sql
@@ -1,0 +1,322 @@
+-- ============================================================================
+-- Onda 2 — ADR-0111 amendment: extend view_aggregate_analytics from 8 -> 12 RPCs.
+--
+-- Adds the external institutional auditor's aggregate action to 4 chapter/comms RPCs,
+-- WITH k-anonymity small-cell suppression so the EXTERNAL auditor never receives
+-- re-identifying detail for a tiny chapter (live: 3 chapters have 1 active member;
+-- members.chapter has no enum/CHECK). The auditor lawful basis (RoPA/LIA §2.3/§8 of
+-- docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md) conditions aggregate
+-- disclosure on small-cell suppression — this migration implements it in code (k=5),
+-- not merely as a process commitment.
+--
+-- Per-RPC:
+--   - exec_chapter_dashboard       : gate OR view_aggregate_analytics; external auditor gets a
+--                                    suppressed marker when the chapter active cohort < 5.
+--   - exec_chapter_comparison      : gate OR view_aggregate_analytics; external auditor gets
+--                                    chapters with < 5 active members collapsed into "Outros (<5 ativos)".
+--   - get_chapter_selection_summary: gate OR view_aggregate_analytics (output = count(*) + cycle
+--                                    metadata only; no member breakdown, no small-cell exposure).
+--   - comms_metrics_latest_by_channel: gate OR (inline) view_aggregate_analytics; the opaque
+--                                    ingestion-controlled `payload` jsonb is NULLed on the auditor
+--                                    path (forward-defense) — only the comms team receives it.
+--
+-- "External auditor" = holds view_aggregate_analytics AND NOT view_internal_analytics. Internal
+-- controllers (GP / chapter_liaison / sponsor via view_internal_analytics or manage_platform) get
+-- the full detail unchanged — behavior-neutral (verified live: 0 current members hold the action).
+--
+-- Bodies below are the LITERAL post-apply definitions (SSOT for the Phase-C drift gate; file==live).
+-- Cross-ref: ADR-0111 (§ Amendment), GOVERNANCE_CHANGELOG (2026-06-29), PERMISSIONS_MATRIX §2.1,
+-- docs/legal/INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md, tests/contracts/institutional-auditor-aggregate-scope.test.mjs.
+-- Security: per-RPC adversarial PII/authority review (8 agents, 2026-06-29) — small-cell finding
+-- on exec_chapter_dashboard/comparison resolved by the suppression implemented here.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.exec_chapter_dashboard(p_chapter text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_caller_chapter text;
+  v_result jsonb;
+  v_year_start date;
+  v_members jsonb;
+  v_production jsonb;
+  v_engagement jsonb;
+  v_certification jsonb;
+BEGIN
+  -- ACL: V4 view_internal_analytics OR own-chapter access (Path Y per ADR-0030)
+  SELECT m.id, m.chapter INTO v_caller_id, v_caller_chapter
+  FROM public.members m
+  WHERE m.auth_id = auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'authentication_required');
+  END IF;
+
+  IF NOT (
+    public.can_by_member(v_caller_id, 'view_internal_analytics')
+    OR public.can_by_member(v_caller_id, 'view_aggregate_analytics')
+    OR v_caller_chapter = p_chapter
+  ) THEN
+    RETURN jsonb_build_object('error', 'permission_denied');
+  END IF;
+
+  -- k-anonymity small-cell suppression (RoPA/LIA s2.3/s8, ADR-0111 amendment): an EXTERNAL
+  -- aggregate auditor (holds view_aggregate_analytics but NOT view_internal_analytics) must not
+  -- receive re-identifying detail for a chapter whose active cohort is below k (5). Internal
+  -- controllers are unaffected -- full detail unchanged (behavior-neutral for the live admin UI).
+  IF public.can_by_member(v_caller_id, 'view_aggregate_analytics')
+     AND NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+    DECLARE v_active_n int;
+    BEGIN
+      SELECT count(*) FILTER (WHERE current_cycle_active) INTO v_active_n
+      FROM public.members WHERE chapter = p_chapter;
+      IF COALESCE(v_active_n, 0) < 5 THEN
+        RETURN jsonb_build_object(
+          'chapter', p_chapter, 'suppressed', true,
+          'reason', 'small_cell_below_threshold', 'threshold', 5);
+      END IF;
+    END;
+  END IF;
+
+  -- Temporal anchor (year kickoff)
+  v_year_start := make_date(EXTRACT(year FROM now())::int, 1, 1);
+  BEGIN
+    SELECT date INTO v_year_start
+    FROM public.events
+    WHERE type = 'general'
+      AND title ILIKE '%kick%off%'
+      AND EXTRACT(year FROM date) = EXTRACT(year FROM now())
+    ORDER BY date ASC
+    LIMIT 1;
+  EXCEPTION WHEN OTHERS THEN
+    v_year_start := make_date(EXTRACT(year FROM now())::int, 1, 1);
+  END;
+  v_year_start := COALESCE(v_year_start, make_date(EXTRACT(year FROM now())::int, 1, 1));
+
+  -- Members
+  SELECT jsonb_build_object(
+    'total', count(*),
+    'active', count(*) FILTER (WHERE current_cycle_active),
+    'by_role', COALESCE((SELECT jsonb_object_agg(operational_role, cnt) FROM (SELECT operational_role, count(*) cnt FROM public.members WHERE chapter = p_chapter AND current_cycle_active GROUP BY operational_role) sub), '{}'::jsonb),
+    'tribes', COALESCE((SELECT jsonb_agg(DISTINCT t.name) FROM public.members m2 JOIN public.tribes t ON t.id = m2.tribe_id WHERE m2.chapter = p_chapter AND m2.current_cycle_active), '[]'::jsonb)
+  ) INTO v_members
+  FROM public.members
+  WHERE chapter = p_chapter;
+
+  -- Production
+  BEGIN
+    SELECT jsonb_build_object(
+      'articles_in_pipeline', count(*) FILTER (WHERE bi.curation_status IS NOT NULL AND bi.curation_status != 'draft'),
+      'articles_published', count(*) FILTER (WHERE bi.curation_status = 'approved'),
+      'board_items_total', count(*)
+    ) INTO v_production
+    FROM public.board_item_assignments bia
+    JOIN public.members m ON m.id = bia.member_id
+    JOIN public.board_items bi ON bi.id = bia.item_id
+    WHERE m.chapter = p_chapter AND bi.created_at >= v_year_start;
+  EXCEPTION WHEN OTHERS THEN
+    v_production := jsonb_build_object('articles_in_pipeline', 0, 'articles_published', 0, 'board_items_total', 0);
+  END;
+
+  -- Engagement
+  BEGIN
+    SELECT jsonb_build_object(
+      'attendance_events', count(DISTINCT a.event_id),
+      'total_hours', COALESCE(round(SUM(e.duration_actual / 60.0)::numeric, 1), 0),
+      'members_present', count(DISTINCT a.member_id)
+    ) INTO v_engagement
+    FROM public.attendance a
+    JOIN public.events e ON e.id = a.event_id
+    JOIN public.members m ON m.id = a.member_id
+    WHERE m.chapter = p_chapter AND e.date >= v_year_start AND a.present = true;
+  EXCEPTION WHEN OTHERS THEN
+    v_engagement := jsonb_build_object('attendance_events', 0, 'total_hours', 0, 'members_present', 0);
+  END;
+
+  -- Certification
+  SELECT jsonb_build_object(
+    'cpmai_certified', count(*) FILTER (WHERE cpmai_certified),
+    'total_active', count(*)
+  ) INTO v_certification
+  FROM public.members
+  WHERE chapter = p_chapter AND current_cycle_active;
+
+  v_result := jsonb_build_object(
+    'chapter', p_chapter,
+    'members', v_members,
+    'production', v_production,
+    'engagement', v_engagement,
+    'certification', v_certification
+  );
+
+  RETURN v_result;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_chapter_selection_summary(p_chapter text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_caller_chapter text;
+  v_chapter text;
+BEGIN
+  SELECT m.id, m.chapter INTO v_caller_id, v_caller_chapter
+  FROM public.members m WHERE m.auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Not authenticated');
+  END IF;
+
+  -- V4 gate (mirrors get_chapter_dashboard): cross-chapter for view_internal_analytics OR the
+  -- external aggregate auditor (view_aggregate_analytics, ADR-0111 amendment), else own chapter.
+  IF public.can_by_member(v_caller_id, 'view_internal_analytics')
+     OR public.can_by_member(v_caller_id, 'view_aggregate_analytics') THEN
+    v_chapter := COALESCE(p_chapter, v_caller_chapter);
+  ELSIF p_chapter IS NULL OR p_chapter = v_caller_chapter THEN
+    v_chapter := v_caller_chapter;
+  ELSE
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  IF v_chapter IS NULL THEN
+    RETURN jsonb_build_object('error', 'No chapter specified');
+  END IF;
+
+  RETURN jsonb_build_object(
+    'open', (
+      SELECT jsonb_build_object(
+        'cycle_code', sc.cycle_code,
+        'title', sc.title,
+        'close_date', sc.close_date,
+        'booking_url', sc.interview_booking_url,
+        'open_apps', (SELECT count(*) FROM public.selection_applications sa WHERE sa.cycle_id = sc.id)
+      )
+      FROM public.selection_cycles sc
+      WHERE sc.contracting_chapter = v_chapter AND sc.status = 'open'
+      ORDER BY sc.created_at DESC LIMIT 1
+    ),
+    'last', (
+      SELECT jsonb_build_object('title', sc.title, 'close_date', sc.close_date)
+      FROM public.selection_cycles sc
+      WHERE sc.contracting_chapter = v_chapter
+      ORDER BY sc.created_at DESC LIMIT 1
+    )
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.comms_metrics_latest_by_channel(p_days integer DEFAULT 14)
+ RETURNS TABLE(metric_date date, channel text, audience bigint, reach bigint, engagement numeric, leads bigint, source text, updated_at timestamp with time zone, payload jsonb)
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  with latest as (
+    select max(metric_date) as d
+    from public.comms_metrics_daily
+  )
+  select
+    c.metric_date,
+    c.channel,
+    c.audience,
+    c.reach,
+    c.engagement_rate as engagement,
+    c.leads,
+    c.source,
+    c.updated_at,
+    -- ADR-0111 amendment forward-defense: payload is an opaque ingestion-controlled jsonb; only the
+    -- comms team (can_view_comms_analytics) receives it. The external aggregate auditor gets NULL.
+    case when public.can_view_comms_analytics() then c.payload else null end as payload
+  from public.comms_metrics_daily c
+  where (public.can_view_comms_analytics()
+         or public.can_by_member((select id from public.members where auth_id = auth.uid()), 'view_aggregate_analytics'))
+    and c.metric_date >= coalesce((select d from latest) - greatest(p_days, 1) + 1, current_date)
+  order by c.metric_date desc, c.reach desc nulls last, c.channel asc;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.exec_chapter_comparison()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_result jsonb;
+BEGIN
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN RAISE EXCEPTION 'access_denied'; END IF;
+  -- ADR-0111 amendment: external aggregate auditor (view_aggregate_analytics) joins GP (manage_platform).
+  IF NOT (public.can_by_member(v_caller_id, 'manage_platform')
+          OR public.can_by_member(v_caller_id, 'view_aggregate_analytics')) THEN
+    RAISE EXCEPTION 'access_denied';
+  END IF;
+
+  IF public.can_by_member(v_caller_id, 'view_aggregate_analytics')
+     AND NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+    -- EXTERNAL auditor path: k-anonymity small-cell bucketing (RoPA/LIA s2.3/s8). Chapters with
+    -- < 5 active members collapse into one "Outros (<5 ativos)" bucket so a single-member chapter is
+    -- never an individual record keyed by a real chapter code.
+    WITH base AS (
+      SELECT
+        m.chapter,
+        count(*)::bigint AS total_members,
+        count(*) FILTER (WHERE m.current_cycle_active)::bigint AS active_members,
+        count(*) FILTER (WHERE m.cpmai_certified)::bigint AS cpmai_certified,
+        COALESCE((SELECT count(*) FROM public.board_item_assignments bia2
+          JOIN public.board_items bi2 ON bi2.id = bia2.item_id
+          WHERE bia2.member_id = ANY(array_agg(m.id))
+          AND bi2.curation_status = 'approved'), 0)::bigint AS articles_approved,
+        COALESCE((SELECT count(DISTINCT a2.event_id) FROM public.attendance a2
+          WHERE a2.member_id = ANY(array_agg(m.id))
+          AND a2.present = true), 0)::bigint AS attendance_events
+      FROM public.members m
+      WHERE m.chapter IS NOT NULL
+      GROUP BY m.chapter
+    ),
+    shaped AS (
+      SELECT chapter, total_members, active_members, cpmai_certified, articles_approved, attendance_events
+      FROM base
+      WHERE active_members >= 5
+      UNION ALL
+      SELECT 'Outros (<5 ativos)'::text, sum(total_members)::bigint, sum(active_members)::bigint,
+             sum(cpmai_certified)::bigint, sum(articles_approved)::bigint, sum(attendance_events)::bigint
+      FROM base
+      WHERE active_members < 5
+      HAVING count(*) > 0
+    )
+    SELECT jsonb_agg(row_to_json(s) ORDER BY s.active_members DESC) INTO v_result
+    FROM shaped s;
+  ELSE
+    -- internal / GP path: ORIGINAL query verbatim (byte-neutral full named list).
+    SELECT jsonb_agg(row_to_json(r)) INTO v_result
+    FROM (
+      SELECT
+        m.chapter,
+        count(*) AS total_members,
+        count(*) FILTER (WHERE m.current_cycle_active) AS active_members,
+        count(*) FILTER (WHERE m.cpmai_certified) AS cpmai_certified,
+        COALESCE((SELECT count(*) FROM board_item_assignments bia2
+          JOIN board_items bi2 ON bi2.id = bia2.item_id
+          WHERE bia2.member_id = ANY(array_agg(m.id))
+          AND bi2.curation_status = 'approved'), 0) AS articles_approved,
+        COALESCE((SELECT count(DISTINCT a2.event_id) FROM attendance a2
+          WHERE a2.member_id = ANY(array_agg(m.id))
+          AND a2.present = true), 0) AS attendance_events
+      FROM members m
+      WHERE m.chapter IS NOT NULL
+      GROUP BY m.chapter
+      ORDER BY count(*) FILTER (WHERE m.current_cycle_active) DESC
+    ) r;
+  END IF;
+
+  RETURN COALESCE(v_result, '[]'::jsonb);
+END;
+$function$;

--- a/tests/contracts/institutional-auditor-aggregate-scope.test.mjs
+++ b/tests/contracts/institutional-auditor-aggregate-scope.test.mjs
@@ -29,15 +29,33 @@ import { resolve } from 'node:path';
 const ROOT = process.cwd();
 const MIGRATIONS_DIR = resolve(ROOT, 'supabase/migrations');
 const FU3_FILE = '20260805000292_onda2_fu3_institutional_auditor.sql';
+const AMENDMENT_FILE = '20260805000294_onda2_adr0111_amend_aggregate_chapter_comms_rpcs.sql';
 
 const ACTION = 'view_aggregate_analytics';
 const KIND = 'institutional_auditor';
 
-// The curated allowlist: live-verified to return zero individual PII and perform zero writes.
-const SAFE_RPCS = [
+// The original FU-3 curated allowlist (8): live-verified zero individual PII / zero write. Pinned to FU3_FILE.
+const FU3_SAFE_RPCS = [
   'get_cycle_report', 'get_annual_kpis', 'get_selection_pipeline_metrics', 'get_diversity_dashboard',
   'get_portfolio_items', 'get_in_dashboard', 'get_comms_to_adoption_funnel', 'exec_role_transitions',
 ];
+
+// ADR-0111 amendment (AMENDMENT_FILE): 4 chapter/comms aggregate RPCs join the allowlist (8 -> 12).
+// Per-RPC adversarial review (2026-06-29) found a k-anonymity small-cell risk on the two chapter
+// member-breakdown RPCs; exec_chapter_dashboard + exec_chapter_comparison therefore implement
+// suppression for the EXTERNAL auditor (see SUPPRESSION_RPCS). get_chapter_selection_summary returns
+// count(*)+cycle metadata only; comms_metrics_latest_by_channel NULLs the opaque payload on the auditor path.
+const AMENDMENT_SAFE_RPCS = [
+  'exec_chapter_dashboard', 'get_chapter_selection_summary', 'exec_chapter_comparison',
+  'comms_metrics_latest_by_channel',
+];
+
+// The full curated allowlist (12) — the action must reach EXACTLY these and nothing else.
+const SAFE_RPCS = [...FU3_SAFE_RPCS, ...AMENDMENT_SAFE_RPCS];
+
+// RPCs that MUST keep the external-auditor k-anonymity small-cell suppression (security control,
+// not just a gate). A future edit dropping it for these re-opens the re-identification finding.
+const SUPPRESSION_RPCS = ['exec_chapter_dashboard', 'exec_chapter_comparison'];
 
 // RPCs proven to return individual PII or write — the auditor action must NEVER reach these.
 const PII_OR_WRITE_RPCS = [
@@ -108,14 +126,45 @@ test('FU-3 seeds the kind + the single auditor action correctly', () => {
   assert.match(body, /ADR-0111/i, 'header must reference ADR-0111');
 });
 
-test('FU-3 wires view_aggregate_analytics into EXACTLY the 8 curated safe RPCs', () => {
+test('FU-3 wires view_aggregate_analytics into EXACTLY the original 8 curated safe RPCs', () => {
   const body = stripComments(loadMigrations().find((x) => x.name === FU3_FILE).body);
-  for (const fn of SAFE_RPCS) {
+  for (const fn of FU3_SAFE_RPCS) {
     const bodies = functionBodies(body, fn);
     assert.ok(bodies.length >= 1, `${fn} CREATE OR REPLACE must be in the FU-3 migration`);
     assert.ok(bodies[bodies.length - 1].includes(ACTION),
       `${fn} gate must honor ${ACTION}`);
   }
+});
+
+test('ADR-0111 amendment wires the action into EXACTLY the 4 chapter/comms RPCs (20260805000294)', () => {
+  const m = loadMigrations().find((x) => x.name === AMENDMENT_FILE);
+  assert.ok(m, `${AMENDMENT_FILE} must exist`);
+  const body = stripComments(m.body);
+  for (const fn of AMENDMENT_SAFE_RPCS) {
+    const bodies = functionBodies(body, fn);
+    assert.ok(bodies.length >= 1, `${fn} CREATE OR REPLACE must be in the amendment migration`);
+    assert.ok(bodies[bodies.length - 1].includes(ACTION),
+      `${fn} gate must honor ${ACTION}`);
+  }
+});
+
+test('ADR-0111 amendment keeps k-anonymity small-cell suppression in the member-breakdown RPCs', () => {
+  // Forward-defense for the SECURITY CONTROL itself (not just the gate): the per-RPC adversarial
+  // review found a re-identification risk for an external auditor on tiny chapters (live: 3 chapters
+  // with 1 active member). The suppression must survive future edits.
+  const body = loadMigrations().find((x) => x.name === AMENDMENT_FILE).body;
+  for (const fn of SUPPRESSION_RPCS) {
+    const bodies = functionBodies(stripComments(body), fn);
+    assert.ok(bodies.length >= 1, `${fn} must be in the amendment migration`);
+    const live = bodies[bodies.length - 1];
+    // the external-auditor predicate (has aggregate action AND NOT internal analytics) gates suppression
+    assert.match(live, /can_by_member\([^)]*'view_aggregate_analytics'\)\s*\n?\s*AND NOT public\.can_by_member\([^)]*'view_internal_analytics'\)/i,
+      `${fn} must branch suppression on (view_aggregate_analytics AND NOT view_internal_analytics)`);
+  }
+  // dashboard returns a suppressed marker; comparison buckets into "Outros (<5 ativos)"
+  const full = body;
+  assert.match(full, /small_cell_below_threshold/i, 'exec_chapter_dashboard must return the small-cell suppressed marker');
+  assert.match(full, /Outros \(<5 ativos\)/, 'exec_chapter_comparison must collapse small chapters into the bucket');
 });
 
 test('forward-defense: view_aggregate_analytics reaches ONLY the curated allowlist (true bound, no drift)', () => {


### PR DESCRIPTION
## O quê

Estende a action `view_aggregate_analytics` do **auditor institucional externo** de **8 → 12 RPCs** (decisão do PM via `AskUserQuestion`): dashboards de capítulo (`exec_chapter_dashboard`, `exec_chapter_comparison`, `get_chapter_selection_summary`) + métricas de comms agregadas (`comms_metrics_latest_by_channel`) — **com supressão de célula pequena (k=5) construída em código**.

## Por que não foi um grant repetido

Uma **revisão adversarial por-RPC** (8 sub-agentes: auditor de fidelidade + cético de refutação por RPC, todos consultando o DB ao vivo) pegou um problema **comportamental** de LGPD que a validação de fidelidade (drift/Phase-C, byte-fiel a live) **não** pega:

> `exec_chapter_dashboard`/`exec_chapter_comparison` quebram membros por capítulo, e **ao vivo 3 capítulos têm 1 único membro ativo** (PMI-PR/PMI-SP/Outro; `members.chapter` é texto livre, sem CHECK). Para esses, o "agregado" entregue a um auditor **externo** É o registro de um indivíduo re-identificável — exatamente o risco que o RoPA/LIA do FU-4 condicionava à supressão de célula pequena (até então compromisso de processo, não código).

## Implementação (PM: construir a supressão agora, não diferir)

- **Predicado de auditor externo (inline, sem helper):** `view_aggregate_analytics AND NOT view_internal_analytics` → mantém o invariante `carriers == SAFE_RPCS`; controladores internos nunca disparam supressão (**behavior-neutral**).
- `exec_chapter_dashboard`: capítulo com `<5` ativos → marcador `{suppressed:true, threshold:5}`.
- `exec_chapter_comparison`: capítulos `<5` ativos colapsam em `"Outros (<5 ativos)"`; **caminho interno = query original verbatim** (split IF/ELSE → zero regressão à UI admin).
- `get_chapter_selection_summary`: só `count(*)` + metadados de ciclo (sem supressão).
- `comms_metrics_latest_by_channel`: gate `OR` **inline** (não toca o helper compartilhado `can_view_comms_analytics`, que vazaria `comms_top_media`/`comms_channel_status`); `payload` jsonb opaco **NULL no caminho do auditor** (forward-defense).

**Excluído:** `get_chapter_dashboard` segue negada (roster c/ nomes/fotos); `comms_top_media` (lista de posts). **Achado separado:** `get_comms_dashboard_metrics` é SECDEF **sem gate** (não relacionado).

## Verificação (ao vivo, 2026-06-29)

- `carriers == 12` (8 + 4); teste de contrato `deepEqual(carriers, SAFE_RPCS)` verde.
- **2-lados:** GP (Vitor, `request.jwt.claims`) → `exec_chapter_dashboard('PMI-SP')` detalhe **completo**; `exec_chapter_comparison()` **11 capítulos nomeados** (regressão zero). Auditor (branch) → PMI-SP suprimido; capítulos `<5` colapsados (Outros: total 8 / ativos 7).
- **Dormância:** `holders_of_action=0`, `route_to_suppression=0`.
- **Phase-C file==live** (sem drift); migration `20260805000294` aplicada a prod (já live), arquivo = SSOT literal pós-apply.
- Build verde; suite offline 4321/0; DB-aware migration-coverage 22/0; testes das RPCs tocadas 58/0.

## Docs

ADR-0111 (§ Amendment), GOVERNANCE_CHANGELOG **GC-150**, PERMISSIONS_MATRIX §2.1, `INSTITUTIONAL_AUDITOR_COOPERATION_AND_PROVISIONING.md` §2.1/§2.3 (tabela 8→12 + supressão **implementada**), Anexo R3 #641 §5.3.

## Lição (cross-ref pt12 / [LL] #588)

Revisão adversarial **comportamental** (lente security/LGPD) e validação de **fidelidade** (drift/Phase-C) são **camadas ortogonais**: o gate estava byte-fiel a live E ainda assim entregaria PII por célula pequena. Ambas necessárias.

Refs #952.