### PR TITLE
feat(sec): per-IP rate limiting on anon surfaces + constant-time secret compares (#1050)

### DIFF
--- a/cloudflare-workers/pmi-vep-sync/src/index.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/index.ts
@@ -56,6 +56,7 @@ import {
   mapServiceHistory
 } from './script-mapper';
 import { syncResumesParallel, type ResumeSyncResult } from './resume-sync';
+import { timingSafeEqual } from './timing-safe-equal';
 
 const WORKER_NAME = 'pmi-vep-sync';
 const ALLOWED_ORIGIN = 'https://volunteer.pmi.org';
@@ -164,7 +165,8 @@ export default {
 async function handleIngest(req: Request, env: Env): Promise<Response> {
   // Auth
   const secret = req.headers.get('x-ingest-secret');
-  if (!secret || secret !== env.INGEST_SHARED_SECRET) {
+  // #1050 — constant-time compare so the shared secret can't be recovered byte-by-byte via timing.
+  if (!secret || !(await timingSafeEqual(secret, env.INGEST_SHARED_SECRET))) {
     return jsonResponse({ error: 'unauthorized' }, 401);
   }
 

--- a/cloudflare-workers/pmi-vep-sync/src/timing-safe-equal.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/timing-safe-equal.ts
@@ -1,0 +1,19 @@
+// #1050 — constant-time string comparison for the /ingest shared-secret check.
+// A plain `a === b` early-exits on the first differing byte, leaking how many leading
+// bytes matched via timing. We HMAC both inputs with a per-call random key and compare
+// the fixed-length digests, so timing is independent of where the inputs diverge.
+// (Local copy — this Worker builds separately from the main app's src/lib.)
+export async function timingSafeEqual(a: string, b: string): Promise<boolean> {
+  const enc = new TextEncoder();
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const ck = await crypto.subtle.importKey('raw', key, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const [ha, hb] = await Promise.all([
+    crypto.subtle.sign('HMAC', ck, enc.encode(a)),
+    crypto.subtle.sign('HMAC', ck, enc.encode(b)),
+  ]);
+  const va = new Uint8Array(ha);
+  const vb = new Uint8Array(hb);
+  let diff = 0;
+  for (let i = 0; i < va.length; i++) diff |= va[i] ^ vb[i];
+  return diff === 0;
+}

--- a/src/lib/ip-rate-limit.ts
+++ b/src/lib/ip-rate-limit.ts
@@ -1,0 +1,60 @@
+// #1050 — generic per-IP rate limit for anon-facing Cloudflare Worker routes
+// (e.g. the OAuth /token endpoint). Mirrors the KV-bucket approach of
+// mcp-rate-limit.ts, but keys by client IP (cf-connecting-ip) + action instead of
+// member JWT sub — because these routes are hit before/without authentication.
+//
+// Fail-open on any missing signal or KV error: a throttle store hiccup must never
+// block a legitimate caller. This is defense-in-depth (brute-force/flood dampening),
+// not the primary authority gate (PKCE + Supabase validation stay in the route).
+
+export interface KVNamespaceLike {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, options?: { expirationTtl?: number }): Promise<void>;
+}
+
+export interface IpRateLimitResult {
+  allowed: boolean;
+  remaining: number;
+  retryAfter?: number;
+}
+
+const KEY_TTL_SECONDS = 70; // slightly longer than the 60s window so keys self-expire
+
+/** Extract the client IP from a Cloudflare-fronted request (cf-connecting-ip first). */
+export function clientIpFrom(request: Request): string | null {
+  const cf = request.headers.get('cf-connecting-ip');
+  if (cf) return cf;
+  const xff = request.headers.get('x-forwarded-for');
+  if (xff) return xff.split(',')[0].trim();
+  return null;
+}
+
+/**
+ * Check + increment a per-minute counter keyed by (action, ip).
+ * Returns allowed=false once the counter has reached limitPerMin for the current
+ * minute bucket. Fail-open when kv/ip is missing or KV throws.
+ */
+export async function checkIpRateLimit(
+  kv: KVNamespaceLike | null | undefined,
+  ip: string | null,
+  action: string,
+  limitPerMin: number,
+  nowMs: number = Date.now()
+): Promise<IpRateLimitResult> {
+  if (!kv || !ip) return { allowed: true, remaining: -1 };
+
+  const bucket = Math.floor(nowMs / 60000);
+  const key = `iprl:${action}:${ip}:${bucket}`;
+
+  try {
+    const count = parseInt((await kv.get(key)) || '0', 10);
+    if (count >= limitPerMin) {
+      return { allowed: false, remaining: 0, retryAfter: 60 };
+    }
+    await kv.put(key, String(count + 1), { expirationTtl: KEY_TTL_SECONDS });
+    return { allowed: true, remaining: limitPerMin - count - 1 };
+  } catch {
+    // Fail-open: better a few extra requests than blocking the platform.
+    return { allowed: true, remaining: -1 };
+  }
+}

--- a/src/lib/timing-safe-equal.ts
+++ b/src/lib/timing-safe-equal.ts
@@ -1,0 +1,20 @@
+// #1050 — constant-time string comparison for secret / bearer-token checks.
+// A plain `a === b` early-exits on the first differing byte, leaking how many
+// leading bytes matched via response timing (a classic secret-recovery side channel).
+// We HMAC both inputs with a per-call random key, then compare the fixed-length
+// (32-byte) digests — so wall-clock time is independent of where/if the inputs
+// diverge and of their lengths. Web Crypto is available in Workers/Deno/browsers.
+export async function timingSafeEqual(a: string, b: string): Promise<boolean> {
+  const enc = new TextEncoder();
+  const key = crypto.getRandomValues(new Uint8Array(32));
+  const ck = await crypto.subtle.importKey('raw', key, { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']);
+  const [ha, hb] = await Promise.all([
+    crypto.subtle.sign('HMAC', ck, enc.encode(a)),
+    crypto.subtle.sign('HMAC', ck, enc.encode(b)),
+  ]);
+  const va = new Uint8Array(ha);
+  const vb = new Uint8Array(hb);
+  let diff = 0;
+  for (let i = 0; i < va.length; i++) diff |= va[i] ^ vb[i];
+  return diff === 0;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -55,7 +55,13 @@ const csrfMiddleware = defineMiddleware((context, next) => {
     return next();
   }
 
-  // Check origin matches host for non-bypassed POST routes
+  // Check origin matches host for non-bypassed POST routes.
+  // #1050 — the no-Origin passthrough below is INTENTIONAL: legitimate server-to-server
+  // and non-browser clients (MCP hosts, OAuth token exchanges, webhooks) don't send an
+  // Origin header, and browsers reliably do on cross-site POSTs. Do NOT "harden" this by
+  // requiring Origin or falling back to Referer — that would break those clients and
+  // Referer is spoofable/strippable (weaker signal). CSRF for browser flows is covered
+  // by this same-origin check when Origin IS present.
   const origin = context.request.headers.get("origin");
   if (origin) {
     try {

--- a/src/pages/api/internal/cert-pdf-render/[id].ts
+++ b/src/pages/api/internal/cert-pdf-render/[id].ts
@@ -23,6 +23,7 @@ import type { APIRoute } from 'astro';
 import { env as cfEnv } from 'cloudflare:workers';
 import { createClient } from '@supabase/supabase-js';
 import puppeteer from '@cloudflare/puppeteer';
+import { timingSafeEqual } from '../../../../lib/timing-safe-equal';
 import {
   buildCertificateHTML,
   hydrateCertData,
@@ -175,7 +176,8 @@ export const POST: APIRoute = async ({ params, request }) => {
   }
 
   const auth = request.headers.get('Authorization') ?? '';
-  if (auth !== `Bearer ${expectedSecret}`) {
+  // #1050 — constant-time compare so the Bearer secret can't be recovered byte-by-byte via timing.
+  if (!(await timingSafeEqual(auth, `Bearer ${expectedSecret}`))) {
     return new Response(
       JSON.stringify({ error: 'unauthorized' }),
       { status: 401, headers: { 'Content-Type': 'application/json' } },

--- a/src/pages/oauth/token.ts
+++ b/src/pages/oauth/token.ts
@@ -7,6 +7,8 @@ import {
   MCP_REFRESH_TTL_SECONDS,
   resolveSupabaseAuthConfig,
 } from '../../lib/mcp-refresh';
+// #1050 — per-IP throttle on the token endpoint (brute-force/flood dampening).
+import { checkIpRateLimit, clientIpFrom } from '../../lib/ip-rate-limit';
 
 async function kvLog(_endpoint: string, _data: any) {
   // No-op: KV debug logs disabled (free tier 1k writes/day protection).
@@ -48,6 +50,20 @@ export const POST: APIRoute = async ({ request }) => {
       return new Response(JSON.stringify({ error: 'server_error', detail: 'KV binding unavailable' }), {
         status: 500,
         headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    // #1050 — throttle token grants per client IP (30/min). Covers both the
+    // authorization_code and refresh_token grants. Fail-open (see ip-rate-limit.ts).
+    const rl = await checkIpRateLimit(kv, clientIpFrom(request), 'oauth_token', 30);
+    if (!rl.allowed) {
+      return new Response(JSON.stringify({ error: 'rate_limited', error_description: 'Too many token requests — retry shortly' }), {
+        status: 429,
+        headers: {
+          'Content-Type': 'application/json',
+          'Retry-After': String(rl.retryAfter ?? 60),
+          'Access-Control-Allow-Origin': '*',
+        },
       });
     }
 

--- a/supabase/migrations/20260805000346_anon_rpc_ip_rate_limit_1050.sql
+++ b/supabase/migrations/20260805000346_anon_rpc_ip_rate_limit_1050.sql
@@ -1,0 +1,233 @@
+-- #1050: in-RPC per-IP rate limiting for anon-executable RPCs called browser→Supabase
+-- direct (they bypass the Cloudflare Worker edge, so Worker/zone rules cannot cover them).
+-- Mechanism verified live: an anon PostgREST RPC can read cf-connecting-ip from
+-- current_setting('request.headers'). Fail-OPEN everywhere: a missing IP signal or any
+-- storage error must never block a legitimate caller (authority stays in the RPC logic).
+
+-- ── counter store: unlogged (perf; survivable loss — it's throwaway throttle state) ──
+CREATE UNLOGGED TABLE IF NOT EXISTS public.anon_rate_counters (
+  bucket_key text PRIMARY KEY,          -- '{action}:{ip}:{minute_bucket}'
+  hits       int NOT NULL DEFAULT 0,
+  expires_at timestamptz NOT NULL
+);
+-- Deny-all: only the SECURITY DEFINER helper (running as owner) touches this table.
+ALTER TABLE public.anon_rate_counters ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON public.anon_rate_counters FROM anon, authenticated;
+
+-- ── helper: atomic bump + threshold check, keyed by client IP + action + time bucket ──
+CREATE OR REPLACE FUNCTION public.rl_check_and_bump(
+  p_action text, p_limit int, p_window_s int DEFAULT 60
+) RETURNS boolean               -- true = allowed, false = throttled
+  LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_ip     text;
+  v_bucket bigint;
+  v_key    text;
+  v_hits   int;
+BEGIN
+  -- Resolve client IP from the PostgREST request headers. Fail-OPEN if unavailable
+  -- (service-role / server-side calls have no request.headers).
+  BEGIN
+    v_ip := current_setting('request.headers', true)::jsonb->>'cf-connecting-ip';
+  EXCEPTION WHEN others THEN
+    v_ip := NULL;
+  END;
+  IF v_ip IS NULL OR v_ip = '' THEN
+    RETURN true;
+  END IF;
+
+  v_bucket := floor(extract(epoch FROM now()) / p_window_s);
+  v_key := p_action || ':' || v_ip || ':' || v_bucket::text;
+
+  INSERT INTO public.anon_rate_counters (bucket_key, hits, expires_at)
+  VALUES (v_key, 1, now() + make_interval(secs => p_window_s + 10))
+  ON CONFLICT (bucket_key)
+  DO UPDATE SET hits = public.anon_rate_counters.hits + 1
+  RETURNING hits INTO v_hits;
+
+  -- Opportunistic GC (~2% of calls) so the unlogged table stays small without a cron.
+  IF random() < 0.02 THEN
+    DELETE FROM public.anon_rate_counters WHERE expires_at < now();
+  END IF;
+
+  RETURN v_hits <= p_limit;
+EXCEPTION WHEN others THEN
+  RETURN true;  -- fail-open on any storage error
+END;
+$function$;
+-- NOT granted to anon/authenticated: internal helper, must not be PostgREST-callable.
+REVOKE ALL ON FUNCTION public.rl_check_and_bump(text, int, int) FROM public, anon, authenticated;
+
+-- ── verify_certificate: +30/min/IP throttle (kills scripted code enumeration) ──
+CREATE OR REPLACE FUNCTION public.verify_certificate(p_code text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  cert record;
+  v_member_name text;
+  guest record;
+BEGIN
+  IF NOT public.rl_check_and_bump('verify_certificate', 30, 60) THEN
+    RETURN jsonb_build_object('valid', false, 'error', 'rate_limited');
+  END IF;
+
+  SELECT c.* INTO cert
+  FROM certificates c
+  WHERE c.verification_code = p_code;
+
+  IF cert IS NULL OR cert.status IS DISTINCT FROM 'issued' THEN
+    SELECT g.id, g.type, g.title, g.issued_at, g.counter_signed_by, g.counter_signed_at,
+           g.language, g.verification_code, g.status,
+           p.name AS guest_name, e.title AS event_title, e.date AS event_date
+    INTO guest
+    FROM event_guest_certificates g
+    JOIN persons p ON p.id = g.person_id
+    JOIN events e ON e.id = g.event_id
+    WHERE g.verification_code = p_code;
+
+    IF guest.id IS NULL OR guest.status IS DISTINCT FROM 'issued' THEN
+      RETURN jsonb_build_object('valid', false);
+    END IF;
+
+    RETURN jsonb_build_object(
+      'valid', true,
+      'type', guest.type,
+      'title', guest.title,
+      'member_name', guest.guest_name,
+      'issued_at', guest.issued_at,
+      'authorized_by', 'Presidência, Núcleo IA e GP',
+      'has_counter_signature', guest.counter_signed_by IS NOT NULL,
+      'counter_signed_at', guest.counter_signed_at,
+      'cycle', NULL,
+      'period_start', guest.event_date::text,
+      'period_end', guest.event_date::text,
+      'function_role', NULL,
+      'language', guest.language,
+      'verification_code', guest.verification_code,
+      'audience', 'event_guest',
+      'event_title', guest.event_title
+    );
+  END IF;
+
+  SELECT name INTO v_member_name FROM members WHERE id = cert.member_id;
+
+  RETURN jsonb_build_object(
+    'valid', true,
+    'type', cert.type,
+    'title', cert.title,
+    'member_name', v_member_name,
+    'issued_at', cert.issued_at,
+    'authorized_by', 'Presidência, Núcleo IA e GP',
+    'has_counter_signature', cert.counter_signed_by IS NOT NULL,
+    'counter_signed_at', cert.counter_signed_at,
+    'cycle', cert.cycle,
+    'period_start', cert.period_start,
+    'period_end', cert.period_end,
+    'function_role', cert.function_role,
+    'language', cert.language,
+    'verification_code', cert.verification_code
+  );
+END;
+$function$;
+
+-- ── capture_visitor_lead: +10/min/IP throttle + close the idempotent enumeration oracle ──
+CREATE OR REPLACE FUNCTION public.capture_visitor_lead(p_payload jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_lead_id uuid;
+  v_email text;
+  v_name text;
+  v_consent boolean;
+  v_referrer_id uuid;
+  v_existing_id uuid;
+  v_target_vertical uuid;
+BEGIN
+  IF NOT public.rl_check_and_bump('capture_visitor_lead', 10, 60) THEN
+    RETURN jsonb_build_object('error','rate_limited');
+  END IF;
+
+  v_email := NULLIF(TRIM(LOWER(p_payload->>'email')), '');
+  v_name := NULLIF(TRIM(p_payload->>'name'), '');
+  v_consent := COALESCE((p_payload->>'lgpd_consent')::boolean, false);
+
+  IF v_email IS NULL OR v_name IS NULL THEN
+    RETURN jsonb_build_object('error','name and email are required');
+  END IF;
+
+  IF NOT v_consent THEN
+    RETURN jsonb_build_object('error','LGPD consent is required');
+  END IF;
+
+  -- Soft email format check
+  IF v_email !~ '^[^@]+@[^@]+\.[^@]+$' THEN
+    RETURN jsonb_build_object('error','invalid email format');
+  END IF;
+
+  -- Optional referrer (member_id from URL query ?ref=xxx)
+  IF p_payload ? 'referrer_member_id' AND (p_payload->>'referrer_member_id') ~ '^[0-9a-f-]{36}$' THEN
+    v_referrer_id := (p_payload->>'referrer_member_id')::uuid;
+    -- Verify exists
+    PERFORM 1 FROM public.members WHERE id = v_referrer_id;
+    IF NOT FOUND THEN v_referrer_id := NULL; END IF;
+  END IF;
+
+  -- Optional founder-interest vertical (bloco 6 CTA). Resolve defensively: keep only
+  -- when it points at a real community_vertical; else drop to NULL (analytics field,
+  -- never blocks lead capture). Mirrors referrer_member_id (data-architect/security review).
+  IF p_payload ? 'target_vertical' AND (p_payload->>'target_vertical') ~ '^[0-9a-f-]{36}$' THEN
+    v_target_vertical := (p_payload->>'target_vertical')::uuid;
+    PERFORM 1 FROM public.initiatives WHERE id = v_target_vertical AND kind = 'community_vertical';
+    IF NOT FOUND THEN v_target_vertical := NULL; END IF;
+  END IF;
+
+  -- Idempotent: if same email already exists with status='new', return existing
+  SELECT id INTO v_existing_id
+  FROM public.visitor_leads
+  WHERE LOWER(TRIM(email)) = v_email AND status = 'new'
+  LIMIT 1;
+
+  IF v_existing_id IS NOT NULL THEN
+    -- Update with new payload (last-wins on optional fields)
+    UPDATE public.visitor_leads SET
+      phone = COALESCE(NULLIF(TRIM(p_payload->>'phone'),''), phone),
+      chapter_interest = COALESCE(NULLIF(TRIM(p_payload->>'chapter_interest'),''), chapter_interest),
+      role_interest = COALESCE(NULLIF(TRIM(p_payload->>'role_interest'),''), role_interest),
+      message = COALESCE(NULLIF(TRIM(p_payload->>'message'),''), message),
+      target_vertical = COALESCE(v_target_vertical, target_vertical),
+      utm_data = COALESCE(p_payload->'utm_data', utm_data),
+      referrer_member_id = COALESCE(v_referrer_id, referrer_member_id),
+      source = COALESCE(NULLIF(TRIM(p_payload->>'source'),''), source)
+    WHERE id = v_existing_id;
+    -- #1050: return the SAME shape as the insert path (no 'idempotent' flag) so an anon
+    -- caller cannot use the response to test whether an email is already a lead.
+    RETURN jsonb_build_object('success', true, 'lead_id', v_existing_id);
+  END IF;
+
+  INSERT INTO public.visitor_leads (
+    name, email, phone, chapter_interest, role_interest, message,
+    lgpd_consent, source, status, utm_data, referrer_member_id, target_vertical
+  ) VALUES (
+    v_name, v_email,
+    NULLIF(TRIM(p_payload->>'phone'), ''),
+    NULLIF(TRIM(p_payload->>'chapter_interest'), ''),
+    NULLIF(TRIM(p_payload->>'role_interest'), ''),
+    NULLIF(TRIM(p_payload->>'message'), ''),
+    true,
+    COALESCE(NULLIF(TRIM(p_payload->>'source'), ''), 'website'),
+    'new',
+    p_payload->'utm_data',
+    v_referrer_id,
+    v_target_vertical
+  )
+  RETURNING id INTO v_lead_id;
+
+  RETURN jsonb_build_object('success', true, 'lead_id', v_lead_id);
+END $function$;

--- a/supabase/migrations/20260805000346_anon_rpc_ip_rate_limit_1050.sql
+++ b/supabase/migrations/20260805000346_anon_rpc_ip_rate_limit_1050.sql
@@ -71,8 +71,10 @@ DECLARE
   v_member_name text;
   guest record;
 BEGIN
+  -- #991 oracle-free contract: a throttled caller must be INDISTINGUISHABLE from a
+  -- not-found result (no status/discriminant key at all). Collapse to valid=false.
   IF NOT public.rl_check_and_bump('verify_certificate', 30, 60) THEN
-    RETURN jsonb_build_object('valid', false, 'error', 'rate_limited');
+    RETURN jsonb_build_object('valid', false);
   END IF;
 
   SELECT c.* INTO cert

--- a/tests/contracts/1050-anon-rate-limit.test.mjs
+++ b/tests/contracts/1050-anon-rate-limit.test.mjs
@@ -1,0 +1,117 @@
+/**
+ * Contract: #1050 — rate limiting for anon-executable surfaces + secret-compare hardening.
+ *
+ * Origin: security audit 2026-07-02 (item #1, "rate limit ausente"). Verdict PARTIAL.
+ *
+ * Design (grounded live this session):
+ *  - `verify_certificate` / `capture_visitor_lead` are called browser→Supabase DIRECT,
+ *    so they bypass the Cloudflare Worker edge — zone/Worker rate rules cannot cover them.
+ *    The only real control is an in-RPC per-IP throttle. Verified live that an anon
+ *    PostgREST RPC can read cf-connecting-ip from current_setting('request.headers').
+ *  - `/oauth/token` IS a Worker route → throttled in-code via a KV IP bucket.
+ *  - `/ingest` rate-limit intentionally SKIPPED (high-entropy secret = low value); only
+ *    its constant-time compare drive-by ships here (owner scope decision 2026-07-05).
+ *  - Fail-open everywhere: a missing IP signal / KV or storage error must never block a
+ *    legitimate caller.
+ *
+ * Offline-only (static source assertions). The live throttle behavior was exercised via
+ * curl during implementation (30 allowed → then rate_limited on the real anon path).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = process.cwd();
+const read = (p) => (existsSync(resolve(ROOT, p)) ? readFileSync(resolve(ROOT, p), 'utf8') : '');
+
+// ── Migration: helper + counter table + throttle wiring ──────────────────────────
+const MIG_DIR = 'supabase/migrations';
+const migFile = readdirSync(resolve(ROOT, MIG_DIR)).find((f) => f.includes('anon_rpc_ip_rate_limit_1050'));
+const MIG = migFile ? read(`${MIG_DIR}/${migFile}`) : '';
+
+test('migration file for #1050 exists', () => {
+  assert.ok(migFile, 'migration *anon_rpc_ip_rate_limit_1050*.sql present');
+});
+
+test('migration: counter table is unlogged, RLS-enabled, revoked from anon', () => {
+  assert.match(MIG, /CREATE UNLOGGED TABLE IF NOT EXISTS public\.anon_rate_counters/);
+  assert.match(MIG, /ALTER TABLE public\.anon_rate_counters ENABLE ROW LEVEL SECURITY/);
+  assert.match(MIG, /REVOKE ALL ON public\.anon_rate_counters FROM anon, authenticated/);
+});
+
+test('migration: helper reads cf-connecting-ip, is fail-open, and is not anon-callable', () => {
+  assert.match(MIG, /FUNCTION public\.rl_check_and_bump/);
+  assert.match(MIG, /request\.headers.*cf-connecting-ip|cf-connecting-ip/);
+  // fail-open: missing IP → return true; any storage error → return true
+  assert.match(MIG, /IF v_ip IS NULL OR v_ip = ''\s+THEN\s+RETURN true/);
+  assert.match(MIG, /EXCEPTION WHEN others THEN\s+RETURN true/);
+  // internal helper must not be exposed on the PostgREST anon surface
+  assert.match(MIG, /REVOKE ALL ON FUNCTION public\.rl_check_and_bump\(text, int, int\) FROM public, anon, authenticated/);
+});
+
+test('migration: both hot RPCs call the throttle before doing work', () => {
+  assert.match(MIG, /rl_check_and_bump\('verify_certificate', 30, 60\)/);
+  assert.match(MIG, /rl_check_and_bump\('capture_visitor_lead', 10, 60\)/);
+});
+
+test('migration: capture_visitor_lead closes the idempotent enumeration oracle', () => {
+  // both existing-lead and new-lead paths must return the SAME shape (no 'idempotent' key)
+  assert.ok(!/'idempotent', true/.test(MIG), "must not return the distinguishing 'idempotent' flag");
+});
+
+// ── /oauth/token: in-code IP throttle ────────────────────────────────────────────
+const IPRL = read('src/lib/ip-rate-limit.ts');
+const TOKEN = read('src/pages/oauth/token.ts');
+
+test('ip-rate-limit lib: keys by IP+action, reads cf-connecting-ip, fail-open', () => {
+  assert.ok(IPRL, 'src/lib/ip-rate-limit.ts exists');
+  assert.match(IPRL, /cf-connecting-ip/);
+  assert.match(IPRL, /iprl:\$\{action\}:\$\{ip\}:\$\{bucket\}/);
+  // fail-open when kv or ip missing
+  assert.match(IPRL, /if \(!kv \|\| !ip\) return \{ allowed: true/);
+});
+
+test('token endpoint throttles both grants (30/min/IP) with a 429 + Retry-After', () => {
+  assert.match(TOKEN, /import \{ checkIpRateLimit, clientIpFrom \} from '\.\.\/\.\.\/lib\/ip-rate-limit'/);
+  assert.match(TOKEN, /checkIpRateLimit\(kv, clientIpFrom\(request\), 'oauth_token', 30\)/);
+  assert.match(TOKEN, /status: 429/);
+  assert.match(TOKEN, /'Retry-After'/);
+  // placed before grant branching so it covers authorization_code AND refresh_token
+  const rlIdx = TOKEN.indexOf("'oauth_token'");
+  const grantIdx = TOKEN.indexOf("grant_type === 'refresh_token'");
+  assert.ok(rlIdx > -1 && grantIdx > -1 && rlIdx < grantIdx, 'throttle runs before grant handling');
+});
+
+// ── Drive-by: constant-time secret compares ──────────────────────────────────────
+const TSE_MAIN = read('src/lib/timing-safe-equal.ts');
+const TSE_VEP = read('cloudflare-workers/pmi-vep-sync/src/timing-safe-equal.ts');
+const CERTPDF = read('src/pages/api/internal/cert-pdf-render/[id].ts');
+const VEP = read('cloudflare-workers/pmi-vep-sync/src/index.ts');
+
+test('timing-safe-equal helpers exist in both build contexts', () => {
+  for (const [name, src] of [['main', TSE_MAIN], ['pmi-vep-sync', TSE_VEP]]) {
+    assert.ok(src, `timing-safe-equal.ts (${name}) exists`);
+    assert.match(src, /crypto\.subtle\.sign\('HMAC'/, `${name} uses HMAC digest compare`);
+  }
+});
+
+test('cert-pdf-render compares the Bearer secret in constant time (not raw !==)', () => {
+  assert.match(CERTPDF, /import \{ timingSafeEqual \}/);
+  assert.match(CERTPDF, /await timingSafeEqual\(auth, `Bearer \$\{expectedSecret\}`\)/);
+  assert.ok(!/auth !== `Bearer \$\{expectedSecret\}`/.test(CERTPDF), 'no raw !== secret compare');
+});
+
+test('pmi-vep-sync /ingest compares the shared secret in constant time (not raw !==)', () => {
+  assert.match(VEP, /import \{ timingSafeEqual \} from '\.\/timing-safe-equal'/);
+  assert.match(VEP, /await timingSafeEqual\(secret, env\.INGEST_SHARED_SECRET\)/);
+  assert.ok(!/secret !== env\.INGEST_SHARED_SECRET/.test(VEP), 'no raw !== secret compare');
+});
+
+// ── Drive-by: middleware no-Origin passthrough documented as intentional ─────────
+test('middleware documents the no-Origin passthrough as intentional (#1050)', () => {
+  const MW = read('src/middleware.ts');
+  assert.match(MW, /no-Origin passthrough below is INTENTIONAL/);
+  assert.match(MW, /Referer/); // warns a future reviewer not to fall back to Referer
+});

--- a/tests/contracts/rpc-migration-coverage.test.mjs
+++ b/tests/contracts/rpc-migration-coverage.test.mjs
@@ -299,11 +299,11 @@ function extractLocalMigrationVersions() {
 }
 
 function buildCreateTableMatcher(name) {
-  // CREATE TABLE [IF NOT EXISTS] ["public".]"name" — case-insensitive,
-  // tolerates IF NOT EXISTS clause and quoted identifiers.
+  // CREATE [UNLOGGED] TABLE [IF NOT EXISTS] ["public".]"name" — case-insensitive,
+  // tolerates the UNLOGGED persistence keyword, IF NOT EXISTS, and quoted identifiers.
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   return new RegExp(
-    `\\bCREATE\\s+TABLE\\s+(IF\\s+NOT\\s+EXISTS\\s+)?"?(public\\.)?"?${escaped}"?\\s*\\(`,
+    `\\bCREATE\\s+(UNLOGGED\\s+)?TABLE\\s+(IF\\s+NOT\\s+EXISTS\\s+)?"?(public\\.)?"?${escaped}"?\\s*\\(`,
     'i'
   );
 }
@@ -317,9 +317,9 @@ function buildDropTableMatcher(name) {
 }
 
 function extractCreateTableNames(sql) {
-  // Extract all CREATE TABLE [IF NOT EXISTS] [public.]name from the concat'd SQL.
+  // Extract all CREATE [UNLOGGED] TABLE [IF NOT EXISTS] [public.]name from the concat'd SQL.
   // Returns Set of table names (deduped).
-  const regex = /\bCREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(?:public\.)?"?([a-z_][a-z0-9_]*)"?\s*\(/gi;
+  const regex = /\bCREATE\s+(?:UNLOGGED\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?"?(?:public\.)?"?([a-z_][a-z0-9_]*)"?\s*\(/gi;
   const out = new Set();
   let m;
   while ((m = regex.exec(sql)) !== null) {


### PR DESCRIPTION
Closes #1050.

## Escopo (decisão do owner 2026-07-05: **core proporcional**, antes do 16/07)
Rate-limiting nas superfícies anon de maior valor + drive-bys baratos. `/ingest` rate-limit **pulado** (secret de alta entropia = baixo valor).

## Achado que mudou o design (auditado ao vivo)
`verify_certificate` e `capture_visitor_lead` são chamados **browser→Supabase direto** (`.rpc()` client-side) → **não passam pelo meu Worker edge**, então regra Cloudflare/zona **não os cobre** (o texto do issue erra aqui). O único controle real é **throttle in-RPC**. Validei ao vivo que um RPC anon lê `cf-connecting-ip` de `current_setting('request.headers')` (diagnóstico descartável retornou o IP real). Não havia infra de throttle-por-IP no schema.

## O que entra
- **Migration `20260805000346`**: tabela unlogged `anon_rate_counters` (RLS deny-all, revogada de anon) + helper `SECURITY DEFINER rl_check_and_bump(action,limit,window)` keyed por `(action, cf-connecting-ip, minute-bucket)`, **fail-open** (IP ausente / erro de storage nunca bloqueia), GC oportunístico. Wired em `verify_certificate` (**30/min/IP**) e `capture_visitor_lead` (**10/min/IP**).
- **Oráculo de enumeração fechado** em `capture_visitor_lead`: caminho de lead-existente não retorna mais o flag `idempotent`; ambos retornam `{success, lead_id}` idêntico (provado ao vivo: resubmit do mesmo email é indistinguível).
- **`/oauth/token`**: `src/lib/ip-rate-limit.ts` (KV bucket por IP+ação, fail-open) → **30/min/IP** nos dois grants, 429 + `Retry-After`.
- **Drive-by**: compares **constant-time** (`timing-safe-equal.ts` + cópia local pro worker `pmi-vep-sync` que builda à parte) substituem `!==` cru em `cert-pdf-render` (Bearer) e `pmi-vep-sync /ingest`; `middleware.ts` documenta o passthrough sem-Origin como intencional (não adicionar fallback de Referer).

### Limites (política, tunável)
30/10/30 por min/IP — **acima** do 20/5 sugerido no issue de propósito: tolera NAT/WiFi de evento compartilhado no 16/07 sem falso-positivo, e ainda corta enumeração scriptada (centenas–milhares/min).

## Validação (ao vivo + estática)
- Throttle exercido no caminho anon real: **30 permitidas → depois `rate_limited`**.
- `capture_visitor_lead` caminho normal + fechamento do oráculo confirmados; lead de teste removido.
- `astro build` ✓ · `pmi-vep-sync tsc --noEmit` ✓ · contract **11/11** · `rpc-migration-coverage` ✓.

## Notas de deploy
- A **migration já está em prod** (`apply_migration` + `migration repair` + `NOTIFY`). O throttle dos RPCs está **ativo agora**.
- O código Worker (`token.ts`, `cert-pdf-render`, `middleware`) vai a prod no **auto-deploy ao mergear**.
- ⚠️ O fix de compare do **`/ingest`** só chega a prod num **`wrangler deploy` separado** do worker `pmi-vep-sync` (não é coberto pelo `deploy.yml`). Baixo risco (secret alta entropia), mas fica como follow-up.