### PR TITLE
fix(termo/governance): superfície de contra-assinatura (Lorena) + ativação carimba cadeia ratificada

### DIFF
--- a/src/components/admin/VolunteerAgreementPanel.tsx
+++ b/src/components/admin/VolunteerAgreementPanel.tsx
@@ -91,6 +91,8 @@ const L: Record<string, Record<string, string>> = {
     actions: 'Ações',
     reject: 'Rejeitar',
     reissue: 'Re-emitir',
+    counterSign: 'Contra-assinar',
+    counterSignConfirm: 'Contra-assinar o Termo de {name}? Isso conclui a assinatura pela diretoria e libera o certificado ao voluntário.',
     rejectPrompt: 'Motivo da rejeição do termo (o voluntário será notificado para reassinar):',
     rejectPromptCountersigned: 'Atenção: este termo já foi contra-assinado (ato bilateral). Rejeitá-lo equivale a um distrato formal. Motivo:',
     reissuePrompt: 'Motivo da reemissão (o termo atual será substituído e o voluntário deverá reassinar):',
@@ -136,6 +138,8 @@ const L: Record<string, Record<string, string>> = {
     actions: 'Actions',
     reject: 'Reject',
     reissue: 'Reissue',
+    counterSign: 'Counter-sign',
+    counterSignConfirm: 'Counter-sign {name}’s Agreement? This completes the board signature and releases the certificate to the volunteer.',
     rejectPrompt: 'Reason for rejecting the agreement (the volunteer will be asked to re-sign):',
     rejectPromptCountersigned: 'Warning: this agreement was already counter-signed (bilateral act). Rejecting it amounts to a formal rescission. Reason:',
     reissuePrompt: 'Reason for reissuing (the current agreement will be superseded and the volunteer must re-sign):',
@@ -181,6 +185,8 @@ const L: Record<string, Record<string, string>> = {
     actions: 'Acciones',
     reject: 'Rechazar',
     reissue: 'Reemitir',
+    counterSign: 'Contrafirmar',
+    counterSignConfirm: 'Contrafirmar el Acuerdo de {name}? Esto completa la firma de la directiva y libera el certificado al voluntario.',
     rejectPrompt: 'Motivo del rechazo del término (el voluntario será notificado para volver a firmar):',
     rejectPromptCountersigned: 'Atención: este término ya fue contra-firmado (acto bilateral). Rechazarlo equivale a una rescisión formal. Motivo:',
     reissuePrompt: 'Motivo de la reemisión (el término actual será reemplazado y el voluntario deberá volver a firmar):',
@@ -223,6 +229,7 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
   const [template, setTemplate] = useState<TemplateData | null>(null);
   const [showTemplate, setShowTemplate] = useState(false);
   const [isManager, setIsManager] = useState(false);
+  const [canCounterSign, setCanCounterSign] = useState(false);
   const [callerChapter, setCallerChapter] = useState<string>('');
   const [authorized, setAuthorized] = useState(false);
   const [filter, setFilter] = useState<'all' | 'signed' | 'pending'>('all');
@@ -246,6 +253,7 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
       setFocalPoints(d.focal_points || []);
       setTemplate(d.template || null);
       setIsManager(d.is_manager || false);
+      setCanCounterSign(d.can_counter_sign || false);
       setCallerChapter(d.caller_chapter || '');
     }
   }, []);
