### PR TITLE
#1159 — Permitir ViaCEP no CSP (autocomplete de CEP no perfil)

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -9,7 +9,7 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   Permissions-Policy: camera=(), microphone=(), geolocation=()
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://us.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://ldrfrvwhxsmgaabwmaik.supabase.co https://*.googleusercontent.com https://i.ytimg.com; connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://cloudflareinsights.com; frame-src https://calendar.google.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://us-assets.i.posthog.com https://us.posthog.com https://static.cloudflareinsights.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob: https://ldrfrvwhxsmgaabwmaik.supabase.co https://*.googleusercontent.com https://i.ytimg.com; connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://cloudflareinsights.com https://viacep.com.br; frame-src https://calendar.google.com; object-src 'none'; frame-ancestors 'none'; base-uri 'self'
 
 # SSR pages — no caching
 /tribe/*

--- a/src/lib/securityHeaders.ts
+++ b/src/lib/securityHeaders.ts
@@ -43,7 +43,7 @@ export const CSP =
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; " +
   "font-src 'self' https://fonts.gstatic.com; " +
   "img-src 'self' data: blob: https://ldrfrvwhxsmgaabwmaik.supabase.co https://*.googleusercontent.com https://i.ytimg.com; " +
-  "connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://cloudflareinsights.com; " +
+  "connect-src 'self' https://ldrfrvwhxsmgaabwmaik.supabase.co wss://ldrfrvwhxsmgaabwmaik.supabase.co https://us.posthog.com https://us.i.posthog.com https://us-assets.i.posthog.com https://*.sentry.io https://cloudflareinsights.com https://viacep.com.br; " +
   "frame-src https://calendar.google.com; " +
   "object-src 'none'; " +
   "frame-ancestors 'none'; " +


### PR DESCRIPTION
Closes #1159.

## Sintoma
Voluntários brasileiros recebiam `❌ Erro ao consultar CEP` ao preencher o endereço no perfil (Hanae Monma, Luiz Ramom, Luana Andrade — e sistêmico p/ todo membro BR).

## Causa-raiz
`src/pages/profile.astro` faz `fetch('https://viacep.com.br/ws/{cep}/json/')` para autocompletar endereço/cidade/UF (CEP não é persistido; é lookup). A CSP `connect-src` não listava `viacep.com.br` → o browser bloqueia a chamada → `catch` → erro.

## Fix
`https://viacep.com.br` adicionado ao `connect-src` em **`public/_headers`** e **`src/lib/securityHeaders.ts`** (byte-idênticos; guard `855-ssr-security-headers-parity` 9/9).

## Impacto
Desbloqueia o preenchimento de endereço no pré-onboarding do Ciclo 4 (campo obrigatório para o Termo de Voluntariado).

## Fora de escopo
Bug do LinkedIn (Honorio Dias): sem validação server-side/CHECK, valor `null` — precisa reprodução (campo URL vs OAuth "Vincular LinkedIn"). Não incluído.

astro build ✓ · 855 parity 9/9 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)