### PR TITLE
docs(governance): #1165 Onda 2 (re-aceite dos ativos) — runbook + spec do backfill do ledger

### DIFF
--- a/docs/runbooks/GO-LIVE-onda2-reacceptance.md
+++ b/docs/runbooks/GO-LIVE-onda2-reacceptance.md
@@ -1,0 +1,136 @@
+# Runbook — Go-live Onda 2 (re-aceite do Termo v9 pelos voluntários ativos)
+
+**Audiência:** GP / Gerente de Projeto (`manage_platform`).
+**Status:** DRAFT / planejamento (2026-07-07). Onda 2 é DESACOPLADA da Onda 1.
+**Spec:** `docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md`.
+**Máquina:** #976 PR-4 de #571 (`open_reacceptance_obligations` e cia), migration `20260805000304`.
+**Base legal:** Termo 15.3 (cascata material) · 15.4.3 (objeção) · 15.4.5 (licenças preservadas).
+
+> **Objetivo de negócio.** Levar os voluntários **ativos que assinaram versões antigas** do Termo
+> a **re-aceitar a v9** (mudança material — rodada jurídica Aaron/Angeline). A Onda 1 destravou a
+> assinatura para os C4 novos; a Onda 2 fecha o círculo com quem já estava dentro.
+
+> **O que Claude NÃO faz.** Claude não dispara o fan-out real (`p_dry_run=false`) nem envia e-mail
+> aos voluntários sem go explícito do GP **e** o gate OUTWARD #334 (DPO/ANPD). Claude prepara,
+> aterra ao vivo e verifica; a decisão de disparar a cascata (que pode desligar não-respondentes) é humana.
+
+---
+
+## 0. O bloqueador que a Onda 2 resolve primeiro (LER)
+
+A máquina de re-aceite faz fan-out sobre `member_document_signatures` (ledger). **Esse ledger está
+VAZIO** — as 48 assinaturas reais estão em `certificates`. Sem popular o ledger, o fan-out é vazio.
+Por isso a Onda 2 tem uma **etapa de backfill** (§2) que a Onda 1 não tinha. Detalhe e SQL na spec.
+
+---
+
+## 1. Estado aterrado (re-conferir SEMPRE antes de executar — Onda 1 está viva)
+
+```sql
+-- Template ativo + change_class (esperado: v9, material)
+SELECT gd.id, gd.current_version_id, dv.version_label, dv.change_class
+FROM governance_documents gd JOIN document_versions dv ON dv.id=gd.current_version_id
+WHERE gd.doc_type='volunteer_term_template' AND gd.status='active';
+
+-- Ledger (fonte do fan-out) — 0 ANTES do backfill; 48 DEPOIS
+SELECT count(*) AS ledger_rows FROM member_document_signatures;
+
+-- Distribuição e alvo (ver §4 da spec para a CTE completa)
+-- Esperado 2026-07-07: 40 históricos (30 active = ALVO), 8+ na v9 (excluídos)
+```
+
+Valores de referência (2026-07-07, re-aterrar):
+| Fato | Valor |
+|---|---|
+| template ativo | v9 `246ff8be`, `change_class=material` |
+| ledger | 0 linhas (bloqueio) |
+| alvo Onda 2 (active + histórico) | **30** (todos com `organization_id`) |
+| já na v9 (Onda 1) | 8 e subindo (excluídos) |
+
+---
+
+## 2. Backfill do ledger (pré-requisito — ato do GP via migration)
+
+**Antes:** confirmar D1 (versão âncora, legal) e D2 (escopo 48 vs 30) da spec §1.
+
+- [ ] Aplicar `supabase/migrations/<ts>_onda2_backfill_member_doc_signatures.sql` (SQL na spec §2)
+      via `apply_migration`. É DML idempotente.
+- [ ] Sync local + `supabase migration repair --status applied <ts>` (`feedback-apply-migration-creates-tracking-row`).
+- [ ] Verificar: ledger espelha os certs, 1 corrente por membro, v9-signers apontam v9, históricos a âncora (spec §2).
+
+---
+
+## 3. Pré-flight da cascata
+
+- [ ] **Onda 1 assentada.** E-mail C4 entregue, adesões v9 em curso estáveis. Não disparar Onda 2 no
+      mesmo dia do go-live C4.
+- [ ] **Gate OUTWARD #334 (DPO/ANPD).** SPEC_571 §208: o fan-out real (aviso-30d aos voluntários) só
+      dispara com PM-OK **e** #334. Sem isto, PARAR.
+- [ ] **change_class = material.** Confirmado na §1. Se fosse editorial, o caminho seria
+      `notify_editorial_change_awareness` (ciência tácita, sem obrigação) — NÃO é o caso.
+- [ ] **D3 (liderança).** Confirmar que GP/co-GP entram no re-aceite (assinaram versão antiga como voluntários).
+
+---
+
+## 4. Dry-run do fan-out (read-only — ato do GP autenticado)
+
+`open_reacceptance_obligations` exige `auth.uid()` + `manage_platform` (não roda por service role).
+O GP autenticado chama com `p_dry_run=>true`:
+
+```sql
+SELECT public.open_reacceptance_obligations(
+  '280c2c56-e0e3-4b10-be68-6c731d1b4520'::uuid,   -- doc
+  '246ff8be-9ed8-4a81-9211-bf097750c4c7'::uuid,   -- v9
+  true);                                          -- DRY-RUN
+```
+- [ ] `target_count` = **30** (ou o número re-aterrado). Se vier 0 → o backfill não foi aplicado. Se
+      vier 40 → D2 ficou em (a) sem filtro active; decidir antes do run real.
+- [ ] Conferir os nomes em `targets` contra o preview.
+
+---
+
+## 5. Fan-out real (ato do GP — dispara a cascata)
+
+**Só após #334 + dry-run conferido.** Idempotente (índice parcial impede dupla obrigação).
+
+```sql
+SELECT public.open_reacceptance_obligations(
+  '280c2c56-e0e3-4b10-be68-6c731d1b4520'::uuid,
+  '246ff8be-9ed8-4a81-9211-bf097750c4c7'::uuid,
+  false);   -- REAL: cria obrigações + aviso-30d in-app; e-mail via jobid 9
+```
+- [ ] `created` = alvo esperado. `admin_audit_log` action `reacceptance.obligations_opened`.
+- [ ] Prazos no retorno: `effective_from` (+30d), `window_closes_at` (+15 úteis GO), `suspended_until` (+30d).
+
+---
+
+## 6. Ciclo e monitoramento (cron dirige; humanos respondem)
+
+- **Membro** vê o banner/countdown via `get_my_reacceptance_obligations`; re-aceita via
+  `express_reacceptance(obligation)` (permitido `in_window`, `suspended` tardio, `accommodation`).
+- **Objeção fundamentada (15.4.3):** `register_reacceptance_objection` congela a cascata; Comitê
+  responde em 10 úteis via `respond_reacceptance_objection` (accepted→recircula / rejected→retoma /
+  accommodation→5 úteis). Acolhida ⇒ recircular o instrumento e `link_reacceptance_recirculation`.
+- **Recusa expressa (15.3(e)):** `refuse_reacceptance` → desligamento imediato, licenças preservadas.
+- **Lapso:** cron diário move `notified→in_window→suspended→lapsed_disengaged`; `_reacceptance_disengage`
+  desliga (status `inactive`, engagements fechados) **preservando** `member_document_signatures` (15.4.5).
+- [ ] Monitorar `member_reacceptance_obligations` por estado. Bounces do e-mail via `email_webhook_events`.
+
+---
+
+## 7. Rollback / abortar
+
+- **Antes do fan-out real:** nada a desfazer além do backfill (que é verdade do ledger — manter).
+- **Após o fan-out, antes de qualquer desligamento:** as obrigações `notified`/`in_window` podem ser
+  neutralizadas marcando `state='superseded'` (ato administrativo com `manage_platform` + nota no
+  audit log). NÃO deletar linhas (audit-trail).
+- Desligamentos por recusa/lapso **preservam licenças** — não são reversíveis por este runbook (o
+  membro retorna via re-engajamento normal, `member_status` é reversível).
+
+---
+
+## 8. Cross-ref
+- Spec: `docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md`
+- Máquina: `docs/specs/SPEC_571_CAMADA5_MATERIAL_CHANGE.md` (§5 PR-4, §9.5, §208 gate OUTWARD)
+- Onda 1: `docs/runbooks/GO-LIVE-onda1-volunteer-term.md`
+- Drift das 2 representações: memory `reference-volunteer-term-signing-representation-drift`

