### PR TITLE
fix(#1106): type EF Supabase clients → deno check 0; gate now blocking

### DIFF
--- a/.github/workflows/deno-ef-check.yml
+++ b/.github/workflows/deno-ef-check.yml
@@ -1,16 +1,18 @@
-# #1106 step-1 — type-check + lint the Supabase Edge Functions (Deno).
+# #1106 — type-check + lint the Supabase Edge Functions (Deno).
 # Closes the biggest hole in the verification net: supabase/functions/** is excluded
 # from the app's TypeScript strict build (tsconfig exclude) and had NO deno check/lint
 # in CI — yet nucleo-mcp/index.ts is the ~300-tool authority gate.
 #
-# GATE STATE (owner decision 2026-07-06):
-#  - `deno lint` is BLOCKING (repo is clean at 0 problems, with two idiom-false-positive
-#    rules excluded: no-explicit-any and no-import-prefix — the pervasive `any` reduction
-#    and the npm:/jsr: inline specifiers are the step-2 refactor's job, not correctness).
-#  - `deno check` is REPORT-ONLY (continue-on-error): the never-type-checked
-#    nucleo-mcp/index.ts carries ~1836 pre-existing type errors that only the step-2
-#    modularization can retire. This step gives visibility + ratchets down over time; it
-#    is NOT a merge gate until that refactor lands (or a changed-files variant is added).
+# GATE STATE (step-2, 2026-07-06 — both checks now BLOCKING):
+#  - `deno lint` is BLOCKING (clean at 0 problems, with two idiom-false-positive rules
+#    excluded: no-explicit-any and no-import-prefix — pervasive `any` and the npm:/jsr:
+#    inline specifiers are Supabase-EF idiom, not correctness).
+#  - `deno check` is BLOCKING. Step-2 root-caused the ~1836 "errors" as the untyped
+#    Supabase client (createClient without a Database generic → rpc() data:never +
+#    args:undefined). Typing every client as <any,"public",any> (+ a handful of genuine
+#    residual casts) took the whole supabase/functions/** glob to 0 type errors — WITHOUT
+#    the registerTools() modularization, which does not affect the type-error count
+#    (organizational only; deferred). The net is now fully closed; keep it at 0.
 name: Deno EF Check
 
 on:
@@ -39,6 +41,5 @@ jobs:
       - name: deno lint (BLOCKING)
         run: deno lint --rules-exclude=no-explicit-any,no-import-prefix supabase/functions/
 
-      - name: deno check (report-only)
-        continue-on-error: true
+      - name: deno check (BLOCKING)
         run: deno check --node-modules-dir=auto "supabase/functions/**/*.ts"

--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ docs/**/*peer_review_briefing*
 docs/**/*WHATSAPP_CROSS_GROUP*
 docs/drafts/p131_email_*
 docs/drafts/p277_*
+
+# Deno lockfile — EF deps are managed by the Supabase bundler; CI runs lockless (#1106)
+deno.lock

--- a/supabase/functions/_shared/drive-sa.ts
+++ b/supabase/functions/_shared/drive-sa.ts
@@ -20,7 +20,7 @@ const VAULT_KEY = "google_drive_service_account_json";
 export const DRIVE_WRITE_SCOPE = "https://www.googleapis.com/auth/drive";
 
 export async function getServiceAccountKey(): Promise<{ available: boolean; key?: any; error?: string }> {
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error) return { available: false, error: `Vault read error: ${error.message}` };
   if (!data || typeof data !== "string" || data.length === 0) {

--- a/supabase/functions/_shared/ots.ts
+++ b/supabase/functions/_shared/ots.ts
@@ -370,7 +370,7 @@ export async function stamp(
       const resp = await fetch(`${cal.replace(/\/$/, "")}/digest`, {
         method: "POST",
         headers: { "Accept": "application/vnd.opentimestamps.v1", "Content-Type": "application/x-www-form-urlencoded" },
-        body: S,
+        body: S as BodyInit,
         signal: AbortSignal.timeout(timeoutMs),
       });
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);

--- a/supabase/functions/_shared/service-auth.ts
+++ b/supabase/functions/_shared/service-auth.ts
@@ -31,7 +31,7 @@ export async function isServiceRoleToken(
   if (injected && token === injected) return true;
 
   try {
-    const probe = createClient(supabaseUrl, token, {
+    const probe = createClient<any, "public", any>(supabaseUrl, token, {
       auth: { persistSession: false, autoRefreshToken: false },
     });
     const { data, error } = await probe.rpc("current_caller_role");

--- a/supabase/functions/analyze-application-video/index.ts
+++ b/supabase/functions/analyze-application-video/index.ts
@@ -35,7 +35,7 @@
 // on selection_applications). ai_processing_log has a hardcoded org_id default so
 // is unaffected — asymmetric design preserved intentionally.
 
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -75,7 +75,7 @@ function json(body: unknown, status = 200) {
 // pmi-video-test-transcribe, drive-upload-to-folder, etc). Service account JWT was
 // initial attempt but the SA email doesn't have access to candidate-uploaded folders;
 // OAuth user-delegated does, since the upload itself happened with these credentials.
-async function getDriveAccessToken(sb: ReturnType<typeof createClient>): Promise<string> {
+async function getDriveAccessToken(sb: SupabaseClient<any, "public", any>): Promise<string> {
   const credsStr = await getVaultSecret(sb, "google_drive_oauth_credentials");
   if (!credsStr) throw new Error("google_drive_oauth_credentials not in vault");
   const creds = JSON.parse(credsStr) as { client_id: string; client_secret: string; refresh_token: string };
@@ -130,7 +130,7 @@ async function driveGetThumbnailBytes(fileId: string, accessToken: string): Prom
 
 async function whisperTranscribe(videoBytes: Uint8Array, mime: string, openaiKey: string): Promise<string> {
   const form = new FormData();
-  form.append("file", new Blob([videoBytes], { type: mime }), `video.${mime.split("/")[1] ?? "mp4"}`);
+  form.append("file", new Blob([videoBytes as BlobPart], { type: mime }), `video.${mime.split("/")[1] ?? "mp4"}`);
   form.append("model", "whisper-1");
   form.append("language", "pt"); // PT-BR primary; Whisper auto-detects but seeding helps
   form.append("response_format", "text");
@@ -197,7 +197,7 @@ async function claudeAnalyzePillar(args: {
   };
 }
 
-async function getVaultSecret(sb: ReturnType<typeof createClient>, name: string): Promise<string | null> {
+async function getVaultSecret(sb: SupabaseClient<any, "public", any>, name: string): Promise<string | null> {
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: name });
   if (error) {
     console.warn(`vault_secret_${name}_failed:`, error.message);
@@ -211,7 +211,7 @@ async function getVaultSecret(sb: ReturnType<typeof createClient>, name: string)
 // but Whisper+Drive download is 10-30s per pillar). EdgeRuntime.waitUntil keeps the
 // runtime alive until the work finishes (Deno Edge Functions supports it).
 async function processVideosBackground(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   application_id: string,
   pillar: string | null,
   triggeredBy: string,
@@ -361,7 +361,7 @@ Deno.serve(async (req: Request) => {
   const { application_id, pillar, triggered_by } = body ?? {};
   if (!application_id) return json({ error: "missing_application_id" }, 400);
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const triggeredBy = typeof triggered_by === "string" ? triggered_by : "service_role";
 
   // Return 200 immediately so pg_net doesn't time out (default 5s). Slow work runs in background.

--- a/supabase/functions/audit-drive-offboarding-access/index.ts
+++ b/supabase/functions/audit-drive-offboarding-access/index.ts
@@ -43,7 +43,7 @@ interface DrivePermission { id: string; type: string; role: string; emailAddress
 interface DriveItem { id: string; name: string; mimeType: string; webViewLink?: string; driveId?: string; parents?: string[]; permissions?: DrivePermission[]; }
 
 async function getServiceAccountKey(): Promise<{ available: boolean; key?: any; error?: string }> {
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error) return { available: false, error: `Vault read error: ${error.message}` };
   if (!data || typeof data !== "string" || data.length === 0) {
@@ -170,7 +170,7 @@ Deno.serve(async (req) => {
     }), { status: 503 });
   }
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const errors: string[] = [];
   let accessToken: string;
   try { accessToken = await getAccessToken(saResult.key, READONLY_SCOPE); }

--- a/supabase/functions/drive-create-subfolder/index.ts
+++ b/supabase/functions/drive-create-subfolder/index.ts
@@ -25,7 +25,7 @@ interface OAuthCreds {
 }
 
 async function getOAuthCreds(): Promise<{ available: boolean; creds?: OAuthCreds; error?: string }> {
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error) return { available: false, error: `Vault read error: ${error.message}` };
   if (!data || typeof data !== "string" || data.length === 0) {

--- a/supabase/functions/drive-discover-atas/index.ts
+++ b/supabase/functions/drive-discover-atas/index.ts
@@ -28,7 +28,7 @@ Deno.serve(async (req) => {
     return new Response(JSON.stringify({ error: "Method not allowed" }), { status: 405 });
   }
   const startedAt = Date.now();
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   // Pull active minutes folders
   const { data: links, error: linksErr } = await sb

--- a/supabase/functions/drive-list-folder-files/index.ts
+++ b/supabase/functions/drive-list-folder-files/index.ts
@@ -34,7 +34,7 @@ interface DriveFile {
 }
 
 async function getServiceAccountKey(): Promise<{ available: boolean; key?: any; error?: string }> {
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   // Use SECDEF RPC helper — vault.decrypted_secrets não é acessível direto via JS client
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error) {

--- a/supabase/functions/drive-upload-to-folder/index.ts
+++ b/supabase/functions/drive-upload-to-folder/index.ts
@@ -36,7 +36,7 @@ interface OAuthCreds {
 }
 
 async function getOAuthCreds(): Promise<{ available: boolean; creds?: OAuthCreds; error?: string }> {
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error) return { available: false, error: `Vault read error: ${error.message}` };
   if (!data || typeof data !== "string" || data.length === 0) {

--- a/supabase/functions/extract-cv-text/index.ts
+++ b/supabase/functions/extract-cv-text/index.ts
@@ -20,7 +20,7 @@
  *       (_trg_purge_ai_analysis_on_consent_revocation) + retenção via cycle_decision_date.
  */
 
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { isServiceRoleToken } from "../_shared/service-auth.ts";
 import { extractText, getDocumentProxy } from "npm:unpdf@1.6.2";
 
@@ -98,7 +98,7 @@ async function fetchResume(url: string): Promise<{ bytes: Uint8Array; contentTyp
 // writes PDFs to selection-resumes/cycle-{cycle_code}/{vep_app_id}.pdf. service_role
 // has read access — no signed URL needed for server-side fetch.
 async function fetchResumeFromStorage(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   path: string
 ): Promise<{ bytes: Uint8Array; contentType: string }> {
   const { data, error } = await sb.storage.from("selection-resumes").download(path);
@@ -160,7 +160,7 @@ Deno.serve(async (req) => {
     ? triggered_by
     : "service_role_call";
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const t0 = Date.now();
   let logId: string | null = null;
 

--- a/supabase/functions/get-comms-metrics/index.ts
+++ b/supabase/functions/get-comms-metrics/index.ts
@@ -7,7 +7,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const sb = createClient(
+    const sb = createClient<any, "public", any>(
       Deno.env.get('SUPABASE_URL')!,
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
     )

--- a/supabase/functions/import-calendar-legacy/index.ts
+++ b/supabase/functions/import-calendar-legacy/index.ts
@@ -67,7 +67,7 @@ Deno.serve(async (req) => {
     const anonKey = Deno.env.get('SUPABASE_ANON_KEY')!
     const token = authHeader.replace(/^Bearer\s+/i, '')
 
-    const uc = createClient(supabaseUrl, anonKey, {
+    const uc = createClient<any, "public", any>(supabaseUrl, anonKey, {
       global: { headers: { Authorization: 'Bearer ' + token } },
     })
     const { data: { user }, error: userErr } = await uc.auth.getUser()
@@ -78,7 +78,7 @@ Deno.serve(async (req) => {
       )
     }
 
-    const sb = createClient(supabaseUrl, serviceRoleKey)
+    const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey)
 
     const { data: caller } = await sb
       .from('members')

--- a/supabase/functions/import-trello-legacy/index.ts
+++ b/supabase/functions/import-trello-legacy/index.ts
@@ -81,7 +81,7 @@ Deno.serve(async (req) => {
     const anonKey = Deno.env.get('SUPABASE_ANON_KEY')!
     const token = authHeader.replace(/^Bearer\s+/i, '')
 
-    const uc = createClient(supabaseUrl, anonKey, {
+    const uc = createClient<any, "public", any>(supabaseUrl, anonKey, {
       global: { headers: { Authorization: 'Bearer ' + token } },
     })
     const { data: { user }, error: userErr } = await uc.auth.getUser()
@@ -92,7 +92,7 @@ Deno.serve(async (req) => {
       )
     }
 
-    const sb = createClient(supabaseUrl, serviceRoleKey)
+    const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey)
 
     const { data: caller } = await sb
       .from('members')

--- a/supabase/functions/manage-curation-drive-grant/index.ts
+++ b/supabase/functions/manage-curation-drive-grant/index.ts
@@ -51,7 +51,7 @@ Deno.serve(async (req) => {
     return new Response(JSON.stringify({ error: "action must be 'grant' or 'revoke'" }), { status: 400 });
   }
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   const { data: row, error: rowErr } = await sb.rpc("get_curation_grant_row", { p_grant_id: grantId });
   if (rowErr) return new Response(JSON.stringify({ error: "rpc_error", detail: rowErr.message }), { status: 500 });

--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -174,7 +174,7 @@
 import { Hono } from "jsr:@hono/hono@4.12.9";
 import { McpServer } from "npm:@modelcontextprotocol/sdk@1.29.0/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "npm:@modelcontextprotocol/sdk@1.29.0/server/webStandardStreamableHttp.js";
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { z } from "npm:zod@4.3.6";
 import {
   htmlToMarkdown,
@@ -189,8 +189,16 @@ const app = new Hono().basePath("/nucleo-mcp");
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY")!;
 
+// Permissive client type. This EF has no generated `Database` types, so the default
+// createClient generic resolves rpc() data to `never` and its args to `undefined` —
+// which produced 1757 spurious deno-check errors (1483 TS2339 + 271 TS2345). Typing the
+// client as <any,"public",any> makes rpc()/from() permissive (runtime-erased, no behavior
+// change) and is what actually closes the type-check hole. Modularizing registerTools()
+// does NOT affect this count. #1106 step-2.
+type Sb = SupabaseClient<any, "public", any>;
+
 function createAuthenticatedClient(token?: string) {
-  return createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  return createClient<any, "public", any>(SUPABASE_URL, SUPABASE_ANON_KEY, {
     global: { headers: token ? { Authorization: `Bearer ${token}` } : {} },
   });
 }
@@ -203,7 +211,7 @@ function ok(data: unknown) {
   return { content: [{ type: "text" as const, text: JSON.stringify(data, null, 2) }] };
 }
 
-async function getMember(sb: ReturnType<typeof createClient>) {
+async function getMember(sb: Sb) {
   const { data, error } = await sb.rpc("get_my_member_record");
   if (error || !data) return null;
   if (Array.isArray(data)) return data.length > 0 ? data[0] : null;
@@ -213,7 +221,7 @@ async function getMember(sb: ReturnType<typeof createClient>) {
 
 // V4: Authority gate via engagement-derived can() (ADR-0007)
 // Replaces legacy canWrite/canWriteBoard with DB-driven permissions
-async function canV4(sb: ReturnType<typeof createClient>, memberId: string, action: string, resourceType?: string, resourceId?: string): Promise<boolean> {
+async function canV4(sb: Sb, memberId: string, action: string, resourceType?: string, resourceId?: string): Promise<boolean> {
   const { data, error } = await sb.rpc("can_by_member", {
     p_member_id: memberId,
     p_action: action,
@@ -230,12 +238,12 @@ function isUUID(v: string | undefined): boolean { return !!v && UUID_RE.test(v);
 const NO_TRIBE_HINT = "No tribe assigned. Pass tribe_id parameter (1-8) to specify which tribe. Use list_boards or get_portfolio_overview for board IDs.";
 
 // V4: resolve legacy tribe_id → initiative UUID for _by_initiative RPCs
-async function resolveInitiativeId(sb: ReturnType<typeof createClient>, tribeId: number): Promise<string | null> {
+async function resolveInitiativeId(sb: Sb, tribeId: number): Promise<string | null> {
   const { data } = await sb.from("initiatives").select("id").eq("legacy_tribe_id", tribeId).single();
   return data?.id || null;
 }
 
-async function logUsage(sb: ReturnType<typeof createClient>, memberId: string | null, toolName: string, success: boolean, errorMsg?: string, startTime?: number, resultKind?: "preview" | "execute", responseSummary?: unknown) {
+async function logUsage(sb: Sb, memberId: string | null, toolName: string, success: boolean, errorMsg?: string, startTime?: number, resultKind?: "preview" | "execute", responseSummary?: unknown) {
   try {
     const execMs = startTime ? Date.now() - startTime : null;
     await sb.rpc("log_mcp_usage", { p_auth_user_id: null, p_member_id: memberId, p_tool_name: toolName, p_success: success, p_error_message: errorMsg || null, p_execution_ms: execMs, p_result_kind: resultKind || "execute", p_response_summary: responseSummary ?? null });
@@ -244,7 +252,7 @@ async function logUsage(sb: ReturnType<typeof createClient>, memberId: string | 
 
 // --- Knowledge Layer: Prompts + Resources ---
 
-function registerKnowledge(mcp: McpServer, sb: ReturnType<typeof createClient>) {
+function registerKnowledge(mcp: McpServer, sb: Sb) {
 
   // Dynamic prompt — adapts to authenticated member's role and permissions
   mcp.registerPrompt(
@@ -967,7 +975,7 @@ Quando engagement.status='active' é criado (via aceite de invite OU aprovação
 
 // --- Register MCP tools (runtime source of truth: MCP tools/list + /health; never hardcode the count here) ---
 
-function registerTools(mcp: McpServer, sb: ReturnType<typeof createClient>) {
+function registerTools(mcp: McpServer, sb: Sb) {
 
   // ===== READ TOOLS (1-10, 16-19, 20-23) =====
 
@@ -1552,7 +1560,7 @@ function registerTools(mcp: McpServer, sb: ReturnType<typeof createClient>) {
   // get_recurrence_stockout (#415) — recurring series running out of future occurrences
   mcp.tool("get_recurrence_stockout", "Lists recurring event series running out of future occurrences (recently active, last date within the horizon, no events beyond it). Returns estimated cadence, last date, next expected date, and suggested next dates to resupply. Requires manage_event.", {
     horizon_days: z.number().int().optional().describe("Days ahead within which a series counts as low-on-buffer. Default: 30")
-  }, async (params) => {
+  }, async (params: any) => {
     const start = Date.now();
     const member = await getMember(sb);
     if (!member) { await logUsage(sb, null, "get_recurrence_stockout", false, "Not authenticated", start); return err("Not authenticated"); }
@@ -2656,7 +2664,7 @@ function registerTools(mcp: McpServer, sb: ReturnType<typeof createClient>) {
         .optional()
         .describe("Optional initiative kind filter: 'research_tribe' (default) | 'workgroup' | 'committee' | 'study_group' | 'congress' | 'all' (cross-kind). Omit for research_tribe."),
     },
-    async (params) => {
+    async (params: any) => {
       const start = Date.now();
       const member = await getMember(sb);
       if (!member) { await logUsage(sb, null, "get_tribes_comparison", false, "Not authenticated", start); return err("Not authenticated"); }
@@ -7299,7 +7307,7 @@ function registerTools(mcp: McpServer, sb: ReturnType<typeof createClient>) {
     }
 
     // Service-role client for reading app data + writing log (bypasses RLS after canV4 gate above)
-    const sbSrv = createClient(SUPABASE_URL, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+    const sbSrv = createClient<any, "public", any>(SUPABASE_URL, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
     const { data: app, error: appErr } = await sbSrv
       .from("selection_applications")
       .select("id, applicant_name, role_applied, motivation_letter, leadership_experience, academic_background, proposed_theme, reason_for_applying, certifications, areas_of_interest, ai_analysis, ai_triage_score, ai_triage_reasoning, ai_triage_confidence")
@@ -7666,7 +7674,7 @@ function buildSemanticError(args: { tool: string; semantic_domain: string; code:
   };
 }
 
-function registerSemanticTools(mcp: McpServer, sb: ReturnType<typeof createClient>) {
+function registerSemanticTools(mcp: McpServer, sb: Sb) {
 
   // ── SEMANTIC TOOL 1/3: get_my_context ──────────────────────────────────────
   mcp.tool(
@@ -7809,7 +7817,7 @@ function registerSemanticTools(mcp: McpServer, sb: ReturnType<typeof createClien
       const sources = (params.sources && params.sources.length > 0) ? params.sources : ["hub", "wiki", "knowledge_assets"] as const;
       const limit = Math.min(Math.max(params.limit_per_source ?? 5, 1), 10);
 
-      const tasks: Promise<{ source: string; data: any[]; error: string | null }>[] = [];
+      const tasks: PromiseLike<{ source: string; data: any[]; error: string | null }>[] = [];
       if (sources.includes("hub")) {
         tasks.push(
           sb.rpc("search_hub_resources", { p_query: query, p_asset_type: null, p_limit: limit })

--- a/supabase/functions/ots-stamp/index.ts
+++ b/supabase/functions/ots-stamp/index.ts
@@ -70,7 +70,7 @@ Deno.serve(async (req) => {
     if (typeof body?.limit === "number" && body.limit > 0) limit = Math.min(Math.floor(body.limit), MAX_LIMIT);
   } catch { /* default limit */ }
 
-  const sb = createClient(supabaseUrl, serviceRoleKey);
+  const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey);
 
   try {
     const { data: claimed, error: claimErr } = await sb.rpc("_ots_claim_unstamped_assets", { p_limit: limit });
@@ -94,7 +94,7 @@ Deno.serve(async (req) => {
         failed++;
         const msg = extractError(e);
         // best-effort error mark (status flips to 'error' on the 5th attempt); never throws the whole batch
-        await sb.rpc("_ots_mark_error", { p_asset_id: a.id, p_error: msg.slice(0, 500) }).catch(() => {});
+        await sb.rpc("_ots_mark_error", { p_asset_id: a.id, p_error: msg.slice(0, 500) }).then(() => {}, () => {});
         results.push({ id: a.id, status: "error", error: msg });
       }
     }

--- a/supabase/functions/ots-upgrade/index.ts
+++ b/supabase/functions/ots-upgrade/index.ts
@@ -80,7 +80,7 @@ Deno.serve(async (req) => {
     if (typeof body?.limit === "number" && body.limit > 0) limit = Math.min(Math.floor(body.limit), MAX_LIMIT);
   } catch { /* default */ }
 
-  const sb = createClient(supabaseUrl, serviceRoleKey);
+  const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey);
 
   try {
     const { data: pendingRows, error: listErr } = await sb.rpc("_ots_list_pending", { p_limit: limit });
@@ -121,7 +121,7 @@ Deno.serve(async (req) => {
       } catch (e) {
         errors++;
         const msg = extractError(e);
-        await sb.rpc("_ots_mark_error", { p_asset_id: row.id, p_error: msg.slice(0, 500) }).catch(() => {});
+        await sb.rpc("_ots_mark_error", { p_asset_id: row.id, p_error: msg.slice(0, 500) }).then(() => {}, () => {});
         results.push({ id: row.id, status: "error", error: msg });
       }
     }

--- a/supabase/functions/pmi-ai-analyze-research/index.ts
+++ b/supabase/functions/pmi-ai-analyze-research/index.ts
@@ -160,7 +160,7 @@ Deno.serve(async (req) => {
   const { application_id } = body ?? {};
   if (!application_id) return json({ error: "missing application_id" }, 400);
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const t0 = Date.now();
   let runId: string | null = null;
 

--- a/supabase/functions/pmi-ai-analyze/index.ts
+++ b/supabase/functions/pmi-ai-analyze/index.ts
@@ -181,7 +181,7 @@ Deno.serve(async (req) => {
   const { application_id } = body ?? {};
   if (!application_id) return json({ error: "missing application_id" }, 400);
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const t0 = Date.now();
 
   // Optional triggered_by from caller (give_consent_via_token / request_application_enrichment / cron / admin)

--- a/supabase/functions/pmi-ai-briefing/index.ts
+++ b/supabase/functions/pmi-ai-briefing/index.ts
@@ -202,12 +202,12 @@ Deno.serve(async (req) => {
   let callerMemberId: string | null = null;
   if (!isServiceRole) {
     if (!SUPABASE_ANON_KEY) return json({ error: "anon_key_missing" }, 503);
-    const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    const userClient = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_ANON_KEY, {
       global: { headers: { Authorization: ah } },
     });
     const { data: userData } = await userClient.auth.getUser();
     if (!userData?.user) return json({ error: "unauthorized" }, 401);
-    const sbSrv = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const sbSrv = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
     const { data: memberRow } = await sbSrv.from("members").select("id").eq("auth_id", userData.user.id).maybeSingle();
     if (!memberRow?.id) return json({ error: "member_not_found" }, 403);
     const { data: canRes } = await sbSrv.rpc("can_by_member", {
@@ -224,7 +224,7 @@ Deno.serve(async (req) => {
   const { application_id } = body ?? {};
   if (!application_id) return json({ error: "missing application_id" }, 400);
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const t0 = Date.now();
   let logId: string | null = null;
 

--- a/supabase/functions/pmi-ai-triage/index.ts
+++ b/supabase/functions/pmi-ai-triage/index.ts
@@ -298,12 +298,12 @@ Deno.serve(async (req) => {
   if (!isServiceRole) {
     const SUPABASE_ANON_KEY = Deno.env.get("SUPABASE_ANON_KEY") ?? "";
     if (!SUPABASE_ANON_KEY) return json({ error: "anon_key_missing" }, 503);
-    const userClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    const userClient = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_ANON_KEY, {
       global: { headers: { Authorization: ah } },
     });
     const { data: userData } = await userClient.auth.getUser();
     if (!userData?.user) return json({ error: "unauthorized" }, 401);
-    const sbSrv = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+    const sbSrv = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
     const { data: memberRow } = await sbSrv.from("members").select("id").eq("auth_id", userData.user.id).maybeSingle();
     if (!memberRow?.id) return json({ error: "member_not_found" }, 403);
     const { data: canRes } = await sbSrv.rpc("can_by_member", {
@@ -320,7 +320,7 @@ Deno.serve(async (req) => {
   const { application_id, triggered_by } = body ?? {};
   if (!application_id) return json({ error: "missing application_id" }, 400);
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const t0 = Date.now();
   let logId: string | null = null;
   const triggeredBy = typeof triggered_by === "string" && triggered_by.length > 0

--- a/supabase/functions/pmi-video-finalize-upload/index.ts
+++ b/supabase/functions/pmi-video-finalize-upload/index.ts
@@ -49,7 +49,7 @@ Deno.serve(async (req) => {
   if (!token || !pillar || !drive_file_id) return json({ error: "missing required fields" }, 400);
   if (!Number.isInteger(question_index) || question_index < 1 || question_index > 10) return json({ error: "invalid question_index" }, 400);
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   // RPC enforces: token + scope + source_type='pmi_application' + storage_consistency CHECK
   const { data, error } = await sb.rpc("register_video_screening", {

--- a/supabase/functions/pmi-video-init-upload/index.ts
+++ b/supabase/functions/pmi-video-init-upload/index.ts
@@ -27,7 +27,7 @@
  *     max_size_bytes: number
  *   }
  */
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
 const SUPABASE_SERVICE_ROLE_KEY = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
@@ -51,7 +51,7 @@ const MAX_SIZE_BYTES = 500 * 1024 * 1024; // 500 MB
 
 interface OAuthCreds { client_id: string; client_secret: string; refresh_token: string; }
 
-async function getOAuthCreds(sb: ReturnType<typeof createClient>): Promise<{ available: boolean; creds?: OAuthCreds; error?: string }> {
+async function getOAuthCreds(sb: SupabaseClient<any, "public", any>): Promise<{ available: boolean; creds?: OAuthCreds; error?: string }> {
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error) return { available: false, error: `Vault read error: ${error.message}` };
   if (!data || typeof data !== "string" || data.length === 0) return { available: false, error: `Vault key '${VAULT_KEY}' not seeded` };
@@ -145,7 +145,7 @@ Deno.serve(async (req) => {
     }, 503);
   }
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   // Validate token
   const { data: tokenRow, error: tokErr } = await sb

--- a/supabase/functions/pmi-video-test-transcribe/index.ts
+++ b/supabase/functions/pmi-video-test-transcribe/index.ts
@@ -18,7 +18,7 @@
  *       PM. Worker dedicado (ai-interview-drafter) será criado em phase futura
  *       que sim atualiza o DB.
  */
-import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { isServiceRoleToken } from "../_shared/service-auth.ts";
 
 const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
@@ -31,7 +31,7 @@ const json = (d: unknown, s = 200) =>
 
 interface OAuthCreds { client_id: string; client_secret: string; refresh_token: string; }
 
-async function getDriveAccessToken(sb: ReturnType<typeof createClient>): Promise<string> {
+async function getDriveAccessToken(sb: SupabaseClient<any, "public", any>): Promise<string> {
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error || !data) throw new Error(`Vault read failed: ${error?.message ?? "no data"}`);
   const creds = JSON.parse(data as string) as OAuthCreds;
@@ -94,7 +94,7 @@ async function uploadToGeminiFileAPI(bytes: Uint8Array, mimeType: string, displa
       "X-Goog-Upload-Offset": "0",
       "X-Goog-Upload-Command": "upload, finalize",
     },
-    body: bytes,
+    body: bytes as BodyInit,
   });
   if (!upRes.ok) throw new Error(`Gemini upload bytes: ${upRes.status} ${await upRes.text()}`);
   const uploaded = await upRes.json();
@@ -169,7 +169,7 @@ Deno.serve(async (req) => {
   const { video_screening_id } = body ?? {};
   if (!video_screening_id) return json({ error: "missing video_screening_id" }, 400);
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   const { data: vs, error: vsErr } = await sb
     .from("pmi_video_screenings")

--- a/supabase/functions/posthog-proxy/index.ts
+++ b/supabase/functions/posthog-proxy/index.ts
@@ -30,7 +30,7 @@ function isAllowedQuery(q: string): q is AllowedQuery {
 }
 
 async function verifyAdmin(authHeader: string): Promise<boolean> {
-  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  const supabase = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_ANON_KEY, {
     global: { headers: { Authorization: authHeader } },
   });
   const { data: { user }, error } = await supabase.auth.getUser();

--- a/supabase/functions/publish-instagram/index.ts
+++ b/supabase/functions/publish-instagram/index.ts
@@ -174,7 +174,7 @@ Deno.serve(async (req) => {
     return json({ success: false, error: 'Unauthorized' }, 401)
   }
 
-  const sb = createClient(supabaseUrl, serviceKey!)
+  const sb = createClient<any, "public", any>(supabaseUrl, serviceKey!)
   const payload: PublishPayload = await req.json().catch(() => ({}))
 
   // Load the Instagram channel credential (same row the metrics cron reads).

--- a/supabase/functions/publish-linkedin/index.ts
+++ b/supabase/functions/publish-linkedin/index.ts
@@ -98,7 +98,7 @@ async function uploadImage(orgUrn: string, token: string, imageUrl: string): Pro
   const putRes = await fetch(uploadUrl, {
     method: 'PUT',
     headers: { 'Authorization': `Bearer ${token}` },
-    body: bytes,
+    body: bytes as BodyInit,
   })
   if (!putRes.ok) throw new Error(`image upload PUT ${putRes.status}`)
   return imageUrn
@@ -125,7 +125,7 @@ async function uploadDocument(orgUrn: string, token: string, documentUrl: string
   const putRes = await fetch(uploadUrl, {
     method: 'PUT',
     headers: { 'Authorization': `Bearer ${token}`, 'Content-Type': 'application/pdf' },
-    body: bytes,
+    body: bytes as BodyInit,
   })
   if (!putRes.ok) throw new Error(`document upload PUT ${putRes.status}`)
   return documentUrn
@@ -160,7 +160,7 @@ async function uploadVideo(orgUrn: string, token: string, videoUrl: string): Pro
     const putRes = await fetch(ins.uploadUrl, {
       method: 'PUT',
       headers: { 'Authorization': `Bearer ${token}` },
-      body: part,
+      body: part as BodyInit,
     })
     if (!putRes.ok) throw new Error(`video upload PUT ${putRes.status}`)
     const etag = putRes.headers.get('etag') ?? putRes.headers.get('ETag')
@@ -251,7 +251,7 @@ Deno.serve(async (req) => {
     return json({ success: false, error: 'Unauthorized' }, 401)
   }
 
-  const sb = createClient(supabaseUrl, serviceKey)
+  const sb = createClient<any, "public", any>(supabaseUrl, serviceKey)
   const payload: PublishPayload = await req.json().catch(() => ({}))
 
   // Load the LinkedIn channel credential (same row the metrics cron reads).

--- a/supabase/functions/publish-scheduled/index.ts
+++ b/supabase/functions/publish-scheduled/index.ts
@@ -63,7 +63,7 @@ Deno.serve(async (req) => {
     return json({ success: false, error: 'Unauthorized' }, 401)
   }
 
-  const sb = createClient(supabaseUrl, serviceKey!)
+  const sb = createClient<any, "public", any>(supabaseUrl, serviceKey!)
 
   // 1) reclaim rows stuck in 'publishing' (a prior run died mid-flight) back to pending.
   await sb

--- a/supabase/functions/resend-webhook/index.ts
+++ b/supabase/functions/resend-webhook/index.ts
@@ -30,9 +30,9 @@ Deno.serve(async (req) => {
       return json({ error: 'Missing resend_id or event_type' }, 400)
     }
 
-    const data = (payload.data || {}) as Record<string, unknown>
+    const data = (payload.data || {}) as Record<string, any>
 
-    const sb = createClient(
+    const sb = createClient<any, "public", any>(
       Deno.env.get('SUPABASE_URL') ?? '',
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
     )

--- a/supabase/functions/revoke-drive-permission/index.ts
+++ b/supabase/functions/revoke-drive-permission/index.ts
@@ -27,7 +27,7 @@ const VAULT_KEY = "google_drive_service_account_json";
 const WRITE_SCOPE = "https://www.googleapis.com/auth/drive";
 
 async function getServiceAccountKey(): Promise<{ available: boolean; key?: any; error?: string }> {
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
   const { data, error } = await sb.rpc("_get_vault_secret", { p_name: VAULT_KEY });
   if (error) return { available: false, error: `Vault read error: ${error.message}` };
   if (!data || typeof data !== "string" || data.length === 0) {
@@ -83,7 +83,7 @@ Deno.serve(async (req) => {
   const auditId = body.audit_id?.trim();
   if (!auditId) return new Response(JSON.stringify({ error: "audit_id required" }), { status: 400 });
 
-  const sb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  const sb = createClient<any, "public", any>(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
 
   const { data: row, error: rowErr } = await sb.rpc("get_drive_revocation_row", { p_audit_id: auditId });
   if (rowErr) return new Response(JSON.stringify({ error: "rpc_error", detail: rowErr.message }), { status: 500 });

--- a/supabase/functions/send-account-claim/index.ts
+++ b/supabase/functions/send-account-claim/index.ts
@@ -85,7 +85,7 @@ Deno.serve(async (req) => {
     const token = (body?.token ?? '').toString()
     if (!token || token.length < 16) return json({ error: 'Missing or short token' }, 400)
 
-    const sb = createClient(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
+    const sb = createClient<any, "public", any>(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
 
     const { data: pending, error: pErr } = await sb
       .from('email_verification_pending')

--- a/supabase/functions/send-allocation-notify/index.ts
+++ b/supabase/functions/send-allocation-notify/index.ts
@@ -27,12 +27,12 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    const uc = createClient(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
+    const uc = createClient<any, "public", any>(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
     const ur = await uc.auth.getUser()
     if (ur.error || !ur.data?.user) return json({ error: 'Bad token' }, 401)
     const uid = ur.data.user.id
 
-    const sb = createClient(url, srk)
+    const sb = createClient<any, "public", any>(url, srk)
 
     const cr = await sb.from('members')
       .select('id, operational_role, is_superadmin, name, phone, linkedin_url')

--- a/supabase/functions/send-campaign/index.ts
+++ b/supabase/functions/send-campaign/index.ts
@@ -32,7 +32,7 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    const sb = createClient(url, srk)
+    const sb = createClient<any, "public", any>(url, srk)
     // Service-role gate (#738): exact env-key match, else PostgREST verifies the
     // JWT signature via current_caller_role() (accepts the vault service_role_key
     // pg_net sends, rejects forgeries). A non-service token still falls through to

--- a/supabase/functions/send-email-verification/index.ts
+++ b/supabase/functions/send-email-verification/index.ts
@@ -82,7 +82,7 @@ Deno.serve(async (req) => {
     const token = (body?.token ?? '').toString()
     if (!token || token.length < 16) return json({ error: 'Missing or short token' }, 400)
 
-    const sb = createClient(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
+    const sb = createClient<any, "public", any>(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
 
     // Pull pending row
     const { data: pending, error: pErr } = await sb

--- a/supabase/functions/send-global-onboarding/index.ts
+++ b/supabase/functions/send-global-onboarding/index.ts
@@ -98,7 +98,7 @@ Deno.serve(async (req) => {
 
     if (!rkey) return json({ error: 'No RESEND key' }, 500)
 
-    const sb = createClient(url, srk)
+    const sb = createClient<any, "public", any>(url, srk)
 
     // CLI/automated invocation via dedicated secret in x-cli-secret header
     const cliSecret = req.headers.get('x-cli-secret') ?? ''
@@ -119,7 +119,7 @@ Deno.serve(async (req) => {
       const tk = ah.replace(/^Bearer\s+/i, '').trim()
       if (!tk) return json({ error: 'No token' }, 401)
 
-      const uc = createClient(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
+      const uc = createClient<any, "public", any>(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
       const ur = await uc.auth.getUser()
       if (ur.error || !ur.data?.user) return json({ error: 'Bad token' }, 401)
 

--- a/supabase/functions/send-notification-email/index.ts
+++ b/supabase/functions/send-notification-email/index.ts
@@ -477,7 +477,7 @@ Deno.serve(async (_req) => {
 
     if (!rkey) return new Response(JSON.stringify({ error: 'No RESEND_API_KEY' }), { status: 500 })
 
-    const sb = createClient(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
+    const sb = createClient<any, "public", any>(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
 
     // ADR-0022 W1: filter by delivery_mode = 'transactional_immediate' instead of
     // type IN CRITICAL_TYPES. Catalog drives routing; EF stays type-agnostic.

--- a/supabase/functions/send-tribe-broadcast/index.ts
+++ b/supabase/functions/send-tribe-broadcast/index.ts
@@ -45,12 +45,12 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    const uc = createClient(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
+    const uc = createClient<any, "public", any>(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
     const ur = await uc.auth.getUser()
     if (ur.error || !ur.data?.user) return json({ error: 'Bad token', d: ur.error?.message }, 401)
     const uid = ur.data.user.id
 
-    const sb = createClient(url, srk)
+    const sb = createClient<any, "public", any>(url, srk)
 
     const cr = await sb.from('members')
       .select('id, tribe_id, operational_role, is_superadmin, name, phone, linkedin_url')

--- a/supabase/functions/send-weekly-member-digest/index.ts
+++ b/supabase/functions/send-weekly-member-digest/index.ts
@@ -39,7 +39,7 @@ Deno.serve(async (req) => {
     const srk = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
     if (!url || !srk) return json({ error: 'missing env' }, 500)
 
-    const sb = createClient(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
+    const sb = createClient<any, "public", any>(url, srk, { auth: { autoRefreshToken: false, persistSession: false } })
 
     const { data, error } = await sb.rpc('generate_weekly_member_digest_cron')
     if (error) return json({ error: 'orchestrator_failed', detail: error.message }, 500)

--- a/supabase/functions/sync-artia/index.ts
+++ b/supabase/functions/sync-artia/index.ts
@@ -271,7 +271,7 @@ Deno.serve(async (req) => {
   }
 
   try {
-    const sb = createClient(
+    const sb = createClient<any, "public", any>(
       Deno.env.get('SUPABASE_URL')!,
       Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
     )

--- a/supabase/functions/sync-attendance-points/index.ts
+++ b/supabase/functions/sync-attendance-points/index.ts
@@ -38,7 +38,7 @@ Deno.serve(async (req) => {
 
   const isServiceRole = token === serviceRoleKey
 
-  const sb = createClient(supabaseUrl, serviceRoleKey)
+  const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey)
 
   let callerMemberId: string | null = null
 

--- a/supabase/functions/sync-comms-metrics/index.ts
+++ b/supabase/functions/sync-comms-metrics/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 
 // Retry with exponential backoff for external API calls
@@ -140,7 +140,7 @@ function buildRunKey(input?: string): string {
 
 
 async function logRun(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   payload: {
     run_key: string
     source: string
@@ -616,7 +616,7 @@ function isTokenExpiringSoon(cfg: ChannelConfig): boolean {
 // secrets. No-op for non-LinkedIn channels. Returns the (possibly updated) cfg;
 // on any failure leaves the stored token untouched (downstream flags expiry).
 async function maybeRefreshLinkedInToken(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   cfg: ChannelConfig,
   force = false,
 ): Promise<ChannelConfig> {
@@ -694,7 +694,7 @@ async function maybeRefreshLinkedInToken(
 // ─── Per-channel sync orchestrator ───
 
 async function syncFromChannelConfigs(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   triggeredBy: string,
   dryRun: boolean,
   filterChannels?: string[],
@@ -878,7 +878,7 @@ Deno.serve(async (req) => {
     return unauthorizedResponse()
   }
 
-  const sb = createClient(
+  const sb = createClient<any, "public", any>(
     Deno.env.get('SUPABASE_URL')!,
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
   )

--- a/supabase/functions/sync-credly-all/index.ts
+++ b/supabase/functions/sync-credly-all/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 import { classifyBadge, PMI_TRAIL_KEYWORDS } from '../_shared/classify-badge.ts'
 
@@ -82,7 +82,7 @@ function analyzeBadges(badges: CredlyBadge[]) {
 }
 
 async function upsertCredlyPoints(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   memberId: string,
   badge: { name: string; points: number; issued_at: string; category: string },
 ) {
@@ -127,7 +127,7 @@ async function upsertCredlyPoints(
 }
 
 async function syncTrailProgressFromCredly(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   memberId: string,
   pmiTrail: { code: string; issued_at: string }[],
 ) {
@@ -192,7 +192,7 @@ async function syncTrailProgressFromCredly(
 }
 
 async function processMember(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   member: { id: string; credly_url: string },
 ): Promise<{ success: boolean; member_id: string; error?: string; total_points?: number }> {
   const username = extractUsername(member.credly_url)
@@ -270,7 +270,7 @@ Deno.serve(async (req) => {
     const token = authHeader.replace(/^Bearer\s+/i, '')
     const isServiceRole = token === serviceRoleKey
 
-    const sb = createClient(supabaseUrl, serviceRoleKey)
+    const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey)
 
     // Admin-only: verify caller has tier >= admin (batch operation)
     if (!isServiceRole) {

--- a/supabase/functions/sync-knowledge-insights/index.ts
+++ b/supabase/functions/sync-knowledge-insights/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 
 type SyncPayload = {
@@ -159,7 +159,7 @@ function dedupKey(c: Candidate): string {
 }
 
 async function logRun(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   payload: {
     run_key: string
     status: 'started' | 'success' | 'partial' | 'error'
@@ -195,7 +195,7 @@ Deno.serve(async (req) => {
     return unauthorizedResponse()
   }
 
-  const sb = createClient(
+  const sb = createClient<any, "public", any>(
     Deno.env.get('SUPABASE_URL')!,
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
   )

--- a/supabase/functions/sync-knowledge-social-content/index.ts
+++ b/supabase/functions/sync-knowledge-social-content/index.ts
@@ -44,11 +44,11 @@ Deno.serve(async (req) => {
     const tk = ah.replace(/^Bearer\s+/i, '').trim()
     if (!tk) return json({ error: 'No token' }, 401)
 
-    const uc = createClient(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
+    const uc = createClient<any, "public", any>(url, anon, { global: { headers: { Authorization: 'Bearer ' + tk } } })
     const ur = await uc.auth.getUser()
     if (ur.error || !ur.data?.user) return json({ error: 'Bad token' }, 401)
 
-    const sb = createClient(url, srk)
+    const sb = createClient<any, "public", any>(url, srk)
 
     const cr = await sb.from('members')
       .select('id, is_superadmin, operational_role')

--- a/supabase/functions/sync-knowledge-youtube/index.ts
+++ b/supabase/functions/sync-knowledge-youtube/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 
 type RawKnowledgeRow = Record<string, unknown>
@@ -132,7 +132,7 @@ async function fetchRowsFromEndpoint(): Promise<RawKnowledgeRow[]> {
 }
 
 async function logRun(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   payload: {
     run_key: string
     status: 'started' | 'success' | 'error' | 'partial'
@@ -168,7 +168,7 @@ Deno.serve(async (req) => {
     return unauthorizedResponse()
   }
 
-  const sb = createClient(
+  const sb = createClient<any, "public", any>(
     Deno.env.get('SUPABASE_URL')!,
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,
   )

--- a/supabase/functions/sync-wiki/index.ts
+++ b/supabase/functions/sync-wiki/index.ts
@@ -113,7 +113,7 @@ Deno.serve(async (req) => {
   if (event === 'ping') return json({ ok: true, message: 'pong' })
   if (event !== 'push') return json({ error: `Unsupported event: ${event}` }, 400)
 
-  let payload: Record<string, unknown>
+  let payload: Record<string, any>
   try {
     payload = JSON.parse(rawBody)
   } catch {
@@ -153,7 +153,7 @@ Deno.serve(async (req) => {
   const ghToken = Deno.env.get('GITHUB_TOKEN')
   if (!ghToken) return json({ error: 'GITHUB_TOKEN not configured' }, 500)
 
-  const sb = createClient(
+  const sb = createClient<any, "public", any>(
     Deno.env.get('SUPABASE_URL') ?? '',
     Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? ''
   )

--- a/supabase/functions/upload-member-asset/index.ts
+++ b/supabase/functions/upload-member-asset/index.ts
@@ -47,7 +47,7 @@ Deno.serve(async (req) => {
   if (!authHeader.startsWith("Bearer ")) return json({ error: "missing bearer token" }, 401);
 
   // 1) authenticate the caller (their own JWT)
-  const userClient = createClient(SUPABASE_URL, ANON, {
+  const userClient = createClient<any, "public", any>(SUPABASE_URL, ANON, {
     global: { headers: { Authorization: authHeader } },
     auth: { persistSession: false, autoRefreshToken: false },
   });
@@ -70,7 +70,7 @@ Deno.serve(async (req) => {
   if (!cfg.mimes.includes(file.type)) return json({ error: "unsupported type", got: file.type, allowed: cfg.mimes }, 415);
 
   // 3) resolve the caller's OWN member record (service role) — path is always the caller's
-  const admin = createClient(SUPABASE_URL, SERVICE_ROLE, { auth: { persistSession: false, autoRefreshToken: false } });
+  const admin = createClient<any, "public", any>(SUPABASE_URL, SERVICE_ROLE, { auth: { persistSession: false, autoRefreshToken: false } });
   const { data: member, error: mErr } = await admin
     .from("members").select("id,email").eq("auth_id", user.id).maybeSingle();
   if (mErr) return json({ error: "member lookup failed", detail: mErr.message }, 500);

--- a/supabase/functions/verify-credly/index.ts
+++ b/supabase/functions/verify-credly/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { classifyBadge, PMI_TRAIL_KEYWORDS } from '../_shared/classify-badge.ts'
 
 // Retry with exponential backoff for external API calls
@@ -64,7 +64,7 @@ async function fetchBadges(username: string): Promise<CredlyBadge[]> {
 }
 
 async function upsertCredlyPoints(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   memberId: string,
   badge: { name: string; points: number; issued_at: string; category: string },
 ) {
@@ -109,7 +109,7 @@ async function upsertCredlyPoints(
 }
 
 async function syncTrailProgressFromCredly(
-  sb: ReturnType<typeof createClient>,
+  sb: SupabaseClient<any, "public", any>,
   memberId: string,
   pmiTrail: { code: string; issued_at: string }[],
 ) {
@@ -216,7 +216,7 @@ Deno.serve(async (req) => {
 
   try {
     const { member_id, credly_url } = await req.json()
-    const sb = createClient(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+    const sb = createClient<any, "public", any>(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
 
     // Resolve username
     let username: string | null = credly_url ? extractUsername(credly_url) : null


### PR DESCRIPTION
## O que muda

Step-2 do #1106. **Root-cause dos ~1836 "erros de tipo" medidos no step-1:** não são sintoma do monolito de 8.2k linhas — são do **cliente Supabase destipado** (`createClient` sem generic `Database` → `rpc()` resolve `data: never` e args `undefined`). Modularizar `registerTools()` **não altera essa contagem** (é ganho só organizacional).

O fix real (só-tipo, inerte em runtime):
- Tipar todo cliente EF como `createClient<any,"public",any>` / `SupabaseClient<any,"public",any>` — **59 call sites + 16 anotações `ReturnType<typeof createClient>` em 46 arquivos**.
- 5 residuais no nucleo-mcp (2 handlers com `params` sem tipo, 1 array `PromiseLike`).
- 10 residuais genuínos nas demais EFs: 6 casts `Uint8Array→BodyInit/BlobPart` (generic de lib do Deno), 2 `.catch()→.then(ok,err)` em thenables do Postgrest (também corrige um `.catch`-is-not-a-function latente; alinha com a convenção "no .catch on rpc" do próprio repo), 2 payloads de webhook `Record<string,any>`.

## Resultado (medido, deno 2.9.1 local)

| | antes | depois |
|---|---|---|
| `deno check "supabase/functions/**/*.ts"` | ~1836 (nucleo-mcp) / 79 (glob) | **0** ✅ |
| `deno lint` (excl. no-explicit-any, no-import-prefix) | limpo | limpo ✅ |

**`deno check` agora é BLOCKING** em `deno-ef-check.yml` (era report-only). Sem tool add/remove (336). Sem mudança de comportamento em runtime.

## Verificação
- `deno check` 0 + `deno lint` limpo (local deno 2.9.1)
- `npx astro build` exit 0
- `npm test` (offline): 4578 pass / 0 fail / 444 skip (DB-aware)
- Guards MCP (nomes duplicados, Zod 3→4) limpos

## Adiado (documentado em #1106)
- **Modularização do `registerTools()`**: não afeta a contagem de erros (organizacional). Fica como item de manutenibilidade separado.
- **De-dup do `generate_interview_briefing`**: as duas implementações (inline vs EF `pmi-ai-briefing`) **divergiram** — a inline tem mais campos no user-prompt e não persiste; a EF persiste + tem retry. Unificá-las **altera o comportamento do prompt de IA** numa superfície de seleção ativa → precisa de decisão de prompt canônico própria, não um bundle numa PR de tipagem inerte.

Closes parte do #1106 (item verificação-net + gate blocking).

🤖 Assisted by Claude (Anthropic)