### PR TITLE
fix(gamification): scoring-taxonomy curadoria — chip Artefato→Entregável + Champions/Curadoria/Produção no modal

### DIFF
--- a/src/components/ui/ScoringInfoPopover.tsx
+++ b/src/components/ui/ScoringInfoPopover.tsx
@@ -22,6 +22,15 @@ interface Props {
     badge: string;
     showcase: string;
     showcaseSub: string;
+    deliverable: string;
+    deliverableSub: string;
+    artifact: string;
+    action: string;
+    actionSub: string;
+    champion: string;
+    championSub: string;
+    curation: string;
+    curationSub: string;
     attendance: string;
     goal: string;
   };
@@ -79,6 +88,26 @@ export default function ScoringInfoPopover({ i18n }: Props) {
         <div className={ROW}>
           <div><span className={LABEL}>🎤 {i18n.showcase}</span><div className={SUB}>{i18n.showcaseSub}</div></div>
           <span className={XP}>15–25 XP</span>
+        </div>
+        <div className={ROW}>
+          <div><span className={LABEL}>📦 {i18n.deliverable}</span><div className={SUB}>{i18n.deliverableSub}</div></div>
+          <span className={XP}>30 XP</span>
+        </div>
+        <div className={ROW}>
+          <div><span className={LABEL}>📝 {i18n.artifact}</span></div>
+          <span className={XP}>15 XP</span>
+        </div>
+        <div className={ROW}>
+          <div><span className={LABEL}>☑️ {i18n.action}</span><div className={SUB}>{i18n.actionSub}</div></div>
+          <span className={XP}>5 XP</span>
+        </div>
+        <div className={ROW}>
+          <div><span className={LABEL}>🏅 {i18n.champion}</span><div className={SUB}>{i18n.championSub}</div></div>
+          <span className={XP}>20–60 XP</span>
+        </div>
+        <div className={ROW}>
+          <div><span className={LABEL}>🔎 {i18n.curation}</span><div className={SUB}>{i18n.curationSub}</div></div>
+          <span className={XP}>5–30 XP</span>
         </div>
         <div className={`${ROW} border-b-0`}>
           <div><span className={LABEL}>✅ {i18n.attendance}</span></div>

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -3037,6 +3037,7 @@ const enUS: Record<string, string> = {
   'gamification.pointsLegend.attendance': 'Attendance',
   'gamification.pointsLegend.course': 'Course',
   'gamification.pointsLegend.artifact': 'Artifact',
+  'gamification.pointsLegend.deliverable': 'Deliverable',
   'gamification.pointsLegend.profile': '100% Profile',
   'gamification.pointsLegend.bonus': 'Special bonus',
   // ── Scoring popover ──
@@ -3060,6 +3061,15 @@ const enUS: Record<string, string> = {
   'gamification.scoring.badge': 'Badge / Community',
   'gamification.scoring.showcase': 'Showcase / Protagonist',
   'gamification.scoring.showcaseSub': 'Presentation at general meeting',
+  'gamification.scoring.deliverable': 'Deliverable (card) completed',
+  'gamification.scoring.deliverableSub': 'Tribe WBS card · +10 if on time',
+  'gamification.scoring.artifact': 'Rich minutes published',
+  'gamification.scoring.action': 'Action/task resolved',
+  'gamification.scoring.actionSub': 'Meeting task · +2 if on time',
+  'gamification.scoring.champion': 'Champion (recognition)',
+  'gamification.scoring.championSub': 'General / tribe / deliverable',
+  'gamification.scoring.curation': 'Document curation',
+  'gamification.scoring.curationSub': 'Publish 30 · ratify 25 · author 20 · lock 10 · resolve 5',
   'gamification.scoring.attendance': 'Meeting attendance',
   'gamification.scoring.goal': '2026 Goal: 70% of team with trail complete (6/6)',
   // ── Board rules popover ──

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -3037,6 +3037,7 @@ const esLATAM: Record<string, string> = {
   'gamification.pointsLegend.attendance': 'Asistencia',
   'gamification.pointsLegend.course': 'Curso',
   'gamification.pointsLegend.artifact': 'Artefacto',
+  'gamification.pointsLegend.deliverable': 'Entregable',
   'gamification.pointsLegend.profile': 'Perfil 100%',
   'gamification.pointsLegend.bonus': 'Bono especial',
   // ── Scoring popover ──
@@ -3060,6 +3061,15 @@ const esLATAM: Record<string, string> = {
   'gamification.scoring.badge': 'Badge / Comunidad',
   'gamification.scoring.showcase': 'Showcase / Protagonismo',
   'gamification.scoring.showcaseSub': 'Presentación en reunión general',
+  'gamification.scoring.deliverable': 'Entregable (card) completado',
+  'gamification.scoring.deliverableSub': 'Card WBS de la tribu · +10 si a tiempo',
+  'gamification.scoring.artifact': 'Acta enriquecida publicada',
+  'gamification.scoring.action': 'Acción/tarea resuelta',
+  'gamification.scoring.actionSub': 'Tarea de la reunión · +2 si a tiempo',
+  'gamification.scoring.champion': 'Champion (reconocimiento)',
+  'gamification.scoring.championSub': 'Reunión general / tribu / entregable',
+  'gamification.scoring.curation': 'Curaduría de documentos',
+  'gamification.scoring.curationSub': 'Publicar 30 · ratificar 25 · autorar 20 · bloquear 10 · resolver 5',
   'gamification.scoring.attendance': 'Asistencia a reunión',
   'gamification.scoring.goal': 'Meta 2026: 70% del equipo con ruta completa (6/6)',
   // ── Board rules popover ──

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -3042,6 +3042,7 @@ const ptBR: Record<string, string> = {
   'gamification.pointsLegend.attendance': 'Presença',
   'gamification.pointsLegend.course': 'Curso',
   'gamification.pointsLegend.artifact': 'Artefato',
+  'gamification.pointsLegend.deliverable': 'Entregável',
   'gamification.pointsLegend.profile': 'Perfil 100%',
   'gamification.pointsLegend.bonus': 'Bônus especial',
   // ── Scoring popover ──
@@ -3065,6 +3066,15 @@ const ptBR: Record<string, string> = {
   'gamification.scoring.badge': 'Badge / Comunidade',
   'gamification.scoring.showcase': 'Showcase / Protagonismo',
   'gamification.scoring.showcaseSub': 'Apresentação em reunião geral',
+  'gamification.scoring.deliverable': 'Entregável (card) concluído',
+  'gamification.scoring.deliverableSub': 'Card WBS da tribo · +10 se no prazo',
+  'gamification.scoring.artifact': 'Ata rica publicada',
+  'gamification.scoring.action': 'Ação/atividade resolvida',
+  'gamification.scoring.actionSub': 'Tarefa da reunião · +2 se no prazo',
+  'gamification.scoring.champion': 'Champion (reconhecimento)',
+  'gamification.scoring.championSub': 'Reunião geral / tribo / entregável',
+  'gamification.scoring.curation': 'Curadoria de documentos',
+  'gamification.scoring.curationSub': 'Publicar 30 · ratificar 25 · autorar 20 · travar 10 · resolver 5',
   'gamification.scoring.attendance': 'Presença em reunião',
   'gamification.scoring.goal': 'Meta 2026: 70% do time com trilha completa (6/6)',
   // ── Board rules popover ──

--- a/src/pages/gamification.astro
+++ b/src/pages/gamification.astro
@@ -181,6 +181,15 @@ const SCORING_I18N = {
   badge: t('gamification.scoring.badge', lang),
   showcase: t('gamification.scoring.showcase', lang),
   showcaseSub: t('gamification.scoring.showcaseSub', lang),
+  deliverable: t('gamification.scoring.deliverable', lang),
+  deliverableSub: t('gamification.scoring.deliverableSub', lang),
+  artifact: t('gamification.scoring.artifact', lang),
+  action: t('gamification.scoring.action', lang),
+  actionSub: t('gamification.scoring.actionSub', lang),
+  champion: t('gamification.scoring.champion', lang),
+  championSub: t('gamification.scoring.championSub', lang),
+  curation: t('gamification.scoring.curation', lang),
+  curationSub: t('gamification.scoring.curationSub', lang),
   attendance: t('gamification.scoring.attendance', lang),
   goal: t('gamification.scoring.goal', lang),
 };
@@ -267,7 +276,7 @@ const SCORING_I18N = {
         </div>
         <div class="flex items-center gap-2">
           <span class="w-8 h-8 rounded-lg bg-emerald-50 text-emerald-600 flex items-center justify-center font-bold text-[11px]">+30</span>
-          <span class="text-[var(--text-secondary)]">{t('gamification.pointsLegend.artifact', lang)}</span>
+          <span class="text-[var(--text-secondary)]">{t('gamification.pointsLegend.deliverable', lang)}</span>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Curadoria da taxonomia de gamificação em `/gamification`

Correção de um erro de taxonomia no "Como ganhar pontos" + preenchimento de gaps de cobertura no modal de scoring. **Frontend/i18n only, sem migration.**

### 🔴 Discrepância corrigida
O chip **"+30 Artefato"** exibia o valor de `deliverable_completed` (**30** = card/entregável WBS concluído) mas com o rótulo "Artefato". No backend, `artifact_published` (**Ata rica**) vale **15**, não 30 — os termos estavam trocados.
- Chip relabel: **`+30 Artefato` → `+30 Entregável`**, alinhado à taxonomia canônica do sistema (`board.rules`: **CARD = Entregável (WBS)**).

### 🟡 Gaps de cobertura preenchidos (modal `ScoringInfoPopover`)
O modal omitia 3 mecanismos que pontuam de verdade. Adicionados:
- **Entregável (card) concluído** — 30 XP (+10 no prazo) · `deliverable_completed`
- **Ata rica publicada** — 15 XP · `artifact_published`
- **Ação/atividade resolvida** — 5 XP (+2 no prazo) · `action_resolved`
- **Champion (reconhecimento)** — 20–60 XP (base 30/20/40 +5/critério, caps 50/40/60)
- **Curadoria de documentos** — 5–30 XP (publicar 30 · ratificar 25 · autorar 20 · travar 10 · resolver 5)

### ✅ Já estava correto (verificado ao vivo)
- Os 12 cards de certificação do modal batem 100% com `gamification_rules`.
- Níveis (Explorador→Lenda) são construto de frontend, internamente consistentes.
- Ordenação do leaderboard já com `ORDER BY sum(points) DESC` (fix #1068/pt47 vivo em prod).

### Grounding
Aterrado nesta sessão contra `gamification_rules`, `award_champion`, `trg_tribe_deliverable_completed_xp`, `trg_meeting_artifact_published_xp`. Build `npx astro build` limpo; 10 novas chaves i18n em pt-BR/en-US/es-LATAM (paridade 3/3).

### ⚠️ Fora de escopo (registrado p/ decisão)
"Card de portfólio concluído" (flag `is_portfolio_item`) **não pontua como categoria própria** — o card pontua 30 via `tribe_deliverable` com ou sem o flag. Dar pontos extras ao flag seria feature de backend (nova regra + trigger), separada desta curadoria de rótulos.
