### PR TITLE
feat(tribe): #1139 — jornada de tribo pré-kickoff (empty-state de inelegibilidade + fila do líder)

### DIFF
--- a/src/components/tribe/TribeRequestBlock.tsx
+++ b/src/components/tribe/TribeRequestBlock.tsx
@@ -41,6 +41,9 @@ interface PendingRequest {
 }
 interface Context {
   eligible: boolean;
+  // #1139: when eligible=false, the server names WHY so we render an explicit empty-state (never blank).
+  ineligible_reason?: 'no_member' | 'inactive' | 'has_tribe' | 'pending_term' | 'ineligible' | null;
+  current_tribe_title?: string | null;
   pending: PendingRequest | null;
   tribes: TribeOption[];
 }
@@ -63,6 +66,12 @@ interface Copy {
   pendingYourMessage: string;
   emptyTitle: string;
   emptyBody: string;
+  // #1139 ineligibility empty-states
+  termTitle: string;
+  termBody: string;
+  termCta: string;
+  hasTribeTitle: string;
+  hasTribeBody: (title: string | null) => string;
   toastSent: string;
   toastError: string;
 }
@@ -86,6 +95,13 @@ const COPY: Record<string, Copy> = {
     pendingYourMessage: 'Sua mensagem',
     emptyTitle: 'Nenhuma tribo disponível',
     emptyBody: 'Não há tribos abertas para ingresso no momento. Fale com a coordenação do Núcleo.',
+    termTitle: 'Assine seu termo de voluntário',
+    termBody: 'Para escolher uma tribo de pesquisa, você precisa primeiro assinar o Termo de Adesão ao Serviço Voluntário. Assim que ele estiver assinado, a escolha de tribo aparece aqui.',
+    termCta: 'Assinar termo de voluntário',
+    hasTribeTitle: 'Você já participa de uma tribo',
+    hasTribeBody: (title) => title
+      ? `Você já faz parte da tribo ${title}. Para trocar de tribo, fale com a coordenação do Núcleo.`
+      : 'Você já participa de uma tribo de pesquisa. Para trocar de tribo, fale com a coordenação do Núcleo.',
     toastSent: 'Pedido enviado! O líder da tribo vai revisar.',
     toastError: 'Não foi possível enviar. Tente novamente.',
   },
@@ -107,6 +123,13 @@ const COPY: Record<string, Copy> = {
     pendingYourMessage: 'Your message',
     emptyTitle: 'No tribes available',
     emptyBody: 'There are no tribes open to join right now. Contact the Núcleo coordination.',
+    termTitle: 'Sign your volunteer term',
+    termBody: 'To choose a research tribe, you first need to sign the Volunteer Service Agreement. Once it is signed, tribe selection will appear here.',
+    termCta: 'Sign volunteer term',
+    hasTribeTitle: 'You are already in a tribe',
+    hasTribeBody: (title) => title
+      ? `You are already part of the ${title} tribe. To switch tribes, contact the Núcleo coordination.`
+      : 'You are already part of a research tribe. To switch tribes, contact the Núcleo coordination.',
     toastSent: 'Request sent! The tribe leader will review it.',
     toastError: 'Could not send. Please try again.',
   },
@@ -128,6 +151,13 @@ const COPY: Record<string, Copy> = {
     pendingYourMessage: 'Tu mensaje',
     emptyTitle: 'No hay tribus disponibles',
     emptyBody: 'No hay tribus abiertas para unirse en este momento. Contacta a la coordinación del Núcleo.',
+    termTitle: 'Firma tu término de voluntariado',
+    termBody: 'Para elegir una tribu de investigación, primero debes firmar el Término de Adhesión al Servicio Voluntario. Una vez firmado, la elección de tribu aparecerá aquí.',
+    termCta: 'Firmar término de voluntariado',
+    hasTribeTitle: 'Ya participas en una tribu',
+    hasTribeBody: (title) => title
+      ? `Ya formas parte de la tribu ${title}. Para cambiar de tribu, contacta a la coordinación del Núcleo.`
+      : 'Ya participas en una tribu de investigación. Para cambiar de tribu, contacta a la coordinación del Núcleo.',
     toastSent: '¡Solicitud enviada! El líder de la tribu la revisará.',
     toastError: 'No se pudo enviar. Inténtalo de nuevo.',
   },
