### PR TITLE
feat(filiacao): #1175 F2 parser de capítulo registry-driven + backfill (Wave 2)

### DIFF
--- a/cloudflare-workers/pmi-vep-sync/src/chapter-matcher.test.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/chapter-matcher.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { buildBrChapterMatcher, parseBrChapterCode, type ChapterMatcherRow } from './mapper';
+
+/**
+ * #1175 F2 — chapter-name resolution is chapter_registry-driven. The fixture mirrors
+ * the live registry shape (bare codes, state names, vep_name_aliases); the matcher must
+ * mirror resolve_br_chapter_code() (migration 20260805000364). Index case: the VEP name
+ * "Amazônia Chapter" (no ", Brazil Chapter" suffix; registry state "Amazonas") resolved
+ * to null under the old suffix-gated parser, leaving the member with 0 affiliations.
+ */
+
+const REGISTRY: ChapterMatcherRow[] = [
+  { chapter_code: 'GO', state: 'Goiás', vep_name_aliases: [] },
+  { chapter_code: 'MG', state: 'Minas Gerais', vep_name_aliases: [] },
+  { chapter_code: 'RS', state: 'Rio Grande do Sul', vep_name_aliases: [] },
+  { chapter_code: 'RJ', state: 'Rio de Janeiro', vep_name_aliases: [] },
+  { chapter_code: 'SE', state: 'Sergipe', vep_name_aliases: null },
+  { chapter_code: 'AM', state: 'Amazonas', vep_name_aliases: ['Amazônia Chapter', 'Amazonia Chapter'] },
+];
+
+const match = buildBrChapterMatcher(REGISTRY);
+
+describe('#1175 F2 buildBrChapterMatcher', () => {
+  it('resolves the canonical "<State>, Brazil Chapter" form from registry state names', () => {
+    expect(match('Goiás, Brazil Chapter')).toBe('GO');
+    expect(match('Minas Gerais, Brazil Chapter')).toBe('MG');
+    expect(match('Rio Grande do Sul, Brazil Chapter')).toBe('RS');
+    expect(match('Sergipe, Brazil Chapter')).toBe('SE');
+  });
+
+  it('resolves vep_name_aliases without the ", Brazil Chapter" suffix (index case AM)', () => {
+    expect(match('Amazônia Chapter')).toBe('AM');
+    expect(match('Amazonia Chapter')).toBe('AM');
+  });
+
+  it('is case- and diacritic-insensitive', () => {
+    expect(match('amazônia chapter')).toBe('AM');
+    expect(match('AMAZONIA CHAPTER')).toBe('AM');
+    expect(match('goias, brazil chapter')).toBe('GO');
+  });
+
+  it('returns null for non-BR chapters (BR-only FACT table, ADR-0104)', () => {
+    expect(match('PMI Global')).toBeNull();
+    expect(match('Washington, DC Chapter')).toBeNull();
+    expect(match('Angola Chapter')).toBeNull();
+    expect(match('Honduras Chapter')).toBeNull();
+    expect(match('Central Italy Chapter')).toBeNull();
+  });
+
+  it('returns null for empty / nullish input', () => {
+    expect(match(null)).toBeNull();
+    expect(match(undefined)).toBeNull();
+    expect(match('')).toBeNull();
+  });
+
+  it('does not let a state substring match without the Brazil Chapter suffix', () => {
+    // Only an explicit alias may skip the suffix gate.
+    expect(match('Sergipe')).toBeNull();
+    expect(match('Rio de Janeiro Chapter')).toBeNull();
+  });
+});
+
+describe('#1175 F2 static fallback parity (parseBrChapterCode)', () => {
+  it('fallback still resolves the canonical suffix form', () => {
+    expect(parseBrChapterCode('Minas Gerais, Brazil Chapter')).toBe('MG');
+    expect(parseBrChapterCode('Sergipe, Brazil Chapter')).toBe('SE');
+  });
+
+  it('fallback misses aliases by construction (registry is the fix, not this map)', () => {
+    expect(parseBrChapterCode('Amazônia Chapter')).toBeNull();
+  });
+});

