### PR TITLE
fix(mcp): single-refresher model — cure ~1h re-login (#1053)

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -144,12 +144,28 @@ mcp.tool("tool_name", "Description.", {}, async () => { ... });
 - GET /mcp → 406 (native transport returns Not Acceptable when no session)
 - Transport handles: initialize, tools/list, tool/call, notifications, SSE streams
 
-## Auto-Refresh (server-side token renewal)
-- Worker proxy (`src/pages/mcp.ts`) decodes JWT `exp` before forwarding upstream
-- If expired or expiring within 5 minutes, looks up `mcp_refresh:{sub}` from KV
-- Calls Supabase Auth API directly (`/auth/v1/token?grant_type=refresh_token`)
-- Forwards request with new access_token — transparent to MCP host
-- KV keys: `mcp_refresh:{user_id}` with 30-day TTL (set at token issuance + refresh)
-- Token endpoint (`/oauth/token`) stores refresh_token in KV on both `authorization_code` and `refresh_token` grants
-- Supabase JWT TTL is 3600s (1h) — auto-refresh compensates
-- Best practice: never depend on MCP hosts to implement refresh — do it server-side
+## Token refresh — single-refresher model (#1053, 2026-07-05)
+**The client (Claude) is the SOLE refresher. The proxies do NOT refresh server-side.**
+- Claude refreshes its own token (proactively ~5 min before expiry + reactively on 401)
+  by calling `/oauth/token` with `grant_type=refresh_token` (`src/pages/oauth/token.ts`).
+  That endpoint exchanges against Supabase Auth, returns the rotated token to Claude,
+  AND re-stores it in KV `mcp_refresh:{sub}` — so the single rotation chain stays in sync.
+- `token.ts` also stores the refresh_token in KV on the `authorization_code` grant.
+- Supabase JWT TTL is 3600s (1h). KV key `mcp_refresh:{user_id}`, 30-day TTL.
+
+### Why the proxies must NEVER refresh (the #1053 bug)
+The proxies (`src/pages/mcp.ts`, `src/pages/mcp/semantic.ts`) used to auto-refresh
+server-side (`tryAutoRefresh`) on any expiring request. That was a **second refresher**
+racing Claude over the SAME rotating Supabase refresh token: whoever refreshed first
+rotated R→R' and invalidated the other's copy. When the proxy won, Claude's next
+refresh 400'd ("already used") → `token.ts` returned `invalid_grant` → **Claude
+re-logged-in every ~1h**. #580's KV re-store could not fix it (keeps the *server*
+copy fresh; no channel pushes R' back to Claude). Fix = remove the proxy refresh.
+- `tryAutoRefresh` / `isExpiringSoon` remain in `src/lib/mcp-refresh.ts` (unit-tested)
+  but are **deprecated for proxy use** — do NOT re-wire them into the proxies.
+- Guarded by `tests/contracts/1053-mcp-single-refresher.test.mjs`.
+- Diagnostic note: `kvLog` in both proxies + `token.ts` is a **no-op** (KV free-tier
+  write protection) — there is no `token-refresh-fail`/`auto-refresh-*` telemetry to
+  read; classify refresh issues from code + a live `/oauth/token` smoke, not KV logs.
+- Dashboard (owner-only, Auth → Sessions): keep refresh-token rotation as-is; ensure
+  no aggressive session/inactivity timeout (would re-login even with a perfect flow).

--- a/src/lib/mcp-refresh.ts
+++ b/src/lib/mcp-refresh.ts
@@ -99,6 +99,11 @@ export function decodeJwtPayload(token: string): { sub?: string; exp?: number } 
  * True if a token with the given `exp` (epoch seconds) is already expired or will
  * expire within `skewSeconds` (default 300 = 5 min) — the proactive-refresh
  * window. Equivalent to the prior inline `payload.exp - 300 < now` check.
+ *
+ * DEPRECATED for proxy use (#1053): the Worker proxies no longer refresh
+ * server-side (it collided with Claude's own refresh over the shared rotating
+ * Supabase refresh token → ~1h re-login). Retained + unit-tested for reference;
+ * do NOT re-wire into src/pages/mcp*.ts — a guard test (1053-…) blocks it.
  */
 export function isExpiringSoon(exp: number, skewSeconds = 300, nowSeconds?: number): boolean {
   const now = nowSeconds ?? Math.floor(Date.now() / 1000);
@@ -110,6 +115,13 @@ export function isExpiringSoon(exp: number, skewSeconds = 300, nowSeconds?: numb
  * `mcp_refresh:{sub}`. Returns the new access_token, or null when there is no
  * stored token / the refresh failed.
  *
+ * DEPRECATED for proxy use (#1053): no longer called by the Worker proxies. Doing
+ * a server-side refresh here rotated the shared Supabase refresh token behind
+ * Claude's back, invalidating Claude's own copy → forced re-login each ~1h token
+ * cycle. Claude is now the sole refresher (via /oauth/token). Retained + unit-
+ * tested for reference; do NOT re-wire into the proxies (guarded by 1053-… test).
+ *
+
  * CONTRACT (#580): this function NEVER throws — every KV/network/parse failure
  * resolves to null so the caller (the Worker proxy) falls open to the original
  * token rather than crashing the request into a 500/502. A transient blip must

--- a/src/pages/mcp.ts
+++ b/src/pages/mcp.ts
@@ -6,13 +6,12 @@ import {
   GENERAL_LIMIT_PER_MIN,
   DESTRUCTIVE_LIMIT_PER_MIN,
 } from '../lib/mcp-rate-limit';
-// #580 — shared server-side refresh helpers (single source for both proxies + token.ts)
-import {
-  decodeJwtPayload,
-  isExpiringSoon,
-  resolveSupabaseAuthConfig,
-  tryAutoRefresh,
-} from '../lib/mcp-refresh';
+// #1053 — single-refresher model: the proxy no longer refreshes server-side. It
+// used to race Claude's own client-side refresh over the SAME rotating Supabase
+// refresh token and invalidate it → forced re-login each ~1h token cycle. Claude
+// is now the sole refresher (via /oauth/token, which keeps the KV mcp_refresh:{sub}
+// copy in sync). We import decodeJwtPayload only to read `sub` for the rate limit.
+import { decodeJwtPayload } from '../lib/mcp-refresh';
 import { CANONICAL_ORIGIN } from '../lib/canonical';
 
 async function kvLog(_endpoint: string, _data: any) {
@@ -61,26 +60,15 @@ export const ALL: APIRoute = async ({ request }) => {
     });
   }
 
-  // ── Auto-refresh: check if JWT is expired and refresh transparently ──
-  let activeToken = authHeader.replace(/^Bearer\s+/i, '');
+  // #1053 — NO server-side refresh here. Forward the bearer as-is; Claude refreshes
+  // its own token (proactively ~5 min before expiry, reactively on 401) through
+  // /oauth/token. A second refresher in the proxy rotated the shared Supabase
+  // refresh token behind Claude's back, so Claude's next refresh 400'd
+  // ("already used") → re-login each token cycle. `payload` is decoded only to key
+  // the per-member rate limit below.
+  const activeToken = authHeader.replace(/^Bearer\s+/i, '');
   const kv = (env as any).SESSION;
   const payload = decodeJwtPayload(activeToken);
-
-  // Refresh if expired or will expire within 5 minutes
-  if (kv && payload?.sub && payload?.exp && isExpiringSoon(payload.exp)) {
-    await kvLog("mcp-auto-refresh-attempt", { sub: payload.sub, exp: payload.exp });
-    const supabaseAuth = resolveSupabaseAuthConfig(env as any, import.meta.env);
-    const newToken = await tryAutoRefresh(payload.sub, kv, {
-      anonKey: supabaseAuth.anonKey,
-      supabaseUrl: supabaseAuth.url,
-    });
-    if (newToken) {
-      activeToken = newToken;
-      await kvLog("mcp-auto-refresh-ok", { sub: payload.sub });
-    } else {
-      await kvLog("mcp-auto-refresh-fail", { sub: payload.sub });
-    }
-  }
 
   // ── ADR-0018 W2: rate limit per-member (100/min general + 10/min destructive) ──
   // Fail-open on KV errors; the RPC layer canV4 gate remains the authority guard.

--- a/src/pages/mcp/semantic.ts
+++ b/src/pages/mcp/semantic.ts
@@ -12,13 +12,11 @@ import {
   GENERAL_LIMIT_PER_MIN,
   DESTRUCTIVE_LIMIT_PER_MIN,
 } from '../../lib/mcp-rate-limit';
-// #580 — shared server-side refresh helpers (single source for both proxies + token.ts)
-import {
-  decodeJwtPayload,
-  isExpiringSoon,
-  resolveSupabaseAuthConfig,
-  tryAutoRefresh,
-} from '../../lib/mcp-refresh';
+// #1053 — single-refresher model: this proxy no longer refreshes server-side (see
+// src/pages/mcp.ts for the rationale — it raced Claude's own refresh over the same
+// rotating Supabase refresh token → forced re-login each ~1h). Claude refreshes via
+// /oauth/token. decodeJwtPayload is imported only to read `sub` for the rate limit.
+import { decodeJwtPayload } from '../../lib/mcp-refresh';
 import { CANONICAL_ORIGIN } from '../../lib/canonical';
 
 async function kvLog(_endpoint: string, _data: any) {
@@ -64,24 +62,12 @@ export const ALL: APIRoute = async ({ request }) => {
     });
   }
 
-  let activeToken = authHeader.replace(/^Bearer\s+/i, '');
+  // #1053 — NO server-side refresh (see mcp.ts). Forward the bearer as-is; Claude
+  // is the sole refresher via /oauth/token. `payload` is decoded only to key the
+  // per-member rate limit below.
+  const activeToken = authHeader.replace(/^Bearer\s+/i, '');
   const kv = (env as any).SESSION;
   const payload = decodeJwtPayload(activeToken);
-
-  if (kv && payload?.sub && payload?.exp && isExpiringSoon(payload.exp)) {
-    await kvLog("mcp-semantic-auto-refresh-attempt", { sub: payload.sub, exp: payload.exp });
-    const supabaseAuth = resolveSupabaseAuthConfig(env as any, import.meta.env);
-    const newToken = await tryAutoRefresh(payload.sub, kv, {
-      anonKey: supabaseAuth.anonKey,
-      supabaseUrl: supabaseAuth.url,
-    });
-    if (newToken) {
-      activeToken = newToken;
-      await kvLog("mcp-semantic-auto-refresh-ok", { sub: payload.sub });
-    } else {
-      await kvLog("mcp-semantic-auto-refresh-fail", { sub: payload.sub });
-    }
-  }
 
   // ADR-0018 W2: rate limit per-member (semantic surface is read-only so destructive cap unused)
   if (kv && payload?.sub) {

--- a/tests/contracts/1053-mcp-single-refresher.test.mjs
+++ b/tests/contracts/1053-mcp-single-refresher.test.mjs
@@ -1,0 +1,71 @@
+/**
+ * #1053 — MCP re-login every ~1h: single-refresher model.
+ *
+ * Root cause (confirmed by code read, 2026-07-05): TWO refreshers competed over
+ * the SAME rotating Supabase refresh token —
+ *   1. the Worker proxies (src/pages/mcp.ts + src/pages/mcp/semantic.ts) did a
+ *      server-side auto-refresh on every expiring request, rotating R→R' and
+ *      re-storing R' in KV, but never handing R' back to Claude; and
+ *   2. Claude itself refreshed proactively ~5 min before expiry with its OWN copy.
+ * Under Supabase refresh-token rotation (default ON) whoever refreshed first
+ * invalidated the other's token. When the proxy won, Claude's next refresh 400'd
+ * ("already used") → /oauth/token returned invalid_grant → Claude dropped to a
+ * full re-login, each ~1h token cycle. The #580 KV re-store could not fix it: it
+ * kept the SERVER copy fresh, but there is no channel to push R' back to Claude.
+ *
+ * Fix: remove the proxy-side refresh entirely. Claude is the sole refresher (it
+ * refreshes reactively on 401 + proactively before expiry, per the official
+ * connector behaviour), through /oauth/token — which keeps the KV mcp_refresh:{sub}
+ * copy in sync on the single rotation chain.
+ *
+ * This test LOCKS that model: the proxies must not refresh server-side, and
+ * /oauth/token must keep implementing the refresh_token grant.
+ *
+ * Cross-ref: #1053, #234, #580, src/lib/mcp-refresh.ts (helpers retained but
+ * deprecated for proxy use).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (rel) => readFileSync(resolve(ROOT, rel), 'utf8');
+
+const PROXIES = ['src/pages/mcp.ts', 'src/pages/mcp/semantic.ts'];
+
+test('#1053: neither proxy performs a server-side token refresh', () => {
+  for (const rel of PROXIES) {
+    const src = read(rel);
+    assert.doesNotMatch(src, /tryAutoRefresh\s*\(/, `${rel} must not call tryAutoRefresh (single-refresher model, #1053)`);
+    assert.doesNotMatch(src, /isExpiringSoon\s*\(/, `${rel} must not gate on isExpiringSoon (no proxy refresh, #1053)`);
+    assert.doesNotMatch(src, /grant_type=refresh_token/, `${rel} must not hit the Supabase refresh grant directly`);
+  }
+});
+
+test('#1053: proxies still forward the bearer as-is (no token mutation before upstream)', () => {
+  for (const rel of PROXIES) {
+    const src = read(rel);
+    // The forwarded token comes straight from the Authorization header, unmodified.
+    assert.match(src, /const activeToken = authHeader\.replace\(\/\^Bearer\\s\+\/i, ''\);/, `${rel} must forward the bearer verbatim`);
+    assert.doesNotMatch(src, /activeToken\s*=\s*newToken/, `${rel} must not reassign the token from a refresh`);
+  }
+});
+
+test('#1053: /oauth/token remains the sole server-side refresher (refresh_token grant intact)', () => {
+  const src = read('src/pages/oauth/token.ts');
+  assert.match(src, /grant_type === 'refresh_token'/, 'token.ts must still handle the refresh_token grant');
+  assert.match(src, /grant_type=refresh_token/, 'token.ts must still call the Supabase refresh endpoint');
+  // It keeps the KV copy in sync on rotation so the single chain stays consistent.
+  assert.match(src, /mcp_refresh:\$\{refreshPayload\.sub\}/, 'token.ts must re-store the rotated refresh token in KV');
+});
+
+test('#1053: rate limiting still keys off the decoded JWT sub in both proxies', () => {
+  // The decode stayed for rate limiting only; guard it did not get removed by accident.
+  for (const rel of PROXIES) {
+    const src = read(rel);
+    assert.match(src, /const payload = decodeJwtPayload\(activeToken\);/, `${rel} must still decode the JWT for rate-limit keying`);
+    assert.match(src, /checkRateLimit\(kv, payload\.sub/, `${rel} must still rate-limit per member`);
+  }
+});

--- a/tests/contracts/234-mcp-refresh-runtime-env.test.mjs
+++ b/tests/contracts/234-mcp-refresh-runtime-env.test.mjs
@@ -42,11 +42,17 @@ test('#234: fallback config supplies URL but requires anon key binding', () => {
   assert.equal(cfg.anonKey, '');
 });
 
-test('#234: MCP proxies and token endpoint use shared runtime resolver', () => {
-  for (const rel of ['src/pages/mcp.ts', 'src/pages/mcp/semantic.ts', 'src/pages/oauth/token.ts']) {
+test('#234 / #1053: token endpoint is the sole server-side refresher and uses the runtime resolver', () => {
+  // #1053 removed the proxy-side refreshers (dual-refresher collision → ~1h re-login),
+  // so /oauth/token is the ONLY server-side refresh path. It must still read Worker
+  // runtime env; the proxies must no longer resolve auth config at all.
+  const tokenSrc = read('src/pages/oauth/token.ts');
+  assert.match(tokenSrc, /resolveSupabaseAuthConfig\(env as any, import\.meta\.env\)/, 'token.ts must read Worker runtime env');
+  assert.doesNotMatch(tokenSrc, /anonKey:\s*import\.meta\.env\.PUBLIC_SUPABASE_ANON_KEY\s*\|\|\s*''/, 'token.ts must not pass empty anonKey');
+
+  for (const rel of ['src/pages/mcp.ts', 'src/pages/mcp/semantic.ts']) {
     const src = read(rel);
-    assert.match(src, /resolveSupabaseAuthConfig\(env as any, import\.meta\.env\)/, `${rel} must read Worker runtime env`);
-    assert.doesNotMatch(src, /anonKey:\s*import\.meta\.env\.PUBLIC_SUPABASE_ANON_KEY\s*\|\|\s*''/, `${rel} must not pass empty anonKey`);
+    assert.doesNotMatch(src, /resolveSupabaseAuthConfig/, `${rel} must not resolve auth config — single-refresher model (#1053)`);
   }
 });
 

--- a/tests/contracts/mcp-semantic-gateway-bridge.test.mjs
+++ b/tests/contracts/mcp-semantic-gateway-bridge.test.mjs
@@ -228,16 +228,15 @@ test('worker proxy preserves OAuth 401 + WWW-Authenticate gate', () => {
   assert.match(PROXY, /resource_metadata="\$\{BASE\}\/\.well-known\/oauth-protected-resource"/, 'expected resource_metadata pointer to OAuth metadata endpoint');
 });
 
-test('worker proxy preserves auto-refresh (delegated to shared lib/mcp-refresh post-#580)', () => {
+test('worker proxy does NOT refresh server-side (single-refresher model, #1053)', () => {
   const PROXY = readFileSync(PROXY_PATH, 'utf8');
-  // Post-#580 the auto-refresh helpers (decodeJwtPayload + tryAutoRefresh + the KV key
-  // prefix) live in src/lib/mcp-refresh.ts — a single source shared by both proxies so the
-  // "always re-store the rotated refresh token" fix can't diverge. semantic.ts imports +
-  // calls them rather than inlining the logic.
-  assert.match(PROXY, /import\s*\{[^}]*\btryAutoRefresh\b[^}]*\}\s*from\s*['"]\.\.\/\.\.\/lib\/mcp-refresh['"]/, 'expected tryAutoRefresh import from shared ../../lib/mcp-refresh');
-  assert.match(PROXY, /decodeJwtPayload\(/, 'expected decodeJwtPayload call');
-  assert.match(PROXY, /tryAutoRefresh\(/, 'expected tryAutoRefresh call');
-  // The mcp_refresh: KV key prefix invariant now lives in the shared module.
+  // #1053: the proxy-side refresh was removed — it raced Claude's own refresh over the
+  // same rotating Supabase refresh token → ~1h re-login. Claude is the sole refresher
+  // (via /oauth/token). The proxy only decodes the JWT `sub` for rate limiting.
+  assert.doesNotMatch(PROXY, /tryAutoRefresh\(/, 'proxy must NOT call tryAutoRefresh (#1053)');
+  assert.match(PROXY, /decodeJwtPayload\(/, 'still decodes the JWT for rate-limit keying');
+  // The shared refresh helpers + KV key prefix stay in the module (used by /oauth/token,
+  // and unit-tested), just not wired into the proxy anymore.
   const REFRESH_LIB = readFileSync(resolve(process.cwd(), 'src/lib/mcp-refresh.ts'), 'utf8');
   assert.match(REFRESH_LIB, /mcp_refresh:/, 'expected mcp_refresh KV key prefix in shared lib/mcp-refresh');
 });


### PR DESCRIPTION
Closes #1053.

## Root cause (confirmed by code read — the issue's kvLog plan is dead)
`kvLog` is a **no-op** in both proxies + `token.ts` (KV free-tier write protection), so there is no `token-refresh-fail`/`auto-refresh-*` telemetry to classify from. Diagnosed from the code + live metadata instead.

The server metadata is **correct** (verified live): `grant_types=[authorization_code, refresh_token]`, `scopes=[mcp:tools, offline_access]`. So the stale-connector hypothesis (A) is not the cause. The real cause is **two refreshers competing over the same rotating Supabase refresh token** (PM's hypothesis B):

1. **Proxy server-side** (`src/pages/mcp.ts` + `mcp/semantic.ts`): auto-refreshed on any expiring request (`tryAutoRefresh`), rotating R→R' and re-storing R' in KV — but **never handed R' back to Claude**.
2. **Claude client-side**: refreshes proactively ~5 min before expiry with its **own** copy.

Under Supabase refresh-token rotation (default ON), whoever refreshed first invalidated the other's token. When the proxy won, Claude's next refresh 400'd (`already used`) → `/oauth/token` returned `invalid_grant` → **Claude re-logged-in, each ~1h token cycle**. `#580`'s KV re-store cannot fix it (keeps the *server* copy fresh; no channel pushes R' back to Claude). It **persists across reconnects** because it is structural — matching the reported symptom exactly.

## Fix
Remove the proxy-side refresh. **Claude is the sole refresher** (reactive on 401 + proactive before expiry, per official connector behaviour) via `/oauth/token`, which keeps the single rotation chain + KV `mcp_refresh:{sub}` in sync. Safe whether rotation is ON (cures the collision) or OFF (neutral).

- `src/pages/mcp.ts`, `mcp/semantic.ts`: drop the `tryAutoRefresh` block; keep the JWT decode only to key the per-member rate limit; forward the bearer verbatim.
- `src/lib/mcp-refresh.ts`: `tryAutoRefresh` + `isExpiringSoon` retained + unit-tested but **deprecated for proxy use** (do not re-wire).
- **tests**: new `1053-mcp-single-refresher` (locks the model); updated `#234` (token.ts is the sole resolver consumer) + `mcp-semantic-gateway-bridge` (proxy must NOT refresh).
- `.claude/rules/mcp.md`: rewrote the Auto-Refresh section + kvLog-is-no-op note.

## Validation
- `npx astro build` ✓ (pre-existing CSS warning unrelated)
- MCP contract suite: **116 pass / 0 fail / 3 skip** (DB-gated skips w/o env)
- Pre-deploy dup-tool-name check: empty ✓

## Post-deploy acceptance (closes the #234 loop that was never verified)
Merge auto-deploys the Worker. Then: **reconnect the Núcleo connector once**, confirm the OAuth flow requests `offline_access`, and observe **multi-day continuity** (no ~1h re-login).

## Owner-only dashboard check (not blocking)
Supabase → Auth → Sessions: confirm no aggressive **session / inactivity timeout** (would re-login even with a perfect flow). Rotation setting can stay as-is either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)