### PR TITLE
fix(comms): CAROUSEL espera container FINISHED antes do publish (Graph 9007)

### DIFF
--- a/supabase/functions/publish-instagram/index.ts
+++ b/supabase/functions/publish-instagram/index.ts
@@ -143,6 +143,10 @@ async function buildContainer(
       children: childIds.join(','),
       caption,
     }, token)
+    // The carousel parent container must reach FINISHED before media_publish, else
+    // Graph returns 9007/2207027 "Media ID is not available" (same trap the STORIES
+    // branch documents; hit live on the first CAROUSEL publish, 2026-07-04).
+    await waitForContainer(id, token)
     return id
   }
 


### PR DESCRIPTION
Primeira publicação CAROUSEL real (carrossel C3, hoje 15:00 UTC) falhou com Graph `9007/2207027 Media ID is not available`: o branch CAROUSEL de `buildContainer` não chamava `waitForContainer` no container-pai antes do `media_publish` — a armadilha que o branch STORIES já documentava (REELS também espera). O dry-run não pega porque retorna antes do publish.

Fix de 1 chamada (espelha STORIES/REELS) + comentário com o achado vivo. **Já deployado em prod às 15:13:57 UTC**, antes do retry automático das 15:15 (drain preservou o row `pending`, attempts=1/3).

Refs #1099