### PR TITLE
fix(board): #300 Gap 2 — unbreak update/delete_checklist_item (lifecycle CHECK)

### DIFF
--- a/supabase/migrations/20260805000300_300_gap2_checklist_lifecycle_actions.sql
+++ b/supabase/migrations/20260805000300_300_gap2_checklist_lifecycle_actions.sql
@@ -1,0 +1,39 @@
+-- =====================================================================
+-- #300 Gap 2 — unbreak update_checklist_item / delete_checklist_item
+-- =====================================================================
+-- Both RPCs write board_lifecycle_events rows with:
+--   update_checklist_item  -> action = 'activity_updated'
+--   delete_checklist_item  -> action = 'activity_deleted'
+-- but board_lifecycle_events_action_check (last set by p197,
+-- 20260715000000) omits BOTH values. Result: EVERY call to either
+-- MCP-exposed RPC throws board_lifecycle_events_action_check violation —
+-- a live, 100%-reproducible broken-RPC / data-integrity bug
+-- (discovered p225, 2026-05-23; grounded live this session 2026-06-29).
+--
+-- Fix: extend the CHECK to include the two values, consistent with the
+-- existing activity_* family (activity_added/completed/reopened/assigned).
+-- Widening an IN-list CHECK never fails on existing data. Drop+recreate
+-- per constraint-change discipline.
+-- =====================================================================
+
+ALTER TABLE public.board_lifecycle_events
+  DROP CONSTRAINT IF EXISTS board_lifecycle_events_action_check;
+
+ALTER TABLE public.board_lifecycle_events
+  ADD CONSTRAINT board_lifecycle_events_action_check
+  CHECK (action = ANY (ARRAY[
+    'board_archived', 'board_restored', 'item_archived', 'item_restored',
+    'archived', 'deleted', 'created', 'status_change', 'forecast_update',
+    'actual_completion', 'mirror_created', 'assigned', 'member_assigned',
+    'member_unassigned', 'submitted_for_curation', 'reviewer_assigned',
+    'curation_review', 'curation_approved', 'moved_out', 'moved_in',
+    'baseline_set', 'baseline_locked', 'baseline_changed', 'forecast_changed',
+    'title_changed', 'portfolio_flag_changed', 'activity_added',
+    'activity_completed', 'activity_reopened', 'activity_assigned',
+    -- #300 Gap 2: written by update_checklist_item / delete_checklist_item
+    'activity_updated', 'activity_deleted',
+    'comment_added', 'comment_edited', 'comment_deleted',
+    -- p197 fix B1: distinct from 'curation_review' (curator scoring)
+    'peer_review_completed',
+    'leader_review_completed'
+  ]));


### PR DESCRIPTION
## What

`update_checklist_item` and `delete_checklist_item` — **both MCP-exposed** — write `board_lifecycle_events` rows with `action='activity_updated'` / `action='activity_deleted'`, but `board_lifecycle_events_action_check` (last set by p197, `20260715000000`) **omitted both values**. Result: **every call** to either RPC threw a `board_lifecycle_events_action_check` violation.

Live, 100%-reproducible broken-RPC / data-integrity bug. Discovered p225 (2026-05-23, #300 Gap 2); grounded live this session.

## Fix

Widen the CHECK to include `activity_updated` + `activity_deleted`, consistent with the existing `activity_*` family (`activity_added`/`completed`/`reopened`/`assigned`). Drop+recreate per constraint discipline. Widening an IN-list CHECK cannot fail on existing data.

Migration `20260805000300`.

## Acceptance evidence (grounded live)

- **Before:** constraint enum = 35 values; `update_checklist_item` writes `activity_updated`, `delete_checklist_item` writes `activity_deleted` → both absent → CHECK violation on every call.
- **After apply:** `pg_get_constraintdef` contains both values (`has_updated=true, has_deleted=true`).
- **End-to-end smoke (zero side-effect):** transactional INSERT of both action values into `board_lifecycle_events` succeeded then rolled back via RAISE (`SMOKE_OK_BOTH_ACCEPTED_rollback`). Had the constraint rejected, the error would have been a `check_violation` on the INSERT, not the trailing RAISE.
- `npx astro build` ✓ · `npm test` **4793 pass / 0 fail / 0 skip** (incl. DB-aware `rpc-migration-coverage` — no phantom drift).

## Rollback

`ALTER TABLE public.board_lifecycle_events DROP CONSTRAINT board_lifecycle_events_action_check;` then re-add the p197 35-value form. No data migration to reverse (widening only).

## Scope

Narrow child of the #300 umbrella (Gap 2 only). The umbrella is being decomposed + downgraded separately (the #292 sprint that gated it is now closed).

Refs #300.