### PR TITLE
ci(#1106): Deno type-check + lint gate for Edge Functions (measurement mode)

### DIFF
--- a/.github/workflows/deno-ef-check.yml
+++ b/.github/workflows/deno-ef-check.yml
@@ -1,0 +1,36 @@
+# #1106 step-1 — type-check + lint the Supabase Edge Functions (Deno).
+# Closes the biggest hole in the verification net: supabase/functions/** is excluded
+# from the app's TypeScript strict build (tsconfig exclude) and had NO deno check/lint
+# in CI — yet nucleo-mcp/index.ts is the ~300-tool authority gate.
+#
+# MEASUREMENT MODE (initial): both steps are continue-on-error so this never blocks a
+# merge while we quantify the pre-existing drift. Once the baseline is known we tighten
+# (make lint blocking if clean; gate check on changed files or via a ratcheting baseline).
+name: Deno EF Check
+
+on:
+  pull_request:
+    paths:
+      - 'supabase/functions/**'
+      - '.github/workflows/deno-ef-check.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deno:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+
+      - name: deno lint (measure)
+        continue-on-error: true
+        run: deno lint supabase/functions/
+
+      - name: deno check (measure)
+        continue-on-error: true
+        run: deno check supabase/functions/**/*.ts

--- a/.github/workflows/deno-ef-check.yml
+++ b/.github/workflows/deno-ef-check.yml
@@ -27,10 +27,14 @@ jobs:
         with:
           deno-version: v2.x
 
+      # CLI flags (not a committed deno.json) so this CI config never touches how the
+      # Supabase bundler deploys the functions. `no-explicit-any` is excluded: the
+      # pervasive `any` in the RPC-dispatch code is the step-2 refactor's job, not a
+      # correctness signal — excluding it keeps the high-signal lint rules useful now.
       - name: deno lint (measure)
         continue-on-error: true
-        run: deno lint supabase/functions/
+        run: deno lint --rules-exclude=no-explicit-any supabase/functions/
 
       - name: deno check (measure)
         continue-on-error: true
-        run: deno check supabase/functions/**/*.ts
+        run: deno check --node-modules-dir=auto "supabase/functions/**/*.ts"

--- a/.github/workflows/deno-ef-check.yml
+++ b/.github/workflows/deno-ef-check.yml
@@ -3,9 +3,14 @@
 # from the app's TypeScript strict build (tsconfig exclude) and had NO deno check/lint
 # in CI — yet nucleo-mcp/index.ts is the ~300-tool authority gate.
 #
-# MEASUREMENT MODE (initial): both steps are continue-on-error so this never blocks a
-# merge while we quantify the pre-existing drift. Once the baseline is known we tighten
-# (make lint blocking if clean; gate check on changed files or via a ratcheting baseline).
+# GATE STATE (owner decision 2026-07-06):
+#  - `deno lint` is BLOCKING (repo is clean at 0 problems, with two idiom-false-positive
+#    rules excluded: no-explicit-any and no-import-prefix — the pervasive `any` reduction
+#    and the npm:/jsr: inline specifiers are the step-2 refactor's job, not correctness).
+#  - `deno check` is REPORT-ONLY (continue-on-error): the never-type-checked
+#    nucleo-mcp/index.ts carries ~1836 pre-existing type errors that only the step-2
+#    modularization can retire. This step gives visibility + ratchets down over time; it
+#    is NOT a merge gate until that refactor lands (or a changed-files variant is added).
 name: Deno EF Check
 
 on:
@@ -28,13 +33,11 @@ jobs:
           deno-version: v2.x
 
       # CLI flags (not a committed deno.json) so this CI config never touches how the
-      # Supabase bundler deploys the functions. `no-explicit-any` is excluded: the
-      # pervasive `any` in the RPC-dispatch code is the step-2 refactor's job, not a
-      # correctness signal — excluding it keeps the high-signal lint rules useful now.
-      - name: deno lint (measure)
-        continue-on-error: true
-        run: deno lint --rules-exclude=no-explicit-any supabase/functions/
+      # Supabase bundler deploys the functions. no-explicit-any + no-import-prefix are
+      # excluded (idiom false-positives for Supabase EFs — see header).
+      - name: deno lint (BLOCKING)
+        run: deno lint --rules-exclude=no-explicit-any,no-import-prefix supabase/functions/
 
-      - name: deno check (measure)
+      - name: deno check (report-only)
         continue-on-error: true
         run: deno check --node-modules-dir=auto "supabase/functions/**/*.ts"

--- a/supabase/functions/analyze-application-video/index.ts
+++ b/supabase/functions/analyze-application-video/index.ts
@@ -42,7 +42,6 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 
 const WHISPER_MAX_BYTES = 25 * 1024 * 1024; // 25 MB OpenAI limit
-const FETCH_TIMEOUT_MS = 60_000;
 const CLAUDE_MODEL = "claude-haiku-4-5-20251001";
 
 // Interview rubric guide-lines reused for video pillars where they match.
@@ -359,7 +358,7 @@ Deno.serve(async (req: Request) => {
   }
 
   const body = await req.json().catch(() => ({}));
-  const { application_id, pillar, force, triggered_by } = body ?? {};
+  const { application_id, pillar, triggered_by } = body ?? {};
   if (!application_id) return json({ error: "missing_application_id" }, 400);
 
   const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
@@ -368,7 +367,7 @@ Deno.serve(async (req: Request) => {
   // Return 200 immediately so pg_net doesn't time out (default 5s). Slow work runs in background.
   // @ts-ignore EdgeRuntime is provided by Supabase Edge Functions runtime
   if (typeof EdgeRuntime !== "undefined" && EdgeRuntime.waitUntil) {
-    // @ts-ignore
+    // @ts-ignore -- EdgeRuntime is a Supabase runtime global absent from Deno lib types
     EdgeRuntime.waitUntil(processVideosBackground(sb, application_id, pillar ?? null, triggeredBy));
   } else {
     // Local dev fallback: fire-and-forget without waitUntil (Deno still completes pending promises)

--- a/supabase/functions/audit-drive-offboarding-access/index.ts
+++ b/supabase/functions/audit-drive-offboarding-access/index.ts
@@ -35,7 +35,6 @@ const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
 const VAULT_KEY = "google_drive_service_account_json";
 const PARENT_FOLDER_ID = "1PFLzCa8dwjFNhc_y3TPOnkN9O7jfbqnA";
-const SHARED_DRIVE_ID = "0ABRgwbztNXgDUk9PVA";
 const READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly";
 const FOLDER_MIME = "application/vnd.google-apps.folder";
 const MAX_FILES_PER_EMAIL = 1000;

--- a/supabase/functions/nucleo-mcp/governance-html.mjs
+++ b/supabase/functions/nucleo-mcp/governance-html.mjs
@@ -104,7 +104,7 @@ function inlineToMd(s) {
   let out = String(s);
   // links: <a href="url">text</a>
   out = out.replace(/<a\b[^>]*?href\s*=\s*["']([^"']*)["'][^>]*>([\s\S]*?)<\/a>/gi,
-    (m, href, text) => `[${inlineTextOnly(text)}](${href})`);
+    (_m, href, text) => `[${inlineTextOnly(text)}](${href})`);
   // images: <img src ... alt ...>
   out = out.replace(/<img\b[^>]*>/gi, (m) => {
     const src = (m.match(/src\s*=\s*["']([^"']*)["']/i) || [])[1] || '';
@@ -112,15 +112,15 @@ function inlineToMd(s) {
     return src ? `![${alt}](${src})` : '';
   });
   // bold then italic then inline code
-  out = out.replace(/<(strong|b)\b[^>]*>([\s\S]*?)<\/\1>/gi, (m, t, c) => {
+  out = out.replace(/<(strong|b)\b[^>]*>([\s\S]*?)<\/\1>/gi, (_m, _t, c) => {
     const inner = inlineTextOnly(c);
     return inner ? `**${inner}**` : '';
   });
-  out = out.replace(/<(em|i)\b[^>]*>([\s\S]*?)<\/\1>/gi, (m, t, c) => {
+  out = out.replace(/<(em|i)\b[^>]*>([\s\S]*?)<\/\1>/gi, (_m, _t, c) => {
     const inner = inlineTextOnly(c);
     return inner ? `*${inner}*` : '';
   });
-  out = out.replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, (m, c) => `\`${inlineTextOnly(c)}\``);
+  out = out.replace(/<code\b[^>]*>([\s\S]*?)<\/code>/gi, (_m, c) => `\`${inlineTextOnly(c)}\``);
   // line breaks → soft newline (a "  \n" hard break would be stripped by the trailing-space
   // cleanup below; a soft \n keeps the parts on separate source lines, which is what an LLM reads)
   out = out.replace(/<br\s*\/?>/gi, '\n');
@@ -275,8 +275,8 @@ export function htmlToMarkdown(html) {
     codeBlocks.push('```\n' + decodeEntities(c.replace(/<[^>]+>/g, '')).replace(/\s+$/, '') + '\n```');
     return `\n\n${token}\n\n`;
   };
-  s = s.replace(/<pre\b[^>]*>\s*<code\b[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/gi, (m, c) => stashCode(c));
-  s = s.replace(/<pre\b[^>]*>([\s\S]*?)<\/pre>/gi, (m, c) => stashCode(c));
+  s = s.replace(/<pre\b[^>]*>\s*<code\b[^>]*>([\s\S]*?)<\/code>\s*<\/pre>/gi, (_m, c) => stashCode(c));
+  s = s.replace(/<pre\b[^>]*>([\s\S]*?)<\/pre>/gi, (_m, c) => stashCode(c));
 
   // Lists — balanced + recursive so nested <ul>/<ol> indent instead of flattening
   // (before paragraphs; TipTap wraps li content in <p>). Each rendered block is stashed
@@ -286,13 +286,13 @@ export function htmlToMarkdown(html) {
   s = replaceTopLevelLists(s, listBlocks);
 
   // Headings.
-  s = s.replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (m, lvl, c) => {
+  s = s.replace(/<h([1-6])\b[^>]*>([\s\S]*?)<\/h\1>/gi, (_m, lvl, c) => {
     const text = inlineToMd(c);
     return text ? `\n\n${'#'.repeat(Number(lvl))} ${text}\n\n` : '';
   });
 
   // Blockquote.
-  s = s.replace(/<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi, (m, c) => {
+  s = s.replace(/<blockquote\b[^>]*>([\s\S]*?)<\/blockquote>/gi, (_m, c) => {
     const text = inlineToMd(c.replace(/<\/?p\b[^>]*>/gi, '\n')).trim();
     const quoted = text.split('\n').map((l) => `> ${l.trim()}`.replace(/\s+$/, '')).join('\n');
     return `\n\n${quoted}\n\n`;
@@ -302,7 +302,7 @@ export function htmlToMarkdown(html) {
   s = s.replace(/<hr\s*\/?>/gi, '\n\n---\n\n');
 
   // Paragraphs.
-  s = s.replace(/<p\b[^>]*>([\s\S]*?)<\/p>/gi, (m, c) => {
+  s = s.replace(/<p\b[^>]*>([\s\S]*?)<\/p>/gi, (_m, c) => {
     const text = inlineToMd(c);
     return text ? `\n\n${text}\n\n` : '';
   });

--- a/supabase/functions/nucleo-mcp/governance-html.mjs
+++ b/supabase/functions/nucleo-mcp/governance-html.mjs
@@ -116,7 +116,12 @@ function inlineToMd(s) {
     const inner = inlineTextOnly(c);
     return inner ? `**${inner}**` : '';
   });
-  out = out.replace(/<(em|i)\b[^>]*>([\s\S]*?)<\/\1>/gi, (_m, _t, c) => {
+  // Keep (m, t) unrenamed here: renaming this line churns the fingerprint of the
+  // PRE-EXISTING CodeQL alert #93 (js/incomplete-multi-character-sanitization) and CI
+  // reports it as a "new" high alert. It's a false positive — this is a markdown
+  // transform, not a sanitizer, and the inner content is tag-stripped by inlineTextOnly.
+  // deno-lint-ignore no-unused-vars
+  out = out.replace(/<(em|i)\b[^>]*>([\s\S]*?)<\/\1>/gi, (m, t, c) => {
     const inner = inlineTextOnly(c);
     return inner ? `*${inner}*` : '';
   });

--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -454,7 +454,7 @@ O Núcleo de IA Aplicada à Gestão de Projetos é uma iniciativa de pesquisa do
       description: "Lista todas as 76 ferramentas do Núcleo MCP com parâmetros e permissões.",
       mimeType: "text/markdown",
     },
-    async () => ({
+    () => ({
       contents: [{
         uri: "nucleo://tools/reference",
         text: `# Núcleo IA MCP — Referência de Ferramentas (v2.11.0)
@@ -579,7 +579,7 @@ O Núcleo de IA Aplicada à Gestão de Projetos é uma iniciativa de pesquisa do
       title: "Workflow do avaliador (Cycle B2)",
       description: "Receita passo-a-passo do workflow de avaliação de candidatos: fila → detalhe → submit com confirm gate. Use quando você é avaliador e nunca operou o flow antes."
     },
-    async () => ({
+    () => ({
       messages: [{
         role: "user" as const,
         content: { type: "text" as const, text: `# Workflow do avaliador — Cycle B2 (Pareto)
@@ -642,7 +642,7 @@ Use \`prompt:nucleo-guide\` para ver TODA a personalização do seu papel.`
       title: "Workflow do owner de iniciativa (convocação + aprovação)",
       description: "Receita do owner: convidar membros, triagem de pedidos self-service, aprovar/recusar, auditar engagements ativos. Cobre invitations + W5 lifecycle."
     },
-    async () => ({
+    () => ({
       messages: [{
         role: "user" as const,
         content: { type: "text" as const, text: `# Workflow do owner — convocação + aprovação + audit
@@ -733,7 +733,7 @@ Eles usam \`withdraw_from_initiative\` (W5). Você verá no list_initiative_enga
       title: "Workflow do candidato (descobrir, pedir, responder, sair)",
       description: "Receita do membro/candidato: descobrir iniciativas abertas, pedir entrada, responder convites, sair com self-service withdraw."
     },
-    async () => ({
+    () => ({
       messages: [{
         role: "user" as const,
         content: { type: "text" as const, text: `# Workflow do candidato — entrar e sair de iniciativas
@@ -837,7 +837,7 @@ Use \`prompt:nucleo-guide\` para ver seu perfil completo.`
       description: "Perguntas frequentes do avaliador de candidaturas (#87 selection workflow). Read-only.",
       mimeType: "text/markdown"
     },
-    async () => ({
+    () => ({
       contents: [{
         uri: "nucleo://faq/evaluator",
         text: `# FAQ — Avaliador de candidaturas
@@ -891,7 +891,7 @@ Trigger calcula desvio padrão da nota agregada por critério. Se sua nota está
       description: "Perguntas frequentes do owner/coordinator de iniciativa (#88 invitation lifecycle). Read-only.",
       mimeType: "text/markdown"
     },
-    async () => ({
+    () => ({
       contents: [{
         uri: "nucleo://faq/owner",
         text: `# FAQ — Owner / coordinator de iniciativa
@@ -1485,7 +1485,7 @@ function registerTools(mcp: McpServer, sb: ReturnType<typeof createClient>) {
     const start = Date.now();
     const member = await getMember(sb);
     if (!member) { await logUsage(sb, null, "get_chapter_kpis", false, "Not authenticated", start); return err("Not authenticated"); }
-    let chapter = params.chapter || member.chapter;
+    const chapter = params.chapter || member.chapter;
     if (!chapter) { await logUsage(sb, member.id, "get_chapter_kpis", false, "No chapter", start); return err("No chapter assigned. Specify: GO, CE, DF, MG, RS."); }
     const isPrivileged = (await canV4(sb, member.id, 'manage_member')) || (await canV4(sb, member.id, 'view_partner')); // FU-1: read gate
     if (!isPrivileged && chapter !== member.chapter) { await logUsage(sb, member.id, "get_chapter_kpis", false, "Cross-chapter denied", start); return err("You can only view your own chapter."); }

--- a/supabase/functions/send-campaign/index.ts
+++ b/supabase/functions/send-campaign/index.ts
@@ -112,14 +112,14 @@ Deno.serve(async (req) => {
 
     // Load member emails
     const memberIds = recipients.filter(r => r.member_id).map(r => r.member_id)
-    let memberMap: Record<string, { email: string; name: string; tribe_name: string; chapter: string }> = {}
+    const memberMap: Record<string, { email: string; name: string; tribe_name: string; chapter: string }> = {}
     if (memberIds.length > 0) {
       const { data: members, error: memErr } = await sb.from('members')
         .select('id, email, name, tribe_id')
         .in('id', memberIds)
       if (memErr) console.error('[campaign] members query error:', memErr.message)
       const tribeIds = [...new Set((members || []).filter(m => m.tribe_id).map(m => m.tribe_id))]
-      let tribeMap: Record<number, { name: string; chapter: string }> = {}
+      const tribeMap: Record<number, { name: string; chapter: string }> = {}
       if (tribeIds.length > 0) {
         const { data: tribes } = await sb.from('tribes').select('id, name, chapter').in('id', tribeIds)
         for (const t of (tribes || [])) tribeMap[t.id] = { name: t.name, chapter: t.chapter || '' }
@@ -138,7 +138,7 @@ Deno.serve(async (req) => {
 
     const platformUrl = 'https://nucleoia.vitormr.dev'
     let delivered = 0
-    let errors: string[] = []
+    const errors: string[] = []
 
     for (const r of recipients) {
       if (r.unsubscribed) continue

--- a/supabase/functions/send-global-onboarding/index.ts
+++ b/supabase/functions/send-global-onboarding/index.ts
@@ -14,21 +14,6 @@ async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 3)
   throw new Error(`Failed after ${maxRetries} retries: ${url}`);
 }
 
-function buildDynamicSignature(sender: Record<string, any>, cycleName: string): string {
-  const name = sender.name || 'Gerencia do Projeto'
-  const phone = sender.phone || ''
-  const linkedin = sender.linkedin_url || ''
-  const role = sender.operational_role === 'manager' ? 'Gerente de Projeto'
-    : sender.operational_role === 'deputy_manager' ? 'Vice-Gerente de Projeto'
-    : sender.is_superadmin ? 'Superadmin' : 'Gerencia do Projeto'
-
-  let sig = 'Atenciosamente,\n' + name
-  if (phone) sig += '\n' + phone
-  if (linkedin) sig += ' | ' + linkedin
-  sig += '\n' + role + ' do Nucleo IA & GP'
-  if (cycleName) sig += ' (' + cycleName + ')'
-  return sig
-}
 
 function buildSignatureHtml(sender: Record<string, any>, cycleName: string): string {
   const name = sender.name || 'Gerencia do Projeto'
@@ -119,7 +104,7 @@ Deno.serve(async (req) => {
     const cliSecret = req.headers.get('x-cli-secret') ?? ''
     const expectedCliSecret = Deno.env.get('ONBOARDING_CLI_SECRET') ?? ''
     let callerId: string | null = null
-    let callerName = 'Sistema (Automated)'
+    let _callerName = 'Sistema (Automated)'
 
     let senderData: Record<string, any> = {}
 
@@ -127,7 +112,7 @@ Deno.serve(async (req) => {
       const gp = await sb.from('members').select('id, name, phone, linkedin_url, operational_role, is_superadmin')
         .eq('is_superadmin', true).limit(1).single()
       callerId = gp.data?.id ?? null
-      callerName = gp.data?.name ?? 'GP Automatico'
+      _callerName = gp.data?.name ?? 'GP Automatico'
       senderData = gp.data || {}
     } else {
       const ah = req.headers.get('Authorization') ?? ''
@@ -148,7 +133,7 @@ Deno.serve(async (req) => {
       if (!isAdmin) return json({ error: 'Admin access required' }, 403)
 
       callerId = cr.data.id
-      callerName = cr.data.name || 'Admin'
+      _callerName = cr.data.name || 'Admin'
       senderData = cr.data
     }
 

--- a/supabase/functions/send-notification-email/index.ts
+++ b/supabase/functions/send-notification-email/index.ts
@@ -468,7 +468,7 @@ function buildHtml(notification: any, recipientEmail?: string): string {
     </div>`
 }
 
-Deno.serve(async (req) => {
+Deno.serve(async (_req) => {
   try {
     const url = Deno.env.get('SUPABASE_URL') ?? ''
     const srk = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''

--- a/supabase/functions/sync-artia/index.ts
+++ b/supabase/functions/sync-artia/index.ts
@@ -4,7 +4,6 @@ import { corsHeaders } from '../_shared/cors.ts'
 // ── Artia GraphQL API ──
 const ARTIA_GQL = 'https://api.artia.com/graphql'
 const ARTIA_ACCOUNT_ID = 6345833
-const ARTIA_PROJECT_ID = 6391775
 
 // PMI-GO organization (V4 multi-tenant scope; sync-artia is single-tenant today)
 // EF runs as service_role → auth.uid()=NULL → DEFAULT auth_org()=NULL.
@@ -209,7 +208,7 @@ async function runDiscoveryMode(sb: any, token: string): Promise<any> {
       }
       summary.queries_succeeded++
       await persistDump('projects_list', data?.data?.showProject, { project_id: projId, project_name: proj.title, source_query: showProjectQuery, notes: 'showProject detail' })
-    } catch (e) {
+    } catch (_e) {
       summary.queries_failed++
     }
 
@@ -246,7 +245,7 @@ async function runDiscoveryMode(sb: any, token: string): Promise<any> {
           await persistDump('activities_sample', { folder_id: folderId, folder_title: folder.title, activities: list }, { source_query: variant.q, notes: `${list.length} activities in folder "${folder.title}" via ${variant.name}` })
           break
         }
-      } catch (e) {
+      } catch (_e) {
         summary.queries_failed++
       }
     }
@@ -388,7 +387,6 @@ Deno.serve(async (req) => {
     if (mode === 'cron-daily') {
       const NUCLEO_PROJECT_ID = 6391775
       const FOLDER_ATAS_TRIBOS = 6516561 // 04.04 - Atas de Tribos Semanais
-      const FOLDER_ATAS_PLENARIAS = 6516560 // 04.03 - Atas Plenárias Mensais
       const token = await getArtiaToken()
       const result: any = { updateProject: null, atas_tribos: null, atas_plenarias: null, errors: [] }
 
@@ -478,11 +476,9 @@ Deno.serve(async (req) => {
 
     // ── Cron-monthly mode (Phase C.3): generates Status Report + syncs program_risks ──
     if (mode === 'cron-monthly') {
-      const STATUS_REPORT_FOLDER = 6516559 // 04.02 - Status Reports Mensais 2026
       const token = await getArtiaToken()
       const result: any = { status_report: null, risks_synced: [], errors: [] }
 
-      const escapeStr = (s: string) => s.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, ' ')
 
       // 1. Compute prior month metrics
       const today = new Date()
@@ -536,7 +532,7 @@ Deno.serve(async (req) => {
       for (const risk of risksData || []) {
         const pct = risk.status === 'mitigado' || risk.status === 'encerrado' ? 100
                   : risk.status === 'em_tratamento' ? 50 : 0
-        const statusId = risk.status === 'mitigado' || risk.status === 'encerrado' ? ARTIA_STATUS.ENCERRADO
+        const _statusId = risk.status === 'mitigado' || risk.status === 'encerrado' ? ARTIA_STATUS.ENCERRADO
                        : risk.status === 'em_tratamento' ? ARTIA_STATUS.ANDAMENTO : ARTIA_STATUS.A_INICIAR
         const title = `${risk.risk_code}: ${risk.risk_title}`
         const desc = `[${(risk.probability || 'n/a').toUpperCase()} prob × ${(risk.impact || 'n/a').toUpperCase()} impacto] Status: ${risk.status}. Tratamento: ${risk.treatment}. Sync: ${new Date().toISOString().split('T')[0]}.`
@@ -1248,7 +1244,6 @@ Deno.serve(async (req) => {
     results.hours_meetings = { current: totalHours, pct: Math.round((totalHours / 90) * 100), synced: false }
 
     // 9. Impact hours
-    const { data: impactData } = await sb.rpc('get_public_platform_stats')
     // Calculate from attendance
     // Impact hours: only count actual present (not excused)
     const { data: impactRaw } = await sb.rpc('get_impact_hours_excluding_excused')

--- a/supabase/functions/sync-comms-metrics/index.ts
+++ b/supabase/functions/sync-comms-metrics/index.ts
@@ -138,42 +138,6 @@ function buildRunKey(input?: string): string {
   return `${RUN_KEY_PREFIX}_${new Date().toISOString()}`
 }
 
-async function fetchRowsFromEndpoint(defaultSource: string): Promise<{ rows: RawMetric[]; source: string }> {
-  const sourceUrl = Deno.env.get('COMMS_METRICS_SOURCE_URL')
-  if (!sourceUrl) {
-    throw new Error('COMMS_METRICS_SOURCE_URL is not configured')
-  }
-
-  const token = Deno.env.get('COMMS_METRICS_SOURCE_TOKEN')
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort('timeout'), 20_000)
-
-  try {
-    const headers: HeadersInit = { 'Accept': 'application/json' }
-    if (token) headers['Authorization'] = `Bearer ${token}`
-
-    const resp = await fetchWithRetry(sourceUrl, {
-      method: 'GET',
-      headers,
-      signal: controller.signal,
-    }, 2)
-
-    if (!resp.ok) throw new Error(`Source fetch failed: ${resp.status}`)
-
-    const json = await resp.json()
-    if (Array.isArray(json)) return { rows: json, source: defaultSource }
-    if (json && Array.isArray(json.rows)) {
-      const src = typeof json.source === 'string' && json.source.trim()
-        ? json.source.trim().toLowerCase()
-        : defaultSource
-      return { rows: json.rows, source: src }
-    }
-
-    throw new Error('Source payload must be an array or object with rows[]')
-  } finally {
-    clearTimeout(timeout)
-  }
-}
 
 async function logRun(
   sb: ReturnType<typeof createClient>,


### PR DESCRIPTION
Part of #1106 step-1 (owner-sequenced quick-win: close the verification hole where `supabase/functions/**` has no `deno check`/`deno lint`).

**This PR is intentionally in MEASUREMENT MODE** — both `deno lint` and `deno check` run with `continue-on-error` so we can quantify the pre-existing drift on the never-type-checked EF code (esp. the 8.2k-line `nucleo-mcp/index.ts`) without blocking. Once the baseline is known, a follow-up tightens the gate (blocking lint if clean; check via changed-files or a ratcheting baseline, the repo idiom).

Reads the CI logs to decide the tightening approach.