### PR TITLE
fix(termo/certificates): elegibilidade positiva do Termo + dedupe de e-mail de cert (#1169) [PR-A]

### DIFF
--- a/docs/adr/ADR-0022-notification-types-catalog.json
+++ b/docs/adr/ADR-0022-notification-types-catalog.json
@@ -28,8 +28,8 @@
       "rationale": "Operational alert (cron failure, capacity issue, etc.) — must page admins now."
     },
     "certificate_ready": {
-      "delivery_mode": "transactional_immediate",
-      "rationale": "Counter-signed certificate ready for download — recipient expects within minutes."
+      "delivery_mode": "suppress",
+      "rationale": "#1169: redundant with certificate_issued (every ready-cert already fired an issued email; measured 0 ready-without-issued over 60d). Kept in-app to kill the duplicate per-batch email; the issued notification carries the single email."
     },
     "member_offboarded": {
       "delivery_mode": "transactional_immediate",

--- a/src/components/admin/VolunteerAgreementPanel.tsx
+++ b/src/components/admin/VolunteerAgreementPanel.tsx
@@ -12,6 +12,8 @@ interface MemberRow {
   signed: boolean;
   signed_at: string | null;
   verification_code: string | null;
+  // PMI affiliation signal (not an eligibility gate — see get_volunteer_agreement_status; #1129 defers a hard validity gate)
+  pmi_id_verified: boolean;
   cycle_code: string | null;
   cycle_start: string | null;
   cycle_end: string | null;
@@ -45,6 +47,7 @@ interface Summary {
   total_eligible: number;
   signed: number;
   unsigned: number;
+  not_verified: number;
   pct: number;
 }
 
@@ -102,6 +105,11 @@ const L: Record<string, Record<string, string>> = {
     actionError: 'Erro ao executar a ação.',
     rejectConfirmCountersigned: 'O termo de {name} já foi contra-assinado (ato bilateral). Rejeitá-lo é um distrato formal e não pode ser desfeito. Continuar?',
     rejectedBadgeAria: 'Termo rejeitado — aguarda reassinatura do voluntário',
+    contextEligible: 'voluntários com engagement ativo no ciclo (elegíveis a assinar)',
+    contextUnverified: 'com filiação PMI não verificada',
+    affiliationBadge: 'filiação?',
+    affiliationBadgeTitle: 'Filiação PMI não verificada — acompanhar (não bloqueia a assinatura)',
+    filterUnverified: 'Filiação não verificada',
   },
   'en-US': {
     title: 'Volunteer Agreement',
@@ -149,6 +157,11 @@ const L: Record<string, Record<string, string>> = {
     actionError: 'Error performing the action.',
     rejectConfirmCountersigned: "{name}'s agreement was already counter-signed (bilateral act). Rejecting it is a formal rescission and cannot be undone. Continue?",
     rejectedBadgeAria: 'Agreement rejected — awaiting the volunteer to re-sign',
+    contextEligible: 'volunteers with an active engagement this cycle (eligible to sign)',
+    contextUnverified: 'with unverified PMI affiliation',
+    affiliationBadge: 'affiliation?',
+    affiliationBadgeTitle: 'Unverified PMI affiliation — follow up (does not block signing)',
+    filterUnverified: 'Unverified affiliation',
   },
   'es-LATAM': {
     title: 'Acuerdo de Voluntariado',
@@ -196,6 +209,11 @@ const L: Record<string, Record<string, string>> = {
     actionError: 'Error al ejecutar la acción.',
     rejectConfirmCountersigned: 'El término de {name} ya fue contra-firmado (acto bilateral). Rechazarlo es una rescisión formal y no se puede deshacer. ¿Continuar?',
     rejectedBadgeAria: 'Término rechazado — esperando que el voluntario vuelva a firmar',
+    contextEligible: 'voluntarios con engagement activo en el ciclo (elegibles para firmar)',
+    contextUnverified: 'con afiliación PMI no verificada',
+    affiliationBadge: 'afiliación?',
+    affiliationBadgeTitle: 'Afiliación PMI no verificada — dar seguimiento (no bloquea la firma)',
+    filterUnverified: 'Afiliación no verificada',
   },
 };
 
@@ -234,6 +252,7 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
   const [authorized, setAuthorized] = useState(false);
   const [filter, setFilter] = useState<'all' | 'signed' | 'pending'>('all');
   const [chapterFilter, setChapterFilter] = useState<string>('');
+  const [unverifiedOnly, setUnverifiedOnly] = useState(false);
   const [search, setSearch] = useState('');
   const [notifying, setNotifying] = useState(false);
   const [acting, setActing] = useState<string | null>(null);
@@ -266,6 +285,7 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
     if (filter === 'signed' && !m.signed) return false;
     if (filter === 'pending' && m.signed) return false;
     if (chapterFilter && m.chapter !== chapterFilter) return false;
+    if (unverifiedOnly && m.pmi_id_verified) return false;
     if (search && !m.name.toLowerCase().includes(search.toLowerCase()) && !m.email.toLowerCase().includes(search.toLowerCase())) return false;
     return true;
   });
@@ -383,9 +403,12 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
 
   return (
     <div className="space-y-5">
-      {/* Context: who is counted */}
+      {/* Context: who is counted (derived from the live eligible set — no hardcoded totals) */}
       <div className="text-[10px] text-[var(--text-muted)] bg-[var(--surface-section-cool)] rounded-lg px-3 py-1.5">
-        {summary.total_eligible} voluntários operacionais de 52 membros ativos (sponsors, liaisons e observers isentos)
+        {summary.total_eligible} {t.contextEligible}
+        {summary.not_verified > 0 && (
+          <> · <span className="text-amber-600 dark:text-amber-400">{summary.not_verified} {t.contextUnverified}</span></>
+        )}
       </div>
 
       {/* Summary cards */}
@@ -609,6 +632,20 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
             {uniqueChapters.map(ch => <option key={ch} value={ch}>{ch}</option>)}
           </select>
 
+          {summary.not_verified > 0 && (
+            <button
+              onClick={() => setUnverifiedOnly(v => !v)}
+              title={t.affiliationBadgeTitle}
+              className={`px-2.5 py-1.5 rounded-lg border text-[10px] font-semibold cursor-pointer transition-colors ${
+                unverifiedOnly
+                  ? 'bg-amber-500 text-white border-amber-500'
+                  : 'border-amber-300 text-amber-700 dark:text-amber-400 bg-transparent hover:bg-amber-50 dark:hover:bg-amber-900/20'
+              }`}
+            >
+              ⚠ {t.filterUnverified} ({summary.not_verified})
+            </button>
+          )}
+
           <div className="flex rounded-lg border border-[var(--border-default)] overflow-hidden">
             {(['all', 'signed', 'pending'] as const).map(f => (
               <button
@@ -661,6 +698,12 @@ export default function VolunteerAgreementPanel({ lang: propLang }: Props) {
                 <tr key={m.id} className="border-b border-[var(--border-subtle)] hover:bg-[var(--surface-hover)]">
                   <td className="px-4 py-2 font-medium text-[var(--text-primary)]">
                     <a href={`/admin/members/${m.id}`} className="text-navy hover:underline no-underline">{m.name}</a>
+                    {!m.pmi_id_verified && (
+                      <span
+                        title={t.affiliationBadgeTitle}
+                        className="ml-1.5 inline-block px-1.5 py-0.5 rounded-full text-[8px] font-bold bg-amber-100 text-amber-700 align-middle"
+                      >⚠ {t.affiliationBadge}</span>
+                    )}
                   </td>
                   <td className="px-3 py-2 text-[var(--text-secondary)]">{m.chapter || '—'}</td>
                   <td className="px-3 py-2 text-[var(--text-secondary)]">{m.role}</td>

--- a/supabase/migrations/20260805000359_volunteer_agreement_eligibility_positive_rule.sql
+++ b/supabase/migrations/20260805000359_volunteer_agreement_eligibility_positive_rule.sql
@@ -1,0 +1,240 @@
+-- Fase 0 (certificates admin revamp): fix WHO must sign the Volunteer Term.
+--
+-- Root cause: get_volunteer_agreement_status derived the eligible set from a NEGATIVE
+-- blocklist on operational_role (NOT IN sponsor/chapter_liaison/observer/candidate/visitor)
+-- + current_cycle_active. That blocklist leaks: `guest` slips through, so external reviewers
+-- (external_reviewer engagements — e.g. Angeline Prado, Mario Trentim) and synthetic test rows
+-- were counted as "must sign the volunteer term", even though they are not active volunteers.
+--
+-- Fix: replace the blocklist with the POSITIVE rule the domain actually means — eligible =
+-- active member (members.is_active) AND has an ACTIVE volunteer engagement (auth_engagements
+-- kind='volunteer' status='active'). An active volunteer engagement is by construction the
+-- current cycle's engagement (C4), so this also anchors "cycle 4 volunteer" without a brittle
+-- cycle join. Measured effect (2026-07-07, live): eligible 77 -> 72 (55 signed, 17 unsigned).
+--
+-- PMI affiliation validity: there is no reliable membership-validity source in members/persons
+-- (only pmi_id_verified, a verification-workflow flag — 11 of the 72 are unverified yet include
+-- real signed tribe leaders). So affiliation is surfaced as a SIGNAL (pmi_id_verified per row +
+-- not_verified in summary), NOT a hard exclusion. A hard validity gate is deferred to #1129 (VEP).
+--
+-- Also flips external_reviewer engagements out of the agreement pipeline (requires_agreement=FALSE):
+-- external reviewers are not PMI-GO volunteers and should not be asked to sign the volunteer term.
+-- study_group_owner is intentionally left in place (needs its own template, separate track).
+
+CREATE OR REPLACE FUNCTION public.get_volunteer_agreement_status()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_result jsonb;
+  v_caller_id uuid;
+  v_caller_chapter text;
+  v_caller_person_id uuid;
+  v_is_manage_member boolean;
+  v_is_chapter_board boolean;
+  v_is_vol_director boolean;
+  v_contracting_chapter text;
+  v_can_counter_sign boolean;
+BEGIN
+  SELECT m.id, m.chapter, m.person_id
+    INTO v_caller_id, v_caller_chapter, v_caller_person_id
+  FROM public.members m WHERE m.auth_id = auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  v_is_manage_member := public.can_by_member(v_caller_id, 'manage_member');
+  v_is_chapter_board := EXISTS (
+    SELECT 1 FROM public.auth_engagements ae
+    WHERE ae.person_id = v_caller_person_id
+      AND ae.kind = 'chapter_board'
+      AND ae.status = 'active'
+  );
+  -- WS-3: sede volunteer-director designation = program-wide read of the roster (function-anchored).
+  v_is_vol_director := EXISTS (
+    SELECT 1 FROM public.members m
+    WHERE m.id = v_caller_id AND 'voluntariado_director' = ANY(m.designations)
+  );
+
+  IF NOT v_is_manage_member AND NOT v_is_chapter_board AND NOT v_is_vol_director THEN
+    RETURN jsonb_build_object('error', 'Unauthorized');
+  END IF;
+
+  -- The contracting party is ALWAYS the contracting chapter (PMI-GO, C3). Mirror the exact
+  -- authority gate of counter_sign_certificate so the panel only shows the button to callers
+  -- the RPC will accept: manage_member OR a chapter_board member of the contracting chapter.
+  SELECT 'PMI-' || cr.chapter_code INTO v_contracting_chapter
+  FROM public.chapter_registry cr
+  WHERE cr.is_contracting_chapter AND cr.is_active
+  LIMIT 1;
+
+  v_can_counter_sign := v_is_manage_member
+    OR (v_is_chapter_board AND v_caller_chapter IS NOT DISTINCT FROM v_contracting_chapter);
+
+  SELECT jsonb_build_object(
+    'generated_at', now(),
+    'caller_chapter', v_caller_chapter,
+    'is_manager', v_is_manage_member,
+    'can_counter_sign', v_can_counter_sign,
+    'summary', (
+      SELECT jsonb_build_object(
+        'total_eligible', count(*),
+        'signed', count(*) FILTER (WHERE EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        )),
+        'unsigned', count(*) FILTER (WHERE NOT EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        )),
+        'not_verified', count(*) FILTER (WHERE m.pmi_id_verified IS NOT TRUE),
+        'pct', ROUND(
+          count(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+            AND c.status = 'issued'
+            AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ))::numeric / NULLIF(count(*), 0) * 100, 1
+        )
+      )
+      FROM public.members m WHERE m.is_active
+      AND EXISTS (
+        SELECT 1 FROM public.auth_engagements ae
+        WHERE ae.person_id = m.person_id AND ae.kind = 'volunteer' AND ae.status = 'active'
+      )
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    ),
+    'by_chapter', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'chapter', sub.chapter, 'total', sub.total, 'signed', sub.signed, 'unsigned', sub.total - sub.signed
+      ) ORDER BY sub.chapter), '[]'::jsonb)
+      FROM (
+        SELECT m.chapter, count(*) as total,
+          count(*) FILTER (WHERE EXISTS (
+            SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+            AND c.status = 'issued'
+            AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          )) as signed
+        FROM public.members m WHERE m.is_active
+        AND EXISTS (
+          SELECT 1 FROM public.auth_engagements ae
+          WHERE ae.person_id = m.person_id AND ae.kind = 'volunteer' AND ae.status = 'active'
+        )
+        AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+        GROUP BY m.chapter
+      ) sub
+    ),
+    'focal_points', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', m.id, 'name', m.name, 'chapter', m.chapter, 'role', m.operational_role
+      ) ORDER BY m.chapter, m.name), '[]'::jsonb)
+      FROM public.members m WHERE m.is_active AND 'chapter_board' = ANY(m.designations)
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    ),
+    'template', (
+      SELECT jsonb_build_object('id', gd.id, 'title', gd.title, 'version', gd.version, 'content', gd.content)
+      FROM public.governance_documents gd WHERE gd.doc_type = 'volunteer_term_template' AND gd.status = 'active'
+      ORDER BY gd.created_at DESC LIMIT 1
+    ),
+    'members', (
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id', m.id, 'name', m.name, 'email', m.email, 'chapter', m.chapter,
+        'tribe_id', m.tribe_id, 'role', m.operational_role,
+        'pmi_id_verified', COALESCE(m.pmi_id_verified, false),
+        'cycle_code', (
+          SELECT mch.cycle_code FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'cycle_start', (
+          SELECT mch.cycle_start FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'cycle_end', (
+          SELECT mch.cycle_end FROM public.member_cycle_history mch
+          WHERE mch.member_id = m.id AND mch.is_active
+          ORDER BY mch.cycle_start DESC LIMIT 1
+        ),
+        'contract_start', (
+          SELECT c.period_start FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'contract_end', (
+          SELECT c.period_end FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'signed', EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+        ),
+        'signed_at', (
+          SELECT c.issued_at FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'counter_signed', EXISTS (
+          SELECT 1 FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          AND c.counter_signed_at IS NOT NULL
+        ),
+        'counter_signed_at', (
+          SELECT c.counter_signed_at FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'verification_code', (
+          SELECT c.verification_code FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'agreement_cert_id', (
+          SELECT c.id FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status IN ('issued', 'rejected')
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        ),
+        'agreement_status', (
+          SELECT c.status FROM public.certificates c WHERE c.member_id = m.id AND c.type = 'volunteer_agreement'
+          AND c.status IN ('issued', 'rejected')
+          AND EXTRACT(YEAR FROM c.issued_at) = EXTRACT(YEAR FROM now())
+          ORDER BY c.issued_at DESC LIMIT 1
+        )
+      ) ORDER BY m.chapter, m.name), '[]'::jsonb)
+      FROM public.members m WHERE m.is_active
+      AND EXISTS (
+        SELECT 1 FROM public.auth_engagements ae
+        WHERE ae.person_id = m.person_id AND ae.kind = 'volunteer' AND ae.status = 'active'
+      )
+      AND (v_is_manage_member OR v_is_vol_director OR m.chapter = v_caller_chapter)
+    )
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;
+
+-- External reviewers are not PMI-GO volunteers: take them out of the agreement pipeline so they
+-- are neither prompted to sign the volunteer term nor surfaced in the pending-agreement queue.
+-- requires_agreement is a per-KIND config (engagement_kinds, ADR-0009 "types = admin config"),
+-- surfaced read-only by the auth_engagements view via ek.requires_agreement. study_group_owner
+-- and volunteer are intentionally left requiring an agreement.
+UPDATE public.engagement_kinds
+SET requires_agreement = false
+WHERE slug = 'external_reviewer'
+  AND requires_agreement IS TRUE;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260805000360_1169_certificate_ready_suppress_email_dedup.sql
+++ b/supabase/migrations/20260805000360_1169_certificate_ready_suppress_email_dedup.sql
@@ -1,0 +1,81 @@
+-- #1169: certificate_issued + certificate_ready fire for the same certificate lifecycle, so a
+-- counter-signed cert produced TWO emails per member per batch (measured: 46 members, 2 emails
+-- each on the cycle-3 completion batch). They are not truly redundant events (issue vs
+-- counter-sign), but at the email layer they duplicate.
+--
+-- Fix: suppress certificate_ready (in-app only), keep certificate_issued as the single email.
+-- Grounding (2026-07-07, 60d window): every certificate_ready recipient also received a
+-- certificate_issued (ready_but_no_issued = 0), so no member loses their email. The inverse is
+-- NOT safe: 5-6 Alumni recognition certs fire issued-only and never get a ready (auto-issued,
+-- never counter-signed), so suppressing certificate_issued would strand their only email.
+--
+-- Mirrors the ADR-0022 catalog (docs/adr/ADR-0022-notification-types-catalog.json); the parity
+-- contract test keeps _delivery_mode_for and the catalog in lock-step.
+
+CREATE OR REPLACE FUNCTION public._delivery_mode_for(p_type text)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE PARALLEL SAFE
+ SET search_path TO ''
+AS $function$
+  SELECT CASE p_type
+    -- PR-2 (email audit): the per-signing leadership alert is now in-app only; the daily
+    -- digest (volunteer_term_signed_digest) carries the single aggregated email.
+    WHEN 'volunteer_agreement_signed'    THEN 'suppress'
+    WHEN 'volunteer_term_signed_digest'  THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_pending'  THEN 'transactional_immediate'
+    WHEN 'system_alert'                  THEN 'transactional_immediate'
+    -- #1169: ready is redundant with issued at the email layer (issued carries the single email);
+    -- kept in-app only. Every ready-cert already fired an issued email (0 ready-without-issued/60d).
+    WHEN 'certificate_ready'             THEN 'suppress'
+    WHEN 'certificate_issued'            THEN 'transactional_immediate'
+    WHEN 'member_offboarded'             THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_advanced'    THEN 'transactional_immediate'
+    WHEN 'ip_ratification_chain_approved'   THEN 'transactional_immediate'
+    WHEN 'ip_ratification_awaiting_members' THEN 'transactional_immediate'
+    WHEN 'webinar_status_confirmed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_completed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_cancelled'      THEN 'transactional_immediate'
+    WHEN 'weekly_card_digest_member'     THEN 'transactional_immediate'
+    WHEN 'governance_cr_new'             THEN 'transactional_immediate'
+    WHEN 'governance_cr_vote'            THEN 'transactional_immediate'
+    WHEN 'governance_cr_approved'        THEN 'transactional_immediate'
+    WHEN 'sponsor_finance_entry_logged'  THEN 'transactional_immediate'
+    WHEN 'governance_manual_proposed'    THEN 'transactional_immediate'
+    WHEN 'engagement_renewal_d7_urgent'  THEN 'transactional_immediate'
+    -- p153 OPP-153.1: project_charter (TAP) notifications
+    WHEN 'project_charter_invite'        THEN 'transactional_immediate'
+    WHEN 'project_charter_approved'      THEN 'transactional_immediate'
+    -- p159 S#1 T1 (2026-05-14): selection_termo_due é o "email principal" pós-VEP-Active
+    WHEN 'selection_termo_due'           THEN 'transactional_immediate'
+    -- p228 #260 W2 Leaf 1 (2026-05-23): Selection funnel Policy Matrix
+    WHEN 'selection_approved'            THEN 'transactional_immediate'
+    WHEN 'selection_interview_scheduled' THEN 'transactional_immediate'
+    WHEN 'peer_review_requested'         THEN 'transactional_immediate'
+    WHEN 'selection_evaluation_complete' THEN 'suppress'
+    WHEN 'selection_interview_noshow'    THEN 'digest_weekly'
+    -- p228 #260 W2 Leaf 2 (2026-05-23): admin reminder for overdue interviews
+    WHEN 'selection_interview_overdue'   THEN 'digest_weekly'
+    -- p228 #260 W2 Leaf 4 (2026-05-23): candidate invite to book interview after
+    -- objective evaluations cleared + research_score >= cycle cutoff.
+    WHEN 'selection_cutoff_approved'     THEN 'transactional_immediate'
+    -- (end p228)
+    -- #186 (2026-06-05): curation committee broadcast when an item enters curation_pending
+    WHEN 'curation_item_submitted'       THEN 'transactional_immediate'
+    WHEN 'engagement_renewal_d30'        THEN 'digest_weekly'
+    WHEN 'engagement_renewal_d60_gp_aggregate' THEN 'digest_weekly'
+    -- #625 F3 (2026-06-11): radar de renovação de filiação
+    WHEN 'affiliation_renewal_d7_urgent'  THEN 'transactional_immediate'
+    WHEN 'affiliation_renewal_d30'        THEN 'digest_weekly'
+    WHEN 'affiliation_verification_stale' THEN 'digest_weekly'
+    -- #740 Wave 3c-i (B8): agreement rejected / reissued — member must re-sign, deliver immediately
+    WHEN 'volunteer_agreement_rejected'  THEN 'transactional_immediate'
+    WHEN 'volunteer_agreement_reissued'  THEN 'transactional_immediate'
+    WHEN 'attendance_detractor'          THEN 'suppress'
+    WHEN 'info'                          THEN 'suppress'
+    WHEN 'system'                        THEN 'suppress'
+    ELSE 'digest_weekly'
+  END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Contexto
PR-A do revamp de \`/admin/certificates\` (inspeção fullstack, sessão 2026-07-07). Correctness backend + frontend mínimo. PR-B (abas/filtros + contra-assinatura em lote) vem em seguida.

## Fase 0 — corrige QUEM deve assinar o Termo
`get_volunteer_agreement_status` decidia elegibilidade por **blocklist de `operational_role`** — furada (deixa `guest` passar) e negativa. Contava como "deve assinar" **externos** (external_reviewer: Angeline Prado, Mario Trentim) + 4 linhas sintéticas de teste.

- Regra **positiva**: `is_active` + engagement `volunteer` ativo (= ciclo corrente/C4). Elegíveis **77 → 72** (medido ao vivo).
- **Filiação PMI = sinal, não gate**: `pmi_id_verified` por membro + `not_verified` no summary + badge/filtro no painel. Não há fonte confiável de validade de membresia (só `pmi_id_verified`; 11 dos 72 não-verificados são voluntários reais já assinados, incl. líderes de tribo). Gate duro deferido ao **#1129** (VEP).
- **external_reviewer** sai do pipeline de acordo (`engagement_kinds.requires_agreement=false`, config por-kind ADR-0009). `study_group_owner`/`volunteer` mantidos.
- Remove o **hardcode "52 membros ativos"** do painel.

## Fase 3 — e-mail de certificado duplicado (#1169)
`certificate_issued` + `certificate_ready` = 2 e-mails/cert por lote (46 no lote do ciclo 3). **`certificate_ready` → `suppress`** (in-app); `issued` carrega o e-mail único. Seguro: **0 ready-sem-issued em 60d**, enquanto suprimir `issued` deixaria os ~6 Alumni (issued-only, nunca contra-assinados) sem e-mail. Catálogo ADR-0022 + parity test.

## Verificação ao vivo (PROD)
- `total_eligible=72`, `not_verified=11`, external_reviewer fora da fila de acordos, `_delivery_mode_for('certificate_ready')=suppress`.
- `npx astro build` ok; body-drift=0; sem phantom tracking-rows.
- Falhas restantes da suíte = timeout de carga concorrente / baseline flaky documentado (p276 passa 18/0 isolada; m3/M6/p65/preview_gate são baseline).

## Migrations
- `20260805000359` — regra positiva de elegibilidade + `pmi_id_verified` + flip external_reviewer.
- `20260805000360` — `_delivery_mode_for` certificate_ready → suppress.

🤖 Assisted by Claude (Anthropic)