--- a/docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md
+++ b/docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md
@@ -1,0 +1,188 @@
+# SPEC — Onda 2 (re-aceite dos ativos): backfill do ledger + fan-out da máquina #976
+
+**Status:** DRAFT / planejamento (2026-07-07). Nada aplicado ao banco.
+**Escopo:** habilitar a Onda 2 (re-aceite do Termo v9 pelos voluntários ativos que assinaram
+versões antigas), resolvendo o bloqueador do ledger vazio antes de qualquer fan-out.
+**Deps:** Onda 1 ATIVADA (v9 `246ff8be` = `status='active'`, `change_class='material'`).
+Máquina de estados #976 (PR-4 de #571, migration `20260805000304`) já vive DORMENTE.
+**Runbook operacional:** `docs/runbooks/GO-LIVE-onda2-reacceptance.md`.
+**Feridas legais:** Termo 15.3 (cascata de re-aceite) · 15.4.5 (licenças preservadas) · SPEC_571 §208 (OUTWARD-gate #334).
+
+---
+
+## 0. O bloqueador (aterrado ao vivo, projeto `ldrfrvwhxsmgaabwmaik`, 2026-07-07)
+
+A máquina `open_reacceptance_obligations(doc, to_version)` faz fan-out sobre
+`member_document_signatures` (`is_current=true`). **Essa tabela tem 0 linhas.** As assinaturas
+reais do Termo vivem em `certificates` (`type='volunteer_agreement'`), porque
+`sign_volunteer_agreement` escreve lá, nunca no ledger (drift das 2 representações —
+`reference-volunteer-term-signing-representation-drift`).
+
+**Consequência:** rodar `open_reacceptance_obligations('280c2c56…', '246ff8be…')` hoje →
+fan-out **VAZIO**. A Onda 2 depende de **popular o ledger primeiro**.
+
+Números aterrados (re-aterrar antes de executar — Onda 1 está viva, os `has_v9` sobem):
+
+| Fato | Valor | Query |
+|---|---|---|
+| `member_document_signatures` | **0 linhas** | `SELECT count(*) FROM member_document_signatures` |
+| certs `volunteer_agreement` | 48 membros distintos (0 fora de `members`) | ver §4 |
+| históricos (pré-v9, sem `body_version_id`) | **40** (30 active, 10 inativos) | ver §4 |
+| já na v9 (Onda 1) | **8 e subindo** → excluídos | ver §4 |
+| conjuntos | disjuntos (40+8=48; nenhum membro tem antigo E v9) | ver §4 |
+| **alvo do re-aceite (active + histórico + org≠null)** | **30** | ver §4 |
+| versão âncora candidata (última pré-v9) | v2.7 `29a2d175` (lacrada 2026-05-12) | `document_versions` |
+
+Constraints do ledger (confirmados ao vivo):
+- `uq_member_doc_sigs_current` UNIQUE `(member_id, document_id) WHERE is_current` → 1 corrente por (membro,doc)
+- `member_document_signatures_member_id_signed_version_id_key` UNIQUE `(member_id, signed_version_id)`
+- trigger `trg_member_doc_sig_supersede_previous` AFTER INSERT WHEN `is_current=true` → auto-supersede
+- `signed_version_id` é **NOT NULL** → históricos EXIGEM uma versão âncora (não podem ser NULL)
+
+---
+
+## 1. Decisões ABERTAS (confirmar antes de aplicar — impacto legal)
+
+### D1 — Versão âncora dos 40 históricos
+Os históricos assinaram **18/02→14/04**, mas a versão nº1 sob 280c2c56 só foi lacrada em
+**18/04**. Eles assinaram o **clauseN JSON pré-versionamento** (sem pin; `content_snapshot`
+só tem a chave `clauses`). Não existe `document_version` que corresponda ao que assinaram.
+Como `signed_version_id` é NOT NULL, é preciso ESCOLHER uma âncora. A escolha só afeta o
+`from_version_id` do audit-trail (todos os não-v9 disparam obrigação igual).
+
+- **Recomendado:** v2.7 `29a2d175` (última pré-v9) → delta de auditoria "v2.7 → v9" = o delta
+  jurídico real que a rodada Aaron/Angeline produziu.
+- Alternativa: v1 `0f61a8db` (mais antiga) — "assinou a linhagem mais antiga".
+- Verdade documentada: assinaram texto pré-versionamento; a âncora é uma convenção de auditoria.
+- **Confirmar com legal_counsel.**
+
+### D2 — Escopo do backfill: 48 (verdade) vs 30 (active)
+`open_reacceptance_obligations` **NÃO filtra `members.is_active`** (SPEC_571 §302, por design —
+para não perder ninguém). Se o backfill incluir os 40 históricos, o fan-out atinge **40** (inclui
+10 inativos), não 30. Opções:
+- **(a) backfill 48 (ledger = verdade) + fan-out Onda 2 restrito a active** (wrapper que filtra, ou
+  aceitar que os 10 inativos recebem obrigação no-op — já estão offboarded; `_reacceptance_disengage`
+  é idempotente em inativo). **Recomendado (a) com filtro explícito** para não mandar e-mail
+  "re-aceite ou desligamento" a alumni.
+- (b) backfill só os 30 active (ledger incompleto; se um alumnus voltar, sua assinatura não está registrada).
+- **Recomendado:** (a) — backfill dos 48 para verdade do ledger; a Onda 2 obriga só os 30 active.
+
+### D3 — Liderança na população
+Os 30 incluem **GP (Vitor)** e **co-GP/curador (Fabricio Costa)** — assinaram versão antiga como
+voluntários; ratificaram a v9 como curadores. Papéis distintos ⇒ re-aceitam como voluntários.
+Confirmar que não há exclusão de liderança desejada.
+
+### D4 — Wiring forward do `sign_volunteer_agreement` (§3) é PR separado
+Tocar a RPC do fluxo de assinatura VIVO (Onda 1 em curso) é delicado (#648 imutabilidade). NÃO
+empacotar com o backfill. PR dedicado, testado, depois que a Onda 1 assentar.
+
+---
+
+## 2. Backfill (DML idempotente) — NÃO aplicar até D1/D2 confirmados
+
+> Migration file: `supabase/migrations/<timestamp>_onda2_backfill_member_doc_signatures.sql`
+> (timestamp > head atual). DML puro (INSERT) — mesmo assim vai como migration + `migration repair`
+> per `feedback-apply-migration-creates-tracking-row`. Aplicar via `apply_migration`.
+
+```sql
+-- Onda 2 backfill: popular member_document_signatures a partir de certificates
+-- (volunteer_agreement) para a máquina de re-aceite #976 enxergar os signatários reais.
+-- Idempotente (guard NOT EXISTS). 1 linha corrente por membro (conjuntos disjuntos, ledger vazio).
+DO $$
+DECLARE
+  v_doc    uuid := '280c2c56-e0e3-4b10-be68-6c731d1b4520';  -- volunteer_term_template
+  v_v9     uuid := '246ff8be-9ed8-4a81-9211-bf097750c4c7';  -- versão material vigente
+  v_anchor uuid := '29a2d175-a9d7-4993-8147-3b476e4d896e';  -- D1: v2.7 (última pré-v9) — CONFIRMAR
+BEGIN
+  INSERT INTO public.member_document_signatures
+    (member_id, document_id, signed_version_id, certificate_id, signed_at, is_current)
+  SELECT DISTINCT ON (c.member_id)
+    c.member_id,
+    v_doc,
+    CASE WHEN (c.content_snapshot->>'body_version_id') = v_v9::text THEN v_v9 ELSE v_anchor END,
+    c.id,
+    COALESCE((c.content_snapshot->>'signed_at')::timestamptz, c.created_at, now()),
+    true
+  FROM public.certificates c
+  WHERE c.type = 'volunteer_agreement'
+    -- D2 (a): backfill dos 48 = comentar o filtro; para (b) só-active, descomentar:
+    -- AND EXISTS (SELECT 1 FROM public.members m WHERE m.id=c.member_id AND m.member_status='active')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.member_document_signatures x
+      WHERE x.member_id = c.member_id AND x.document_id = v_doc AND x.is_current)
+  ORDER BY c.member_id, (c.content_snapshot->>'signed_at') DESC NULLS LAST;
+END $$;
+```
+
+Pós-backfill (verificação):
+```sql
+-- ledger espelha os certs; v9-signers apontam v9, históricos apontam a âncora
+SELECT signed_version_id::text, count(*)
+FROM public.member_document_signatures WHERE document_id='280c2c56-e0e3-4b10-be68-6c731d1b4520'
+GROUP BY 1;
+-- 1 corrente por membro:
+SELECT count(*) FILTER (WHERE is_current) AS current_rows,
+       count(DISTINCT member_id) AS members FROM public.member_document_signatures;
+```
+
+---
+
+## 3. Wiring forward (D4 — PR separado, NÃO neste ciclo)
+
+Sem isto, todo re-aceite/adesão nova continua indo só p/ `certificates` e o ledger volta a
+divergir. Em `sign_volunteer_agreement` (após gravar o certificate), adicionar INSERT no ledger:
+
+```sql
+-- dentro de sign_volunteer_agreement, após o INSERT em certificates (v_cert_id):
+INSERT INTO public.member_document_signatures
+  (member_id, document_id, signed_version_id, certificate_id, signed_at, is_current)
+VALUES (v_member_id, v_doc_id, v_active_version_id, v_cert_id, now(), true)
+ON CONFLICT DO NOTHING;  -- trigger auto-supersede cuida da versão anterior
+```
+Exige aterrar `v_doc_id`/`v_active_version_id` dentro da RPC (hoje ela seleciona o template
+`active`). Cobrir com contract test: toda adesão nova cria 1 linha corrente no ledger.
+
+---
+
+## 4. Queries de aterramento (read-only — re-rodar antes de executar)
+
+```sql
+-- Distribuição + alvo (corrige a lógica ternária: body_version_id NULL ≠ false)
+WITH sig AS (
+  SELECT c.member_id,
+         COALESCE(bool_or((c.content_snapshot->>'body_version_id')
+                          = '246ff8be-9ed8-4a81-9211-bf097750c4c7'), false) AS has_v9
+  FROM public.certificates c WHERE c.type='volunteer_agreement' GROUP BY c.member_id)
+SELECT
+  count(*) AS distinct_cert_members,
+  count(*) FILTER (WHERE NOT s.has_v9) AS historical,
+  count(*) FILTER (WHERE NOT s.has_v9 AND m.member_status='active') AS hist_active_target,
+  count(*) FILTER (WHERE s.has_v9) AS v9_signers
+FROM sig s LEFT JOIN public.members m ON m.id=s.member_id;
+```
+
+Lista nominal (PII → não commitar; rodar ao vivo): ver o `WHERE NOT has_v9 AND active` do §4 com
+`m.name`. Preview de 2026-07-07 (30 membros) ficou no scratchpad da sessão, fora do repo.
+
+---
+
+## 5. Sequência da Onda 2 (resumo — detalhe no runbook)
+
+1. Confirmar D1–D4 (legal_counsel em D1/D3; PM em D2).
+2. Aplicar backfill (§2) via `apply_migration` + sync local + `migration repair`.
+3. **Gate OUTWARD #334 (DPO/ANPD)** — SPEC_571 §208. Sem isto, não disparar fan-out real.
+4. `open_reacceptance_obligations('280c2c56…','246ff8be…', p_dry_run=>true)` → conferir target = 30.
+5. Idem `p_dry_run=>false` (ato do GP, `manage_platform`, autenticado) → aviso-30d in-app + e-mail (jobid 9).
+6. Monitorar a cascata (30d vigência → 15 úteis janela → 30d suspensão → desligamento). UI:
+   `get_my_reacceptance_obligations`. Objeção/recusa: `register_reacceptance_objection`/`refuse_reacceptance`.
+7. **Timing:** só depois da Onda 1 / e-mail C4 assentarem. Não no mesmo dia do go-live.
+
+---
+
+## 6. Invariantes / o que NÃO fazer
+
+- NÃO rodar `open_reacceptance_obligations(p_dry_run=false)` antes do backfill (fan-out vazio) NEM
+  antes do gate #334.
+- NÃO deletar/mutar linhas de `certificates` (imutáveis #648) — o backfill só LÊ delas.
+- NÃO empacotar o wiring forward (§3, toca RPC viva) com o backfill.
+- Desligamento por lapso/recusa **preserva** `member_document_signatures` (15.4.5) — nunca deletar.


### PR DESCRIPTION
Planejamento da **Onda 2** (re-aceite do Termo v9 pelos voluntários ativos que assinaram versões antigas). Docs-only, **nada aplicado ao banco**. Closes parte do planejamento de #1165.

## Achado central (aterrado ao vivo 2026-07-07)
A máquina de re-aceite #976 (`open_reacceptance_obligations`) faz fan-out sobre `member_document_signatures` = **0 linhas**; as 48 assinaturas reais vivem em `certificates`. Fan-out hoje = vazio → Onda 2 depende de **backfill `certificates→ledger` + wiring forward** primeiro.

## Conteúdo
- `docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md` — SQL do backfill idempotente + decisões D1–D4 + wiring forward
- `docs/runbooks/GO-LIVE-onda2-reacceptance.md` — sequência operacional (backfill → gate #334 → dry-run → run real → cascata → rollback)

## Alvo aterrado
30 ativos históricos (pré-v9, todos com `organization_id`). v9 `246ff8be` = `material`. Gate OUTWARD #334 (DPO/ANPD) obrigatório antes do run real; não disparar no mesmo dia do go-live C4.

Decisões ratificadas pelo PM: D1 âncora v2.7 · D2 backfill 48 + fan-out 30 · D3 GP/co-GP re-aceitam · D4 wiring = PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)