### PR TITLE
#1130 — Reconciliação VEP↔plataforma por papel×coorte + correção causa-raiz do bucket B

### DIFF
--- a/docs/audit/VEP_BUCKET_B_ROOT_CAUSE_1130.md
+++ b/docs/audit/VEP_BUCKET_B_ROOT_CAUSE_1130.md
@@ -1,0 +1,94 @@
+# #1130 — Causa-raiz do "bucket B" (62) e reconciliação VEP↔plataforma
+
+> Grounding: todas as contagens abaixo vieram de queries ao vivo em 2026-07-07 (projeto
+> `ldrfrvwhxsmgaabwmaik`) + CSV oficial PMI `pmi_volunteer_service_history_2026-07-05.csv`.
+> Re-consultar antes de citar em qualquer decisão futura.
+
+## TL;DR
+
+O "62 divergentes" do `get_vep_divergence_report` (bucket B / `onboarding_divergent`) **não era um
+backlog de recruiter** — era o **roster ativo saudável contado como divergência**. O bucket marcava
+`status IN (approved,converted) AND vep_status_raw IN ('Submitted','Active')`, mas no ciclo de vida do
+VEP **`Active` é o estado de quem JÁ ACEITOU a oferta e está na jornada** (só vira `Complete` quando o
+termo encerra). Logo o bucket "crescia sem parar" porque crescia junto com o número de voluntários
+ativos. Corrigido: divergência de pré-onboarding = aprovado/convertido **mas ainda pré-aceite** no VEP
+(`Submitted` = sem oferta, ou `OfferExtended` = oferta emitida aguardando aceite). Resultado ao vivo:
+**62 → 6** (os 6 = C4 com oferta emitida que falta aceitar).
+
+## Ciclo de vida do status VEP (confirmado com o owner 2026-07-07)
+
+```
+Submitted  →  OfferExtended  →  Active  →  Complete
+(sem oferta)  (oferta emitida,  (aceitou,   (termo
+              aguardando        na jornada)  encerrado)
+              aceite)
+```
+
+- **Pré-onboarding acionável** = `Submitted` + `OfferExtended`. Aceitar a oferta é parte do
+  pré-onboarding; sem listar esses, o owner perde a visibilidade de "quem falta aceitar e já deveria
+  estar na jornada".
+- **`Active` = saudável** (não é divergência).
+- Terminais negativos: `Withdrawn` / `Declined` / `OfferNotExtended` / `OfferExpired` / `Expired`.
+
+## Fatos aterrados (2026-07-07)
+
+| Métrica | Valor |
+|---|---|
+| Plataforma — contratos de voluntário ativos (distinct person) | **71** (12 líder + 57 pesq + 1 co_gp + 1 manager) |
+| Plataforma por coorte | 46 C4 · 20 C3 · 1 C3-b2 · 4 sem ciclo |
+| VEP-mirror (`vep_status_raw='Active'`) | **62** |
+| Bucket B **antigo** (approved/converted + Submitted/Active) | 62 (falso-positivo) |
+| Bucket B **novo** (approved/converted + Submitted/OfferExtended) | **6** (todos C4) |
+| `Submitted` no banco | **0** |
+| Distribuição `vep_status_raw` | Active 62 · OfferNotExtended 47 · Complete 10 · OfferExtended 7 · null 6 · Expired 3 · Withdrawn 2 · OfferExpired 1 |
+| vep_status das 71 pessoas ativas | 58 Active · 6 OfferExtended · 1 OfferNotExtended · 6 sem match de app |
+
+## As três "verdades VEP" divergem entre si
+
+| Fonte | Líderes | Pesquisadores | Total |
+|---|---|---|---|
+| Dashboard PMI ao vivo (owner) | 12 | 65 | 77 |
+| CSV oficial 05/07 (endDate ≥ hoje) | 9 | 46 | 55 |
+| Mirror DB (`vep_status_raw='Active'`) | — | — | 62 |
+
+Os próprios exports do PMI divergem (55 no CSV × 77 no dashboard). Conclusão: **reconciliação pontual
+manual não escala** — precisa de view viva com join estável. A nova RPC usa o **mirror como piso
+reconciliável**, não como verdade externa (campo `mirror_note` deixa isso explícito na resposta).
+
+## Causa-raiz por trás do "62 crescendo"
+
+1. **Bug de definição (principal).** `Active` foi tratado como divergência. É o estado normal do
+   voluntário onboarded. Não há sync quebrado nem recruiter negligente por trás dos 62 — o número
+   era o roster. **Corrigido no `get_vep_divergence_report` (migration `20260805000354`).**
+2. **Mirror defasa do dashboard externo (secundário).** O worker `pmi-vep-sync` só espelha quem passou
+   pelo funil da plataforma; adds diretos no VEP e drift de export não entram. Por isso mirror(62) ≠
+   dashboard(77). Não é regressão — é limite estrutural do espelho. A view expõe isso em vez de
+   esconder (delta nominal + `mirror_note`).
+
+## O que fica visível agora (visibilidade de pré-onboarding)
+
+Os **6 `OfferExtended`** (todos C4, aprovados/convertidos) são exatamente os que têm oferta emitida e
+**falta aceitar** — aparecem no bucket B corrigido (`onboarding_divergent`) e também no
+`platform_only` da matriz quando já têm contrato ativo. Nominalmente: Adailson Santos, Francisco Jose
+Nascimento de Oliveira, Hector Rigon, Jhonathan Brandao, Joao Leite de Oliveira Neto, Marcela Foligno.
+
+Caso Ricardo França (`active_members_divergent` + `vep_only`): offboarded na plataforma mas `Active` no
+VEP — divergência legítima, com ação sugerida "reativar contrato ou encerrar no VEP".
+
+## Recomendação de automação/alerta
+
+O fix estrutural (semântica do bucket) elimina o ruído. Para o que sobra:
+
+- **Alerta de acúmulo de pré-onboarding**: `OfferExtended` aprovado envelhecendo > N dias (candidato
+  não aceitou a oferta) — é o único acúmulo real e acionável (nudge ao voluntário / recruiter).
+- **Breakdown por coorte** já é emitido em `summary.onboarding_by_cohort` (hoje `{cycle4-2026: 6}`).
+- Não automatizar nada sobre `Active` — não é divergência.
+
+## Superfícies
+
+- RPC: `get_vep_divergence_report` (bucket B corrigido) + nova `get_vep_role_cohort_reconciliation`
+  (matriz papel×coorte + listas nominais, join estável por `pmi_id` → e-mail). Migration
+  `supabase/migrations/20260805000354_1130_vep_role_cohort_reconciliation.sql`.
+- Frontend: `src/components/admin/VepReconciliationIsland.tsx` (aba Matriz + F3 estado de erro + F4
+  navegação cruzada para `/admin/selection?cycle=` e `/admin/filiacao`).
+- Contract test: `tests/contracts/1130-vep-role-cohort-reconciliation.test.mjs`.

--- a/src/components/admin/VepReconciliationIsland.tsx
+++ b/src/components/admin/VepReconciliationIsland.tsx
@@ -3,7 +3,7 @@ import { canForAdminEntry } from '../../lib/permissions';
 
 interface Props { lang?: string; }
 
