### PR TITLE
fix(test): #1065 — #630 weekly-cadence gate por semana (não weekday fixo); destrava CI verde

### DIFF
--- a/tests/contracts/630-tribe-agenda-reconciliation.test.mjs
+++ b/tests/contracts/630-tribe-agenda-reconciliation.test.mjs
@@ -96,22 +96,26 @@ test('#630 live: confirmed tribes have seven linked weekly tribe events through 
     .lte('date', '2026-07-31');
   assert.ifError(e2);
 
+  // Monday-anchored week key for an ISO date — collapses each event to the Mon–Sun
+  // week it falls in.
+  const weekKey = (iso) => {
+    const d = new Date(`${iso}T12:00:00Z`);
+    d.setUTCDate(d.getUTCDate() - ((d.getUTCDay() + 6) % 7)); // rewind to Monday
+    return d.toISOString().slice(0, 10);
+  };
   for (const [tribeId, spec] of expected) {
-    const rows = (events ?? []).filter((event) => {
-      const eventDate = new Date(`${event.date}T12:00:00Z`);
-      return byInitiative.get(event.initiative_id) === tribeId
-        && eventDate.getUTCDay() === spec.day;
-    });
-    // #803 (BUG-630.A): assert the seeded weekly cadence by counting DISTINCT
-    // dates on the expected weekday in ANY status. A legitimately cancelled
-    // instance keeps its row, so it still counts as a planned slot. The window
-    // holds exactly `spec.count` occurrences of the weekday, so `>= spec.count`
-    // distinct dates proves full coverage with no gap — and stays green through
-    // legitimate cancellations/reschedules, unlike the old "exactly N active" gate.
-    const distinctDates = new Set(rows.map((event) => event.date));
+    const rows = (events ?? []).filter((event) => byInitiative.get(event.initiative_id) === tribeId);
+    // #1065 (was #803/BUG-630.A): assert the weekly cadence by counting DISTINCT
+    // Mon-anchored WEEKS covered — not distinct dates on one fixed weekday. A weekly
+    // occurrence legitimately rescheduled to another weekday within the same week
+    // (e.g. tribe 6's 2026-06-24 Wed slot held Fri 2026-06-26 — same recurrence
+    // series/link/time) still covers that week. The invariant is "one meeting per
+    // week, no gap", not "always on weekday N"; a cross-week move leaves a real gap
+    // and still fails. `spec.day` is retained as the nominal cadence anchor.
+    const distinctWeeks = new Set(rows.map((event) => weekKey(event.date)));
     assert.ok(
-      distinctDates.size >= spec.count,
-      `tribe ${tribeId} weekly grid: expected >= ${spec.count} distinct weekday-${spec.day} slots, got ${distinctDates.size}`,
+      distinctWeeks.size >= spec.count,
+      `tribe ${tribeId} weekly grid: expected >= ${spec.count} distinct weekly slots (day-${spec.day} cadence), got ${distinctWeeks.size}`,
     );
     assert.ok(rows.every((event) => event.type === 'tribo'), `tribe ${tribeId} all events type=tribo`);
     assert.ok(rows.every((event) => event.initiative_id), `tribe ${tribeId} all events linked to initiative`);


### PR DESCRIPTION
Fixes #1065. Closes the root cause of the recent `--admin` bypass streak (#1064/#1068/#1070/#1072).

## Root cause
`#630 live: confirmed tribes have seven linked weekly tribe events through July` exigia **>=7 datas distintas no weekday nominal** de cada tribo. A tribo 6 (ROI & Portfólio, série `bb5a48fe`) teve a ocorrência semanal de **2026-06-24 (qua)** realizada em **2026-06-26 (sex)** — mesma série, mesmo link (`dgz-koyy-erw`), mesmo horário (18:30/90min). Reschedule **legítimo dentro da mesma semana** → só 6 quartas distintas → **CI validate vermelho em TODO PR** (o gate roda contra prod).

## Fix (test-only, sem mutar prod)
Contar **semanas distintas (âncora segunda-feira)** cobertas pelos eventos `tribo` da tribo na janela `2026-06-13..2026-07-31`, em vez de datas num weekday fixo.
- Invariante real = "uma reunião por semana, sem lacuna" — não "sempre no weekday N".
- Reschedule intra-semana (qua→sex) **conta** (a semana está coberta); movimento **cross-week** deixa lacuna real e **continua falhando**.
- Não move o evento de sexta → **não falsifica o histórico** (não sei se a tribo se reuniu de fato na quarta; a fonte de verdade é o registro).

## Grounding (live)
- Tribo 6 na janela: Jun17(qua)·**Jun26(sex)**·Jul1·8·15·22·29(qua) → sob semana-âncora = **7 semanas distintas**.
- As demais tribos (1/2/4/5/7/8) já tinham 7 no weekday → seguem 7 sob semana-âncora (sem regressão).

## Verificação
- `node --test 630-tribe-agenda-reconciliation.test.mjs` → **6/6 pass** (com DB creds).
- `npx astro build` ✓.

Depois de mergear, o `validate` volta a **verde de verdade** e cessa a necessidade de `--admin` por causa do #630.