@@ -317,6 +325,29 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
     setActing(m.id);
     try {
       const { data, error } = await sb.rpc('reject_certificate', { p_certificate_id: m.agreement_cert_id, p_reason: reason.trim() });
+      if (error || data?.error) throw new Error(data?.error || error?.message);
+      (window as any).toast?.(t.actionSuccess, 'success');
+      await load();
+    } catch {
+      (window as any).toast?.(t.actionError, 'error');
+    } finally {
+      setActing(null);
+    }
+  };
+
+  // Counter-sign a member's issued term (board signature, 2nd wave). Authority is enforced by
+  // counter_sign_certificate (manage_member OR chapter_board of the contracting chapter); the
+  // button only renders when get_volunteer_agreement_status returned can_counter_sign=true, so
+  // the two stay in lock-step. Mirrors the working call in admin/certificates.astro (omits p_signed_ip).
+  const counterSignAgreement = async (m: MemberRow) => {
+    if (!m.agreement_cert_id) return;
+    if (!window.confirm(t.counterSignConfirm.replace('{name}', m.name))) return;
+    const sb = (window as any).navGetSb?.();
+    if (!sb) return;
+    setActing(m.id);
+    try {
+      const ua = typeof navigator !== 'undefined' ? navigator.userAgent.substring(0, 500) : null;
+      const { data, error } = await sb.rpc('counter_sign_certificate', { p_certificate_id: m.agreement_cert_id, p_signed_user_agent: ua });
       if (error || data?.error) throw new Error(data?.error || error?.message);
       (window as any).toast?.(t.actionSuccess, 'success');
       await load();
@@ -678,6 +709,15 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
                   <td className="px-3 py-2 text-right whitespace-nowrap">
                     {m.agreement_status === 'issued' ? (
                       <div className="inline-flex gap-1.5">
+                        {canCounterSign && m.signed && !m.counter_signed && (
+                          <button
+                            onClick={() => counterSignAgreement(m)}
+                            disabled={acting === m.id}
+                            className="px-2 py-0.5 rounded-md bg-emerald-600 text-white text-[10px] font-semibold border-0 cursor-pointer hover:bg-emerald-700 disabled:opacity-50"
+                          >
+                            ✍️ {t.counterSign}
+                          </button>
+                        )}
                         <button
                           onClick={() => rejectAgreement(m)}
                           disabled={acting === m.id}

--- a/supabase/migrations/20260805000355_term_countersign_surface_can_flag.sql
+++ b/supabase/migrations/20260805000355_term_countersign_surface_can_flag.sql
@@ -1,0 +1,209 @@
+-- Term counter-signature surface fix (Lorena / voluntariado_director sede).
+--
+-- Problem: there was no working UI path to counter-sign a volunteer TERM.
+--   1. get_pending_countersign (the only list with a counter-sign button) filters
+--      out `type = 'volunteer_agreement'`, so terms never appear there.
+--   2. VolunteerAgreementPanel shows the term roster with an inert "Aguarda diretor"
+--      badge but no counter-sign action (only Reject/Reissue).
+-- The sede voluntariado director (chapter_board of the contracting chapter) is already
+-- authorized by counter_sign_certificate, but had no surface to act on the 29 pending terms.
+--
+-- Fix (Option A): expose a `can_counter_sign` flag from get_volunteer_agreement_status so
+-- the panel can render an actionable "Contra-assinar" button next to the awaiting-director
+-- badge. The flag mirrors counter_sign_certificate's real authority gate EXACTLY (so we never
+-- render a button that would 403): manage_member OR (chapter_board of the CONTRACTING chapter).
+-- No behaviour change to any existing caller; this only adds a JSON field.
+CREATE OR REPLACE FUNCTION public.get_volunteer_agreement_status()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_result jsonb;
+  v_caller_id uuid;
+  v_caller_chapter text;
+  v_caller_person_id uuid;
+  v_is_manage_member boolean;
+  v_is_chapter_board boolean;
+  v_is_vol_director boolean;
+  v_contracting_chapter text;
+  v_can_counter_sign boolean;
+BEGIN
+  SELECT m.id, m.chapter, m.person_id
+    INTO v_caller_id, v_caller_chapter, v_caller_person_id
+  FROM public.members m WHERE m.auth_id = auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  v_is_manage_member := public.can_by_member(v_caller_id, 'manage_member');
+  v_is_chapter_board := EXISTS (
+    SELECT 1 FROM public.auth_engagements ae
+    WHERE ae.person_id = v_caller_person_id
+      AND ae.kind = 'chapter_board'
+      AND ae.status = 'active'
+  );
+  -- WS-3: sede volunteer-director designation = program-wide read of the roster (function-anchored).
+  v_is_vol_director := EXISTS (
+    SELECT 1 FROM public.members m
+    WHERE m.id = v_caller_id AND 'voluntariado_director' = ANY(m.designations)
+  );
+
+  IF NOT v_is_manage_member AND NOT v_is_chapter_board AND NOT v_is_vol_director THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  -- The contracting party is ALWAYS the contracting chapter (PMI-GO, C3). Mirror the exact
+  -- authority gate of counter_sign_certificate so the panel only shows the button to callers
+  -- the RPC will accept: manage_member OR a chapter_board member of the contracting chapter.
+  SELECT 'PMI-' || cr.chapter_code INTO v_contracting_chapter
+  FROM public.chapter_registry cr
+  WHERE cr.is_contracting_chapter AND cr.is_active
+  LIMIT 1;
+
+  v_can_counter_sign := v_is_manage_member
+    OR (v_is_chapter_board AND v_caller_chapter IS NOT DISTINCT FROM v_contracting_chapter);
+
+  SELECT jsonb_build_object(
+    'generated_at', now(),
+    'caller_chapter', v_caller_chapter,
+    'is_manager', v_is_manage_member,
+    'can_counter_sign', v_can_counter_sign,
+    'summary', (
+      SELECT jsonb_build_object(
+        'total_eligible', count(*),
+        'signed', count(*) FILTER (WHERE EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        )),
+        'unsigned', count(*) FILTER (WHERE NOT EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        )),
+        'pct', ROUND(
+          count(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+            AND c.status = 'issued'
+            AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ))::numeric / NULLIF(count(*), 0) * 100, 1
+        )
+      )
+      FROM public.members m WHERE m.is_active AND m.current_cycle_active
+      AND m.operational_role NOT IN ('sponsor', 'chapter_liaison', 'observer', 'candidate', 'visitor')
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    ),
+    'by_chapter', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'chapter', sub.chapter, 'total', sub.total, 'signed', sub.signed, 'unsigned', sub.total - sub.signed
+      ) ORDER BY sub.chapter), '[]'::jsonb)
+      FROM (
+        SELECT m.chapter, count(*) as total,
+          count(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+            AND c.status = 'issued'
+            AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          )) as signed
+        FROM public.members m WHERE m.is_active AND m.current_cycle_active
+        AND m.operational_role NOT IN ('sponsor', 'chapter_liaison', 'observer', 'candidate', 'visitor')
+        AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+        GROUP BY m.chapter
+      ) sub
+    ),
+    'focal_points', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', m.id, 'name', m.name, 'chapter', m.chapter, 'role', m.operational_role
+      ) ORDER BY m.chapter, m.name), '[]'::jsonb)
+      FROM public.members m WHERE m.is_active AND 'chapter_board' = ANY(m.designations)
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    ),
+    'template', (
+      SELECT jsonb_build_object('id', gd.id, 'title', gd.title, 'version', gd.version, 'content', gd.content)
+      FROM public.governance_documents gd WHERE gd.doc_type = 'volunteer_term_template' AND gd.status = 'active'
+      ORDER BY gd.created_at DESC LIMIT 1
+    ),
+    'members', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', m.id, 'name', m.name, 'email', m.email, 'chapter', m.chapter,
+        'tribe_id', m.tribe_id, 'role', m.operational_role,
+        'cycle_code', (
+          SELECT mch.cycle_code FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'cycle_start', (
+          SELECT mch.cycle_start FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'cycle_end', (
+          SELECT mch.cycle_end FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'contract_start', (
+          SELECT c.period_start FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'contract_end', (
+          SELECT c.period_end FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'signed', EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        ),
+        'signed_at', (
+          SELECT c.issued_at FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'counter_signed', EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          AND c.counter_signed_at IS NOT NULL
+        ),
+        'counter_signed_at', (
+          SELECT c.counter_signed_at FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'verification_code', (
+          SELECT c.verification_code FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'agreement_cert_id', (
+          SELECT c.id FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status IN ('issued', 'rejected')
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'agreement_status', (
+          SELECT c.status FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status IN ('issued', 'rejected')
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        )
+      ) ORDER BY m.chapter, m.name), '[]'::jsonb)
+      FROM public.members m WHERE m.is_active AND m.current_cycle_active
+      AND m.operational_role NOT IN ('sponsor', 'chapter_liaison', 'observer', 'candidate', 'visitor')
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;

--- a/supabase/migrations/20260805000356_term_activation_stamps_ratified_chain.sql
+++ b/supabase/migrations/20260805000356_term_activation_stamps_ratified_chain.sql
@@ -1,0 +1,114 @@
+-- Term activation must stamp the ratified approval chain.
+--
+-- Root cause of the live V_status_chain_coherence violation (doc 280c2c56, the v9 term
+-- template activated in Onda 1 on 2026-07-07): activate_volunteer_term_version flips the
+-- document to status='active' but never sets governance_documents.current_ratified_chain_id
+-- nor approval_chains.activated_at. The invariant (#315 P0-Q6) requires every approved/active
+-- governance_document to carry a non-null current_ratified_chain_id, so the activation left the
+-- doc in an incoherent state.
+--
+-- Fix:
+--   1. (root cause) On activation, resolve the approved chain for the current version and stamp
+--      both current_ratified_chain_id (on the doc) and activated_at (on the chain).
+--   2. (backfill) Repair any already-active/approved governance_document whose ratified chain is
+--      null but which has an approved chain for its current version (covers doc 280c2c56 now).
+CREATE OR REPLACE FUNCTION public.activate_volunteer_term_version(p_doc_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_actor_member uuid;
+  v_doc record;
+  v_html text;
+  v_deactivated int := 0;
+  v_chain_id uuid;
+BEGIN
+  SELECT id INTO v_actor_member FROM members WHERE auth_id = auth.uid();
+  IF v_actor_member IS NULL THEN RETURN jsonb_build_object('error', 'not_authenticated'); END IF;
+
+  IF NOT public.can_by_member(v_actor_member, 'manage_platform', NULL, NULL) THEN
+    RETURN jsonb_build_object('error', 'forbidden',
+      'message', 'Apenas manage_platform pode ativar uma versão do Termo de Voluntariado.');
+  END IF;
+
+  SELECT g.id, g.doc_type, g.status, g.current_version_id, g.version
+    INTO v_doc
+  FROM governance_documents g WHERE g.id = p_doc_id;
+  IF v_doc.id IS NULL THEN RETURN jsonb_build_object('error', 'document_not_found'); END IF;
+  IF v_doc.doc_type <> 'volunteer_term_template' THEN
+    RETURN jsonb_build_object('error', 'wrong_doc_type', 'doc_type', v_doc.doc_type);
+  END IF;
+
+  SELECT dv.content_html INTO v_html
+  FROM document_versions dv
+  WHERE dv.id = v_doc.current_version_id AND dv.locked_at IS NOT NULL;
+  IF v_html IS NULL OR length(btrim(v_html)) = 0 THEN
+    RETURN jsonb_build_object('error', 'no_locked_body',
+      'message', 'A versão corrente não está travada (locked) ou não tem corpo HTML. Trave a versão na cadeia antes de ativar.',
+      'current_version_id', v_doc.current_version_id);
+  END IF;
+
+  UPDATE governance_documents
+     SET status = 'superseded', updated_at = now()
+   WHERE doc_type = 'volunteer_term_template' AND status = 'active' AND id <> p_doc_id;
+  GET DIAGNOSTICS v_deactivated = ROW_COUNT;
+
+  -- Resolve the ratified (approved) chain for the version being activated and stamp coherence:
+  -- the doc carries the ratified chain, the chain is marked activated. Without this the doc
+  -- violates V_status_chain_coherence (current_ratified_chain_id must be NOT NULL when active).
+  SELECT ac.id INTO v_chain_id
+  FROM approval_chains ac
+  WHERE ac.document_id = p_doc_id
+    AND ac.version_id = v_doc.current_version_id
+    AND ac.status = 'approved'
+  ORDER BY ac.approved_at DESC NULLS LAST
+  LIMIT 1;
+
+  UPDATE governance_documents
+     SET status = 'active',
+         current_ratified_chain_id = COALESCE(v_chain_id, current_ratified_chain_id),
+         updated_at = now()
+   WHERE id = p_doc_id;
+
+  IF v_chain_id IS NOT NULL THEN
+    UPDATE approval_chains
+       SET activated_at = COALESCE(activated_at, now()), updated_at = now()
+     WHERE id = v_chain_id;
+  END IF;
+
+  INSERT INTO admin_audit_log (actor_id, action, target_type, target_id, changes)
+  VALUES (v_actor_member, 'volunteer_term_activated', 'governance_document', p_doc_id,
+    jsonb_build_object('version', v_doc.version, 'current_version_id', v_doc.current_version_id,
+      'superseded_count', v_deactivated, 'ratified_chain_id', v_chain_id));
+
+  RETURN jsonb_build_object('success', true, 'activated', p_doc_id,
+    'version', v_doc.version, 'superseded', v_deactivated, 'ratified_chain_id', v_chain_id);
+END;
+$function$;
+
+-- Backfill: repair active/approved governance_documents whose ratified chain is null but which
+-- have an approved chain for their current version. Stamps the chain's activated_at too.
+-- Idempotent (guarded by current_ratified_chain_id IS NULL). Fixes doc 280c2c56 (v9 term, Onda 1).
+WITH resolved AS (
+  SELECT gd.id AS doc_id, ac.id AS chain_id
+  FROM public.governance_documents gd
+  JOIN public.approval_chains ac
+    ON ac.document_id = gd.id
+   AND ac.version_id = gd.current_version_id
+   AND ac.status = 'approved'
+  WHERE gd.status IN ('approved', 'active')
+    AND gd.current_ratified_chain_id IS NULL
+)
+UPDATE public.governance_documents gd
+   SET current_ratified_chain_id = r.chain_id, updated_at = now()
+  FROM resolved r
+ WHERE gd.id = r.doc_id;
+
+UPDATE public.approval_chains ac
+   SET activated_at = COALESCE(ac.activated_at, now()), updated_at = now()
+  FROM public.governance_documents gd
+ WHERE gd.current_ratified_chain_id = ac.id
+   AND ac.activated_at IS NULL
+   AND gd.status IN ('approved', 'active');

--- a/supabase/migrations/20260805000356_term_activation_stamps_ratified_chain.sql
+++ b/supabase/migrations/20260805000356_term_activation_stamps_ratified_chain.sql
@@ -55,9 +55,6 @@ BEGIN
    WHERE doc_type = 'volunteer_term_template' AND status = 'active' AND id <> p_doc_id;
   GET DIAGNOSTICS v_deactivated = ROW_COUNT;
 
-  -- Resolve the ratified (approved) chain for the version being activated and stamp coherence:
-  -- the doc carries the ratified chain, the chain is marked activated. Without this the doc
-  -- violates V_status_chain_coherence (current_ratified_chain_id must be NOT NULL when active).
   SELECT ac.id INTO v_chain_id
   FROM approval_chains ac
   WHERE ac.document_id = p_doc_id


### PR DESCRIPTION
Dois fixes de governança do Termo descobertos nesta sessão (ambos aplicados em PROD + verificados ao vivo; migrations 20260805000355/356 registradas via repair; deploy do Worker pendente p/ o botão da Lorena).

## Fix 1 — superfície de contra-assinatura do Termo (reportado: Lorena não via a pendência)

Não havia caminho de UI funcional para contra-assinar um Termo:
- `get_pending_countersign` (única lista com botão) filtra `type != 'volunteer_agreement'` → termos nunca aparecem.
- `VolunteerAgreementPanel` mostra o selo inerte "✍️ Aguarda diretor" sem ação (só Rejeitar/Reemitir).

A diretora de voluntariado da sede já é autorizada por `counter_sign_certificate` (chapter_board do capítulo contratante PMI-GO), mas não tinha superfície para agir sobre os ~25 termos represados.

**Fix (Opção A):** `get_volunteer_agreement_status` expõe `can_counter_sign` — espelha exatamente o gate de `counter_sign_certificate` (manage_member OU chapter_board do capítulo contratante) para nunca renderizar um botão que daria 403. O painel renderiza "Contra-assinar" (i18n pt/en/es) quando `can_counter_sign && signed && !counter_signed`. Migration 20260805000355.

Grounding ao vivo (impersonação Lorena): `can_counter_sign=true`, `is_manager=false`, 25 termos "aguardando diretor" visíveis. Controle (voluntário sem board): false.

## Fix 2 — ativação do Termo carimba a cadeia ratificada (invariant V_status_chain_coherence)

A ativação da Onda 1 (`activate_volunteer_term_version`) flipava o doc para `active` mas nunca setava `current_ratified_chain_id` nem `approval_chains.activated_at`, deixando o doc v9 (280c2c56) incoerente e disparando o invariant `V_status_chain_coherence` (#315 P0-Q6).

**Fix:** a RPC agora resolve a cadeia approved da versão corrente e carimba `current_ratified_chain_id` (doc) + `activated_at` (cadeia) + `ratified_chain_id` no audit; backfill idempotente cobre o 280c2c56 → c72ceca4. Migration 20260805000356.

Grounding ao vivo: `check_schema_invariants()` = 0 violations; doc 280c2c56 → chain c72ceca4 (approved, activated_at carimbado).

## Notas de CI

- `astro build` verde. Gates de drift verdes (Phase C body-hash + ADR-0097 missing-file) após: alinhar o corpo do 356 ao vivo + limpar 2 phantom tracking-rows do apply_migration.
- Falhas restantes na suíte DB-aware (`m3` engagement/reliability, `M6` trail, `p65`, `preview_gate_eligibles`) são **pré-existentes/flaky** (asserções de dados vivos com baseline defasado, ex. "cohort 37 vs got 52"; timeouts de 33s) e **não nomeiam** nenhum objeto tocado aqui.

## Pendente
Deploy do Worker (`npx wrangler deploy`) para o botão da contra-assinatura ficar visível à Lorena — sessão dev/main.

🤖 Assisted by Claude