-type TabKey = 'selection' | 'onboarding' | 'active_members';
+type TabKey = 'matrix' | 'selection' | 'onboarding' | 'active_members';
 
 const L: Record<string, Record<string, string>> = {
   'pt-BR': {
@@ -13,7 +13,7 @@ const L: Record<string, Record<string, string>> = {
     tabOnboarding: 'Onboarding',
     tabActiveMembers: 'Membros',
     tabSelectionHint: 'VEP: terminal (Withdrawn/Declined/OfferNotExtended) · Núcleo: ainda no funil',
-    tabOnboardingHint: 'Núcleo: aprovado/convertido · VEP: ainda Submitted/Active',
+    tabOnboardingHint: 'Núcleo: aprovado/convertido · VEP pré-aceite (Submitted = sem oferta / OfferExtended = oferta emitida aguardando aceite). Active = já aceitou, na jornada — não é divergência (#1130).',
     tabActiveMembersHint: 'Membro inativo no Núcleo · VEP: ainda Submitted/Active',
     loading: 'Carregando…',
     noDivergence: 'Sem divergências nesta categoria.',
@@ -55,6 +55,21 @@ const L: Record<string, Record<string, string>> = {
     colOnb: 'Onboarding',
     colActMem: 'Active mem',
     colMissing: 'Missing VEP',
+    // #1130 — matriz papel×coorte + F3/F4
+    tabMatrix: 'Matriz papel×coorte',
+    tabMatrixHint: 'Plataforma (contrato voluntário ativo) × VEP (mirror Active) por papel e coorte. Join estável por PMI id.',
+    mLeader: 'Líder', mResearcher: 'Pesquisador', mOther: 'Outro (GP)',
+    colRole: 'Papel', colCohort: 'Coorte', colPlatform: 'Plataforma', colVepActive: 'VEP ativo', colDelta: 'Δ',
+    totalRow: 'Total', colVepStatus: 'Status VEP', colMemberActive: 'Member?',
+    platformOnlyTitle: 'Ativos na plataforma sem VEP-ativo (mirror)',
+    platformOnlyHint: 'Contrato ativo no Núcleo mas mirror VEP não está Active (sync defasado ou oferta não estendida).',
+    vepOnlyTitle: 'Ativos no VEP sem contrato de voluntário ativo',
+    vepOnlyHint: 'VEP Active mas sem contrato ativo na plataforma (ex.: offboarded).',
+    mirrorNote: 'ⓘ "VEP ativo" é o espelho do worker pmi-vep-sync — pode defasar do dashboard PMI ao vivo. Piso reconciliável, não verdade externa.',
+    matrixEmpty: 'Sem dados de matriz.',
+    errTitle: 'Falha ao carregar', errRetry: 'Tentar novamente',
+    linkFiliacao: '→ Fila de filiação', linkSelectionCycle: 'ver ciclo',
+    yes: 'sim', no: 'não',
   },
   'en-US': {
     title: 'VEP ↔ Núcleo Reconciliation',
@@ -63,7 +78,7 @@ const L: Record<string, Record<string, string>> = {
     tabOnboarding: 'Onboarding',
     tabActiveMembers: 'Members',
     tabSelectionHint: 'VEP: terminal (Withdrawn/Declined/OfferNotExtended) · Núcleo: still in funnel',
-    tabOnboardingHint: 'Núcleo: approved/converted · VEP: still Submitted/Active',
+    tabOnboardingHint: 'Núcleo: approved/converted · VEP pre-acceptance (Submitted = no offer / OfferExtended = offer emitted awaiting acceptance). Active = accepted, in journey — not a divergence (#1130).',
     tabActiveMembersHint: 'Inactive member in Núcleo · VEP: still Submitted/Active',
     loading: 'Loading…',
     noDivergence: 'No divergence in this category.',
@@ -105,6 +120,21 @@ const L: Record<string, Record<string, string>> = {
     colOnb: 'Onboarding',
     colActMem: 'Active mem',
     colMissing: 'Missing VEP',
+    // #1130 — role×cohort matrix + F3/F4
+    tabMatrix: 'Role×cohort matrix',
+    tabMatrixHint: 'Platform (active volunteer contract) × VEP (Active mirror) by role and cohort. Stable join by PMI id.',
+    mLeader: 'Leader', mResearcher: 'Researcher', mOther: 'Other (GP)',
+    colRole: 'Role', colCohort: 'Cohort', colPlatform: 'Platform', colVepActive: 'VEP active', colDelta: 'Δ',
+    totalRow: 'Total', colVepStatus: 'VEP status', colMemberActive: 'Member?',
+    platformOnlyTitle: 'Active on platform without VEP-active (mirror)',
+    platformOnlyHint: 'Active contract in Núcleo but VEP mirror is not Active (stale sync or offer not extended).',
+    vepOnlyTitle: 'Active in VEP without active volunteer contract',
+    vepOnlyHint: 'VEP Active but no active platform contract (e.g. offboarded).',
+    mirrorNote: 'ⓘ "VEP active" is the pmi-vep-sync worker mirror — it may lag the live PMI dashboard. Reconcilable floor, not external truth.',
+    matrixEmpty: 'No matrix data.',
+    errTitle: 'Failed to load', errRetry: 'Retry',
+    linkFiliacao: '→ Affiliation queue', linkSelectionCycle: 'view cycle',
+    yes: 'yes', no: 'no',
   },
   'es-LATAM': {
     title: 'Reconciliación VEP ↔ Núcleo',
@@ -113,7 +143,7 @@ const L: Record<string, Record<string, string>> = {
     tabOnboarding: 'Onboarding',
     tabActiveMembers: 'Miembros',
     tabSelectionHint: 'VEP: terminal (Withdrawn/Declined/OfferNotExtended) · Núcleo: aún en embudo',
-    tabOnboardingHint: 'Núcleo: aprobado/convertido · VEP: aún Submitted/Active',
+    tabOnboardingHint: 'Núcleo: aprobado/convertido · VEP pre-aceptación (Submitted = sin oferta / OfferExtended = oferta emitida esperando aceptación). Active = ya aceptó, en la jornada — no es divergencia (#1130).',
     tabActiveMembersHint: 'Miembro inactivo en Núcleo · VEP: aún Submitted/Active',
     loading: 'Cargando…',
     noDivergence: 'Sin divergencias en esta categoría.',
@@ -155,6 +185,21 @@ const L: Record<string, Record<string, string>> = {
     colOnb: 'Onboarding',
     colActMem: 'Active mem',
     colMissing: 'Missing VEP',
+    // #1130 — matriz papel×coorte + F3/F4
+    tabMatrix: 'Matriz rol×cohorte',
+    tabMatrixHint: 'Plataforma (contrato de voluntario activo) × VEP (mirror Active) por rol y cohorte. Join estable por PMI id.',
+    mLeader: 'Líder', mResearcher: 'Investigador', mOther: 'Otro (GP)',
+    colRole: 'Rol', colCohort: 'Cohorte', colPlatform: 'Plataforma', colVepActive: 'VEP activo', colDelta: 'Δ',
+    totalRow: 'Total', colVepStatus: 'Estado VEP', colMemberActive: 'Member?',
+    platformOnlyTitle: 'Activos en plataforma sin VEP-activo (mirror)',
+    platformOnlyHint: 'Contrato activo en Núcleo pero el mirror VEP no está Active (sync desfasado u oferta no extendida).',
+    vepOnlyTitle: 'Activos en VEP sin contrato de voluntario activo',
+    vepOnlyHint: 'VEP Active pero sin contrato activo en la plataforma (ej.: offboarded).',
+    mirrorNote: 'ⓘ "VEP activo" es el espejo del worker pmi-vep-sync — puede desfasarse del dashboard PMI en vivo. Piso reconciliable, no verdad externa.',
+    matrixEmpty: 'Sin datos de matriz.',
+    errTitle: 'Error al cargar', errRetry: 'Reintentar',
+    linkFiliacao: '→ Cola de afiliación', linkSelectionCycle: 'ver ciclo',
+    yes: 'sí', no: 'no',
   },
 };
 
@@ -196,22 +241,193 @@ const NUCLEO_STATUS_COLOR: Record<string, string> = {
 
 const VEP_STATUS_COLOR: Record<string, string> = {
   Submitted: 'bg-blue-100 text-blue-700',
+  OfferExtended: 'bg-amber-100 text-amber-700',
   Active: 'bg-emerald-100 text-emerald-700',
   Withdrawn: 'bg-red-100 text-red-700',
   Declined: 'bg-red-100 text-red-700',
   OfferNotExtended: 'bg-red-100 text-red-700',
+  OfferExpired: 'bg-red-100 text-red-700',
   Complete: 'bg-gray-100 text-gray-700',
 };
+
+// #1130 — role×cohort reconciliation matrix panel
+function MatrixPanel({ t, data, loading, error, onRetry, roleLabel, cycleHref, renderBadge }: {
+  t: Record<string, string>;
+  data: any;
+  loading: boolean;
+  error: string | null;
+  onRetry: () => void;
+  roleLabel: (r: string) => string;
+  cycleHref: (code: string | null | undefined) => string | null;
+  renderBadge: (status: string | null | undefined, palette: Record<string, string>) => any;
+}) {
+  if (loading && !data) {
+    return <div className="text-center py-10 text-[var(--text-muted)] text-sm">{t.loading}</div>;
+  }
+  if (error && !data) {
+    return (
+      <div className="text-center py-10">
+        <div className="text-sm font-semibold text-red-700 mb-1">{t.errTitle}</div>
+        <div className="text-xs text-[var(--text-muted)] mb-4 font-mono max-w-xl mx-auto break-words">{error}</div>
+        <button onClick={onRetry} className="px-4 py-1.5 rounded-lg text-[12px] font-semibold bg-navy text-white hover:opacity-90 cursor-pointer border-0">
+          ↻ {t.errRetry}
+        </button>
+      </div>
+    );
+  }
+  if (!data) {
+    return <div className="text-center py-10 text-[var(--text-muted)] text-sm">{t.matrixEmpty}</div>;
+  }
+
+  const totals = data.totals || {};
+  const matrix: any[] = data.matrix || [];
+  const platformOnly: any[] = data.platform_only || [];
+  const vepOnly: any[] = data.vep_only || [];
+
+  const deltaCell = (d: number) => {
+    if (d === 0) return <span className="text-[var(--text-muted)]">0</span>;
+    const cls = d > 0 ? 'text-amber-700' : 'text-blue-700';
+    return <span className={`font-bold ${cls}`}>{d > 0 ? '+' : ''}{d}</span>;
+  };
+  const cohortCell = (code: string) => {
+    const href = cycleHref(code);
+    return href ? <a href={href} className="text-navy hover:underline">{code}</a> : <span>{code}</span>;
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Totals headline */}
+      <div className="flex flex-wrap gap-4 items-center rounded-2xl border border-[var(--border-default)] bg-[var(--surface-card)] px-4 py-3">
+        <div className="text-[13px]"><span className="text-[var(--text-muted)]">{t.colPlatform}: </span><strong className="text-navy text-lg">{totals.platform_active ?? 0}</strong></div>
+        <div className="text-[13px]"><span className="text-[var(--text-muted)]">{t.colVepActive}: </span><strong className="text-navy text-lg">{totals.vep_active_mirror ?? 0}</strong></div>
+        <div className="text-[13px]"><span className="text-[var(--text-muted)]">{t.colDelta}: </span>{deltaCell(totals.delta ?? 0)}</div>
+      </div>
+      {data.mirror_note && <div className="text-[11px] text-[var(--text-muted)] italic">{t.mirrorNote}</div>}
+
+      {/* Matrix table */}
+      <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-card)] overflow-hidden overflow-x-auto">
+        <table className="w-full text-[12px]">
+          <thead className="bg-[var(--surface-section-cool)] text-[var(--text-muted)]">
+            <tr>
+              <th className="px-3 py-2 text-left font-semibold">{t.colRole}</th>
+              <th className="px-3 py-2 text-left font-semibold">{t.colCohort}</th>
+              <th className="px-3 py-2 text-right font-semibold">{t.colPlatform}</th>
+              <th className="px-3 py-2 text-right font-semibold">{t.colVepActive}</th>
+              <th className="px-3 py-2 text-right font-semibold">{t.colDelta}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {matrix.map((c, i) => (
+              <tr key={`${c.role}-${c.cohort}-${i}`} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-hover)]">
+                <td className="px-3 py-2 font-semibold text-[var(--text-primary)]">{roleLabel(c.role)}</td>
+                <td className="px-3 py-2 text-[var(--text-secondary)]">{cohortCell(c.cohort)}</td>
+                <td className="px-3 py-2 text-right">{c.platform_active}</td>
+                <td className="px-3 py-2 text-right">{c.vep_active}</td>
+                <td className="px-3 py-2 text-right">{deltaCell(c.delta)}</td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr className="border-t-2 border-[var(--border-default)] bg-[var(--surface-section-cool)]">
+              <td className="px-3 py-2 font-bold text-navy" colSpan={2}>{t.totalRow}</td>
+              <td className="px-3 py-2 text-right font-bold text-navy">{totals.platform_active ?? 0}</td>
+              <td className="px-3 py-2 text-right font-bold text-navy">{totals.vep_active_mirror ?? 0}</td>
+              <td className="px-3 py-2 text-right font-bold">{deltaCell(totals.delta ?? 0)}</td>
+            </tr>
+          </tfoot>
+        </table>
+      </div>
+
+      {/* platform_only nominal list */}
+      <div>
+        <div className="text-[13px] font-bold text-navy mb-1">{t.platformOnlyTitle} <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700">{platformOnly.length}</span></div>
+        <div className="text-[11px] text-[var(--text-muted)] italic mb-2">{t.platformOnlyHint}</div>
+        <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-card)] overflow-hidden overflow-x-auto">
+          {platformOnly.length === 0 ? (
+            <div className="text-center py-6 text-[var(--text-muted)] text-[12px]">{t.emptyState}</div>
+          ) : (
+            <table className="w-full text-[12px]">
+              <thead className="bg-[var(--surface-section-cool)] text-[var(--text-muted)]">
+                <tr>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colName}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colEmail}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colRole}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colCohort}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colVepStatus}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colAction}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {platformOnly.map((r, i) => (
+                  <tr key={`${r.pmi_id || r.email}-${i}`} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-hover)]">
+                    <td className="px-3 py-2 font-semibold text-[var(--text-primary)]">{r.member_name || '—'}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] font-mono text-[11px]">{r.email}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">{roleLabel(r.role)}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">{cohortCell(r.cohort)}</td>
+                    <td className="px-3 py-2">{renderBadge(r.vep_status_raw, VEP_STATUS_COLOR)}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] text-[11px]">{r.suggested_action}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+
+      {/* vep_only nominal list */}
+      <div>
+        <div className="text-[13px] font-bold text-navy mb-1">{t.vepOnlyTitle} <span className="text-[10px] font-bold px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700">{vepOnly.length}</span></div>
+        <div className="text-[11px] text-[var(--text-muted)] italic mb-2">{t.vepOnlyHint}</div>
+        <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-card)] overflow-hidden overflow-x-auto">
+          {vepOnly.length === 0 ? (
+            <div className="text-center py-6 text-[var(--text-muted)] text-[12px]">{t.emptyState}</div>
+          ) : (
+            <table className="w-full text-[12px]">
+              <thead className="bg-[var(--surface-section-cool)] text-[var(--text-muted)]">
+                <tr>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colName}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colEmail}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colRole}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colCohort}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colMemberActive}</th>
+                  <th className="px-3 py-2 text-left font-semibold">{t.colAction}</th>
+                </tr>
+              </thead>
+              <tbody>
+                {vepOnly.map((r, i) => (
+                  <tr key={`${r.pmi_id || r.email}-${i}`} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-hover)]">
+                    <td className="px-3 py-2 font-semibold text-[var(--text-primary)]">{r.applicant_name || '—'}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] font-mono text-[11px]">{r.email}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">{roleLabel(r.role)}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">{cohortCell(r.cohort)}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)]">{r.member_is_active === true ? t.yes : r.member_is_active === false ? t.no : '—'}</td>
+                    <td className="px-3 py-2 text-[var(--text-secondary)] text-[11px]">{r.suggested_action}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
 
 export default function VepReconciliationIsland({ lang: propLang }: Props) {
   const lang = useLang(propLang);
   const t = L[lang] || L['pt-BR'];
   const [authorized, setAuthorized] = useState<boolean | null>(null);
   const [data, setData] = useState<any>(null);
-  const [tab, setTab] = useState<TabKey>('selection');
+  const [tab, setTab] = useState<TabKey>('matrix');
   const [loading, setLoading] = useState(false);
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [toast, setToast] = useState<{ type: 'ok' | 'err'; msg: string } | null>(null);
+  // #1130 F3 — load error separate from data==null (avoid infinite spinner on RPC failure)
+  const [loadError, setLoadError] = useState<string | null>(null);
+  // #1130 — role×cohort matrix (lazy-loaded on tab select)
+  const [matrixData, setMatrixData] = useState<any>(null);
+  const [matrixLoading, setMatrixLoading] = useState(false);
+  const [matrixError, setMatrixError] = useState<string | null>(null);
   // p153 OPP-152.5 — baseline drift panel
   const [baselineData, setBaselineData] = useState<any>(null);
   const [capturingBaseline, setCapturingBaseline] = useState(false);
@@ -270,20 +486,50 @@ export default function VepReconciliationIsland({ lang: propLang }: Props) {
     }
     setAuthorized(true);
     setLoading(true);
+    setLoadError(null);
     try {
       const { data: d, error } = await sb.rpc('get_vep_divergence_report');
       if (error) throw error;
       if (d && typeof d === 'object' && (d as any).error) throw new Error((d as any).error);
       setData(d);
+      setLoadError(null);
     } catch (e: any) {
       console.error('[VepReconciliation] load error:', e?.message);
+      // #1130 F3 — surface a persistent error state (not just a 4s toast) so the GP
+      // never mistakes a failed RPC for "still loading".
+      setLoadError(e?.message || String(e));
       setToast({ type: 'err', msg: e?.message || String(e) });
     } finally {
       setLoading(false);
     }
   }, []);
 
