### PR TITLE
fix(agenda-viva): #1071 — protagonistas confirmáveis após a Reunião Geral (past window admin-reserved + painel window=both)

### DIFF
--- a/src/components/admin/AdminAgendaVivaPanel.tsx
+++ b/src/components/admin/AdminAgendaVivaPanel.tsx
@@ -16,7 +16,7 @@ interface Block {
   format_slug: string;
   title: string;
   duration_min: number;
-  status: 'reserved' | 'confirmed';
+  status: 'reserved' | 'confirmed' | 'no_show';
   sort_order: number;
   external_guest: boolean;
   owner_first_name: string;
@@ -28,6 +28,7 @@ interface EventRow {
   id: string;
   date: string;
   time_start: string | null;
+  is_past?: boolean;
   capacity_used_min: number;
   capacity_remaining_min: number;
   blocks: Block[];
@@ -53,7 +54,10 @@ export default function AdminAgendaVivaPanel({ lang = 'pt-BR' }: { lang?: Lang }
     if (!sb) { setTimeout(load, 300); return; }
     setError(false);
     const [{ data: agenda, error: err }, { data: fmtRows }] = await Promise.all([
-      sb.rpc('get_geral_agenda_viva', { p_limit_events: 2 }),
+      // #1071: 'both' so a General Meeting that already started/ended stays reachable —
+      // the coordinator can still confirm/no-show its protagonists (and credit XP) after
+      // the fact. Past 'reserved' blocks are admin-only in get_geral_agenda_viva.
+      sb.rpc('get_geral_agenda_viva', { p_limit_events: 2, p_window: 'both' }),
       sb.from('agenda_block_formats').select('slug, label_i18n').eq('active', true),
     ]);
     if (err) { setError(true); setLoading(false); return; }
@@ -161,8 +165,20 @@ export default function AdminAgendaVivaPanel({ lang = 'pt-BR' }: { lang?: Lang }
             <section key={ev.id} className="rounded-xl border border-[var(--border)] overflow-hidden">
               <div className="flex items-center justify-between gap-3 px-4 py-3 bg-[var(--bg-subtle)]">
                 <div>
-                  <div className="font-semibold capitalize">{fmtDate(ev.date)}</div>
-                  <div className="text-xs text-[var(--text-muted)]">{ev.capacity_used_min}/90 {t('comp.agendaViva.min', 'min')}</div>
+                  <div className="font-semibold capitalize flex items-center gap-2">
+                    {fmtDate(ev.date)}
+                    {ev.is_past && (
+                      <span className="text-[.6rem] font-bold px-1.5 py-0.5 rounded-full bg-slate-200 text-slate-600">
+                        {t('comp.agendaViva.concludedBadge', 'Concluída')}
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-[var(--text-muted)]">
+                    {ev.capacity_used_min}/90 {t('comp.agendaViva.min', 'min')}
+                    {ev.is_past && ev.blocks.some((b) => b.status === 'reserved') && (
+                      <span className="ml-2 text-amber-600">{t('comp.agendaViva.pastHint', 'Reunião encerrada — confirme os protagonistas para creditar o XP.')}</span>
+                    )}
+                  </div>
                 </div>
                 {ev.blocks.some((b) => b.status === 'reserved') && (
                   <button onClick={() => confirmAll(ev)} disabled={busy === `all-${ev.id}`}
@@ -189,6 +205,7 @@ export default function AdminAgendaVivaPanel({ lang = 'pt-BR' }: { lang?: Lang }
                         <div className="flex items-center gap-1.5 flex-wrap">
                           <span className="font-medium truncate">{b.title}</span>
                           {b.status === 'confirmed' && <span className="text-[.6rem] font-bold px-1.5 py-0.5 rounded-full bg-emerald-100 text-emerald-700">{t('comp.agendaViva.statusConfirmed', 'Confirmado')}</span>}
+                          {b.status === 'no_show' && <span className="text-[.6rem] font-bold px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700">{t('comp.agendaViva.statusNoShow', 'Faltou')}</span>}
                           {b.external_guest && <span className="text-[.6rem] font-bold px-1.5 py-0.5 rounded-full bg-orange/15 text-orange">{t('comp.agendaViva.guestBadge', 'Convidado externo')}</span>}
                         </div>
                         <div className="text-xs text-[var(--text-muted)]">
@@ -202,7 +219,9 @@ export default function AdminAgendaVivaPanel({ lang = 'pt-BR' }: { lang?: Lang }
                         </div>
                       </div>
                       <div className="flex items-center gap-1 shrink-0">
-                        {b.status === 'reserved' ? (
+                        {b.status !== 'confirmed' ? (
+                          // reserved OR no_show → confirm (crediting XP if attendance present);
+                          // confirming a no_show is the reversal path.
                           <button onClick={() => confirmBlock(b)} disabled={busy === b.id} title={t('comp.agendaViva.confirmCta', 'Confirmar')}
                             className="p-1.5 rounded hover:bg-emerald-50 text-emerald-600 disabled:opacity-50">
                             {busy === b.id ? <Loader2 size={15} className="animate-spin" /> : <Check size={15} />}

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -6798,6 +6798,8 @@ const enUS: Record<string, string> = {
   'comp.agendaViva.confirmNoShow': 'Mark this block as no-show? XP will be revoked.',
   'comp.agendaViva.confirmCancelBlock': 'Cancel this block?',
   'comp.agendaViva.xpHint': 'Spotlight XP is credited on confirmation, as long as attendance is registered.',
+  'comp.agendaViva.pastHint': 'Meeting ended — confirm the spotlights to credit their XP.',
+  'comp.agendaViva.statusNoShow': 'No-show',
   'comp.affiliationQueue.loadError': 'Failed to load the queue',
   'comp.affiliationQueue.empty': 'No members pending verification.',
   'comp.affiliationQueue.intro': 'Verify members\' PMI affiliation: (1) active membership and (2) an in-good-standing Brazilian chapter affiliation. VEP affiliation data is shown when available; when a candidate keeps their PMI community private or is not yet affiliated, fill it in manually.',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -6798,6 +6798,8 @@ const esLATAM: Record<string, string> = {
   'comp.agendaViva.confirmNoShow': '¿Marcar este bloque como no-show? El XP será revocado.',
   'comp.agendaViva.confirmCancelBlock': '¿Cancelar este bloque?',
   'comp.agendaViva.xpHint': 'El XP de protagonismo se acredita al confirmar, siempre que haya asistencia registrada.',
+  'comp.agendaViva.pastHint': 'Reunión finalizada — confirma a los protagonistas para acreditar su XP.',
+  'comp.agendaViva.statusNoShow': 'Ausente',
   'comp.affiliationQueue.loadError': 'Error al cargar la cola',
   'comp.affiliationQueue.empty': 'Ningún miembro pendiente de verificación.',
   'comp.affiliationQueue.intro': 'Verifique la afiliación PMI de los miembros: (1) membresía activa y (2) afiliación a un capítulo brasileño vigente. El dato de afiliación del VEP se muestra cuando está disponible; cuando el candidato mantiene la comunidad PMI privada o aún no está afiliado, complete manualmente.',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -6805,6 +6805,8 @@ const ptBR: Record<string, string> = {
   'comp.agendaViva.confirmNoShow': 'Marcar este bloco como no-show? O XP será revogado.',
   'comp.agendaViva.confirmCancelBlock': 'Cancelar este bloco?',
   'comp.agendaViva.xpHint': 'O XP de protagonismo é creditado ao confirmar, desde que haja presença registrada.',
+  'comp.agendaViva.pastHint': 'Reunião encerrada — confirme os protagonistas para creditar o XP.',
+  'comp.agendaViva.statusNoShow': 'Faltou',
   'comp.affiliationQueue.loadError': 'Erro ao carregar a fila',
   'comp.affiliationQueue.empty': 'Nenhum membro pendente de verificação.',
   'comp.affiliationQueue.intro': 'Verifique a filiação PMI dos membros: (1) membresia ativa e (2) filiação a um capítulo brasileiro em dia. O dado de filiação do VEP é exibido quando disponível; quando o candidato mantém a comunidade PMI privada ou ainda não é filiado, preencha manualmente.',

--- a/supabase/migrations/20260805000323_agenda_viva_past_window_admin_reserved.sql
+++ b/supabase/migrations/20260805000323_agenda_viva_past_window_admin_reserved.sql
@@ -1,0 +1,129 @@
+-- #1071: after a General Meeting ends, its Agenda Viva blocks became invisible +
+-- unconfirmable forever. Two defects compounded: (1) the admin panel only requested
+-- the 'upcoming' window, so a meeting vanished once it started; (2) this RPC's past
+-- window hid 'reserved' blocks (showing only confirmed/no_show), so even reaching the
+-- past meeting showed 0 protagonists. Fix (2) here: the past window now includes
+-- 'reserved' blocks ONLY for admins (manage_event), so a coordinator can confirm /
+-- no-show them after the meeting. Public + common-authenticated past view is unchanged
+-- (no new PII surface). Fix (1) is the frontend p_window: 'both' change.
+--
+-- Signature unchanged → CREATE OR REPLACE. Only the `blocks` CTE WHERE clause differs
+-- from the prior body.
+CREATE OR REPLACE FUNCTION public.get_geral_agenda_viva(p_limit_events integer DEFAULT 2, p_member_id uuid DEFAULT NULL::uuid, p_window text DEFAULT 'upcoming'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller   uuid;
+  v_is_admin boolean := false;
+  v_limit    int := LEAST(GREATEST(COALESCE(p_limit_events, 2), 1), 6);
+  v_window   text := lower(COALESCE(p_window, 'upcoming'));
+  v_result   jsonb;
+BEGIN
+  IF v_window NOT IN ('upcoming','past_recent','both') THEN
+    v_window := 'upcoming';
+  END IF;
+
+  -- p_member_id is part of the spec signature, reserved for a future admin "view as member"
+  -- mode (slice 3); the caller is always resolved from auth.uid() here (no impersonation yet).
+  SELECT id INTO v_caller FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller IS NOT NULL THEN
+    v_is_admin := public.can_by_member(v_caller, 'manage_event');
+  END IF;
+
+  WITH all_geral AS (
+    SELECT e.id, e.title, e.date, e.time_start, e.timezone,
+           (e.date + COALESCE(e.time_start,'00:00'::time)) AT TIME ZONE COALESCE(e.timezone,'America/Sao_Paulo') AS start_at
+    FROM public.events e
+    WHERE e.type = 'geral'
+      AND e.status IS DISTINCT FROM 'cancelled'
+  ),
+  upcoming AS (
+    SELECT ag.id, ag.title, ag.date, ag.time_start, ag.timezone, ag.start_at, false AS is_past
+    FROM all_geral ag
+    WHERE v_window IN ('upcoming','both')
+      AND ag.start_at > now()
+    ORDER BY ag.start_at
+    LIMIT v_limit
+  ),
+  past AS (
+    SELECT ag.id, ag.title, ag.date, ag.time_start, ag.timezone, ag.start_at, true AS is_past
+    FROM all_geral ag
+    WHERE v_window IN ('past_recent','both')
+      AND ag.start_at <= now()
+    ORDER BY ag.start_at DESC
+    LIMIT 1
+  ),
+  selected AS (
+    SELECT * FROM past
+    UNION ALL
+    SELECT * FROM upcoming
+  ),
+  blocks AS (
+    SELECT s.is_past, b.event_id, b.id, b.format_slug, b.title, b.duration_min, b.status, b.sort_order,
+           b.external_guest, b.owner_member_id, b.guest_name, b.material_url,
+           split_part(m.name, ' ', 1) AS owner_first_name,
+           m.name AS owner_full_name
+    FROM selected s
+    JOIN public.event_agenda_blocks b ON b.event_id = s.id
+    JOIN public.members m ON m.id = b.owner_member_id
+    -- upcoming: reserved+confirmed (futuro reservável); past: confirmed+no_show (realizado/falta).
+    -- #1071: past 'reserved' also visible to admins (manage_event) so they can confirm/
+    -- no-show a block whose meeting already ended (protagonism never confirmed live).
+    WHERE (NOT s.is_past AND b.status IN ('reserved','confirmed'))
+       OR (s.is_past     AND b.status IN ('confirmed','no_show'))
+       OR (s.is_past AND v_is_admin AND b.status = 'reserved')
+  )
+  SELECT jsonb_build_object(
+    'viewer', jsonb_build_object('is_authenticated', v_caller IS NOT NULL, 'is_admin', v_is_admin),
+    'window', v_window,
+    'events', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'id', s.id, 'title', s.title, 'date', s.date, 'time_start', s.time_start,
+          'timezone', s.timezone, 'start_at', s.start_at,
+          'is_past', s.is_past,
+          'capacity_total_min', 90,
+          'capacity_used_min', COALESCE((SELECT SUM(duration_min) FROM blocks bk WHERE bk.event_id = s.id), 0),
+          'capacity_remaining_min', 90 - COALESCE((SELECT SUM(duration_min) FROM blocks bk WHERE bk.event_id = s.id), 0),
+          'blocks', COALESCE((
+            SELECT jsonb_agg(
+              jsonb_build_object(
+                'id', bk.id, 'format_slug', bk.format_slug, 'title', bk.title,
+                'duration_min', bk.duration_min, 'status', bk.status, 'sort_order', bk.sort_order,
+                'external_guest', bk.external_guest,
+                -- LGPD PD-5: no_show NÃO revela o nome ao público nem ao membro comum; só o
+                -- próprio titular (is_mine) e manage_event. Ver cabeçalho da migration.
+                'owner_first_name', CASE
+                  WHEN bk.status = 'no_show'
+                       AND NOT v_is_admin
+                       AND NOT (v_caller IS NOT NULL AND bk.owner_member_id = v_caller)
+                    THEN NULL
+                  ELSE bk.owner_first_name
+                END,
+                'is_mine', (v_caller IS NOT NULL AND bk.owner_member_id = v_caller)
+              )
+              -- authenticated (non-admin) additionally see the material link
+              || CASE WHEN v_caller IS NOT NULL
+                      THEN jsonb_build_object('material_url', bk.material_url)
+                      ELSE '{}'::jsonb END
+              -- manage_event sees full detail (owner id + full name + guest PII + raw fields)
+              || CASE WHEN v_is_admin
+                      THEN jsonb_build_object(
+                             'owner_member_id', bk.owner_member_id,
+                             'owner_full_name', bk.owner_full_name,
+                             'guest_name', bk.guest_name)
+                      ELSE '{}'::jsonb END
+              ORDER BY bk.sort_order, bk.duration_min DESC
+            ) FROM blocks bk WHERE bk.event_id = s.id
+          ), '[]'::jsonb)
+        ) ORDER BY s.start_at
+      ) FROM selected s
+    ), '[]'::jsonb)
+  ) INTO v_result;
+
+  RETURN v_result;
+END
+$function$

--- a/tests/contracts/1071-agenda-viva-past-admin-reserved.test.mjs
+++ b/tests/contracts/1071-agenda-viva-past-admin-reserved.test.mjs
@@ -1,0 +1,61 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { createClient } from '@supabase/supabase-js';
+
+// #1071: a General Meeting that ended with blocks still 'reserved' (protagonists never
+// confirmed live) became invisible + unconfirmable forever — the admin panel only asked
+// for the 'upcoming' window, and get_geral_agenda_viva's past window hid 'reserved'
+// blocks. Fix: the past window now surfaces 'reserved' blocks to ADMINS (manage_event)
+// only, so a coordinator can confirm/no-show them after the meeting. This SUPERSEDES the
+// p812 "past never reserved" invariant, which now holds for NON-admins only (LGPD).
+const MIGRATION_PATH = 'supabase/migrations/20260805000323_agenda_viva_past_window_admin_reserved.sql';
+const MIGRATION_SQL = readFileSync(MIGRATION_PATH, 'utf8');
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+describe('#1071 — Agenda Viva past window: admin-only reserved visibility', () => {
+  describe('migration static assertions', () => {
+    it('migration file exists and re-creates get_geral_agenda_viva', () => {
+      assert.ok(MIGRATION_SQL.length > 0);
+      assert.match(MIGRATION_SQL, /CREATE OR REPLACE FUNCTION public\.get_geral_agenda_viva\(/);
+    });
+
+    it('past window surfaces reserved blocks ONLY when v_is_admin', () => {
+      // the new third branch of the blocks CTE — gated on v_is_admin.
+      assert.match(MIGRATION_SQL, /s\.is_past AND v_is_admin AND b\.status = 'reserved'/);
+    });
+
+    it('non-admin past view is unchanged (confirmed + no_show only — LGPD invariant)', () => {
+      // base past filter (applies to everyone, admin included) still excludes reserved.
+      assert.match(MIGRATION_SQL, /s\.is_past\s+AND b\.status IN \('confirmed','no_show'\)/);
+      // upcoming branch untouched.
+      assert.match(MIGRATION_SQL, /NOT s\.is_past AND b\.status IN \('reserved','confirmed'\)/);
+    });
+
+    it('keeps SECURITY DEFINER + pinned search_path + STABLE (unchanged surface)', () => {
+      assert.match(MIGRATION_SQL, /STABLE SECURITY DEFINER/);
+      assert.match(MIGRATION_SQL, /SET search_path TO 'public', 'pg_temp'/);
+    });
+  });
+
+  describe('DB-gated: non-admin caller never sees reserved-past (LGPD guard)', () => {
+    const gated = SUPABASE_URL && SERVICE_ROLE ? it : it.skip;
+    // A service-role client resolves v_caller = NULL → v_is_admin = false, i.e. the
+    // "non-admin" path. It must NEVER receive a past block with status 'reserved'.
+    gated('service-role (non-admin) past/both windows expose no reserved block', async () => {
+      const sb = createClient(SUPABASE_URL, SERVICE_ROLE, { auth: { persistSession: false } });
+      for (const p_window of ['past_recent', 'both']) {
+        const { data, error } = await sb.rpc('get_geral_agenda_viva', { p_limit_events: 2, p_window });
+        assert.ifError(error);
+        for (const ev of data.events || []) {
+          if (!ev.is_past) continue;
+          for (const b of ev.blocks || []) {
+            assert.notEqual(b.status, 'reserved', `non-admin past window leaked a reserved block (window=${p_window})`);
+          }
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Fixes #1071.

## Problema (reportado ao vivo 2026-07-02, logo após a Reunião Geral)
Depois da reunião, o coordenador **não conseguia acessar os protagonistas da noite, nem marcar realizado (confirmar → creditar XP), nem ver histórico**. Três defeitos se somavam:

1. **Front** (`AdminAgendaVivaPanel`) pedia `get_geral_agenda_viva` só com `upcoming` → a reunião **sumia do painel ao começar**.
2. **RPC** — na janela `past`, escondia blocos `reserved` (só `confirmed`/`no_show`) → mesmo alcançando a reunião passada, aparecia com **0 protagonistas**.
3. XP só credita com `attendance.present=true` (correto, mas invisível quando 1+2 travavam).

Efeito: bloco `reserved` no momento da reunião = **invisível e não-confirmável para sempre**. Confirmado ao vivo nas Gerais de **02/07 e 18/06** (4 reserved/0 confirmed cada).

## Correção
- **Migration 323**: `get_geral_agenda_viva` inclui `reserved` na janela `past` **só para admins** (`v_is_admin` = manage_event). Supersede o invariante p812 "past never reserved", que passa a valer só para **não-admin** (LGPD — sem nova superfície de PII).
- **Front**: painel pede `p_window: 'both'` (mostra a recém-encerrada); rótulo "Concluída" + hint; badge/status `no_show` + botão de confirmar (reverter no-show).
- **i18n** 3/3 (`pastHint`, `statusNoShow`).
- **Test** `1071-agenda-viva-past-admin-reserved`: estático (cláusula admin-reserved + base não-admin intacta) + DB-gated (não-admin nunca vê reserved-past).

## Verificação
- `npx astro build` ✓ · Phase C body-hash ✓ · missing-file drift ✓ · agenda-viva (p700/p812) ✓ · novo #1071 5/5 ✓.
- Migration **já aplicada à prod** (mig 323 registrada; phantom limpo; `NOTIFY pgrst`). Cláusula admin-reserved confirmada viva.

## Nota operacional (fora do PR)
O XP das duas reuniões travadas **já foi resgatado** via `confirm_event_blocks` (contexto sistema): 02/07 4/4 · 18/06 4 confirmados/3 creditados (Fernando 18/06 sem presença registrada).

## Fora de escopo
- "Marcar reunião como realizada" (`events.status → completed`) é controle separado.

🤖 Frontend deploya no merge (Cloudflare Pages). Migration já está viva. **Sem merge — fila dev (sessão main decide).**
