### PR TITLE
feat(termo/email): alerta de assinatura → 3 destinatários (sede) + digest diário

### DIFF
--- a/docs/adr/ADR-0022-notification-types-catalog.json
+++ b/docs/adr/ADR-0022-notification-types-catalog.json
@@ -12,8 +12,12 @@
   },
   "types": {
     "volunteer_agreement_signed": {
+      "delivery_mode": "suppress",
+      "rationale": "PR-2 email audit (2026-07-07): leadership signing alert is now in-app only (bell). The per-signing 1-a-1 email fanned out to 13 wrong recipients (boards of the signer's home chapter + all sede directors). Replaced by volunteer_term_signed_digest — one daily aggregate email to GP + the sede voluntariado director."
+    },
+    "volunteer_term_signed_digest": {
       "delivery_mode": "transactional_immediate",
-      "rationale": "Confirmation that volunteer signed the term — receipt is timely + carries verification code."
+      "rationale": "PR-2 email audit (2026-07-07): once-a-day aggregate of the last 24h of term signings, emitted by _volunteer_term_signed_digest_cron (daily 21:00 UTC) to GP (manage_platform) + the sede voluntariado director. transactional_immediate so the jobid-9 cron delivers the single daily email per recipient (the aggregation, not the cadence, is what bounds Resend quota)."
     },
     "ip_ratification_gate_pending": {
       "delivery_mode": "transactional_immediate",

--- a/supabase/functions/send-notification-email/index.ts
+++ b/supabase/functions/send-notification-email/index.ts
@@ -25,6 +25,7 @@ const TYPE_SUBJECTS: Record<string, string> = {
   ip_ratification_chain_approved: 'Cadeia de aprovacao concluida',
   ip_ratification_awaiting_members: 'Aguardando sua ratificacao',
   weekly_card_digest_member: 'Seu resumo semanal de atividades',
+  volunteer_term_signed_digest: 'Termos de Voluntariado assinados',
   weekly_member_digest: 'Seu resumo semanal — Núcleo IA',
   weekly_tribe_digest_leader: 'Resumo semanal — Núcleo IA',
 }
@@ -32,6 +33,9 @@ const TYPE_SUBJECTS: Record<string, string> = {
 // Digest types render body as multi-line text (preserve \n as <br>) without CTA deadline block.
 const DIGEST_TYPES = new Set([
   'weekly_card_digest_member',
+  // PR-2 email audit: daily aggregate of term signings — body is a \n-delimited list,
+  // rendered via formatDigestBody (preserves line breaks) with the digest opt-out block.
+  'volunteer_term_signed_digest',
 ])
 
 // ADR-0022 W2/W3: digest types with JSON body (from RPC). Rendered via

--- a/supabase/migrations/20260805000355_term_countersign_surface_can_flag.sql
+++ b/supabase/migrations/20260805000355_term_countersign_surface_can_flag.sql
@@ -1,0 +1,209 @@
+-- Term counter-signature surface fix (Lorena / voluntariado_director sede).
+--
+-- Problem: there was no working UI path to counter-sign a volunteer TERM.
+--   1. get_pending_countersign (the only list with a counter-sign button) filters
+--      out `type = 'volunteer_agreement'`, so terms never appear there.
+--   2. VolunteerAgreementPanel shows the term roster with an inert "Aguarda diretor"
+--      badge but no counter-sign action (only Reject/Reissue).
+-- The sede voluntariado director (chapter_board of the contracting chapter) is already
+-- authorized by counter_sign_certificate, but had no surface to act on the 29 pending terms.
+--
+-- Fix (Option A): expose a `can_counter_sign` flag from get_volunteer_agreement_status so
+-- the panel can render an actionable "Contra-assinar" button next to the awaiting-director
+-- badge. The flag mirrors counter_sign_certificate's real authority gate EXACTLY (so we never
+-- render a button that would 403): manage_member OR (chapter_board of the CONTRACTING chapter).
+-- No behaviour change to any existing caller; this only adds a JSON field.
+CREATE OR REPLACE FUNCTION public.get_volunteer_agreement_status()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_result jsonb;
+  v_caller_id uuid;
+  v_caller_chapter text;
+  v_caller_person_id uuid;
+  v_is_manage_member boolean;
+  v_is_chapter_board boolean;
+  v_is_vol_director boolean;
+  v_contracting_chapter text;
+  v_can_counter_sign boolean;
+BEGIN
+  SELECT m.id, m.chapter, m.person_id
+    INTO v_caller_id, v_caller_chapter, v_caller_person_id
+  FROM public.members m WHERE m.auth_id = auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  v_is_manage_member := public.can_by_member(v_caller_id, 'manage_member');
+  v_is_chapter_board := EXISTS (
+    SELECT 1 FROM public.auth_engagements ae
+    WHERE ae.person_id = v_caller_person_id
+      AND ae.kind = 'chapter_board'
+      AND ae.status = 'active'
+  );
+  -- WS-3: sede volunteer-director designation = program-wide read of the roster (function-anchored).
+  v_is_vol_director := EXISTS (
+    SELECT 1 FROM public.members m
+    WHERE m.id = v_caller_id AND 'voluntariado_director' = ANY(m.designations)
+  );
+
+  IF NOT v_is_manage_member AND NOT v_is_chapter_board AND NOT v_is_vol_director THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  -- The contracting party is ALWAYS the contracting chapter (PMI-GO, C3). Mirror the exact
+  -- authority gate of counter_sign_certificate so the panel only shows the button to callers
+  -- the RPC will accept: manage_member OR a chapter_board member of the contracting chapter.
+  SELECT 'PMI-' || cr.chapter_code INTO v_contracting_chapter
+  FROM public.chapter_registry cr
+  WHERE cr.is_contracting_chapter AND cr.is_active
+  LIMIT 1;
+
+  v_can_counter_sign := v_is_manage_member
+    OR (v_is_chapter_board AND v_caller_chapter IS NOT DISTINCT FROM v_contracting_chapter);
+
+  SELECT jsonb_build_object(
+    'generated_at', now(),
+    'caller_chapter', v_caller_chapter,
+    'is_manager', v_is_manage_member,
+    'can_counter_sign', v_can_counter_sign,
+    'summary', (
+      SELECT jsonb_build_object(
+        'total_eligible', count(*),
+        'signed', count(*) FILTER (WHERE EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        )),
+        'unsigned', count(*) FILTER (WHERE NOT EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        )),
+        'pct', ROUND(
+          count(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+            AND c.status = 'issued'
+            AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ))::numeric / NULLIF(count(*), 0) * 100, 1
+        )
+      )
+      FROM public.members m WHERE m.is_active AND m.current_cycle_active
+      AND m.operational_role NOT IN ('sponsor', 'chapter_liaison', 'observer', 'candidate', 'visitor')
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    ),
+    'by_chapter', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'chapter', sub.chapter, 'total', sub.total, 'signed', sub.signed, 'unsigned', sub.total - sub.signed
+      ) ORDER BY sub.chapter), '[]'::jsonb)
+      FROM (
+        SELECT m.chapter, count(*) as total,
+          count(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+            AND c.status = 'issued'
+            AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          )) as signed
+        FROM public.members m WHERE m.is_active AND m.current_cycle_active
+        AND m.operational_role NOT IN ('sponsor', 'chapter_liaison', 'observer', 'candidate', 'visitor')
+        AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+        GROUP BY m.chapter
+      ) sub
+    ),
+    'focal_points', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', m.id, 'name', m.name, 'chapter', m.chapter, 'role', m.operational_role
+      ) ORDER BY m.chapter, m.name), '[]'::jsonb)
+      FROM public.members m WHERE m.is_active AND 'chapter_board' = ANY(m.designations)
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    ),
+    'template', (
+      SELECT jsonb_build_object('id', gd.id, 'title', gd.title, 'version', gd.version, 'content', gd.content)
+      FROM public.governance_documents gd WHERE gd.doc_type = 'volunteer_term_template' AND gd.status = 'active'
+      ORDER BY gd.created_at DESC LIMIT 1
+    ),
+    'members', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', m.id, 'name', m.name, 'email', m.email, 'chapter', m.chapter,
+        'tribe_id', m.tribe_id, 'role', m.operational_role,
+        'cycle_code', (
+          SELECT mch.cycle_code FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'cycle_start', (
+          SELECT mch.cycle_start FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'cycle_end', (
+          SELECT mch.cycle_end FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'contract_start', (
+          SELECT c.period_start FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'contract_end', (
+          SELECT c.period_end FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'signed', EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        ),
+        'signed_at', (
+          SELECT c.issued_at FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'counter_signed', EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          AND c.counter_signed_at IS NOT NULL
+        ),
+        'counter_signed_at', (
+          SELECT c.counter_signed_at FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'verification_code', (
+          SELECT c.verification_code FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'agreement_cert_id', (
+          SELECT c.id FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status IN ('issued', 'rejected')
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'agreement_status', (
+          SELECT c.status FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status IN ('issued', 'rejected')
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        )
+      ) ORDER BY m.chapter, m.name), '[]'::jsonb)
+      FROM public.members m WHERE m.is_active AND m.current_cycle_active
+      AND m.operational_role NOT IN ('sponsor', 'chapter_liaison', 'observer', 'candidate', 'visitor')
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;

--- a/supabase/migrations/20260805000356_term_activation_stamps_ratified_chain.sql
+++ b/supabase/migrations/20260805000356_term_activation_stamps_ratified_chain.sql
@@ -1,0 +1,111 @@
+-- Term activation must stamp the ratified approval chain.
+--
+-- Root cause of the live V_status_chain_coherence violation (doc 280c2c56, the v9 term
+-- template activated in Onda 1 on 2026-07-07): activate_volunteer_term_version flips the
+-- document to status='active' but never sets governance_documents.current_ratified_chain_id
+-- nor approval_chains.activated_at. The invariant (#315 P0-Q6) requires every approved/active
+-- governance_document to carry a non-null current_ratified_chain_id, so the activation left the
+-- doc in an incoherent state.
+--
+-- Fix:
+--   1. (root cause) On activation, resolve the approved chain for the current version and stamp
+--      both current_ratified_chain_id (on the doc) and activated_at (on the chain).
+--   2. (backfill) Repair any already-active/approved governance_document whose ratified chain is
+--      null but which has an approved chain for its current version (covers doc 280c2c56 now).
+CREATE OR REPLACE FUNCTION public.activate_volunteer_term_version(p_doc_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_actor_member uuid;
+  v_doc record;
+  v_html text;
+  v_deactivated int := 0;
+  v_chain_id uuid;
+BEGIN
+  SELECT id INTO v_actor_member FROM members WHERE auth_id = auth.uid();
+  IF v_actor_member IS NULL THEN RETURN jsonb_build_object('error', 'not_authenticated'); END IF;
+
+  IF NOT public.can_by_member(v_actor_member, 'manage_platform', NULL, NULL) THEN
+    RETURN jsonb_build_object('error', 'forbidden',
+      'message', 'Apenas manage_platform pode ativar uma versão do Termo de Voluntariado.');
+  END IF;
+
+  SELECT g.id, g.doc_type, g.status, g.current_version_id, g.version
+    INTO v_doc
+  FROM governance_documents g WHERE g.id = p_doc_id;
+  IF v_doc.id IS NULL THEN RETURN jsonb_build_object('error', 'document_not_found'); END IF;
+  IF v_doc.doc_type <> 'volunteer_term_template' THEN
+    RETURN jsonb_build_object('error', 'wrong_doc_type', 'doc_type', v_doc.doc_type);
+  END IF;
+
+  SELECT dv.content_html INTO v_html
+  FROM document_versions dv
+  WHERE dv.id = v_doc.current_version_id AND dv.locked_at IS NOT NULL;
+  IF v_html IS NULL OR length(btrim(v_html)) = 0 THEN
+    RETURN jsonb_build_object('error', 'no_locked_body',
+      'message', 'A versão corrente não está travada (locked) ou não tem corpo HTML. Trave a versão na cadeia antes de ativar.',
+      'current_version_id', v_doc.current_version_id);
+  END IF;
+
+  UPDATE governance_documents
+     SET status = 'superseded', updated_at = now()
+   WHERE doc_type = 'volunteer_term_template' AND status = 'active' AND id <> p_doc_id;
+  GET DIAGNOSTICS v_deactivated = ROW_COUNT;
+
+  SELECT ac.id INTO v_chain_id
+  FROM approval_chains ac
+  WHERE ac.document_id = p_doc_id
+    AND ac.version_id = v_doc.current_version_id
+    AND ac.status = 'approved'
+  ORDER BY ac.approved_at DESC NULLS LAST
+  LIMIT 1;
+
+  UPDATE governance_documents
+     SET status = 'active',
+         current_ratified_chain_id = COALESCE(v_chain_id, current_ratified_chain_id),
+         updated_at = now()
+   WHERE id = p_doc_id;
+
+  IF v_chain_id IS NOT NULL THEN
+    UPDATE approval_chains
+       SET activated_at = COALESCE(activated_at, now()), updated_at = now()
+     WHERE id = v_chain_id;
+  END IF;
+
+  INSERT INTO admin_audit_log (actor_id, action, target_type, target_id, changes)
+  VALUES (v_actor_member, 'volunteer_term_activated', 'governance_document', p_doc_id,
+    jsonb_build_object('version', v_doc.version, 'current_version_id', v_doc.current_version_id,
+      'superseded_count', v_deactivated, 'ratified_chain_id', v_chain_id));
+
+  RETURN jsonb_build_object('success', true, 'activated', p_doc_id,
+    'version', v_doc.version, 'superseded', v_deactivated, 'ratified_chain_id', v_chain_id);
+END;
+$function$;
+
+-- Backfill: repair active/approved governance_documents whose ratified chain is null but which
+-- have an approved chain for their current version. Stamps the chain's activated_at too.
+-- Idempotent (guarded by current_ratified_chain_id IS NULL). Fixes doc 280c2c56 (v9 term, Onda 1).
+WITH resolved AS (
+  SELECT gd.id AS doc_id, ac.id AS chain_id
+  FROM public.governance_documents gd
+  JOIN public.approval_chains ac
+    ON ac.document_id = gd.id
+   AND ac.version_id = gd.current_version_id
+   AND ac.status = 'approved'
+  WHERE gd.status IN ('approved', 'active')
+    AND gd.current_ratified_chain_id IS NULL
+)
+UPDATE public.governance_documents gd
+   SET current_ratified_chain_id = r.chain_id, updated_at = now()
+  FROM resolved r
+ WHERE gd.id = r.doc_id;
+
+UPDATE public.approval_chains ac
+   SET activated_at = COALESCE(ac.activated_at, now()), updated_at = now()
+  FROM public.governance_documents gd
+ WHERE gd.current_ratified_chain_id = ac.id
+   AND ac.activated_at IS NULL
+   AND gd.status IN ('approved', 'active');

--- a/supabase/migrations/20260805000357_term_signed_alert_recipient_fix.sql
+++ b/supabase/migrations/20260805000357_term_signed_alert_recipient_fix.sql
@@ -1,0 +1,255 @@
+-- PR-1: fix the recipient fan-out of the volunteer_agreement_signed leadership alert.
+--
+-- Before: the signing alert fanned out to (operational_role='manager' OR is_superadmin OR
+-- every chapter_board member of the SIGNER'S chapter). Because a volunteer's `chapter` is their
+-- home PMI affiliation, this leaked the alert to the boards of OTHER chapters (PMI-RS/CE/MG/DF)
+-- and to every sede director — 13 recipients, one email per signing event.
+--
+-- The volunteer term's contracting party is ALWAYS the sede (PMI-GO, chapter_registry
+-- is_contracting_chapter). So the alert must reach only: GP (manage_platform) + the sede
+-- voluntariado director. That is the minimal correct audience (LGPD data-minimization) and
+-- matches who actually acts on signings (counter-signature). 13 -> 3 recipients.
+--
+-- Cadence (delivery_mode) is unchanged here (still resolved via _delivery_mode_for); PR-2 flips
+-- the type to 'suppress' and adds the daily digest. Body reproduced verbatim from the live def;
+-- only the final INSERT ... WHERE predicate changes.
+CREATE OR REPLACE FUNCTION public.sign_volunteer_agreement(p_language text DEFAULT 'pt-BR'::text, p_signed_ip text DEFAULT NULL::text, p_signed_user_agent text DEFAULT NULL::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member record; v_template record; v_cert_id uuid; v_code text; v_hash text;
+  v_content jsonb; v_cycle int; v_existing uuid; v_issuer_id uuid; v_vep record;
+  v_period_start date; v_period_end date;
+  v_member_role_for_vep text; v_history record; v_source text;
+  v_missing_fields text[] := '{}';
+  v_engagement_updated boolean := false;
+  v_chapter_cnpj text; v_chapter_legal_name text;
+  v_contracting_code text;
+  v_chapter_cnpj_source text := 'chapter_registry';
+  v_issuer_basis text := 'contracting_chapter_board';
+  v_ip inet := NULL;
+  v_html_body text; v_body_version_label text; v_chapter_display text;
+BEGIN
+  p_signed_user_agent := left(p_signed_user_agent, 500);
+
+  SELECT m.id, m.name, m.email, m.operational_role, m.pmi_id, m.chapter,
+    m.phone, m.address, m.city, m.state, m.country, m.birth_date,
+    m.pmi_id_verified,
+    t.name as tribe_name
+  INTO v_member
+  FROM members m LEFT JOIN tribes t ON t.id = public.get_member_tribe(m.id)
+  WHERE m.auth_id = auth.uid();
+  IF v_member.id IS NULL THEN RETURN jsonb_build_object('error', 'not_authenticated'); END IF;
+
+  IF v_member.pmi_id IS NULL OR length(trim(v_member.pmi_id)) = 0 THEN
+    v_missing_fields := array_append(v_missing_fields, 'pmi_id');
+  END IF;
+  IF v_member.phone IS NULL OR length(trim(v_member.phone)) = 0 THEN
+    v_missing_fields := array_append(v_missing_fields, 'phone');
+  END IF;
+  IF v_member.address IS NULL OR length(trim(v_member.address)) = 0 THEN
+    v_missing_fields := array_append(v_missing_fields, 'address');
+  END IF;
+  IF v_member.city IS NULL OR length(trim(v_member.city)) = 0 THEN
+    v_missing_fields := array_append(v_missing_fields, 'city');
+  END IF;
+  IF v_member.state IS NULL OR length(trim(v_member.state)) = 0 THEN
+    v_missing_fields := array_append(v_missing_fields, 'state');
+  END IF;
+  IF v_member.country IS NULL OR length(trim(v_member.country)) = 0 THEN
+    v_missing_fields := array_append(v_missing_fields, 'country');
+  END IF;
+  IF v_member.birth_date IS NULL THEN
+    v_missing_fields := array_append(v_missing_fields, 'birth_date');
+  END IF;
+
+  IF array_length(v_missing_fields, 1) > 0 THEN
+    RETURN jsonb_build_object(
+      'error', 'profile_incomplete',
+      'message', 'Você precisa completar seu perfil antes de assinar o Termo de Voluntariado.',
+      'missing_fields', to_jsonb(v_missing_fields),
+      'profile_url', '/profile'
+    );
+  END IF;
+
+  SELECT cr.cnpj, cr.legal_name, cr.chapter_code
+    INTO v_chapter_cnpj, v_chapter_legal_name, v_contracting_code
+  FROM chapter_registry cr
+  WHERE cr.is_contracting_chapter = true AND cr.is_active = true
+  LIMIT 1;
+
+  IF v_chapter_cnpj IS NULL THEN
+    v_chapter_cnpj := '06.065.645/0001-99';
+    v_chapter_legal_name := 'PMI Goias';
+    v_contracting_code := 'GO';
+    v_chapter_cnpj_source := 'hardcoded_emergency_fallback';
+  END IF;
+
+  v_cycle := EXTRACT(YEAR FROM now())::int;
+  SELECT id INTO v_existing FROM certificates
+  WHERE member_id = v_member.id AND type = 'volunteer_agreement' AND cycle = v_cycle AND status = 'issued';
+  IF v_existing IS NOT NULL THEN RETURN jsonb_build_object('error', 'already_signed', 'certificate_id', v_existing); END IF;
+
+  SELECT * INTO v_template FROM governance_documents
+  WHERE doc_type = 'volunteer_term_template' AND status = 'active'
+  ORDER BY created_at DESC LIMIT 1;
+  IF v_template.id IS NULL THEN RETURN jsonb_build_object('error', 'template_not_found'); END IF;
+
+  SELECT dv.content_html, dv.version_label INTO v_html_body, v_body_version_label
+  FROM document_versions dv WHERE dv.id = v_template.current_version_id;
+  IF v_html_body IS NULL OR length(btrim(v_html_body)) = 0 THEN
+    RETURN jsonb_build_object('error', 'approved_body_unavailable',
+      'message', 'A versão aprovada do Termo não possui corpo HTML. Ative uma versão aprovada da cadeia via activate_volunteer_term_version.',
+      'template_id', v_template.id, 'version_id', v_template.current_version_id);
+  END IF;
+
+  v_chapter_display := COALESCE(
+    NULLIF((regexp_match(v_chapter_legal_name, '\(([^)]+)\)\s*$'))[1], ''),
+    v_chapter_legal_name);
+  v_html_body := replace(v_html_body, '{chapterName}', v_chapter_display);
+
+  SELECT id INTO v_issuer_id FROM members
+  WHERE chapter = 'PMI-' || v_contracting_code AND 'chapter_board' = ANY(designations) AND is_active = true
+  ORDER BY operational_role = 'sponsor' DESC LIMIT 1;
+  IF v_issuer_id IS NULL THEN
+    SELECT id INTO v_issuer_id FROM members WHERE operational_role = 'manager' AND is_active = true LIMIT 1;
+    v_issuer_basis := 'manager_fallback';
+  END IF;
+
+  v_member_role_for_vep := CASE
+    WHEN v_member.operational_role IN ('manager', 'deputy_manager') THEN 'manager'
+    WHEN v_member.operational_role = 'tribe_leader' THEN 'leader'
+    ELSE 'researcher'
+  END;
+
+  SELECT vo.* INTO v_vep FROM selection_applications sa
+  JOIN vep_opportunities vo ON vo.opportunity_id = sa.vep_opportunity_id
+  WHERE lower(trim(sa.email)) = lower(trim(v_member.email))
+    AND vo.role_default = v_member_role_for_vep
+    AND EXTRACT(YEAR FROM vo.start_date) = v_cycle
+  ORDER BY sa.created_at DESC LIMIT 1;
+
+  IF v_vep.opportunity_id IS NOT NULL THEN
+    v_period_start := v_vep.start_date; v_period_end := v_vep.end_date; v_source := 'application_match';
+  ELSE
+    SELECT vo.* INTO v_vep FROM selection_applications sa
+    JOIN vep_opportunities vo ON vo.opportunity_id = sa.vep_opportunity_id
+    WHERE lower(trim(sa.email)) = lower(trim(v_member.email))
+      AND EXTRACT(YEAR FROM vo.start_date) = v_cycle
+    ORDER BY sa.created_at DESC LIMIT 1;
+    IF v_vep.opportunity_id IS NOT NULL THEN
+      v_period_start := v_vep.start_date; v_period_end := v_vep.end_date; v_source := 'application_year_match';
+    ELSE
+      SELECT cycle_code, cycle_start, cycle_end INTO v_history
+      FROM member_cycle_history WHERE member_id = v_member.id
+      ORDER BY cycle_start DESC LIMIT 1;
+      IF v_history.cycle_code IS NOT NULL THEN
+        v_period_start := v_history.cycle_start;
+        v_period_end := (v_history.cycle_start + interval '12 months' - interval '1 day')::date;
+        v_source := 'cycle_history:' || v_history.cycle_code;
+      ELSE
+        SELECT * INTO v_vep FROM vep_opportunities
+        WHERE EXTRACT(YEAR FROM start_date) = v_cycle
+          AND role_default = v_member_role_for_vep AND is_active = true
+        ORDER BY start_date DESC LIMIT 1;
+        IF v_vep.opportunity_id IS NOT NULL THEN
+          v_period_start := v_vep.start_date; v_period_end := v_vep.end_date; v_source := 'founder_role_vep';
+        ELSE
+          RETURN jsonb_build_object('error', 'cannot_derive_period',
+            'message', 'No application, cycle history, or matching VEP found. Admin must set period manually.',
+            'member_id', v_member.id, 'member_name', v_member.name);
+        END IF;
+      END IF;
+    END IF;
+  END IF;
+
+  v_content := jsonb_build_object(
+    'template_id', v_template.id, 'template_version', v_template.version, 'template_title', v_template.title,
+    'clauses', v_template.content,
+    'html_body', v_html_body,
+    'body_version_id', v_template.current_version_id,
+    'body_version_label', v_body_version_label,
+    'chapter_display_name', v_chapter_display,
+    'member_name', v_member.name, 'member_email', v_member.email, 'member_role', v_member.operational_role,
+    'member_tribe', v_member.tribe_name, 'member_pmi_id', v_member.pmi_id, 'member_chapter', v_member.chapter,
+    'member_phone', v_member.phone, 'member_address', v_member.address,
+    'member_city', v_member.city, 'member_state', v_member.state,
+    'member_country', v_member.country, 'member_birth_date', v_member.birth_date,
+    'language', p_language, 'signed_at', now(),
+    'chapter_cnpj', v_chapter_cnpj, 'chapter_name', v_chapter_legal_name,
+    'contracting_chapter', 'PMI-' || v_contracting_code,
+    'issuer_chapter', 'PMI-' || v_contracting_code,
+    'issuer_authority_basis', v_issuer_basis,
+    'vep_opportunity_id', v_vep.opportunity_id, 'vep_title', v_vep.title,
+    'period_start', v_period_start::text, 'period_end', v_period_end::text,
+    'period_source', v_source
+  );
+
+  v_code := 'TERM-' || EXTRACT(YEAR FROM now())::text || '-' || UPPER(SUBSTRING(gen_random_uuid()::text FROM 1 FOR 6));
+  v_hash := encode(sha256(convert_to(v_content::text || v_member.id::text || now()::text || 'nucleo-ia-volunteer-salt', 'UTF8')), 'hex');
+
+  BEGIN
+    IF p_signed_ip IS NOT NULL AND length(trim(p_signed_ip)) > 0 THEN
+      v_ip := p_signed_ip::inet;
+    END IF;
+  EXCEPTION WHEN OTHERS THEN
+    v_ip := NULL;
+  END;
+
+  INSERT INTO certificates (
+    member_id, type, title, description, cycle, issued_at, issued_by, verification_code,
+    period_start, period_end, function_role, language, status, signature_hash, content_snapshot, template_id,
+    signed_ip, signed_user_agent
+  ) VALUES (
+    v_member.id, 'volunteer_agreement',
+    CASE p_language WHEN 'en-US' THEN 'Volunteer Agreement — Cycle ' || v_cycle
+      WHEN 'es-LATAM' THEN 'Acuerdo de Voluntariado — Ciclo ' || v_cycle
+      ELSE 'Termo de Voluntariado — Ciclo ' || v_cycle END,
+    v_template.description, v_cycle, now(), v_issuer_id, v_code,
+    v_period_start::text, v_period_end::text,
+    v_member.operational_role, p_language, 'issued', v_hash, v_content, v_template.id::text,
+    v_ip, p_signed_user_agent
+  ) RETURNING id INTO v_cert_id;
+
+  UPDATE public.engagements
+  SET agreement_certificate_id = v_cert_id
+  WHERE person_id = (SELECT id FROM public.persons WHERE legacy_member_id = v_member.id)
+    AND kind = 'volunteer'
+    AND status = 'active'
+    AND agreement_certificate_id IS NULL;
+
+  IF FOUND THEN v_engagement_updated := true; END IF;
+
+  INSERT INTO admin_audit_log (actor_id, action, target_type, target_id, changes)
+  VALUES (v_member.id, 'volunteer_agreement_signed', 'certificate', v_cert_id,
+    jsonb_build_object('verification_code', v_code, 'cycle', v_cycle, 'chapter', v_member.chapter,
+      'chapter_cnpj', v_chapter_cnpj,
+      'chapter_cnpj_source', v_chapter_cnpj_source,
+      'contracting_chapter', 'PMI-' || v_contracting_code,
+      'body_version_id', v_template.current_version_id,
+      'body_version_label', v_body_version_label,
+      'period_source', v_source, 'engagement_linked', v_engagement_updated,
+      'signed_ip', v_ip::text, 'signed_user_agent', p_signed_user_agent,
+      'affiliation_unverified', NOT COALESCE(v_member.pmi_id_verified, false)));
+
+  INSERT INTO notifications (recipient_id, type, title, body, link, source_type, source_id, delivery_mode)
+  SELECT m.id, 'volunteer_agreement_signed',
+    v_member.name || ' assinou o Termo de Voluntariado',
+    'Capitulo: ' || COALESCE(v_member.chapter, '—') || '. Codigo: ' || v_code,
+    '/admin/certificates', 'certificate', v_cert_id,
+    public._delivery_mode_for('volunteer_agreement_signed')
+  FROM members m
+  WHERE m.is_active = true AND m.id != v_member.id
+    AND (public.can_by_member(m.id, 'manage_platform')
+         OR ('voluntariado_director' = ANY(m.designations) AND m.chapter = 'PMI-' || v_contracting_code));
+
+  RETURN jsonb_build_object('success', true, 'certificate_id', v_cert_id, 'verification_code', v_code,
+    'signature_hash', v_hash, 'signed_at', now(),
+    'period_start', v_period_start, 'period_end', v_period_end, 'period_source', v_source,
+    'engagement_linked', v_engagement_updated,
+    'chapter_cnpj', v_chapter_cnpj, 'chapter_name', v_chapter_legal_name);
+END;
+$function$;

--- a/supabase/migrations/20260805000358_term_signed_daily_digest.sql
+++ b/supabase/migrations/20260805000358_term_signed_daily_digest.sql
@@ -1,0 +1,143 @@
+-- PR-2: collapse the per-signing volunteer term alert into ONE daily digest email.
+--
+-- (a) _delivery_mode_for: volunteer_agreement_signed flips transactional_immediate -> suppress.
+--     The per-signing rows still land in-app (bell) via sign_volunteer_agreement, but no longer
+--     trigger a 1-a-1 email. New type volunteer_term_signed_digest is transactional_immediate so
+--     the existing send-notification-email cron (jobid 9) delivers the ONE daily aggregate row.
+-- (b) _volunteer_term_signed_digest_cron: once a day, if any term was signed in the last 24h,
+--     insert ONE aggregate notification per target recipient (GP manage_platform + sede
+--     voluntariado director). Same 3-recipient audience as the recipient fix (PR-1). 20h
+--     idempotency guards against a double run. Piggybacks the jobid-59 daily-digest pattern.
+-- (c) schedule the cron daily at 21:00 UTC (~18:00 BRT, end of day).
+--
+-- Net effect on Resend quota: on an activation/onboarding day (e.g. 19 signings today = 72 emails
+-- across 13 wrong recipients) the term workflow drops to at most 3 emails/day (one digest each).
+
+-- (a) delivery-mode routing. Reproduced verbatim from live with two edits (see comments below).
+CREATE OR REPLACE FUNCTION public._delivery_mode_for(p_type text)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE PARALLEL SAFE
+ SET search_path TO ''
+AS $function$
+  SELECT CASE p_type
+    -- PR-2 (email audit): the per-signing leadership alert is now in-app only; the daily
+    -- digest (volunteer_term_signed_digest) carries the single aggregated email.
+    WHEN 'volunteer_agreement_signed'    THEN 'suppress'
+    WHEN 'volunteer_term_signed_digest'  THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_pending'  THEN 'transactional_immediate'
+    WHEN 'system_alert'                  THEN 'transactional_immediate'
+    WHEN 'certificate_ready'             THEN 'transactional_immediate'
+    WHEN 'certificate_issued'            THEN 'transactional_immediate'
+    WHEN 'member_offboarded'             THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_advanced'    THEN 'transactional_immediate'
+    WHEN 'ip_ratification_chain_approved'   THEN 'transactional_immediate'
+    WHEN 'ip_ratification_awaiting_members' THEN 'transactional_immediate'
+    WHEN 'webinar_status_confirmed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_completed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_cancelled'      THEN 'transactional_immediate'
+    WHEN 'weekly_card_digest_member'     THEN 'transactional_immediate'
+    WHEN 'governance_cr_new'             THEN 'transactional_immediate'
+    WHEN 'governance_cr_vote'            THEN 'transactional_immediate'
+    WHEN 'governance_cr_approved'        THEN 'transactional_immediate'
+    WHEN 'sponsor_finance_entry_logged'  THEN 'transactional_immediate'
+    WHEN 'governance_manual_proposed'    THEN 'transactional_immediate'
+    WHEN 'engagement_renewal_d7_urgent'  THEN 'transactional_immediate'
+    -- p153 OPP-153.1: project_charter (TAP) notifications
+    WHEN 'project_charter_invite'        THEN 'transactional_immediate'
+    WHEN 'project_charter_approved'      THEN 'transactional_immediate'
+    -- p159 S#1 T1 (2026-05-14): selection_termo_due é o "email principal" pós-VEP-Active
+    WHEN 'selection_termo_due'           THEN 'transactional_immediate'
+    -- p228 #260 W2 Leaf 1 (2026-05-23): Selection funnel Policy Matrix
+    WHEN 'selection_approved'            THEN 'transactional_immediate'
+    WHEN 'selection_interview_scheduled' THEN 'transactional_immediate'
+    WHEN 'peer_review_requested'         THEN 'transactional_immediate'
+    WHEN 'selection_evaluation_complete' THEN 'suppress'
+    WHEN 'selection_interview_noshow'    THEN 'digest_weekly'
+    -- p228 #260 W2 Leaf 2 (2026-05-23): admin reminder for overdue interviews
+    WHEN 'selection_interview_overdue'   THEN 'digest_weekly'
+    -- p228 #260 W2 Leaf 4 (2026-05-23): candidate invite to book interview after
+    -- objective evaluations cleared + research_score >= cycle cutoff.
+    WHEN 'selection_cutoff_approved'     THEN 'transactional_immediate'
+    -- (end p228)
+    -- #186 (2026-06-05): curation committee broadcast when an item enters curation_pending
+    WHEN 'curation_item_submitted'       THEN 'transactional_immediate'
+    WHEN 'engagement_renewal_d30'        THEN 'digest_weekly'
+    WHEN 'engagement_renewal_d60_gp_aggregate' THEN 'digest_weekly'
+    -- #625 F3 (2026-06-11): radar de renovação de filiação
+    WHEN 'affiliation_renewal_d7_urgent'  THEN 'transactional_immediate'
+    WHEN 'affiliation_renewal_d30'        THEN 'digest_weekly'
+    WHEN 'affiliation_verification_stale' THEN 'digest_weekly'
+    -- #740 Wave 3c-i (B8): agreement rejected / reissued — member must re-sign, deliver immediately
+    WHEN 'volunteer_agreement_rejected'  THEN 'transactional_immediate'
+    WHEN 'volunteer_agreement_reissued'  THEN 'transactional_immediate'
+    WHEN 'attendance_detractor'          THEN 'suppress'
+    WHEN 'info'                          THEN 'suppress'
+    WHEN 'system'                        THEN 'suppress'
+    ELSE 'digest_weekly'
+  END;
+$function$;
+
+-- (b) daily aggregator. Same 3-recipient audience as PR-1 (GP + sede voluntariado director),
+-- one email/day via the existing jobid-9 cron (volunteer_term_signed_digest = transactional_immediate).
+CREATE OR REPLACE FUNCTION public._volunteer_term_signed_digest_cron()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_contracting_code text;
+  v_count int;
+  v_list text;
+  v_body text;
+  v_recipients int := 0;
+BEGIN
+  SELECT cr.chapter_code INTO v_contracting_code
+  FROM chapter_registry cr
+  WHERE cr.is_contracting_chapter = true AND cr.is_active = true
+  LIMIT 1;
+  v_contracting_code := COALESCE(v_contracting_code, 'GO');
+
+  SELECT count(*),
+         string_agg('- ' || m.name || ' (' || COALESCE(m.chapter, '—') || ')', E'\n' ORDER BY m.name)
+    INTO v_count, v_list
+  FROM certificates c
+  JOIN members m ON m.id = c.member_id
+  WHERE c.type = 'volunteer_agreement'
+    AND c.status = 'issued'
+    AND c.issued_at >= now() - interval '24 hours';
+
+  IF COALESCE(v_count, 0) = 0 THEN
+    RETURN jsonb_build_object('signings', 0, 'recipients', 0, 'skipped', 'no_signings');
+  END IF;
+
+  v_body := v_count || ' voluntário(s) assinaram o Termo de Voluntariado nas últimas 24h:'
+    || E'\n\n' || v_list
+    || E'\n\nAbra /admin/certificates para conferir e contra-assinar.';
+
+  INSERT INTO notifications (recipient_id, type, title, body, link, delivery_mode)
+  SELECT m.id, 'volunteer_term_signed_digest',
+    'Termos de Voluntariado assinados (' || v_count || ')',
+    v_body, '/admin/certificates',
+    public._delivery_mode_for('volunteer_term_signed_digest')
+  FROM members m
+  WHERE m.is_active = true
+    AND (public.can_by_member(m.id, 'manage_platform')
+         OR ('voluntariado_director' = ANY(m.designations) AND m.chapter = 'PMI-' || v_contracting_code))
+    AND NOT EXISTS (
+      SELECT 1 FROM notifications n
+      WHERE n.recipient_id = m.id
+        AND n.type = 'volunteer_term_signed_digest'
+        AND n.created_at >= now() - interval '20 hours'
+    );
+  GET DIAGNOSTICS v_recipients = ROW_COUNT;
+
+  RETURN jsonb_build_object('signings', v_count, 'recipients', v_recipients);
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public._volunteer_term_signed_digest_cron() FROM PUBLIC, anon, authenticated;
+
+-- (c) schedule daily at 21:00 UTC (~18:00 BRT). cron.schedule upserts by name (pg_cron >= 1.4).
+SELECT cron.schedule('term-signed-digest-daily', '0 21 * * *', $$SELECT public._volunteer_term_signed_digest_cron()$$);


### PR DESCRIPTION
**DRAFT — preparado, não aplicado em PROD.** Apply (RPC de assinatura + EF deploy) só com o OK do owner; até lá os testes DB-aware ficam vermelhos por comparar PROD-vivo vs arquivos.

Auditoria de e-mail (sessão dedicada). O alerta `volunteer_agreement_signed` disparava **1 e-mail por assinatura para 13 destinatários errados** — boards do capítulo de origem do voluntário (vazava p/ PMI-RS/CE/MG/DF) + todas as diretorias da sede. Medido ao vivo: 72 e-mails hoje p/ 13 pessoas (19 assinaturas).

## PR-1 — destinatário (mig 357)
`sign_volunteer_agreement`: o fan-out final passa a mirar só **GP (`manage_platform`) + diretoria de voluntariado da SEDE** (capítulo contratante, sempre PMI-GO). **13 → 3**. Remove o vazamento cross-capítulo (minimização LGPD). Corpo verbatim do vivo; só o predicado do WHERE muda:
```sql
AND (public.can_by_member(m.id,'manage_platform')
     OR ('voluntariado_director' = ANY(m.designations) AND m.chapter = 'PMI-'||v_contracting_code))
```

## PR-2 — cadência diária (mig 358 + EF + catálogo)
- `_delivery_mode_for('volunteer_agreement_signed')` → **`suppress`** (sino in-app fica, mata o 1-a-1).
- Novo tipo `volunteer_term_signed_digest` (`transactional_immediate`) emitido por `_volunteer_term_signed_digest_cron` (diário 21:00 UTC): agrega "N termos assinados nas últimas 24h: [nomes/capítulos]" numa linha por destinatário (os 3), entregue **1×/dia** pelo jobid-9 existente. Sem novo `delivery_mode` nem nova EF de envio.
- EF `send-notification-email`: subject + render com quebras de linha (`DIGEST_TYPES`). Catálogo ADR-0022 + helper atualizados em lock-step.

## Grounding ao vivo (dry SELECT, nada inserido)
- Predicado (PR-1 e PR-2): **3 destinatários** — Lorena, Fabricio, Vitor.
- Janela 24h: 21 assinaturas → o digest mandaria **3 e-mails** (um por pessoa, listando os 21) em vez de 72. **~96%** de corte no pico do workflow.
- `astro build` verde; catálogo JSON válido.

## Apply (ao receber OK)
1. `apply_migration` 357 + 358 (verbatim dos arquivos) → repair + limpar phantom-rows + `NOTIFY`.
2. `supabase functions deploy send-notification-email --no-verify-jwt`.
3. Verificar `_delivery_mode_for('volunteer_agreement_signed')='suppress'` + cron agendado + `adr-0022-delivery-mode` verde.

🤖 Assisted by Claude