+  const loadMatrix = useCallback(async () => {
+    const sb = (window as any).navGetSb?.();
+    if (!sb) return;
+    setMatrixLoading(true);
+    setMatrixError(null);
+    try {
+      const { data: d, error } = await sb.rpc('get_vep_role_cohort_reconciliation');
+      if (error) throw error;
+      if (d && typeof d === 'object' && (d as any).error) throw new Error((d as any).error);
+      setMatrixData(d);
+      setMatrixError(null);
+    } catch (e: any) {
+      console.error('[VepReconciliation] matrix load error:', e?.message);
+      setMatrixError(e?.message || String(e));
+    } finally {
+      setMatrixLoading(false);
+    }
+  }, []);
+
   useEffect(() => { load(); }, [load]);
+  // #1130 — lazy-load the matrix the first time its tab is opened (and on authorize if default)
+  useEffect(() => {
+    if (authorized === true && tab === 'matrix' && matrixData === null && !matrixLoading && !matrixError) {
+      loadMatrix();
+    }
+  }, [authorized, tab, matrixData, matrixLoading, matrixError, loadMatrix]);
   // p153 OPP-152.5 — load baseline history when authorized
   useEffect(() => { if (authorized === true) loadBaselines(); }, [authorized, loadBaselines]);
 
@@ -314,32 +560,59 @@ export default function VepReconciliationIsland({ lang: propLang }: Props) {
   if (authorized === false) {
     return <div className="text-center py-12 text-[var(--text-muted)]">{t.deniedAccess}</div>;
   }
+  // #1130 F3 — a failed RPC must not read as "still loading". Show a real error + retry.
+  if (loadError && !data) {
+    return (
+      <div className="text-center py-12">
+        <div className="text-sm font-semibold text-red-700 mb-1">{t.errTitle}</div>
+        <div className="text-xs text-[var(--text-muted)] mb-4 font-mono max-w-xl mx-auto break-words">{loadError}</div>
+        <button
+          onClick={load}
+          disabled={loading}
+          className="px-4 py-1.5 rounded-lg text-[12px] font-semibold bg-navy text-white hover:opacity-90 cursor-pointer border-0 disabled:opacity-50"
+        >
+          {loading ? t.refreshing : `↻ ${t.errRetry}`}
+        </button>
+      </div>
+    );
+  }
   if (authorized === null || !data) {
     return <div className="text-center py-12 text-[var(--text-muted)]">{t.loading}</div>;
   }
 
   const summary = data.summary || {};
-  const lists: Record<TabKey, any[]> = {
+  const lists: Record<Exclude<TabKey, 'matrix'>, any[]> = {
     selection: data.selection_divergent || [],
     onboarding: data.onboarding_divergent || [],
     active_members: data.active_members_divergent || [],
   };
+  const matrixDivCount = (matrixData?.totals?.platform_only_count ?? 0) + (matrixData?.totals?.vep_only_count ?? 0);
   const tabCounts: Record<TabKey, number> = {
+    matrix: matrixDivCount,
     selection: summary.selection_count ?? lists.selection.length,
     onboarding: summary.onboarding_count ?? lists.onboarding.length,
     active_members: summary.active_members_count ?? lists.active_members.length,
   };
   const tabHints: Record<TabKey, string> = {
+    matrix: t.tabMatrixHint,
     selection: t.tabSelectionHint,
     onboarding: t.tabOnboardingHint,
     active_members: t.tabActiveMembersHint,
   };
   const tabLabels: Record<TabKey, string> = {
+    matrix: t.tabMatrix,
     selection: t.tabSelection,
     onboarding: t.tabOnboarding,
     active_members: t.tabActiveMembers,
   };
-  const currentList = lists[tab];
+  const currentList = tab === 'matrix' ? [] : lists[tab];
+
+  // #1130 F4 — cross-nav helpers to the sibling admin screens.
+  const langPrefix = lang === 'en-US' ? '/en' : lang === 'es-LATAM' ? '/es' : '';
+  const filiacaoHref = `${langPrefix}/admin/filiacao`;
+  const cycleHref = (code: string | null | undefined) =>
+    code && code !== 'no_cycle' ? `${langPrefix}/admin/selection?cycle=${encodeURIComponent(code)}` : null;
+  const roleLabel = (r: string) => (r === 'leader' ? t.mLeader : r === 'researcher' ? t.mResearcher : t.mOther);
 
   const renderBadge = (status: string | null | undefined, palette: Record<string, string>) => {
     if (!status) return <span className="text-[var(--text-muted)]">—</span>;
@@ -356,6 +629,13 @@ export default function VepReconciliationIsland({ lang: propLang }: Props) {
           <p className="text-xs text-[var(--text-secondary)] mt-1 max-w-2xl">{t.subtitle}</p>
         </div>
         <div className="flex items-center gap-3">
+          {/* #1130 F4 — cross-nav to affiliation queue */}
+          <a
+            href={filiacaoHref}
+            className="text-[11px] font-semibold text-navy hover:underline"
+          >
+            {t.linkFiliacao}
+          </a>
           <div className="text-[11px] text-[var(--text-muted)]">
             {t.summary}: <strong className="text-navy text-base ml-1">{summary.total_divergent ?? 0}</strong>
           </div>
@@ -454,7 +734,7 @@ export default function VepReconciliationIsland({ lang: propLang }: Props) {
 
       {/* Tabs */}
       <div className="flex border-b border-[var(--border-default)]">
-        {(['selection', 'onboarding', 'active_members'] as TabKey[]).map((key) => {
+        {(['matrix', 'selection', 'onboarding', 'active_members'] as TabKey[]).map((key) => {
           const active = tab === key;
           const count = tabCounts[key];
           return (
@@ -477,7 +757,22 @@ export default function VepReconciliationIsland({ lang: propLang }: Props) {
       {/* Hint */}
       <div className="text-[11px] text-[var(--text-muted)] italic">{tabHints[tab]}</div>
 
-      {/* Table */}
+      {/* #1130 — Matrix tab */}
+      {tab === 'matrix' && (
+        <MatrixPanel
+          t={t}
+          data={matrixData}
+          loading={matrixLoading}
+          error={matrixError}
+          onRetry={loadMatrix}
+          roleLabel={roleLabel}
+          cycleHref={cycleHref}
+          renderBadge={renderBadge}
+        />
+      )}
+
+      {/* Table (divergence tabs) */}
+      {tab !== 'matrix' && (
       <div className="rounded-2xl border border-[var(--border-default)] bg-[var(--surface-card)] overflow-hidden">
         {currentList.length === 0 ? (
           <div className="text-center py-10 text-[var(--text-muted)] text-sm">{summary.total_divergent === 0 ? t.emptyState : t.noDivergence}</div>
@@ -505,7 +800,12 @@ export default function VepReconciliationIsland({ lang: propLang }: Props) {
                     <tr key={appId || `${row.email}-${row.cycle_code}`} className="border-t border-[var(--border-subtle)] hover:bg-[var(--surface-hover)]">
                       <td className="px-3 py-2 font-semibold text-[var(--text-primary)]">{name}</td>
                       <td className="px-3 py-2 text-[var(--text-secondary)] font-mono text-[11px]">{row.email}</td>
-                      <td className="px-3 py-2 text-[var(--text-secondary)]">{row.cycle_code || '—'}</td>
+                      <td className="px-3 py-2 text-[var(--text-secondary)]">
+                        {/* #1130 F4 — deep-link to the selection screen filtered by cycle */}
+                        {cycleHref(row.cycle_code) ? (
+                          <a href={cycleHref(row.cycle_code)!} className="text-navy hover:underline font-medium" title={t.linkSelectionCycle}>{row.cycle_code}</a>
+                        ) : (row.cycle_code || '—')}
+                      </td>
                       <td className="px-3 py-2">{renderBadge(row.nucleo_status || (row.is_active === false ? 'inactive' : null), NUCLEO_STATUS_COLOR)}</td>
                       <td className="px-3 py-2">{renderBadge(row.vep_status_raw, VEP_STATUS_COLOR)}</td>
                       <td className="px-3 py-2 text-[var(--text-secondary)] text-[11px]">{timeAgo(row.vep_last_seen_at, 'ago')}</td>
@@ -532,6 +832,7 @@ export default function VepReconciliationIsland({ lang: propLang }: Props) {
           </div>
         )}
       </div>
+      )}
 
       {/* Footer */}
       <div className="text-[10px] text-[var(--text-muted)] text-right">

--- a/supabase/migrations/20260805000354_1130_vep_role_cohort_reconciliation.sql
+++ b/supabase/migrations/20260805000354_1130_vep_role_cohort_reconciliation.sql
@@ -1,0 +1,288 @@
+-- #1130 — Reconciliação VEP↔plataforma por papel×coorte + correção de causa-raiz do bucket B
+--
+-- Parte A: get_vep_divergence_report — corrige a semântica do bucket B (onboarding_divergent).
+--   VEP 'Active' = voluntário que JÁ ACEITOU a oferta e está na jornada (estado saudável; só vira
+--   'Complete' quando o termo encerra). O bucket antigo marcava ('Submitted','Active') como
+--   divergência → contava o roster ativo inteiro como "divergente" (62 crescendo sem parar).
+--   Correção: divergência de pré-onboarding = aprovado/convertido no Núcleo MAS ainda em estado
+--   pré-aceite no VEP: 'Submitted' (sem oferta) OU 'OfferExtended' (oferta emitida, aguardando
+--   aceite). Aceitar a oferta é parte do pré-onboarding — sem esta lista o owner perde a
+--   visibilidade de quem falta aceitar e já deveria estar na jornada (feedback do owner 2026-07-07).
+--   NÃO inclui 'Active' (já aceitou). Adiciona breakdown por coorte no summary.
+--
+-- Parte B: get_vep_role_cohort_reconciliation() — matriz plataforma×VEP por papel×coorte, com
+--   listas nominais dos divergentes nos dois sentidos. Join estável por PMI id (fallback e-mail),
+--   resolvendo o falso-gap do caso Paulo (e-mails divergentes, mesmo pmi_id).
+--
+-- Bodies capturados verbatim do vivo (pg_get_functiondef) — GC-097 body-drift parity.
+
+CREATE OR REPLACE FUNCTION public.get_vep_divergence_report()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_result jsonb;
+  v_selection jsonb;
+  v_onboarding jsonb;
+  v_active jsonb;
+  v_onboarding_by_cohort jsonb;
+BEGIN
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.selection_cycles sc
+    WHERE sc.status = 'open' AND public.selection_coi_recused(v_caller_id, sc.id)
+  ) THEN
+    RETURN jsonb_build_object('error', 'recused_conflict_of_interest',
+      'detail', 'Você é candidato(a) em um ciclo aberto — as visões de seleção estão impedidas por conflito de interesse (ADR-0109).');
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'application_id', a.id, 'applicant_name', a.applicant_name, 'email', a.email, 'pmi_id', a.pmi_id,
+    'cycle_code', c.cycle_code, 'nucleo_status', a.status, 'vep_status_raw', a.vep_status_raw,
+    'vep_last_seen_at', a.vep_last_seen_at, 'vep_reconciled_at', a.vep_reconciled_at,
+    'suggested_action', 'Comitê: marcar withdrawn/rejected no Núcleo'
+  ) ORDER BY a.applicant_name), '[]'::jsonb) INTO v_selection
+  FROM public.selection_applications a
+  JOIN public.selection_cycles c ON c.id = a.cycle_id
+  WHERE a.vep_status_raw IN ('Withdrawn', 'Declined', 'OfferNotExtended')
+    AND a.status IN ('submitted', 'screening', 'objective_eval', 'interview_pending', 'interview_scheduled', 'interview_done', 'final_eval')
+    AND c.status = 'open'
+    AND (a.vep_reconciled_at IS NULL OR a.vep_reconciled_at < a.vep_last_seen_at);
+
+  -- #1130 fix: pré-onboarding = aprovado/convertido MAS ainda pré-aceite no VEP
+  -- ('Submitted' sem oferta OU 'OfferExtended' oferta emitida aguardando aceite). 'Active' = já aceitou.
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'application_id', a.id, 'applicant_name', a.applicant_name, 'email', a.email, 'pmi_id', a.pmi_id,
+    'cycle_code', c.cycle_code, 'nucleo_status', a.status, 'vep_status_raw', a.vep_status_raw,
+    'vep_last_seen_at', a.vep_last_seen_at, 'vep_reconciled_at', a.vep_reconciled_at,
+    'suggested_action', CASE
+      WHEN a.vep_status_raw = 'OfferExtended' THEN 'Pré-onboarding: oferta emitida no VEP aguardando aceite do voluntário — acompanhar/nudge para aceitar'
+      ELSE 'Recruiter PMI: sem oferta no VEP — estender oferta ao aprovado'
+    END
+  ) ORDER BY a.applicant_name), '[]'::jsonb) INTO v_onboarding
+  FROM public.selection_applications a
+  JOIN public.selection_cycles c ON c.id = a.cycle_id
+  WHERE a.status IN ('approved', 'converted')
+    AND a.vep_status_raw IN ('Submitted', 'OfferExtended')
+    AND (a.vep_reconciled_at IS NULL OR a.vep_reconciled_at < a.vep_last_seen_at);
+
+  SELECT COALESCE(jsonb_object_agg(cohort, n), '{}'::jsonb) INTO v_onboarding_by_cohort
+  FROM (
+    SELECT COALESCE(c.cycle_code, 'no_cycle') AS cohort, count(*) AS n
+    FROM public.selection_applications a
+    JOIN public.selection_cycles c ON c.id = a.cycle_id
+    WHERE a.status IN ('approved', 'converted')
+      AND a.vep_status_raw IN ('Submitted', 'OfferExtended')
+      AND (a.vep_reconciled_at IS NULL OR a.vep_reconciled_at < a.vep_last_seen_at)
+    GROUP BY 1
+  ) q;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'member_id', m.id, 'member_name', m.name, 'email', m.email, 'pmi_id', a.pmi_id,
+    'is_active', m.is_active, 'last_engagement_end_date', latest_eng.end_date,
+    'latest_application_id', a.id, 'cycle_code', c.cycle_code, 'vep_status_raw', a.vep_status_raw,
+    'vep_last_seen_at', a.vep_last_seen_at, 'vep_reconciled_at', a.vep_reconciled_at,
+    'suggested_action', 'Recruiter PMI: encerrar no VEP (membro offboarded na plataforma)'
+  ) ORDER BY m.name), '[]'::jsonb) INTO v_active
+  FROM public.members m
+  JOIN LATERAL (
+    SELECT sa.* FROM public.selection_applications sa
+    WHERE lower(sa.email) = lower(m.email) AND sa.vep_status_raw IS NOT NULL
+    ORDER BY sa.imported_at DESC NULLS LAST LIMIT 1
+  ) a ON true
+  LEFT JOIN public.selection_cycles c ON c.id = a.cycle_id
+  LEFT JOIN LATERAL (
+    SELECT end_date FROM public.engagements e
+    WHERE e.person_id = m.person_id AND e.end_date IS NOT NULL
+    ORDER BY e.end_date DESC LIMIT 1
+  ) latest_eng ON true
+  WHERE m.is_active = false
+    AND a.vep_status_raw IN ('Submitted', 'Active')
+    AND (a.vep_reconciled_at IS NULL OR a.vep_reconciled_at < a.vep_last_seen_at);
+
+  v_result := jsonb_build_object(
+    'selection_divergent', v_selection,
+    'onboarding_divergent', v_onboarding,
+    'active_members_divergent', v_active,
+    'summary', jsonb_build_object(
+      'total_divergent', (jsonb_array_length(v_selection) + jsonb_array_length(v_onboarding) + jsonb_array_length(v_active)),
+      'selection_count', jsonb_array_length(v_selection),
+      'onboarding_count', jsonb_array_length(v_onboarding),
+      'onboarding_by_cohort', v_onboarding_by_cohort,
+      'active_members_count', jsonb_array_length(v_active),
+      'generated_at', now()
+    )
+  );
+  RETURN v_result;
+END;
+$function$;
+
+
+CREATE OR REPLACE FUNCTION public.get_vep_role_cohort_reconciliation()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_matrix jsonb;
+  v_platform_only jsonb;
+  v_vep_only jsonb;
+  v_plat_total int;
+  v_vep_total int;
+BEGIN
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.selection_cycles sc
+    WHERE sc.status = 'open' AND public.selection_coi_recused(v_caller_id, sc.id)
+  ) THEN
+    RETURN jsonb_build_object('error', 'recused_conflict_of_interest',
+      'detail', 'Você é candidato(a) em um ciclo aberto — impedido por conflito de interesse (ADR-0109).');
+  END IF;
+
+  WITH plat AS (
+    SELECT DISTINCT ON (e.person_id)
+      e.person_id,
+      CASE WHEN e.role = 'researcher' THEN 'researcher' WHEN e.role = 'leader' THEN 'leader' ELSE 'other' END AS role,
+      COALESCE(sc.cycle_code, 'no_cycle') AS cohort,
+      COALESCE(NULLIF(mem.pmi_id, ''), 'e:' || lower(mem.email)) AS match_key,
+      va.vep_status_raw AS vep_status
+    FROM public.engagements e
+    LEFT JOIN public.selection_applications sa ON sa.id = e.selection_application_id
+    LEFT JOIN public.selection_cycles sc ON sc.id = sa.cycle_id
+    LEFT JOIN LATERAL (
+      SELECT m.name, m.email, m.pmi_id FROM public.members m
+      WHERE m.person_id = e.person_id
+      ORDER BY (m.pmi_id IS NOT NULL) DESC, m.updated_at DESC NULLS LAST LIMIT 1
+    ) mem ON true
+    LEFT JOIN LATERAL (
+      SELECT s.vep_status_raw FROM public.selection_applications s
+      WHERE (s.pmi_id = mem.pmi_id AND s.pmi_id IS NOT NULL AND s.pmi_id <> '') OR lower(s.email) = lower(mem.email)
+      ORDER BY s.imported_at DESC NULLS LAST LIMIT 1
+    ) va ON true
+    WHERE e.kind = 'volunteer' AND e.legal_basis = 'contract' AND e.status = 'active'
+    ORDER BY e.person_id, e.start_date DESC NULLS LAST
+  ),
+  vep AS (
+    SELECT DISTINCT ON (COALESCE(NULLIF(a.pmi_id, ''), 'e:' || lower(a.email)))
+      COALESCE(NULLIF(a.pmi_id, ''), 'e:' || lower(a.email)) AS match_key,
+      CASE WHEN a.role_applied = 'researcher' THEN 'researcher' WHEN a.role_applied = 'leader' THEN 'leader' ELSE 'other' END AS role,
+      COALESCE(c.cycle_code, 'no_cycle') AS cohort
+    FROM public.selection_applications a
+    LEFT JOIN public.selection_cycles c ON c.id = a.cycle_id
+    WHERE a.vep_status_raw = 'Active'
+    ORDER BY COALESCE(NULLIF(a.pmi_id, ''), 'e:' || lower(a.email)), a.imported_at DESC NULLS LAST
+  ),
+  joined AS (
+    SELECT COALESCE(p.role, v.role) AS role, COALESCE(p.cohort, v.cohort) AS cohort,
+      p.match_key AS plat_key, v.match_key AS vep_key
+    FROM plat p FULL OUTER JOIN vep v ON v.match_key = p.match_key
+  ),
+  cells AS (
+    SELECT role, cohort, count(plat_key) AS platform_active, count(vep_key) AS vep_active
+    FROM joined GROUP BY role, cohort
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object('role', role, 'cohort', cohort,
+      'platform_active', platform_active, 'vep_active', vep_active, 'delta', platform_active - vep_active
+    ) ORDER BY role, cohort), '[]'::jsonb),
+    COALESCE(sum(platform_active), 0), COALESCE(sum(vep_active), 0)
+  INTO v_matrix, v_plat_total, v_vep_total FROM cells;
+
+  WITH plat AS (
+    SELECT DISTINCT ON (e.person_id)
+      e.person_id,
+      CASE WHEN e.role = 'researcher' THEN 'researcher' WHEN e.role = 'leader' THEN 'leader' ELSE 'other' END AS role,
+      COALESCE(sc.cycle_code, 'no_cycle') AS cohort,
+      COALESCE(NULLIF(mem.pmi_id, ''), 'e:' || lower(mem.email)) AS match_key,
+      mem.name AS member_name, mem.email, mem.pmi_id, va.vep_status_raw AS vep_status
+    FROM public.engagements e
+    LEFT JOIN public.selection_applications sa ON sa.id = e.selection_application_id
+    LEFT JOIN public.selection_cycles sc ON sc.id = sa.cycle_id
+    LEFT JOIN LATERAL (
+      SELECT m.name, m.email, m.pmi_id FROM public.members m
+      WHERE m.person_id = e.person_id ORDER BY (m.pmi_id IS NOT NULL) DESC, m.updated_at DESC NULLS LAST LIMIT 1
+    ) mem ON true
+    LEFT JOIN LATERAL (
+      SELECT s.vep_status_raw FROM public.selection_applications s
+      WHERE (s.pmi_id = mem.pmi_id AND s.pmi_id IS NOT NULL AND s.pmi_id <> '') OR lower(s.email) = lower(mem.email)
+      ORDER BY s.imported_at DESC NULLS LAST LIMIT 1
+    ) va ON true
+    WHERE e.kind = 'volunteer' AND e.legal_basis = 'contract' AND e.status = 'active'
+    ORDER BY e.person_id, e.start_date DESC NULLS LAST
+  ),
+  vep_keys AS (
+    SELECT DISTINCT COALESCE(NULLIF(a.pmi_id, ''), 'e:' || lower(a.email)) AS match_key
+    FROM public.selection_applications a WHERE a.vep_status_raw = 'Active'
+  )
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'member_name', p.member_name, 'email', p.email, 'pmi_id', p.pmi_id, 'role', p.role, 'cohort', p.cohort,
+    'vep_status_raw', COALESCE(p.vep_status, '(sem app VEP)'),
+    'suggested_action', 'Verificar VEP: ativo na plataforma mas mirror não está Active (sync defasado ou oferta não estendida)'
+  ) ORDER BY p.member_name), '[]'::jsonb) INTO v_platform_only
+  FROM plat p WHERE p.match_key NOT IN (SELECT match_key FROM vep_keys);
+
+  WITH plat_keys AS (
+    SELECT DISTINCT COALESCE(NULLIF(mem.pmi_id, ''), 'e:' || lower(mem.email)) AS match_key
+    FROM public.engagements e
+    LEFT JOIN LATERAL (
+      SELECT m.pmi_id, m.email FROM public.members m
+      WHERE m.person_id = e.person_id ORDER BY (m.pmi_id IS NOT NULL) DESC, m.updated_at DESC NULLS LAST LIMIT 1
+    ) mem ON true
+    WHERE e.kind = 'volunteer' AND e.legal_basis = 'contract' AND e.status = 'active' AND mem.email IS NOT NULL
+  ),
+  vep AS (
+    SELECT DISTINCT ON (COALESCE(NULLIF(a.pmi_id, ''), 'e:' || lower(a.email)))
+      COALESCE(NULLIF(a.pmi_id, ''), 'e:' || lower(a.email)) AS match_key,
+      CASE WHEN a.role_applied = 'researcher' THEN 'researcher' WHEN a.role_applied = 'leader' THEN 'leader' ELSE 'other' END AS role,
+      COALESCE(c.cycle_code, 'no_cycle') AS cohort, a.applicant_name, a.email, a.pmi_id, m.is_active AS member_is_active
+    FROM public.selection_applications a
+    LEFT JOIN public.selection_cycles c ON c.id = a.cycle_id
+    LEFT JOIN LATERAL (
+      SELECT mm.is_active FROM public.members mm
+      WHERE (mm.pmi_id = a.pmi_id AND a.pmi_id IS NOT NULL AND a.pmi_id <> '') OR lower(mm.email) = lower(a.email)
+      ORDER BY (mm.pmi_id IS NOT NULL) DESC LIMIT 1
+    ) m ON true
+    WHERE a.vep_status_raw = 'Active'
+    ORDER BY COALESCE(NULLIF(a.pmi_id, ''), 'e:' || lower(a.email)), a.imported_at DESC NULLS LAST
+  )
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'applicant_name', v.applicant_name, 'email', v.email, 'pmi_id', v.pmi_id, 'role', v.role, 'cohort', v.cohort,
+    'member_is_active', v.member_is_active,
+    'suggested_action', CASE
+      WHEN v.member_is_active IS FALSE THEN 'Ativo no VEP mas offboarded na plataforma — reativar contrato ou encerrar no VEP'
+      WHEN v.member_is_active IS NULL THEN 'Ativo no VEP sem member na plataforma — verificar cadastro/vínculo'
+      ELSE 'Ativo no VEP sem contrato de voluntário ativo — verificar engajamento na plataforma'
+    END
+  ) ORDER BY v.applicant_name), '[]'::jsonb) INTO v_vep_only
+  FROM vep v WHERE v.match_key NOT IN (SELECT match_key FROM plat_keys);
+
+  RETURN jsonb_build_object(
+    'matrix', v_matrix, 'platform_only', v_platform_only, 'vep_only', v_vep_only,
+    'totals', jsonb_build_object(
+      'platform_active', v_plat_total, 'vep_active_mirror', v_vep_total, 'delta', v_plat_total - v_vep_total,
+      'platform_only_count', jsonb_array_length(v_platform_only), 'vep_only_count', jsonb_array_length(v_vep_only)
+    ),
+    'mirror_note', 'vep_active_mirror = selection_applications.vep_status_raw=Active (espelho do worker pmi-vep-sync). Pode divergir do dashboard PMI ao vivo; use como piso reconciliável, não como verdade externa.',
+    'generated_at', now()
+  );
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/1130-vep-role-cohort-reconciliation.test.mjs
+++ b/tests/contracts/1130-vep-role-cohort-reconciliation.test.mjs
@@ -1,0 +1,111 @@
+/**
+ * #1130 — Reconciliação VEP↔plataforma por papel×coorte + correção de causa-raiz do bucket B.
+ *
+ * Duas garantias:
+ *
+ *  (A) Semântica do bucket B (onboarding_divergent) em get_vep_divergence_report.
+ *      VEP 'Active' = voluntário que JÁ ACEITOU a oferta e está na jornada (estado saudável).
+ *      O bucket antigo marcava ('Submitted','Active') como divergência → contava o roster ativo
+ *      inteiro (62 crescendo sem parar). Corrigido: divergência = aprovado/convertido MAS ainda
+ *      pré-aceite no VEP ('Submitted' OU 'OfferExtended' = oferta emitida aguardando aceite).
+ *      'Active' NUNCA pode entrar no bucket B — senão o farol volta a ser enganoso.
+ *
+ *  (B) Nova RPC get_vep_role_cohort_reconciliation(): matriz papel×coorte + listas nominais,
+ *      join estável por PMI id (resolve o falso-gap do caso Paulo, e-mails divergentes/mesmo pmi_id).
+ *
+ * Static locks + DB-aware smoke (função deployada e gated). Skips offline como os demais.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+
+const ROOT = process.cwd();
+const MIG = resolve(ROOT, 'supabase/migrations/20260805000354_1130_vep_role_cohort_reconciliation.sql');
+const ISLAND = resolve(ROOT, 'src/components/admin/VepReconciliationIsland.tsx');
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const dbGated = !!(SUPABASE_URL && SUPABASE_KEY);
+const skipMsg = 'Skipped: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required';
+
+// ── STATIC: migration ─────────────────────────────────────────────────────────
+test('#1130 static: migration 20260805000354 exists', () => {
+  assert.ok(existsSync(MIG), 'migration 20260805000354 present');
+});
+
+test('#1130 static: new RPC get_vep_role_cohort_reconciliation defined + gated', () => {
+  const src = readFileSync(MIG, 'utf8');
+  assert.match(src, /CREATE OR REPLACE FUNCTION public\.get_vep_role_cohort_reconciliation\(/,
+    'get_vep_role_cohort_reconciliation defined');
+  assert.match(src, /SECURITY DEFINER/, 'SECURITY DEFINER');
+  assert.match(src, /can_by_member\(v_caller_id,\s*'view_internal_analytics'\)/,
+    'gated on view_internal_analytics');
+  assert.match(src, /selection_coi_recused/, 'COI recusal preserved');
+});
+
+test('#1130 static: matrix joins by stable PMI id key (fallback email)', () => {
+  const src = readFileSync(MIG, 'utf8');
+  // match_key = COALESCE(NULLIF(pmi_id,''), 'e:'||lower(email)) → pmi_id primário, e-mail fallback.
+  assert.match(src, /COALESCE\(NULLIF\([^)]*pmi_id[^)]*,\s*''\),\s*'e:'\s*\|\|\s*lower\(/,
+    'stable match key by pmi_id then email');
+});
+
+test('#1130 static: bucket B corrected — Submitted/OfferExtended, NEVER Active alone', () => {
+  const src = readFileSync(MIG, 'utf8');
+  // The onboarding_divergent predicate must be the pre-acceptance set.
+  assert.match(src, /a\.vep_status_raw IN \('Submitted',\s*'OfferExtended'\)/,
+    "bucket B predicate = IN ('Submitted','OfferExtended')");
+  // Regression guard: the old buggy predicate that swept 'Active' into onboarding must be gone.
+  assert.doesNotMatch(src, /status IN \('approved',\s*'converted'\)[\s\S]{0,120}?vep_status_raw IN \('Submitted',\s*'Active'\)/,
+    "old ('Submitted','Active') onboarding predicate must not resurface");
+});
+
+// ── STATIC: frontend island ────────────────────────────────────────────────────
+test('#1130 static: island wires the matrix RPC + tab + F3 error state + F4 cross-nav', () => {
+  const src = readFileSync(ISLAND, 'utf8');
+  assert.match(src, /get_vep_role_cohort_reconciliation/, 'island calls the new RPC');
+  assert.match(src, /'matrix'/, 'matrix tab key present');
+  assert.match(src, /loadError/, 'F3: dedicated load error state (not just a toast)');
+  assert.match(src, /\/admin\/filiacao/, 'F4: cross-nav to affiliation queue');
+  assert.match(src, /\/admin\/selection\?cycle=/, 'F4: cross-nav to selection by cycle');
+});
+
+// ── DB-AWARE: functions deployed + gated (auth.uid() null → Unauthorized, not 404) ─────
+test('#1130 db: get_vep_role_cohort_reconciliation is deployed and auth-gated', { skip: dbGated ? false : skipMsg }, async () => {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+  const { data, error } = await sb.rpc('get_vep_role_cohort_reconciliation');
+  // PostgREST resolving the function proves it is deployed + schema reloaded. Service-role calls
+  // carry no auth.uid(), so the SECURITY DEFINER gate returns {error:'Unauthorized'} — that is the
+  // expected shape here, NOT a PGRST202 "function not found".
+  assert.equal(error, null, `RPC should resolve (no PostgREST error): ${error?.message || ''}`);
+  assert.ok(data && typeof data === 'object', 'returns a jsonb object');
+  assert.equal(data.error, 'Unauthorized', 'service-role (no auth.uid) must be Unauthorized');
+});
+
+test('#1130 db: divergence report reachable + summary carries onboarding_by_cohort shape', { skip: dbGated ? false : skipMsg }, async () => {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+  const { data, error } = await sb.rpc('get_vep_divergence_report');
+  assert.equal(error, null, `RPC should resolve: ${error?.message || ''}`);
+  assert.ok(data && typeof data === 'object', 'returns object');
+  assert.equal(data.error, 'Unauthorized', 'service-role must be Unauthorized (gated)');
+});
+
+// ── DB-AWARE INVARIANT: the data reality that motivated the fix ─────────────────
+test('#1130 invariant: approved/converted + VEP Active exist and are NOT a pre-onboarding gap', { skip: dbGated ? false : skipMsg }, async () => {
+  const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
+  const { data, error } = await sb
+    .from('selection_applications')
+    .select('id, status, vep_status_raw')
+    .in('status', ['approved', 'converted'])
+    .not('vep_status_raw', 'is', null);
+  assert.equal(error, null, error?.message || '');
+  const active = data.filter((r) => r.vep_status_raw === 'Active');
+  const preAccept = data.filter((r) => ['Submitted', 'OfferExtended'].includes(r.vep_status_raw));
+  // The whole point of #1130: 'Active' approved/converted rows are the HEALTHY roster (should be
+  // large) and must never be conflated with the pre-acceptance gap (which is the actionable set).
+  assert.ok(active.length >= preAccept.length,
+    `sanity: healthy Active roster (${active.length}) should dwarf pre-acceptance gap (${preAccept.length})`);
+});


### PR DESCRIPTION
Closes #1130.

## Contexto
Reconciliação viva plataforma↔PMI VEP por **papel × coorte**, com join estável por PMI id, **+** correção da causa-raiz do "bucket B (62)" do `get_vep_divergence_report`.

## Parte 1 — Matriz papel×coorte (nova RPC)
`get_vep_role_cohort_reconciliation()` (gated `view_internal_analytics` + recusa COI ADR-0109):
- Matriz plataforma × VEP-mirror por papel (líder/pesquisador/outro) e coorte, com **Δ** por célula.
- Listas nominais nos dois sentidos: `platform_only` (ativo na plataforma sem VEP-ativo) e `vep_only` (VEP-ativo sem contrato ativo).
- **Join estável por `pmi_id` → e-mail (fallback)**: resolve o falso-gap do **caso Paulo** (e-mails divergentes, mesmo pmi_id — verificado: 0 aparições como gap). **Ricardo França** (offboarded × VEP-active) aparece em `vep_only` com ação sugerida.

## Parte 2 — Causa-raiz do bucket B (correção in-place)
O bucket antigo marcava `approved/converted + vep IN ('Submitted','Active')` como divergência. Mas no ciclo de vida do VEP **`Active` = já aceitou a oferta e está na jornada (saudável)** — o bucket contava o **roster ativo** como divergente (62 crescendo sem parar).

Corrigido: pré-onboarding = `approved/converted` **+ pré-aceite no VEP** (`Submitted` sem oferta **OU** `OfferExtended` oferta emitida aguardando aceite). Isso dá visibilidade de **quem falta aceitar e já deveria estar na jornada** (feedback do owner). `summary.onboarding_by_cohort` traz o breakdown.

Relatório: `docs/audit/VEP_BUCKET_B_ROOT_CAUSE_1130.md`.

## UX (F3/F4)
- **F3**: estado de erro dedicado com "Tentar novamente" — acaba o spinner infinito quando a RPC falha.
- **F4**: navegação cruzada por linha para `/admin/selection?cycle=` e link para `/admin/filiacao`.

## Antes → depois (ao vivo, 2026-07-07)
| | Antes | Depois |
|---|---|---|
| Bucket B (`onboarding_divergent`) | **62** (roster saudável) | **6** (C4 com oferta emitida, falta aceitar) |
| `total_divergent` | 63 | 7 (6 + Ricardo) |
| Matriz papel×coorte | não existia | 71 plataforma × 62 VEP-mirror (Δ9) |

As 3 "verdades VEP" divergem (dashboard 77 · CSV 55 · mirror 62); a view usa o mirror como **piso reconciliável** e sinaliza via `mirror_note`.

## Critérios de aceite
- [x] Matriz papel×coorte plataforma vs VEP + delta.
- [x] Listas nominais nos dois sentidos.
- [x] Join por PMI id resolve o caso Paulo.
- [x] Ricardo França visível com ação sugerida.
- [x] Relatório de causa-raiz do bucket-B documentado.
- [x] Contract test + re-grounding ao vivo (BEFORE/AFTER).

## Técnico
- Migration `20260805000354` aplicada + registrada (bodies verbatim do vivo p/ paridade GC-097 body-drift; phantom-rows do apply_migration limpas).
- `npx astro build` ✓ · `npm test` **5123/0** ✓ · contract test #1130 **8/8** (DB-aware).

🤖 Generated with [Claude Code](https://claude.com/claude-code)