### PR TITLE
fix(security): #961 gate get_comms_dashboard_metrics behind comms-analytics gate

### DIFF
--- a/src/components/admin/CommsDashboard.tsx
+++ b/src/components/admin/CommsDashboard.tsx
@@ -12,6 +12,7 @@ import {
   Cell,
   Legend,
 } from 'recharts';
+import { usePageI18n } from '../../i18n/usePageI18n';
 
 type CommsMetrics = {
   backlog_count: number;
@@ -33,6 +34,10 @@ const STATUS_LABELS: Record<string, string> = {
 const FORMAT_COLORS = ['#3B82F6', '#8B5CF6', '#10B981', '#F59E0B', '#EF4444', '#06B6D4', '#EC4899', '#6B7280'];
 
 export default function CommsDashboard() {
+  // #961: the comms-analytics gate routes non-comms callers to a zero payload, which
+  // makes the empty-state branches (below) reachable — they call t(), so the i18n hook
+  // must be wired (it was missing, leaving t undefined → ReferenceError once reached).
+  const t = usePageI18n();
   const [metrics, setMetrics] = useState<CommsMetrics | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);

--- a/src/pages/admin/comms-ops.astro
+++ b/src/pages/admin/comms-ops.astro
@@ -6,7 +6,7 @@ import CommsDashboard from '../../components/admin/CommsDashboard';
 import BoardEngine from '../../components/islands/BoardEngine';
 const lang: Lang = getLangFromURL(Astro.url.pathname + Astro.url.search);
 const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
-const i18nBundle = buildPageI18n(['comp.board', 'comp.card', 'common'], lang);
+const i18nBundle = buildPageI18n(['comp.board', 'comp.card', 'comp.comms', 'common'], lang);
 
 // Pre-render strings for inline TS script via define:vars (Ω-B+.4 p141)
 const COMMSOPS_I18N = {

--- a/supabase/migrations/20260805000295_gate_comms_dashboard_metrics_961.sql
+++ b/supabase/migrations/20260805000295_gate_comms_dashboard_metrics_961.sql
@@ -1,0 +1,133 @@
+-- #961: get_comms_dashboard_metrics was SECURITY DEFINER with NO permission check
+-- and EXECUTE granted to `authenticated`, so any logged-in member could read the
+-- communication boards' operational metrics (backlog/overdue/totals/by_status/by_format).
+-- These are internal operational data and must follow the same access model as the
+-- sibling comms-read RPCs (#883): gate behind can_view_comms_analytics()
+-- (= view_internal_analytics OR manage_comms OR comms_leader/comms_member designation).
+-- Body-only change → CREATE OR REPLACE (signature/attributes unchanged); grant unchanged.
+--
+-- Two-sided live verification (2026-06-29):
+--   * Mayanna (comms_leader)  → real data (backlog 41 / overdue 41 / total 99)
+--   * Ana Carla (tribe_leader, no comms) → zeros {} (was leaking the full payload before)
+--   * no-JWT / anon            → zeros {}
+--
+-- Note: the confidential-initiative gate (#785, rls_can_see_*) is a SEPARATE concern;
+-- this function stays correctly in the #785 ALLOWLIST as an 'aggregate' (counts, not
+-- per-board content). This migration adds the orthogonal *authority* gate only.
+CREATE OR REPLACE FUNCTION public.get_comms_dashboard_metrics()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+declare
+  v_result jsonb;
+  v_backlog int;
+  v_overdue int;
+  v_total int;
+  v_by_status jsonb;
+  v_by_format jsonb;
+  v_board_ids uuid[];
+begin
+  -- #961: comms board operational metrics are internal data — same access model as
+  -- the sibling comms-read RPCs (#883, can_view_comms_analytics). Deny for everyone
+  -- else with a zero-shaped payload (the dashboard renders empty; no error path).
+  if not public.can_view_comms_analytics() then
+    return jsonb_build_object(
+      'backlog_count', 0,
+      'overdue_count', 0,
+      'total_publications', 0,
+      'by_status', '{}'::jsonb,
+      'by_format', '{}'::jsonb
+    );
+  end if;
+
+  -- Boards de comunicação (domain_key = 'communication')
+  select array_agg(pb.id)
+    into v_board_ids
+  from public.project_boards pb
+  where coalesce(pb.domain_key, '') = 'communication'
+    and pb.is_active is true;
+
+  if v_board_ids is null or array_length(v_board_ids, 1) = 0 then
+    return jsonb_build_object(
+      'backlog_count', 0,
+      'overdue_count', 0,
+      'total_publications', 0,
+      'by_status', '[]'::jsonb,
+      'by_format', '[]'::jsonb
+    );
+  end if;
+
+  select
+    count(*) filter (where bi.status in ('backlog','todo') or bi.status is null)::int,
+    count(*) filter (where bi.due_date is not null and bi.due_date::date < current_date and coalesce(bi.status, '') not in ('done','review'))::int,
+    count(*)::int
+  into v_backlog, v_overdue, v_total
+  from public.board_items bi
+  where bi.board_id = any(v_board_ids);
+
+  select coalesce(
+    jsonb_object_agg(s.status, s.cnt),
+    '{}'::jsonb
+  )
+  into v_by_status
+  from (
+    select coalesce(bi.status, 'unknown') as status, count(*)::int as cnt
+    from public.board_items bi
+    where bi.board_id = any(v_board_ids)
+    group by coalesce(bi.status, 'unknown')
+  ) s;
+
+  -- Distribuição por formato: tags são string[] no board_items
+  -- Extraímos tags comuns: vídeo, artigo, linkedin, post, etc.
+  with items_tags as (
+    select unnest(
+      case when bi.tags is null or array_length(bi.tags, 1) is null or array_length(bi.tags, 1) = 0
+        then array['outros']::text[] else bi.tags
+      end
+    ) as tag
+    from public.board_items bi
+    where bi.board_id = any(v_board_ids)
+  ),
+  normalized as (
+    select
+      case
+        when lower(tag) in ('video','vídeo') then 'vídeo'
+        when lower(tag) in ('artigo','article','artigos') then 'artigo'
+        when lower(tag) in ('linkedin','linkedin post') then 'LinkedIn'
+        when lower(tag) in ('post','posts') then 'post'
+        when lower(tag) in ('newsletter') then 'newsletter'
+        when lower(tag) in ('podcast') then 'podcast'
+        when lower(tag) in ('infográfico','infographic') then 'infográfico'
+        else coalesce(nullif(trim(tag), ''), 'outros')
+      end as format
+    from items_tags
+  )
+  select coalesce(
+    jsonb_object_agg(n.format, n.cnt),
+    '{}'::jsonb
+  )
+  into v_by_format
+  from (
+    select format, count(*)::int as cnt
+    from normalized
+    group by format
+  ) n;
+
+  -- Se não há tags, default "outros" = total
+  if v_by_format is null or v_by_format = '{}'::jsonb then
+    v_by_format := jsonb_build_object('outros', v_total);
+  end if;
+
+  v_result := jsonb_build_object(
+    'backlog_count', coalesce(v_backlog, 0),
+    'overdue_count', coalesce(v_overdue, 0),
+    'total_publications', coalesce(v_total, 0),
+    'by_status', coalesce(v_by_status, '{}'::jsonb),
+    'by_format', coalesce(v_by_format, '{}'::jsonb)
+  );
+
+  return v_result;
+end;
+$function$;


### PR DESCRIPTION
Closes #961.

## Problem
`public.get_comms_dashboard_metrics()` was `SECURITY DEFINER` with **no permission check** and `EXECUTE` granted to `authenticated`, so **any logged-in member** could read the communication boards' operational metrics (`backlog_count`, `overdue_count`, `total_publications`, `by_status`, `by_format`). The sibling comms-read RPCs (`comms_top_media`, `comms_metrics_latest_by_channel`, `get_comms_metrics_by_channel`) were already gated in the #883 wave; this one slipped through. Found during the ADR-0111 adversarial review (#960).

## Fix (migration `20260805000295`)
Add the established comms gate at the top of the body:
```sql
if not public.can_view_comms_analytics() then
  return jsonb_build_object('backlog_count',0,'overdue_count',0,'total_publications',0,
                            'by_status','{}'::jsonb,'by_format','{}'::jsonb);
end if;
```
`can_view_comms_analytics()` = `view_internal_analytics` OR `manage_comms` OR `comms_leader`/`comms_member` designation — identical to the #883 siblings. Denied callers get a zero-shaped payload (no error path). Body-only `CREATE OR REPLACE`; grant unchanged (`anon` was already revoked in `20260426130254`). The external aggregate auditor (ADR-0111, #960) is deliberately **excluded** — board-level ops metrics are not part of its agreed surface.

## Verification (live, two-sided)
| Caller | Before | After |
|---|---|---|
| Mayanna (comms_leader) | real data | **real data** (backlog 41 / overdue 41 / total 99) |
| Ana Carla (tribe_leader, no comms) | **full payload (leak)** | **zeros** |
| no-JWT / anon | (full payload) | **zeros** |

`npx astro build` ✓ · `npm test` **4772 pass / 0 fail / 0 skipped** (DB-aware contract tests ran: #785 confidential-gate allowlist + rot-sanity, Phase-C body drift, orphan coverage, auditor-scope — all green).

### #785 interaction (deliberately unchanged)
The confidential-initiative gate (`rls_can_see_*`) is **orthogonal** to this authority gate. The #785 audit RPC matches `rls_can_see_*` specifically, so the function stays correctly allowlisted as `'aggregate'` and the "allowlist must not rot" sanity check still passes.

## Frontend (included because the gate exposes it)
The gate routes non-comms callers to a zero payload, which makes `CommsDashboard`'s empty-state branches reachable for the first time. Those branches call `t(...)`, but the component **never wired the i18n hook** (`t` was undefined → `ReferenceError` once the empty state renders). Fixed by wiring `usePageI18n()` (the project convention used by every other admin island) and injecting the `comp.comms` namespace into the `comms-ops` page bundle — the localized strings already existed in all 3 dictionaries, they just weren't loaded.

## Follow-ups discovered (NOT in this PR — adversarial completeness pass)
The same review found other ungated comms-read SECDEF RPCs reachable by any `authenticated` user (verified live), to be triaged separately:
- **`webinars_pending_comms()` — medium/high:** returns `meeting_link` (live Zoom/Meet/Teams URLs) for confirmed/completed webinars, no gate. More sensitive than this issue.
- **`broadcast_history()` — low:** leaks broadcast subject lines, no gate.
- **`comms_check_token_expiry()` — low:** no gate (PM-accepted risk from p58/p59).
- **`board_items` direct PostgREST — low/pre-existing:** authoritative members can read comms board *content* directly (org-level boards, `rls_can_see_initiative(NULL)=true`); the RPC gate is defense-in-depth, not a complete boundary. Design question: are comms boards intended member-visible?

`comms_executive_kpis()` confirmed safe (revoked from `authenticated`).