--- a/cloudflare-workers/pmi-vep-sync/src/db.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/db.ts
@@ -5,7 +5,12 @@
 
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import type { Env, CronRunMetrics } from './types';
-import { parseBrChapterCode } from './mapper';
+import {
+  parseBrChapterCode,
+  buildBrChapterMatcher,
+  type BrChapterMatcher,
+  type ChapterMatcherRow
+} from './mapper';
 
 export function createDbClient(env: Env): SupabaseClient {
   return createClient(env.SUPABASE_URL, env.SUPABASE_SERVICE_ROLE_KEY, {
@@ -678,8 +683,9 @@ export async function findPersonIdByEmail(
  * Wave 3a-iii (#740 / ADR-0104) — populate member_chapter_affiliations from the
  * reliable pmi_memberships snapshot for a resolved person.
  *
- * For each BR ("<State>, Brazil Chapter") membership we resolve the chapter_registry
- * code and call the SECURITY DEFINER RPC upsert_chapter_affiliation with
+ * For each BR membership ("<State>, Brazil Chapter" or a chapter_registry
+ * vep_name_aliases entry, #1175 F2) we resolve the chapter_registry code and call
+ * the SECURITY DEFINER RPC upsert_chapter_affiliation with
  * is_primary=false: the worker asserts which chapters a person belongs to (FACT), it
  * never decides the headline. The RPC owns the one-primary invariant (it preserves the
  * legacy backfill / the future entry_chapter choice, and only promotes a provisional
@@ -690,6 +696,38 @@ export async function findPersonIdByEmail(
  * array of plain name strings, as actually stored in selection_applications.pmi_memberships)
  * and the declared { chapterName } object shape. Returns the count of affiliations upserted.
  */
+// #1175 F2 — per-isolate cache of the registry-driven matcher. Chapter data changes
+// rarely; a short TTL keeps a long-lived isolate from serving a stale alias set while
+// avoiding one registry query per application within a single ingest run.
+const MATCHER_TTL_MS = 5 * 60 * 1000;
+let matcherCache: { at: number; fn: BrChapterMatcher } | null = null;
+
+/**
+ * #1175 F2 — resolve membership names via chapter_registry (state + vep_name_aliases),
+ * the same SSOT the SQL resolver resolve_br_chapter_code() reads. Falls back to the
+ * static parseBrChapterCode map if the registry fetch fails, so an ingest never drops
+ * affiliations on a transient read error (the fallback misses aliases, by design).
+ */
+export async function getBrChapterMatcher(db: SupabaseClient): Promise<BrChapterMatcher> {
+  const now = Date.now();
+  if (matcherCache && now - matcherCache.at < MATCHER_TTL_MS) return matcherCache.fn;
+
+  const { data, error } = await db
+    .from('chapter_registry')
+    .select('chapter_code, state, vep_name_aliases')
+    .eq('is_active', true)
+    .eq('country', 'BR');
+
+  if (error || !Array.isArray(data) || data.length === 0) {
+    console.warn(`[pmi-vep-sync] chapter_registry fetch failed (${error?.message ?? 'empty'}); using static fallback matcher`);
+    return parseBrChapterCode;
+  }
+
+  const fn = buildBrChapterMatcher(data as ChapterMatcherRow[]);
+  matcherCache = { at: now, fn };
+  return fn;
+}
+
 export async function upsertChapterAffiliations(
   db: SupabaseClient,
   personId: string,
@@ -697,13 +735,14 @@ export async function upsertChapterAffiliations(
 ): Promise<number> {
   if (!Array.isArray(memberships) || memberships.length === 0) return 0;
 
+  const matcher = await getBrChapterMatcher(db);
   const codes = new Set<string>();
   for (const m of memberships) {
     const name =
       typeof m === 'string'
         ? m
         : (m && typeof m === 'object' ? ((m as any).chapterName ?? null) : null);
-    const code = parseBrChapterCode(name);
+    const code = matcher(name);
     if (code) codes.add(code);
   }
   if (codes.size === 0) return 0;

--- a/cloudflare-workers/pmi-vep-sync/src/mapper.ts
+++ b/cloudflare-workers/pmi-vep-sync/src/mapper.ts
@@ -137,8 +137,61 @@ function parseChapterFromMembership(ms: string): string | null {
 }
 
 /**
+ * #1175 F2 — chapter_registry rows that drive BR-chapter name resolution.
+ * Mirrors the SQL resolver resolve_br_chapter_code() (migration 20260805000364):
+ * both sides derive from the same SSOT (Pattern 47), so a new alias or chapter is
+ * config in the registry, not code.
+ */
+export interface ChapterMatcherRow {
+  chapter_code: string;
+  state: string | null;
+  vep_name_aliases: string[] | null;
+}
+
+export type BrChapterMatcher = (name: string | null | undefined) => string | null;
+
+/** Case- and diacritic-insensitive normalization for name matching. */
+function foldName(s: string): string {
+  return s.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().trim();
+}
+
+/**
+ * #1175 F2 — build the membership-name → registry-code matcher from live
+ * chapter_registry rows. Resolution order (same as resolve_br_chapter_code):
+ *   1. exact vep_name_aliases match ("Amazônia Chapter" → AM);
+ *   2. "<State>, Brazil Chapter" with the state name coming from the registry.
+ * Anything else (non-BR: "PMI Global", "Washington, DC Chapter") → null, because
+ * member_chapter_affiliations FKs chapter_registry, which is BR-only (ADR-0104).
+ */
+export function buildBrChapterMatcher(rows: ChapterMatcherRow[]): BrChapterMatcher {
+  const aliasToCode = new Map<string, string>();
+  const stateNeedles: Array<{ needle: string; code: string }> = [];
+  for (const r of rows) {
+    for (const a of r.vep_name_aliases ?? []) aliasToCode.set(foldName(a), r.chapter_code);
+    if (r.state) stateNeedles.push({ needle: foldName(r.state), code: r.chapter_code });
+  }
+  return (name) => {
+    if (!name) return null;
+    const n = foldName(name);
+    const byAlias = aliasToCode.get(n);
+    if (byAlias) return byAlias;
+    if (!/,\s*brazil chapter$/.test(n)) return null;
+    for (const s of stateNeedles) {
+      if (n.includes(s.needle)) return s.code;
+    }
+    return null;
+  };
+}
+
+/**
  * Wave 3a-iii (#740 / ADR-0104) — map a SINGLE PMI membership name (e.g.
  * "Minas Gerais, Brazil Chapter") to a bare chapter_registry code ("MG").
+ *
+ * #1175 F2: DEMOTED to static fallback. The primary path is buildBrChapterMatcher()
+ * fed by live chapter_registry rows (db.ts getBrChapterMatcher); this hardcoded map
+ * only backstops a registry fetch failure so an ingest never drops affiliations. It
+ * misses aliases ("Amazônia Chapter") by construction — do not extend it, extend
+ * chapter_registry.vep_name_aliases instead.
  *
  * Returns null for anything that is not an eligible BR chapter:
  *   - non-BR ("PMI Global", "Washington, DC Chapter", "Angola Chapter") — the FACT

--- a/supabase/migrations/20260805000364_1175_f2_chapter_registry_vep_aliases.sql
+++ b/supabase/migrations/20260805000364_1175_f2_chapter_registry_vep_aliases.sql
@@ -1,0 +1,64 @@
+-- #1175 F2: chapter-name resolution becomes chapter_registry-driven (Pattern 47 / smart-code).
+--
+-- The VEP membership snapshot carries chapter names that do NOT all follow the
+-- "<State>, Brazil Chapter" convention the worker's parseBrChapterCode hardcodes
+-- (cloudflare-workers/pmi-vep-sync/src/mapper.ts): the live counter-example is
+-- "Amazônia Chapter" (registry state "Amazonas"), which resolved to null, so the member's
+-- member_chapter_affiliations stayed empty and the profile "Capítulo de Entrada" card
+-- claimed "não encontramos suas filiações" despite the evidence sitting in
+-- selection_applications.pmi_memberships (index case: #1175, audited live 2026-07-08).
+--
+-- This migration makes chapter_registry the SSOT for the mapping:
+--   1. chapter_registry.vep_name_aliases — exact (case-insensitive) VEP chapterName strings
+--      that map to the chapter beyond the canonical "<State>, Brazil Chapter" pattern.
+--      Seeded for AM in both spellings (no unaccent extension in this DB).
+--   2. resolve_br_chapter_code(text) — the SQL resolver used by the #1175 backfill and any
+--      future SQL-side parsing. The worker builds the equivalent matcher in TS from the
+--      same registry rows (cloudflare-workers/pmi-vep-sync/src/mapper.ts
+--      buildBrChapterMatcher), so both sides derive from the one SSOT.
+--
+-- Non-BR names ("PMI Global", "Washington, DC Chapter", "Angola Chapter") intentionally
+-- resolve to NULL: member_chapter_affiliations FKs chapter_registry, which is BR-only by
+-- design (ADR-0104).
+
+ALTER TABLE public.chapter_registry
+  ADD COLUMN IF NOT EXISTS vep_name_aliases text[] NOT NULL DEFAULT '{}';
+
+COMMENT ON COLUMN public.chapter_registry.vep_name_aliases IS
+  '#1175 F2: exact VEP pmi_memberships chapterName strings (case-insensitive) that map to this chapter when they do not follow the "<State>, Brazil Chapter" convention. Ex.: AM = {"Amazônia Chapter","Amazonia Chapter"}. Consumed by resolve_br_chapter_code() and by the pmi-vep-sync worker matcher.';
+
+UPDATE public.chapter_registry
+   SET vep_name_aliases = ARRAY['Amazônia Chapter', 'Amazonia Chapter'],
+       updated_at = now()
+ WHERE chapter_code = 'AM';
+
+-- Resolver: alias exact match wins; otherwise the canonical "<State>, Brazil Chapter"
+-- pattern matched against the registry's own state names (no hardcoded state list).
+-- Returns the bare registry code ("AM", "MG", ...) or NULL for non-BR / unknown names.
+CREATE OR REPLACE FUNCTION public.resolve_br_chapter_code(p_name text)
+ RETURNS text
+ LANGUAGE sql
+ STABLE
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH n AS (SELECT lower(trim(coalesce(p_name, ''))) AS name)
+  SELECT cr.chapter_code
+  FROM public.chapter_registry cr, n
+  WHERE cr.is_active = true
+    AND cr.country = 'BR'
+    AND n.name <> ''
+    AND (
+      EXISTS (SELECT 1 FROM unnest(cr.vep_name_aliases) a WHERE lower(trim(a)) = n.name)
+      OR (n.name ~ ',\s*brazil chapter$' AND position(lower(cr.state) IN n.name) > 0)
+    )
+  ORDER BY
+    (EXISTS (SELECT 1 FROM unnest(cr.vep_name_aliases) a WHERE lower(trim(a)) = n.name)) DESC
+  LIMIT 1
+$function$;
+
+COMMENT ON FUNCTION public.resolve_br_chapter_code(text) IS
+  '#1175 F2: chapter_registry-driven resolution of a VEP membership chapterName to the registry code. Alias match first, then "<State>, Brazil Chapter". NULL = non-BR or unknown (intentionally untracked, ADR-0104).';
+
+GRANT EXECUTE ON FUNCTION public.resolve_br_chapter_code(text) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/w3a-iii-worker-chapter-affiliations.test.mjs
+++ b/tests/contracts/w3a-iii-worker-chapter-affiliations.test.mjs
@@ -99,8 +99,23 @@ describe('w3a-iii — worker write path (db.ts)', () => {
     assert.match(DB, /db\.rpc\('upsert_chapter_affiliation'/);
     assert.match(DB, /p_source: 'pmi_vep'/);
     assert.match(DB, /p_is_primary: false/);
-    // imports the BR mapper
-    assert.match(DB, /import \{ parseBrChapterCode \} from '\.\/mapper'/);
+    // #1175 F2: imports the registry-driven matcher AND the static fallback
+    assert.match(DB, /parseBrChapterCode,?\s*\n\s*buildBrChapterMatcher/);
+  });
+
+  it('#1175 F2: resolution is chapter_registry-driven with static fallback', () => {
+    // db.ts fetches the SSOT rows and builds the matcher (per-isolate cached)
+    assert.match(DB, /export async function getBrChapterMatcher\(/);
+    assert.match(DB, /from\('chapter_registry'\)/);
+    assert.match(DB, /select\('chapter_code, state, vep_name_aliases'\)/);
+    // registry fetch failure falls back to the static map (never drops an ingest)
+    assert.match(DB, /return parseBrChapterCode/);
+    // upsert path resolves via the matcher, not the hardcoded map
+    assert.match(DB, /const matcher = await getBrChapterMatcher\(db\)/);
+    assert.match(DB, /const code = matcher\(name\)/);
+    // mapper exports the pure builder (alias-first, then "<State>, Brazil Chapter")
+    assert.match(MAPPER, /export function buildBrChapterMatcher\(/);
+    assert.match(MAPPER, /vep_name_aliases/);
   });
 
   it('tolerates the real runtime shape (array of name strings) and the declared object shape', () => {


### PR DESCRIPTION
## O que

Wave 2 do #1175 (F2): a resolução de nome de capítulo VEP → código do registry deixa de ser hardcoded no worker e passa a ser dirigida pelo `chapter_registry` (SSOT, Pattern 47).

- **Migration `20260805000364`** (JÁ APLICADA em PROD + repair + NOTIFY):
  - `chapter_registry.vep_name_aliases text[]` — aliases exatos por capítulo; seed `AM = {"Amazônia Chapter","Amazonia Chapter"}`.
  - `resolve_br_chapter_code(text)` — resolver SQL: alias primeiro, depois `"<Estado>, Brazil Chapter"` com estados do próprio registry. Validado ao vivo contra os nomes reais dos snapshots (AM/MG/GO/SE/RS resolvem; PMI Global/Washington DC/Angola/Honduras/Central Italy → NULL, BR-only por design ADR-0104).
- **Worker `pmi-vep-sync`**: `buildBrChapterMatcher()` (puro, mapper.ts) alimentado por fetch do `chapter_registry` com cache por isolate (`getBrChapterMatcher`, db.ts). `parseBrChapterCode` hardcoded vira fallback estático de falha de fetch (ingest nunca dropa afiliações). **Requer `wrangler deploy` do worker após merge** (sessão dev).
- **Testes**: 8 novos no worker (vitest 14/14) + contract `w3a-iii` atualizado para guardar o caminho registry-driven.

## Backfill (Wave 2b — JÁ EXECUTADO em PROD)

A partir de `selection_applications.pmi_memberships` via `resolve_br_chapter_code` + RPC canônica `upsert_chapter_affiliation` (preserva invariante one-primary). Números ao vivo (2026-07-08): 79 pares resolvíveis, **1 faltante** (caso-índice, "Amazônia Chapter" → AM); `member_chapter_affiliations` 114→115. Audit: `admin_audit_log` action `affiliation.backfill_from_vep_snapshots`.

## Por que só 1 par no backfill

O import de 07/07 já tinha upsertado as 77 afiliações na forma canônica com sufixo; o único nome fora do padrão em todo o dataset vivo era o alias AM.

## Merge

Lane de preparação — merge é da sessão dev. Independente do PR #1176 (F1); ordem indiferente.

Refs #1175