### PR TITLE
ci(#1106): run Deno EF check on all PRs (unblock required check)

### DIFF
--- a/.github/workflows/deno-ef-check.yml
+++ b/.github/workflows/deno-ef-check.yml
@@ -14,10 +14,11 @@
 name: Deno EF Check
 
 on:
+  # Runs on EVERY PR (no paths filter) so the required `deno` status check always
+  # reports. A path-filtered required check hangs any PR that doesn't touch the filtered
+  # paths ("Expected — waiting for status"), deadlocking unrelated PRs. The job is fast
+  # (~30s) and `deno lint` is clean on main, so it passes on PRs that don't touch EFs.
   pull_request:
-    paths:
-      - 'supabase/functions/**'
-      - '.github/workflows/deno-ef-check.yml'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Follow-up to making `deno` a required check. A **path-filtered required check deadlocks** any PR that does not touch the filtered paths (it never reports → "Expected — waiting for status" → merge blocked). Removes the `paths:` filter so the `deno` job runs on every PR. It is ~30s and `deno lint` is clean on `main`, so non-EF PRs pass it trivially. This makes the required check safe.