### PR TITLE
fix(certificates): identidade no print do navegador + assinatura acima da linha

### DIFF
--- a/src/lib/certificates/pdf.ts
+++ b/src/lib/certificates/pdf.ts
@@ -601,7 +601,7 @@ export function buildRecognitionHTML(certData: CertificateData): string {
     .rc-bottom{position:absolute;left:0;right:0;bottom:11mm;text-align:center;z-index:2}
     .rc-signs{display:flex;justify-content:center;gap:44mm}
     .rc-sig{text-align:center;width:70mm}
-    .rc-sigimg{display:block;max-height:12mm;max-width:50mm;margin:0 auto;position:relative;bottom:-1.5mm}
+    .rc-sigimg{display:block;max-height:12mm;max-width:50mm;margin:0 auto 0.6mm}
     .rc-sigline{border-top:1px solid #4a5563;width:62mm;margin:0 auto 1.5mm}
     .rc-signame{font-size:11.5pt;font-weight:700;color:#1a365d}
     .rc-sigrole{font-family:Arial,Helvetica,sans-serif;font-size:8.5pt;color:#7a8390}
@@ -722,6 +722,30 @@ async function resolveMemberSignatureUrl(sb: any, memberId: string): Promise<str
 }
 
 export async function hydrateCertData(certData: CertificateData, sb: any): Promise<CertificateData> {
+  // Identity backfill — the CLIENT print path (certificates.astro blob view) passes a
+  // thin payload (member_name: '', no issued_by), so the browser render used to drop
+  // the member name AND the issuer signature while the server renders carried both
+  // (owner report 2026-07-03). One consolidated cert-row fetch feeds member name,
+  // issuer signature and the counter-signer, so every renderer shows the SAME cert.
+  let certRow: { member_id?: string; issued_by?: string; counter_signed_by?: string } | null = null;
+  const needsRow = !certData.member_name || !certData.issued_by || (isRecognitionCert(certData.type) && !certData.co_signature_url);
+  if (sb && needsRow && (certData.verification_code || certData.id)) {
+    try {
+      const keyCol = certData.verification_code ? 'verification_code' : 'id';
+      const { data: row } = await sb
+        .from('certificates')
+        .select('member_id, issued_by, counter_signed_by')
+        .eq(keyCol, keyCol === 'verification_code' ? certData.verification_code : certData.id)
+        .maybeSingle();
+      certRow = row || null;
+      if (certRow?.issued_by && !certData.issued_by) certData.issued_by = certRow.issued_by;
+      if (certRow?.member_id && !certData.member_name) {
+        const { data: m } = await sb.from('public_members').select('name').eq('id', certRow.member_id).single();
+        if (m?.name) certData.member_name = m.name;
+      }
+    } catch {}
+  }
+
   // Issuer signature (GP) — see resolveMemberSignatureUrl.
   if (certData.issued_by && !certData.signature_url && sb) {
     certData.signature_url = await resolveMemberSignatureUrl(sb, certData.issued_by);
@@ -730,20 +754,8 @@ export async function hydrateCertData(certData: CertificateData, sb: any): Promi
   // Recognition certs (Ciclo 3 mockup): dual signatures. The co-image belongs to the
   // member who ACTUALLY counter-signed (certificates.counter_signed_by) — resolved only
   // when that act exists; an un-counter-signed cert renders the plain line + name.
-  if (isRecognitionCert(certData.type) && !certData.co_signature_url && sb) {
-    try {
-      const keyCol = certData.verification_code ? 'verification_code' : certData.id ? 'id' : null;
-      if (keyCol) {
-        const { data: row } = await sb
-          .from('certificates')
-          .select('counter_signed_by')
-          .eq(keyCol, keyCol === 'verification_code' ? certData.verification_code : certData.id)
-          .maybeSingle();
-        if (row?.counter_signed_by) {
-          certData.co_signature_url = await resolveMemberSignatureUrl(sb, row.counter_signed_by);
-        }
-      }
-    } catch {}
+  if (isRecognitionCert(certData.type) && !certData.co_signature_url && sb && certRow?.counter_signed_by) {
+    certData.co_signature_url = await resolveMemberSignatureUrl(sb, certRow.counter_signed_by);
   }
 
   // For volunteer_agreement: load full legal template + extra fields

--- a/tests/contracts/cert-recognition-dual-signature-images.test.mjs
+++ b/tests/contracts/cert-recognition-dual-signature-images.test.mjs
@@ -33,7 +33,9 @@ test('recognition template renders both signature slots with conditional images'
 });
 
 test('co-signature resolves from counter_signed_by via the shared helper', () => {
-  assert.match(SRC, /select\('counter_signed_by'\)/,
+  assert.match(SRC, /select\('member_id, issued_by, counter_signed_by'\)/,
+    'identity backfill + co-signer come from ONE consolidated certificates-row fetch');
+  assert.match(SRC, /certRow\?\.counter_signed_by/,
     'co-signer identity comes from certificates.counter_signed_by (a real counter-sign act)');
   assert.match(SRC, /async function resolveMemberSignatureUrl\(/, 'shared resolver exists');
   const calls = (SRC.match(/resolveMemberSignatureUrl\(sb,/g) || []).length;


### PR DESCRIPTION
## Problema (reporte do owner, blob view)
A via de impressão no NAVEGADOR (/certificates → visualizar) monta payload magro (`member_name: ''`, sem `issued_by`) → render saía **sem o nome do membro e sem a assinatura do GP** (a do Co-GP aparecia porque resolve via `counter_signed_by` no banco). E a imagem de assinatura cruzava a linha (`bottom:-1.5mm`).

## Fix
- `hydrateCertData`: **backfill de identidade** com UMA fetch consolidada da row (`member_id, issued_by, counter_signed_by`) → nome + as duas assinaturas idênticos em todos os renderers (cliente, endpoint puppeteer, backfill).
- CSS `.rc-sigimg`: assinatura senta 0.6mm ACIMA da linha (sem sobrepor).
- Contract test atualizado.

## Operação (fora do PR)
59/59 PDFs do storage re-renderizados com o posicionamento novo; QA no `CERT-2026-F2BD6C`.

Verificação: build ✓ · testes cert 12/12.