@@ -218,8 +248,39 @@ export default function TribeRequestBlock({ lang = 'pt-BR' }: Props) {
     );
   }
 
-  // Not eligible (has a tribe, guest, not termed, …) — render nothing.
-  if (!ctx.eligible) return null;
+  // Not eligible — render an explicit empty-state naming the reason + next step, never a blank block.
+  // #1139: the dominant case at the C4 kickoff is `pending_term` (37 researchers without a signed term).
+  if (!ctx.eligible) {
+    if (ctx.ineligible_reason === 'pending_term') {
+      const langPrefix = (typeof window !== 'undefined' && (window as any).__LANG_PREFIX) || '';
+      return (
+        <section role="region" aria-label={copy.ariaLabel} className="mb-6">
+          <div className="rounded-2xl border border-amber-300/60 bg-amber-50 dark:bg-amber-950/20 p-5">
+            <h2 className="text-base font-extrabold text-navy dark:text-amber-200">{copy.termTitle}</h2>
+            <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{copy.termBody}</p>
+            <a
+              href={`${langPrefix}/volunteer-agreement`}
+              className="mt-3 inline-flex items-center min-h-[44px] px-4 rounded-lg bg-navy text-white text-sm font-bold no-underline hover:opacity-90"
+            >
+              {copy.termCta}
+            </a>
+          </div>
+        </section>
+      );
+    }
+    if (ctx.ineligible_reason === 'has_tribe') {
+      return (
+        <section role="region" aria-label={copy.ariaLabel} className="mb-6">
+          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)] p-5">
+            <h2 className="text-base font-extrabold text-navy dark:text-teal">{copy.hasTribeTitle}</h2>
+            <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{copy.hasTribeBody(ctx.current_tribe_title || null)}</p>
+          </div>
+        </section>
+      );
+    }
+    // inactive / no_member / unknown — the member is not expecting a picker; stay quiet (no noise).
+    return null;
+  }
 
   // Eligible but zero selectable tribes = platform-config gap, not a normal state: don't go blank.
   if (!ctx.tribes || ctx.tribes.length === 0) {

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -551,6 +551,7 @@ const enUS: Record<string, string> = {
   'buddy.pool.offered': 'Offer sent',
   // Tribe Selection Híbrida PR3 — leader's join-request queue
   'tribe.requests.title': 'Join requests',
+  'tribe.requests.pendingBadge': '{n} pending join request(s)',
   'tribe.requests.subtitle': 'Researchers asking to join this tribe.',
   'tribe.requests.accept': 'Accept',
   'tribe.requests.decline': 'Decline',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -551,6 +551,7 @@ const esLATAM: Record<string, string> = {
   'buddy.pool.offered': 'Oferta enviada',
   // Tribe Selection Híbrida PR3 — leader's join-request queue
   'tribe.requests.title': 'Solicitudes de ingreso',
+  'tribe.requests.pendingBadge': '{n} solicitud(es) de ingreso pendiente(s)',
   'tribe.requests.subtitle': 'Investigadores que piden entrar en esta tribu.',
   'tribe.requests.accept': 'Aceptar',
   'tribe.requests.decline': 'Rechazar',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -551,6 +551,7 @@ const ptBR: Record<string, string> = {
   'buddy.pool.offered': 'Oferta enviada',
   // Tribe Selection Híbrida PR3 — leader's join-request queue
   'tribe.requests.title': 'Pedidos de entrada',
+  'tribe.requests.pendingBadge': '{n} pedido(s) de entrada pendente(s)',
   'tribe.requests.subtitle': 'Pesquisadores pedindo para entrar nesta tribo.',
   'tribe.requests.accept': 'Aceitar',
   'tribe.requests.decline': 'Recusar',

--- a/src/pages/tribe/[id].astro
+++ b/src/pages/tribe/[id].astro
@@ -122,6 +122,7 @@ const TRIBE_I18N = {
   reqDeclineConfirm: t('tribe.requests.declineConfirm', lang),
   reqCancel: t('tribe.requests.cancel', lang),
   reqProcessing: t('tribe.requests.processing', lang),
+  reqPendingBadge: t('tribe.requests.pendingBadge', lang),
   lgpdMask: t('tribe.lgpdMask', lang),
   lgpdTooltip: t('tribe.lgpdTooltip', lang),
   broadcastTab: t('tribe.broadcastTab', lang),
@@ -246,7 +247,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
       <button class="tribe-tab px-4 py-2 rounded-full text-[13px] font-semibold cursor-pointer border-2 border-[var(--border-default)] bg-[var(--surface-card)] text-[var(--text-secondary)] transition-all"
               data-tab="board" data-action="switch-tab">{TRIBE_I18N.boardTab}</button>
       <button class="tribe-tab px-4 py-2 rounded-full text-[13px] font-semibold cursor-pointer border-2 border-[var(--border-default)] bg-[var(--surface-card)] text-[var(--text-secondary)] transition-all"
-              data-tab="members" data-action="switch-tab">{t('tribe.membersTab', lang)}</button>
+              data-tab="members" data-action="switch-tab">{t('tribe.membersTab', lang)}<span id="members-req-badge" role="status" class="hidden ml-1.5 inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-amber-500 text-white text-[10px] font-bold align-middle"></span></button>
       <button class="tribe-tab px-4 py-2 rounded-full text-[13px] font-semibold cursor-pointer border-2 border-[var(--border-default)] bg-[var(--surface-card)] text-[var(--text-secondary)] transition-all"
               data-tab="gamification" data-action="switch-tab">🏆 {t('tribe.gamificationTab', lang)}</button>
       <button class="tribe-tab px-4 py-2 rounded-full text-[13px] font-semibold cursor-pointer border-2 border-[var(--border-default)] bg-[var(--surface-card)] text-[var(--text-secondary)] transition-all"
@@ -1136,6 +1137,23 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
   // Leader/GP-only section atop the Members tab. The server RPC enforces the real authority
   // (Caminho-3: GP or volunteer/leader of THIS tribe); isLeaderOfThisTribeV4() is the display gate.
   // Returns '' for non-leaders, RPC errors, or an empty queue (so the section never shows blank).
+  // #1139 Item 2: mirror the leader's pending-request count onto the Membros tab, so it is visible
+  // from any tab (the queue itself only renders inside the Membros panel). Called on load (via
+  // tribeRequestsSectionHtml during renderMembers) and after each review.
+  function syncMembersReqBadge(count: number) {
+    const badge = document.getElementById('members-req-badge');
+    if (!badge) return;
+    if (count > 0) {
+      badge.textContent = String(count);
+      badge.setAttribute('aria-label', (I18N.reqPendingBadge || '{n}').replace('{n}', String(count)));
+      badge.classList.remove('hidden');
+    } else {
+      badge.classList.add('hidden');
+      badge.removeAttribute('aria-label');
+      badge.textContent = '';
+    }
+  }
+
   async function tribeRequestsSectionHtml(): Promise<string> {
     if (!isLeaderOfThisTribeV4()) return '';
     const sb = getSb();
@@ -1146,6 +1164,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
       if (error) return '';
       rows = Array.isArray(data) ? data : [];
     } catch (_) { return ''; }
+    syncMembersReqBadge(rows.length);
     if (rows.length === 0) return '';
     const relDate = (iso: string): string => {
       try {
@@ -1225,6 +1244,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
       const willEmpty = list ? list.children.length <= 1 : true;
       const nextBtn = (card.nextElementSibling as HTMLElement | null)?.querySelector('button') as HTMLElement | null;
       card.remove();
+      syncMembersReqBadge(list ? list.children.length : 0); // keep the Membros-tab badge in sync
       const section = document.getElementById('tribe-requests-section');
       if (willEmpty) {
         section?.remove(); // toast's own live region announces the result

--- a/supabase/migrations/20260805000347_1139_tribe_journey_hardening.sql
+++ b/supabase/migrations/20260805000347_1139_tribe_journey_hardening.sql
@@ -1,0 +1,235 @@
+-- #1139 — Tribe-journey UX hardening (pre-kickoff, DIA 9 2026-07-09).
+-- The hybrid tribe flow (request_tribe_assignment / review_tribe_request, mig 20260805000216)
+-- works end-to-end; the UX around it does not. Two DB-side gaps this migration closes:
+--
+--   Item 1 (HIGH): get_my_tribe_request_context() folds every ineligibility cause into ONE
+--     `eligible` boolean, so the FE (TribeRequestBlock) can only `return null` → a BLANK block.
+--     At the C4 kickoff, ~37 researchers without a signed volunteer term hit exactly this blank
+--     ("parece quebrado"). We surface `ineligible_reason` (+ `current_tribe_title` for the has_tribe
+--     case) so the FE can render an explicit empty-state with the reason + next step. Purely additive:
+--     existing keys (eligible/pending/tribes) are unchanged, so current callers are unaffected.
+--
+--   Item 2 (MEDIUM): request_tribe_assignment() notifies the tribe leader with a bare `/tribe/N`
+--     link, which lands on the default General tab — the pending-request queue only renders on the
+--     Membros tab, so the leader "doesn't see it". Deep-link the notification to `/tribe/N?tab=members`
+--     (the tab router already reads ?tab=). Body text (human-readable) left as `/tribe/N`.
+--
+-- Both functions are CREATE OR REPLACE (same signatures). Live prosrc verified byte-identical to the
+-- 20260805000216/217 capture before reproduction (no drift). Reason order mirrors
+-- request_tribe_assignment's own guard sequence (inactive → has-tribe → term) for parity.
+--
+-- ROLLBACK: re-apply the bodies from 20260805000216 (request_tribe_assignment) and
+--           20260805000217 (get_my_tribe_request_context); NOTIFY pgrst, 'reload schema';
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 1. get_my_tribe_request_context — now reports WHY when ineligible (Item 1).
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.get_my_tribe_request_context()
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp' AS $function$
+DECLARE
+  v_member_id uuid;
+  v_person_id uuid;
+  v_member_status text;
+  v_is_active boolean;
+  v_tribe_id integer;
+  v_has_tribe_engagement boolean;
+  v_eligible boolean;
+  v_reason text;
+  v_current_tribe_title text;
+  v_pending jsonb;
+  v_tribes jsonb;
+BEGIN
+  SELECT m.id, m.person_id, m.member_status, m.is_active, m.tribe_id
+    INTO v_member_id, v_person_id, v_member_status, v_is_active, v_tribe_id
+    FROM public.members m WHERE m.auth_id = auth.uid();
+
+  IF v_member_id IS NULL THEN
+    RETURN jsonb_build_object('eligible', false, 'ineligible_reason', 'no_member', 'current_tribe_title', NULL, 'pending', NULL, 'tribes', '[]'::jsonb);
+  END IF;
+
+  -- caller's pending research_tribe self-request (invitee == me), if any
+  SELECT to_jsonb(p) INTO v_pending FROM (
+    SELECT i.legacy_tribe_id AS tribe_id, i.title, ii.message, ii.created_at, ii.expires_at
+    FROM public.initiative_invitations ii
+    JOIN public.initiatives i ON i.id = ii.initiative_id AND i.kind = 'research_tribe'
+    WHERE ii.invitee_member_id = v_member_id AND ii.status = 'pending'
+    ORDER BY ii.created_at DESC
+    LIMIT 1
+  ) p;
+
+  -- already in a tribe via an active engagement?
+  v_has_tribe_engagement := EXISTS (
+    SELECT 1 FROM public.engagements e
+    JOIN public.initiatives i ON i.id = e.initiative_id AND i.kind = 'research_tribe'
+    WHERE e.person_id = v_person_id AND e.kind = 'volunteer' AND e.status = 'active'
+  );
+
+  -- eligible to self-request: active, termed (not pre-onboarding), no tribe yet (mirrors request_tribe_assignment)
+  v_eligible := v_is_active IS TRUE
+    AND v_tribe_id IS NULL
+    AND NOT v_has_tribe_engagement
+    AND v_person_id IS NOT NULL
+    AND NOT public.member_is_pre_onboarding(v_person_id, v_member_status);
+
+  -- #1139 Item 1: surface WHY when ineligible so the FE renders an explicit empty-state instead of a
+  -- blank block. Priority mirrors request_tribe_assignment's guard sequence: inactive → has-tribe → term.
+  IF v_eligible THEN
+    v_reason := NULL;
+  ELSIF v_person_id IS NULL THEN
+    v_reason := 'no_member';
+  ELSIF v_is_active IS DISTINCT FROM true THEN
+    v_reason := 'inactive';
+  ELSIF v_tribe_id IS NOT NULL OR v_has_tribe_engagement THEN
+    v_reason := 'has_tribe';
+  ELSIF public.member_is_pre_onboarding(v_person_id, v_member_status) THEN
+    v_reason := 'pending_term';
+  ELSE
+    v_reason := 'ineligible';
+  END IF;
+
+  -- the current tribe title (only meaningful for the has_tribe empty-state)
+  IF v_reason = 'has_tribe' THEN
+    SELECT i.title INTO v_current_tribe_title
+    FROM public.initiatives i
+    WHERE i.kind = 'research_tribe'
+      AND (
+        i.legacy_tribe_id = v_tribe_id
+        OR EXISTS (
+          SELECT 1 FROM public.engagements e
+          WHERE e.initiative_id = i.id AND e.person_id = v_person_id
+            AND e.kind = 'volunteer' AND e.status = 'active'
+        )
+      )
+    ORDER BY (i.legacy_tribe_id = v_tribe_id) DESC NULLS LAST
+    LIMIT 1;
+  END IF;
+
+  -- selectable active research_tribe tribes (single source of truth = initiatives, not static data)
+  SELECT coalesce(
+    jsonb_agg(jsonb_build_object('tribe_id', i.legacy_tribe_id, 'title', i.title) ORDER BY i.legacy_tribe_id),
+    '[]'::jsonb
+  ) INTO v_tribes
+  FROM public.initiatives i
+  WHERE i.kind = 'research_tribe' AND i.status = 'active' AND i.legacy_tribe_id IS NOT NULL;
+
+  RETURN jsonb_build_object(
+    'eligible', v_eligible,
+    'ineligible_reason', v_reason,
+    'current_tribe_title', v_current_tribe_title,
+    'pending', v_pending,
+    'tribes', v_tribes
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.get_my_tribe_request_context() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_my_tribe_request_context() TO authenticated;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- 2. request_tribe_assignment — leader notification deep-links to the Membros tab (Item 2).
+--    Body reproduced verbatim from 20260805000216 (live prosrc byte-verified); ONLY the notification
+--    `link` column changes: '/tribe/N' → '/tribe/N?tab=members'.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.request_tribe_assignment(p_tribe_id integer, p_message text)
+RETURNS jsonb
+LANGUAGE plpgsql SECURITY DEFINER SET search_path TO 'public', 'pg_temp' AS $function$
+DECLARE
+  v_member_id uuid;
+  v_person_id uuid;
+  v_member_status text;
+  v_is_active boolean;
+  v_initiative record;
+  v_invitation_id uuid;
+BEGIN
+  SELECT m.id, m.person_id, m.member_status, m.is_active
+    INTO v_member_id, v_person_id, v_member_status, v_is_active
+    FROM public.members m WHERE m.auth_id = auth.uid();
+
+  IF v_member_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+  IF v_is_active IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'Membro inativo' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF length(coalesce(p_message, '')) < 50 THEN
+    RAISE EXCEPTION 'A mensagem deve ter ao menos 50 caracteres descrevendo sua motivação (atual: %)', length(coalesce(p_message, ''))
+      USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- WS-A3 parity with select_tribe: tribe entry requires the signed volunteer term.
+  -- Fail closed if no person row (member_is_pre_onboarding(NULL,...) would return false).
+  IF v_person_id IS NULL OR public.member_is_pre_onboarding(v_person_id, v_member_status) THEN
+    RAISE EXCEPTION 'Assine o termo de voluntário antes de pedir uma tribo'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT * INTO v_initiative
+  FROM public.initiatives
+  WHERE legacy_tribe_id = p_tribe_id AND kind = 'research_tribe';
+
+  IF v_initiative.id IS NULL THEN
+    RAISE EXCEPTION 'Tribo não encontrada' USING ERRCODE = 'no_data_found';
+  END IF;
+  IF v_initiative.status <> 'active' THEN
+    RAISE EXCEPTION 'Esta tribo não está ativa' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- block if already in ANY tribe (self-service is "join your first tribe"; moves are GP-mediated
+  -- via admin force-move). This keeps the AH single-active-engagement invariant intact on approval.
+  IF EXISTS (
+    SELECT 1 FROM public.engagements e
+    JOIN public.initiatives i3 ON i3.id = e.initiative_id AND i3.kind = 'research_tribe'
+    WHERE e.person_id = v_person_id
+      AND e.kind = 'volunteer'
+      AND e.status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'Você já participa de uma tribo' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  -- one pending tribe request at a time (across all research_tribe initiatives)
+  IF EXISTS (
+    SELECT 1
+    FROM public.initiative_invitations ii
+    JOIN public.initiatives i2 ON i2.id = ii.initiative_id AND i2.kind = 'research_tribe'
+    WHERE ii.invitee_member_id = v_member_id
+      AND ii.status = 'pending'
+  ) THEN
+    RAISE EXCEPTION 'Você já tem um pedido de tribo pendente' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  INSERT INTO public.initiative_invitations
+    (initiative_id, invitee_member_id, inviter_member_id, kind_scope, message)
+  VALUES
+    (v_initiative.id, v_member_id, v_member_id, 'volunteer', p_message)
+  RETURNING id INTO v_invitation_id;
+
+  -- notify the tribe leader(s) — no PII in the body (LGPD minimisation).
+  -- #1139 Item 2: link deep-links to the Membros tab (where the approval queue renders).
+  INSERT INTO public.notifications
+    (recipient_id, type, title, body, link, source_type, source_id, actor_id, delivery_mode)
+  SELECT m2.id, 'tribe_request',
+         'Novo pedido de entrada na tribo',
+         'Um pesquisador pediu para entrar na tribo ' || v_initiative.title || '. Revise em /tribe/' || p_tribe_id::text || '.',
+         '/tribe/' || p_tribe_id::text || '?tab=members',
+         'initiative_invitation', v_invitation_id, v_member_id, 'transactional_immediate'
+  FROM public.engagements e
+  JOIN public.members m2 ON m2.person_id = e.person_id
+  WHERE e.initiative_id = v_initiative.id
+    AND e.kind = 'volunteer' AND e.role = 'leader' AND e.status = 'active';
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'invitation_id', v_invitation_id,
+    'tribe_id', p_tribe_id,
+    'initiative_id', v_initiative.id,
+    'expires_at', (now() + interval '72 hours'),
+    'note', 'O líder da tribo vai revisar seu pedido. Acompanhe por list_my_initiative_invitations.'
+  );
+END;
+$function$;
+REVOKE ALL ON FUNCTION public.request_tribe_assignment(integer, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.request_tribe_assignment(integer, text) TO authenticated;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/tribe-selection-hybrid-pr2-fe.test.mjs
+++ b/tests/contracts/tribe-selection-hybrid-pr2-fe.test.mjs
@@ -111,3 +111,45 @@ test('DB: get_my_tribe_request_context returns { eligible, pending, tribes }', {
     assert.ok(typeof t.tribe_id === 'number' && typeof t.title === 'string', 'tribe option shape');
   }
 });
+
+// ── (D) #1139: ineligibility empty-states (reason + next step, never a blank block) ──
+const MIG_1139 = read('supabase/migrations/20260805000347_1139_tribe_journey_hardening.sql');
+const TRIBE_PAGE = read('src/pages/tribe/[id].astro');
+
+test('#1139 migration: get_my_tribe_request_context surfaces ineligible_reason + current_tribe_title', () => {
+  assert.ok(MIG_1139, 'mig 347 exists');
+  assert.match(MIG_1139, /'ineligible_reason'/);
+  assert.match(MIG_1139, /'current_tribe_title'/);
+  assert.match(MIG_1139, /'pending_term'/); // the dominant kickoff case (unsigned volunteer term)
+  assert.match(MIG_1139, /member_is_pre_onboarding/);
+});
+
+test('#1139 migration: request_tribe_assignment deep-links the leader notification to the Membros tab', () => {
+  assert.match(MIG_1139, /'\/tribe\/' \|\| p_tribe_id::text \|\| '\?tab=members'/);
+});
+
+test('#1139 FE: TribeRequestBlock renders pending_term + has_tribe empty-states with a sign-term CTA', () => {
+  assert.match(BLOCK, /ineligible_reason === 'pending_term'/);
+  assert.match(BLOCK, /\/volunteer-agreement/); // actionable next step for the unsigned-term cohort
+  assert.match(BLOCK, /ineligible_reason === 'has_tribe'/);
+});
+
+test('#1139 FE: Membros-tab pending-request badge + sync helper live on the tribe page', () => {
+  assert.match(TRIBE_PAGE, /members-req-badge/);
+  assert.match(TRIBE_PAGE, /function syncMembersReqBadge/);
+  assert.match(TRIBE_PAGE, /tribe\.requests\.pendingBadge/);
+});
+
+test('#1139 i18n: tribe.requests.pendingBadge exists in all 3 dictionaries', () => {
+  for (const f of ['pt-BR', 'en-US', 'es-LATAM']) {
+    assert.match(read(`src/i18n/${f}.ts`), /'tribe\.requests\.pendingBadge'/, `${f} has pendingBadge`);
+  }
+});
+
+test('DB: get_my_tribe_request_context now includes ineligible_reason (no_member for service_role)', { skip: !dbGated && skipMsg }, async () => {
+  const supa = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+  const { data, error } = await supa.rpc('get_my_tribe_request_context');
+  assert.equal(error, null, error ? `rpc failed: ${error.message}` : '');
+  assert.ok('ineligible_reason' in data && 'current_tribe_title' in data, 'has the new reason keys');
+  assert.equal(data.ineligible_reason, 'no_member', 'service_role (no member) -> no_member reason');
+});


### PR DESCRIPTION
Fecha a lacuna de UX da jornada de tribo antes do **kickoff C4 (quinta 2026-07-09)**. O fluxo híbrido (PRs #793/#794/#795) funciona ponta-a-ponta; a UX ao redor não. Termo de voluntário está bloqueado (jurídico) — esta issue é **independente do termo** e evita o "parece quebrado" enquanto o termo não chega.

## Item 1 (HIGH) — empty-state de inelegibilidade
`get_my_tribe_request_context()` antes colapsava todo motivo em um `eligible` boolean → `TribeRequestBlock` só podia `return null` → **bloco em branco**. No kickoff, **37 pesquisadores C4 sem termo assinado** batem exatamente nisso.

Agora a RPC devolve `ineligible_reason` (+ `current_tribe_title`) e o componente renderiza um empty-state explícito:
- **`pending_term`** → *"Assine seu termo de voluntário"* + CTA para `/volunteer-agreement` ← os 37
- **`has_tribe`** → *"Você já participa da tribo X"*
- `inactive` / `no_member` → nada (não esperam o picker; sem ruído)

## Item 2 (MEDIUM) — fila do líder na aba certa
- Notificação do líder deep-linka para `/tribe/N?tab=members` (a fila de aprovação só renderiza na aba **Membros**; o default é **Geral** → "líder não vê o pedido").
- **Badge** com contagem de pedidos pendentes no botão da aba Membros, visível de qualquer aba (com `aria-label` localizado).

## Grounding (queries ao vivo nesta sessão)
Motor de motivo sobre os membros ativos reais: **37 `pending_term` · 35 `has_tribe` · 16 `eligible` · 1 `no_member`**. Os 37 batem com a fila pendente-de-termo (37 researchers).

## Mudanças
- **Mig `20260805000347`** — `CREATE OR REPLACE` das 2 RPCs (body byte-verificado vs 216/217, sem drift; aplicada em prod + repair + phantom tracking-row removida).
- `TribeRequestBlock.tsx` — empty-states + copy 3 locales (in-component `COPY`, padrão do componente).
- `tribe/[id].astro` — badge + `syncMembersReqBadge()`.
- i18n `tribe.requests.pendingBadge` nos 3 dicionários.
- Contract test `pr2-fe` estendido (+6 casos #1139).

## Verificação
- `npx astro build` ✓ · `npm test` **5055 pass / 0 fail / 38 skip** ✓
- `check_schema_invariants()` = **0** (AG/AH intactos — mudança é read/notify, sem mutação)
- Correção do motor de motivo provada sobre a coorte real (acima) + shape DB (`ineligible_reason='no_member'` p/ service_role).
- ⚠️ **QA visual do empty-state `pending_term`**: não impersonável sem sessão de um membro pending_term + FE ainda não deployado. Provado por dados+contract+markup-reuse; recomendo um olhar humano no preview/pós-merge com uma conta pending_term antes de quinta.

Refs #1139