### PR TITLE
fix(landing): popover de INFO dos quadrantes via portal — acima do diagrama radial (#1108)

### DIFF
--- a/src/components/ui/InfoPopover.tsx
+++ b/src/components/ui/InfoPopover.tsx
@@ -1,4 +1,5 @@
-import { useState, useRef, useEffect, type ReactNode } from 'react';
+import { useState, useRef, useEffect, useCallback, type CSSProperties, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
 
 interface InfoPopoverProps {
   trigger?: ReactNode;
@@ -10,11 +11,19 @@ interface InfoPopoverProps {
 
 export default function InfoPopover({ trigger, title, align = 'left', children }: InfoPopoverProps) {
   const [open, setOpen] = useState(false);
+  const [rect, setRect] = useState<DOMRect | null>(null);
   const popoverRef = useRef<HTMLDivElement>(null);
   const triggerRef = useRef<HTMLButtonElement>(null);
 
+  // Anchor the panel to the trigger's viewport rect. Recomputed on open, scroll
+  // and resize so the fixed-position panel tracks the icon.
+  const updateRect = useCallback(() => {
+    if (triggerRef.current) setRect(triggerRef.current.getBoundingClientRect());
+  }, []);
+
   useEffect(() => {
     if (!open) return;
+    updateRect();
     function handleClick(e: MouseEvent) {
       if (
         popoverRef.current && !popoverRef.current.contains(e.target as Node) &&
@@ -28,11 +37,59 @@ export default function InfoPopover({ trigger, title, align = 'left', children }
     }
     document.addEventListener('mousedown', handleClick);
     document.addEventListener('keydown', handleEsc);
+    // capture=true so scrolling any ancestor container repositions the panel
+    window.addEventListener('scroll', updateRect, true);
+    window.addEventListener('resize', updateRect);
     return () => {
       document.removeEventListener('mousedown', handleClick);
       document.removeEventListener('keydown', handleEsc);
+      window.removeEventListener('scroll', updateRect, true);
+      window.removeEventListener('resize', updateRect);
     };
-  }, [open]);
+  }, [open, updateRect]);
+
+  // Fixed positioning escapes every ancestor stacking context / overflow / transform
+  // (the quadrant card's hover:-translate creates a stacking context that would
+  // otherwise trap an absolutely-positioned panel below later siblings).
+  const panelStyle: CSSProperties =
+    rect
+      ? {
+          position: 'fixed',
+          top: rect.bottom + 8,
+          ...(align === 'right'
+            ? { right: Math.max(8, window.innerWidth - rect.right) }
+            : { left: Math.max(8, rect.left) }),
+        }
+      : { position: 'fixed', top: -9999, left: -9999 };
+
+  const panel = (
+    <div
+      ref={popoverRef}
+      role="dialog"
+      aria-label={title}
+      style={panelStyle}
+      className="z-[100] w-[340px] max-w-[90vw]
+        bg-[var(--surface-card)] border border-[var(--border-default)]
+        rounded-xl shadow-lg shadow-black/10 overflow-hidden"
+    >
+      <div className="flex items-center justify-between px-4 pt-3 pb-2">
+        <span className="text-[13px] font-bold text-[var(--text-primary)]">{title}</span>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="w-5 h-5 flex items-center justify-center rounded-full
+            text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-base)]
+            cursor-pointer border-0 bg-transparent text-xs transition-colors"
+          aria-label="Close"
+        >
+          ✕
+        </button>
+      </div>
+      <div className="px-4 pb-4 max-h-[60vh] overflow-y-auto text-[12px] text-[var(--text-secondary)] leading-relaxed">
+        {children}
+      </div>
+    </div>
+  );
 
   return (
     <span className="relative inline-flex items-center">
@@ -50,33 +107,7 @@ export default function InfoPopover({ trigger, title, align = 'left', children }
         {trigger ?? 'ℹ️'}
       </button>
 
-      {open && (
-        <div
-          ref={popoverRef}
-          role="dialog"
-          aria-label={title}
-          className={`absolute ${align === 'right' ? 'right-0' : 'left-0'} top-full mt-2 z-50 w-[340px] max-w-[90vw]
-            bg-[var(--surface-card)] border border-[var(--border-default)]
-            rounded-xl shadow-lg shadow-black/10 overflow-hidden`}
-        >
-          <div className="flex items-center justify-between px-4 pt-3 pb-2">
-            <span className="text-[13px] font-bold text-[var(--text-primary)]">{title}</span>
-            <button
-              type="button"
-              onClick={() => setOpen(false)}
-              className="w-5 h-5 flex items-center justify-center rounded-full
-                text-[var(--text-muted)] hover:text-[var(--text-primary)] hover:bg-[var(--surface-base)]
-                cursor-pointer border-0 bg-transparent text-xs transition-colors"
-              aria-label="Close"
-            >
-              ✕
-            </button>
-          </div>
-          <div className="px-4 pb-4 max-h-[60vh] overflow-y-auto text-[12px] text-[var(--text-secondary)] leading-relaxed">
-            {children}
-          </div>
-        </div>
-      )}
+      {open && typeof document !== 'undefined' && createPortal(panel, document.body)}
     </span>
   );
 }


### PR DESCRIPTION
## Problema (reportado pelo owner, 2026-07-04)

O ícone INFO dos quadrantes (#1108, já em `main`) abria o popover **atrás** do diagrama radial da `VerticalsSection` — os nós PMO/Ágil pintavam por cima do painel, cortando o conteúdo.

## Causa

O painel era `position:absolute z-50` dentro do card do quadrante. O card usa `hover:-translate-y-px`; ao passar o mouse para ler o popover, o `transform` cria um **stacking context** que aprisiona o `z-50` abaixo da `VerticalsSection` (radial, `client:load`), que vem depois no DOM.

## Fix

Renderizar o painel via `createPortal(document.body)` com `position:fixed`, ancorado ao `getBoundingClientRect()` do gatilho (recomputado em scroll/resize com capture). Escapa de qualquer stacking context, overflow e transform de ancestrais. `z-[100]`.

- Blast radius: `InfoPopover` é usado **só** nos 4 quadrantes do `ModelSection`.
- Sem novas strings i18n; sem mudança de API do componente.

## Verificação

- `npx astro build` ✓
- Verificado no navegador (dev server): popover abre **acima** do diagrama radial e **fecha** no clique-fora / Esc.