### PR TITLE
feat(onboarding): página pública Guia do Pré-Onboarding (/guia-pre-onboarding)

### DIFF
--- a/src/data/pre-onboarding-guide.ts
+++ b/src/data/pre-onboarding-guide.ts
@@ -1,0 +1,132 @@
+// Guia do Pré-Onboarding: jornada passo a passo + FAQ para novos voluntários
+// (candidatos aprovados que ainda não assinaram o Termo de Voluntariado).
+//
+// Conteúdo em pt-BR por DESIGN (mesma regra de volunteer-guide.ts): o público
+// são candidatos de capítulos brasileiros do PMI e o material espelha a
+// comunicação oficial feita em português. Apenas o chrome (títulos de seção,
+// banner, rótulos) é localizado via i18n (keys `guiaPre.*`).
+//
+// Origem: dúvidas reais do grupo de pré-onboarding do Ciclo 4 (2026/2).
+// Cada entrada do FAQ corresponde a uma pergunta recorrente dos candidatos.
+
+export interface JourneyStep {
+  title: string;
+  where: string;
+  detail: string;
+  link?: { href: string; label: string };
+}
+
+export interface PreFaqEntry {
+  q: string;
+  a: string;
+}
+
+// A jornada canônica: aprovado → membro ativo
+export const journey: JourneyStep[] = [
+  {
+    title: 'Aceite sua vaga no VEP',
+    where: 'volunteer.pmi.org',
+    detail:
+      'Após a aprovação, o PMI envia um e-mail do remetente <strong>noreply@pmi.org</strong> com o link de aceite. Se não encontrar o e-mail, acesse o VEP e clique em <strong>[My Info &amp; Activity / Minhas Informações e Atividades]</strong> → <strong>[Accept Position / Aceitar Posição]</strong>. Sem o aceite, a jornada não começa.',
+    link: { href: 'https://volunteer.pmi.org/', label: 'Abrir o VEP' },
+  },
+  {
+    title: 'Entre na plataforma do Núcleo',
+    where: 'nucleoia.pmigo.org.br',
+    detail:
+      'Use o <strong>mesmo e-mail cadastrado no PMI</strong>: é ele que vincula sua conta à vaga aceita. Você entrará como <em>Visitante</em>, e isso é esperado nesta fase (veja o FAQ).',
+    link: { href: 'https://nucleoia.pmigo.org.br/', label: 'Entrar na plataforma' },
+  },
+  {
+    title: 'Complete seu perfil',
+    where: 'Meu Perfil (/profile)',
+    detail:
+      'Revise o <strong>consentimento de privacidade</strong>, confira o <strong>nome completo</strong> (formatado, sem caixa alta), carregue a <strong>foto</strong> e preencha <strong>telefone, endereço, cidade, estado, CEP e data de aniversário</strong>. Esses dados são exigidos pela Lei nº 9.608/1998 e pela LGPD, e usados apenas no Termo de Voluntariado e na comunicação institucional. Aproveite para adicionar <strong>LinkedIn</strong>, e-mails alternativos e o <strong>Credly público</strong> (passo a passo no FAQ).',
+    link: { href: 'https://nucleoia.pmigo.org.br/profile', label: 'Abrir Meu Perfil' },
+  },
+  {
+    title: 'Garanta sua filiação PMI ativa',
+    where: 'pmi.org + community.pmi.org',
+    detail:
+      'O programa é um benefício de <strong>filiados a capítulos brasileiros do PMI</strong>: mantenha a membrezia PMI ativa e a filiação a um capítulo do Brasil. Crie também seu perfil na <strong>community.pmi.org</strong> e deixe-o <strong>público</strong>, pois é por ele que a plataforma valida sua filiação e traz seu capítulo automaticamente.',
+    link: { href: 'https://community.pmi.org/profile/', label: 'Perfil na PMI Community' },
+  },
+  {
+    title: 'Assine o Termo de Voluntariado',
+    where: 'Plataforma → Termo de Voluntariado',
+    detail:
+      'Com o perfil completo e a filiação ativa, a assinatura digital fica disponível. É o passo que muda seu papel de <em>Visitante</em> para <strong>Pesquisador ou Líder</strong> (conforme a vaga aprovada) e destrava o restante da plataforma. Dúvidas sobre o conteúdo do termo? Consulte o guia do voluntário no glossário.',
+    link: { href: 'https://nucleoia.pmigo.org.br/governance/glossario', label: 'Guia do voluntário + glossário' },
+  },
+  {
+    title: 'Participe do kickoff e escolha sua tribo',
+    where: 'Evento de abertura do ciclo',
+    detail:
+      'No kickoff os temas de pesquisa do ciclo são apresentados: cada tribo com vídeo do líder, descrição da temática, proposta de valor, marcos de entrega e LinkedIn da liderança. A <strong>escolha da tribo é liberada a partir do kickoff</strong> (com o termo assinado). Ao final do evento há salas com os líderes para tirar dúvidas antes de decidir.',
+    link: { href: 'https://nucleoia.pmigo.org.br/reunioes-gerais', label: 'Agenda de reuniões' },
+  },
+];
+
+// FAQ: perguntas reais do grupo de pré-onboarding
+export const preFaq: PreFaqEntry[] = [
+  {
+    q: 'Por que ainda apareço como "Visitante"?',
+    a: 'Todo mundo aparece como Visitante até assinar o Termo de Voluntariado. Depois da assinatura, seu papel muda automaticamente para <strong>Pesquisador</strong> ou <strong>Líder</strong>, conforme a vaga em que você foi aprovado, e as áreas da plataforma são destravadas. Não é erro: é a fase da jornada.',
+  },
+  {
+    q: 'Já aceitei a vaga no VEP. Por que preciso assinar outro termo?',
+    a: 'O aceite no volunteer.pmi.org é o passo global do PMI. No Brasil, a <strong>Lei do Voluntariado (nº 9.608/1998)</strong> e a <strong>LGPD</strong> exigem um passo a mais: o Termo de Adesão ao Serviço Voluntário, assinado digitalmente na plataforma. São dois atos diferentes e ambos são necessários.',
+  },
+  {
+    q: 'O botão de assinar o termo não aparece (ou aparece "em atualização"). O que faço?',
+    a: 'Duas causas comuns: (1) faltam pré-requisitos, como perfil completo (nome, telefone, endereço completo, data de aniversário) e filiação PMI ativa a um capítulo brasileiro; a tela "Minhas pendências" lista o que falta; (2) o termo está temporariamente pausado para atualização jurídica; nesse caso não é nada do seu lado: você será avisado por e-mail e pelo grupo quando a assinatura reabrir.',
+  },
+  {
+    q: 'O sistema não reconhece meu CEP. E agora?',
+    a: 'A base de CEPs foi atualizada e passou a aceitar também CEPs complementares (de logradouro). Se o seu CEP ainda não for reconhecido, envie-o no grupo de onboarding (pode ser em mensagem privada) para incluirmos na base.',
+  },
+  {
+    q: 'Como pego meu link público do Credly?',
+    a: '1) Acesse <strong>credly.com</strong> e faça login (a mesma conta onde estão suas badges PMI). 2) Em <strong>Settings → Privacy</strong>, deixe seu perfil como <strong>Público</strong>; sem isso a plataforma não consegue ler suas certificações. 3) Abra seu perfil, copie a URL no formato <strong>credly.com/users/seu-usuario</strong> e cole no campo do Meu Perfil. Leva menos de 2 minutos e libera XP automático pelas suas badges.',
+  },
+  {
+    q: 'Por que o Núcleo usa o Credly?',
+    a: 'O Credly agrega certificações de fontes confiáveis (PMI, Microsoft, IBM e outras certificadoras) e tem API pública. A plataforma lê seu perfil público e pontua automaticamente o que é correlato a IA, machine learning, ciência de dados, gestão de projetos e liderança, alimentando a gamificação da sua jornada junto com presença em eventos, entregáveis e protagonismo.',
+  },
+  {
+    q: 'O Credly é pago? Preciso criar conta nova?',
+    a: 'É gratuito. Dá para entrar com SSO (Google, LinkedIn ou Outlook). Dica: cadastre no Credly <strong>todos os e-mails que você usa ou já usou</strong> (inclusive corporativos antigos), pois certificações emitidas para outros e-mails aparecem no seu perfil quando o e-mail está vinculado.',
+  },
+  {
+    q: 'Minha filiação/capítulo não aparece na plataforma. Por quê?',
+    a: 'Em geral é porque o seu perfil na <strong>community.pmi.org</strong> ainda não existe ou está com a opção de não exibir o capítulo. Crie o perfil (ele já nasce público por padrão) e confira a visibilidade: é por essa integração que a plataforma valida membrezia e filiação.',
+  },
+  {
+    q: 'Preciso ser membro do PMI e filiado a um capítulo?',
+    a: 'Sim, o programa é um benefício de filiados a capítulos brasileiros do PMI. Se a sua membrezia está vencida ou você ainda não é filiado, dá para resolver pelo site do PMI (há opção estudantil com desconto expressivo e o parcelamento para o Brasil, piloto do PMI Global). Se precisar, colocamos você em contato com o diretor de filiação do seu capítulo.',
+  },
+  {
+    q: 'Quando escolho minha tribo? Onde vejo os detalhes de cada uma?',
+    a: 'A escolha é liberada <strong>a partir do kickoff do ciclo</strong>, e exige o termo assinado. No kickoff, cada tema de pesquisa é apresentado com vídeo do líder, descrição, proposta de valor, marcos de entrega e LinkedIn da liderança, e há salas com os líderes ao final para tirar dúvidas. Não se preocupe em decidir antes disso.',
+  },
+  {
+    q: 'O que significa a barra "Completude do Perfil"?',
+    a: 'Ela mede os itens do seu cadastro que a jornada usa (foto, PMI ID, LinkedIn, telefone, Credly, e-mail alternativo e, para papéis operacionais, vínculo ao ciclo e ≥1 curso da Trilha PMI AI). Logo abaixo da barra aparece exatamente o que falta. Alguns itens, como a escolha de tribo, só destravam em fases seguintes; a barra não precisa estar em 100% para assinar o termo.',
+  },
+  {
+    q: 'O que é a Trilha PMI AI e por que ela aparece como pendência?',
+    a: 'É a esteira de mini-certificações de IA do PMI Global: cursos gratuitos, do básico ao intermediário, dos quais <strong>6 emitem badge no Credly</strong>. Fazer a trilha gera XP na gamificação, PDUs, e é meta do Núcleo em 2026 (70% dos voluntários ativos com 6/6). Vale começar já no pré-onboarding: o primeiro curso concluído já conta no seu perfil.',
+  },
+  {
+    q: 'Como funcionam as reuniões do Núcleo?',
+    a: 'Dois ritmos: a <strong>tribo</strong> se reúne semanalmente em torno do tema de pesquisa, com metas e entregáveis; e a <strong>reunião geral</strong> (quinzenal, às quintas 19h BRT) é um espaço de protagonismo, com a pauta montada pelos próprios pesquisadores, que reservam blocos de 5 a 30 minutos para apresentar temas, ideias e resultados. Não é reunião de status. A agenda fica sempre com dois eventos à frente em /reunioes-gerais, e as gerais são gravadas e publicadas no YouTube.',
+  },
+  {
+    q: 'Onde encontro as gravações e os canais oficiais?',
+    a: 'YouTube: <strong>youtube.com/@nucleo_ia</strong> (gravações das reuniões gerais e webinars) · LinkedIn: <strong>linkedin.com/company/nucleo-ia</strong> · Instagram: <strong>@nucleo.ia.gp</strong>. Seguir, curtir e comentar ajuda a rede a crescer, e dá projeção a você, que agora faz parte dela.',
+  },
+  {
+    q: 'Encontrei um erro ou algo não salva. O que faço?',
+    a: 'Reporte no grupo de onboarding (print ajuda muito) ou pela Central de Ajuda da plataforma. Vocês são o primeiro ciclo a passar pela jornada 100% digital: o projeto é de Pesquisa &amp; Desenvolvimento e cada erro reportado, crítica ou sugestão melhora a experiência dos próximos ciclos. Bugs de cadastro (CEP, campos que não salvam) têm sido corrigidos no mesmo dia.',
+  },
+];

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -6646,6 +6646,21 @@ const enUS: Record<string, string> = {
   'meStatus.nextStep.waitlist': 'You are on the waitlist. If spots open, we will reach out.',
   'meStatus.evaluationsBlindNote': 'During the evaluation phase you see only the count of submitted evaluations — without evaluator identification (anti-bias).',
 
+  // ── Guia do Pré-Onboarding (/guia-pre-onboarding) ──
+  'guiaPre.metaTitle': 'Pre-Onboarding Guide · Núcleo IA & GP',
+  'guiaPre.title': 'Pre-Onboarding Guide',
+  'guiaPre.subtitle': 'From approval to your first tribe: the step-by-step journey and answers to the most common questions from new volunteers.',
+  'guiaPre.langNote': 'This guide\'s content is maintained in Portuguese (pt-BR), the official communication language of the program.',
+  'guiaPre.banner': 'Living guide: updated with each cycle\'s questions. Didn\'t find your answer? Ask in your cycle\'s onboarding group or use the platform\'s Help Center.',
+  'guiaPre.journeyTitle': 'The journey in 6 steps',
+  'guiaPre.journeySub': 'Follow in order: each step unlocks the next.',
+  'guiaPre.faqTitle': 'Frequently asked questions',
+  'guiaPre.faqSub': 'Collected from the pre-onboarding groups: if you wondered, someone already asked.',
+  'guiaPre.moreHelp': 'More material:',
+  'guiaPre.linkGlossario': 'Volunteer guide + glossary',
+  'guiaPre.linkAgenda': 'General meetings agenda',
+  'guiaPre.footer': 'This guide is support material and does not replace the Volunteer Agreement or the program\'s policies.',
+
   // ── Glossario (Política IP §13 mirror) ──
   'glossario.metaTitle': 'Glossary — Núcleo IA & GP',
   'glossario.title': 'Canonical Glossary',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -6646,6 +6646,21 @@ const esLATAM: Record<string, string> = {
   'meStatus.nextStep.waitlist': 'Estás en lista de espera. Si se abren cupos, te contactaremos.',
   'meStatus.evaluationsBlindNote': 'Durante la fase de evaluación ves solo la cantidad de evaluaciones enviadas — sin identificación de evaluadores (anti-sesgo).',
 
+  // ── Guia do Pré-Onboarding (/guia-pre-onboarding) ──
+  'guiaPre.metaTitle': 'Guía de Pre-Onboarding · Núcleo IA & GP',
+  'guiaPre.title': 'Guía de Pre-Onboarding',
+  'guiaPre.subtitle': 'De la aprobación a tu primera tribu: el paso a paso de la jornada y las respuestas a las dudas más comunes de los nuevos voluntarios.',
+  'guiaPre.langNote': 'El contenido de esta guía se mantiene en portugués (pt-BR), idioma oficial de comunicación del programa.',
+  'guiaPre.banner': 'Guía viva: se actualiza con las dudas de cada ciclo. ¿No encontraste tu respuesta? Pregunta en el grupo de onboarding de tu ciclo o usa el Centro de Ayuda de la plataforma.',
+  'guiaPre.journeyTitle': 'La jornada en 6 pasos',
+  'guiaPre.journeySub': 'Sigue el orden: cada paso desbloquea el siguiente.',
+  'guiaPre.faqTitle': 'Preguntas frecuentes',
+  'guiaPre.faqSub': 'Recopiladas de los grupos de pre-onboarding: si te lo preguntaste, alguien ya lo preguntó.',
+  'guiaPre.moreHelp': 'Más material:',
+  'guiaPre.linkGlossario': 'Guía del voluntario + glosario',
+  'guiaPre.linkAgenda': 'Agenda de reuniones generales',
+  'guiaPre.footer': 'Esta guía es material de apoyo y no sustituye el Término de Voluntariado ni las políticas del programa.',
+
   // ── Glossario (Política IP §13 mirror) ──
   'glossario.metaTitle': 'Glosario — Núcleo IA & GP',
   'glossario.title': 'Glosario Canónico',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -6652,6 +6652,21 @@ const ptBR: Record<string, string> = {
   'meStatus.nextStep.waitlist': 'Você está em lista de espera. Caso vagas se abram, entraremos em contato.',
   'meStatus.evaluationsBlindNote': 'Durante a fase de avaliação, você vê apenas o número de avaliações submetidas — sem identificação dos avaliadores (anti-viés).',
 
+  // ── Guia do Pré-Onboarding (/guia-pre-onboarding) ──
+  'guiaPre.metaTitle': 'Guia do Pré-Onboarding · Núcleo IA & GP',
+  'guiaPre.title': 'Guia do Pré-Onboarding',
+  'guiaPre.subtitle': 'Da aprovação à sua primeira tribo: o passo a passo da jornada e as respostas às dúvidas mais comuns dos novos voluntários.',
+  'guiaPre.langNote': 'O conteúdo deste guia é mantido em português (pt-BR), idioma oficial da comunicação do programa.',
+  'guiaPre.banner': 'Guia vivo: atualizado conforme as dúvidas de cada ciclo. Não encontrou sua resposta? Pergunte no grupo de onboarding do seu ciclo ou use a Central de Ajuda da plataforma.',
+  'guiaPre.journeyTitle': 'A jornada em 6 passos',
+  'guiaPre.journeySub': 'Siga na ordem: cada passo destrava o seguinte.',
+  'guiaPre.faqTitle': 'Perguntas frequentes',
+  'guiaPre.faqSub': 'Coletadas dos grupos de pré-onboarding: se você se perguntou, alguém já perguntou também.',
+  'guiaPre.moreHelp': 'Mais material:',
+  'guiaPre.linkGlossario': 'Guia do voluntário + glossário',
+  'guiaPre.linkAgenda': 'Agenda de reuniões gerais',
+  'guiaPre.footer': 'Este guia é material de apoio e não substitui o Termo de Voluntariado nem as políticas do programa.',
+
   // ── Glossario (Política IP §13 mirror) ──
   'glossario.metaTitle': 'Glossário — Núcleo IA & GP',
   'glossario.title': 'Glossário Canônico',

--- a/src/pages/en/guia-pre-onboarding.astro
+++ b/src/pages/en/guia-pre-onboarding.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { t } from '../../i18n/utils';
+const lang = 'en-US' as const;
+---
+<BaseLayout title={t('guiaPre.metaTitle', lang)} activePage="help" lang={lang}>
+  <meta http-equiv="refresh" content="0;url=/guia-pre-onboarding?lang=en-US">
+  <div class="flex items-center justify-center min-h-[60vh]">
+    <p class="text-[var(--text-muted)] text-sm">{t('common.loading', lang)}</p>
+  </div>
+</BaseLayout>

--- a/src/pages/es/guia-pre-onboarding.astro
+++ b/src/pages/es/guia-pre-onboarding.astro
@@ -1,0 +1,11 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { t } from '../../i18n/utils';
+const lang = 'es-LATAM' as const;
+---
+<BaseLayout title={t('guiaPre.metaTitle', lang)} activePage="help" lang={lang}>
+  <meta http-equiv="refresh" content="0;url=/guia-pre-onboarding?lang=es-LATAM">
+  <div class="flex items-center justify-center min-h-[60vh]">
+    <p class="text-[var(--text-muted)] text-sm">{t('common.loading', lang)}</p>
+  </div>
+</BaseLayout>

--- a/src/pages/guia-pre-onboarding.astro
+++ b/src/pages/guia-pre-onboarding.astro
@@ -1,0 +1,119 @@
+---
+/**
+ * /guia-pre-onboarding — Guia público do Pré-Onboarding
+ *
+ * Página estática, acessível a anon/Visitante, linkável nos grupos de WhatsApp
+ * de cada ciclo. Consolida a jornada canônica (aprovado → membro ativo) e o FAQ
+ * com as dúvidas reais recorrentes dos candidatos (origem: pré-onboarding C4).
+ *
+ * Conteúdo em pt-BR por design (mesma regra de /governance/glossario +
+ * volunteer-guide.ts); apenas o chrome é localizado via i18n `guiaPre.*`.
+ */
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { getLangFromURL, t, type Lang } from '../i18n/utils';
+import { journey, preFaq } from '../data/pre-onboarding-guide';
+const lang: Lang = getLangFromURL(Astro.url.pathname + Astro.url.search);
+const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
+const showLangNote = lang !== 'pt-BR';
+---
+
+<BaseLayout title={t('guiaPre.metaTitle', lang)} activePage="help" lang={lang}>
+  <div class="max-w-[900px] mx-auto px-4 py-10 space-y-10">
+    <header class="text-center space-y-2">
+      <h1 class="text-2xl md:text-3xl font-extrabold text-navy">
+        {t('guiaPre.title', lang)}
+      </h1>
+      <p class="text-sm text-[var(--text-muted)] max-w-2xl mx-auto">
+        {t('guiaPre.subtitle', lang)}
+      </p>
+      {showLangNote && (
+        <p class="text-[11px] text-amber-800 italic">{t('guiaPre.langNote', lang)}</p>
+      )}
+    </header>
+
+    <div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-[12px] text-amber-900">
+      {t('guiaPre.banner', lang)}
+    </div>
+
+    <!-- Jornada passo a passo -->
+    <section aria-labelledby="journey-heading" class="space-y-4">
+      <div class="space-y-1">
+        <h2 id="journey-heading" class="text-xl font-extrabold text-navy">{t('guiaPre.journeyTitle', lang)}</h2>
+        <p class="text-[13px] text-[var(--text-muted)]">{t('guiaPre.journeySub', lang)}</p>
+      </div>
+      <ol class="space-y-3">
+        {journey.map((step, i) => (
+          <li class="flex gap-4 rounded-xl border border-[var(--border-default)] bg-[var(--surface-card)] p-5">
+            <span class="flex-none h-9 w-9 rounded-full bg-navy text-white font-extrabold text-[15px] flex items-center justify-center" aria-hidden="true">{i + 1}</span>
+            <div class="min-w-0 space-y-1.5">
+              <div class="flex flex-wrap items-baseline gap-x-2.5 gap-y-0.5">
+                <h3 class="text-[15.5px] font-bold text-[var(--text-primary)]">{step.title}</h3>
+                <span class="text-[12px] font-semibold text-[var(--text-muted)]">{step.where}</span>
+              </div>
+              <p class="text-[14px] text-[var(--text-secondary)]" set:html={step.detail} />
+              {step.link && (
+                <a href={step.link.href} class="inline-block text-[13px] font-semibold text-navy underline hover:no-underline" rel="noopener">
+                  {step.link.label} →
+                </a>
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+
+    <!-- FAQ -->
+    <section aria-labelledby="prefaq-heading" class="space-y-4">
+      <div class="space-y-1 pt-4 border-t border-[var(--border-default)]">
+        <h2 id="prefaq-heading" class="text-xl font-extrabold text-navy">{t('guiaPre.faqTitle', lang)}</h2>
+        <p class="text-[13px] text-[var(--text-muted)]">{t('guiaPre.faqSub', lang)}</p>
+      </div>
+      <div class="space-y-2">
+        {preFaq.map((item) => (
+          <details class="pg-faq rounded-lg border border-[var(--border-default)] bg-[var(--surface-card)]">
+            <summary class="cursor-pointer select-none px-4 py-3 pr-10 font-semibold text-[15px] text-[var(--text-primary)] relative">
+              {item.q}
+            </summary>
+            <div class="px-4 pb-4 text-[14px] text-[var(--text-secondary)]">
+              <span set:html={item.a} />
+            </div>
+          </details>
+        ))}
+      </div>
+    </section>
+
+    <footer class="text-center pt-6 border-t border-[var(--border-default)] space-y-2">
+      <p class="text-[12px] text-[var(--text-muted)]">
+        {t('guiaPre.moreHelp', lang)}{' '}
+        <a href={`${langPrefix}/governance/glossario`} class="underline hover:text-navy">{t('guiaPre.linkGlossario', lang)}</a>
+        {' · '}
+        <a href={`${langPrefix}/reunioes-gerais`} class="underline hover:text-navy">{t('guiaPre.linkAgenda', lang)}</a>
+      </p>
+      <p class="text-[10px] text-[var(--text-muted)] italic">
+        {t('guiaPre.footer', lang)}
+      </p>
+    </footer>
+  </div>
+</BaseLayout>
+
+<style>
+  .pg-faq summary { list-style: none; }
+  .pg-faq summary::-webkit-details-marker { display: none; }
+  .pg-faq summary::after {
+    content: "+"; position: absolute; right: 1rem; top: 50%; transform: translateY(-50%);
+    font-size: 1.25rem; font-weight: 400; color: var(--navy, #1C5FA8); line-height: 1;
+  }
+  .pg-faq[open] summary::after { content: "\2212"; }
+  .pg-faq[open] summary { color: var(--navy, #1C5FA8); }
+  @media print {
+    .pg-faq { border: 1px solid #ccc; }
+  }
+</style>
+
+<script>
+  // Abre todas as FAQs ao imprimir (details fechado não imprime o conteúdo)
+  const items = Array.from(document.querySelectorAll('.pg-faq')) as HTMLDetailsElement[];
+  let restore: boolean[] = [];
+  window.addEventListener('beforeprint', () => { restore = items.map(d => d.open); items.forEach(d => d.open = true); });
+  window.addEventListener('afterprint', () => { items.forEach((d, i) => d.open = restore[i]); });
+</script>


### PR DESCRIPTION
## O quê

Página pública **/guia-pre-onboarding** (anon/Visitante acessam; linkável nos grupos de WhatsApp de cada ciclo):

- **Jornada em 6 passos**: aceite no VEP → login na plataforma → perfil completo → filiação PMI ativa → Termo de Voluntariado → kickoff/escolha de tribo
- **FAQ com 15 perguntas** coletadas do grupo real de pré-onboarding do Ciclo 4 (por que sou Visitante, CEP não reconhecido, link público do Credly, termo × aceite VEP, quando escolho tribo, Trilha PMI AI, reuniões, canais oficiais, como reportar bugs)

## Como

Segue o padrão `volunteer-guide.ts` + `/governance/glossario`:
- `src/data/pre-onboarding-guide.ts`: conteúdo pt-BR por design (mesma regra do guia do voluntário)
- `src/pages/guia-pre-onboarding.astro`: página com chrome i18n (`guiaPre.*` nas 3 dicionários)
- Redirects `/en/` e `/es/` (regra i18n nº 4)

## Validação

- `npx astro build` verde (rebased em `9df901f5`)
- Smoke no dev server: página renderiza, FAQ presente, `/en/` 200
- GC-097 i18n: 13 keys × 3 dicionários, redirects criados; sem SQL/RPC/rotas dinâmicas

## Origem

Diagnóstico do export do grupo WhatsApp Pré-Onboarding C4 (586 mensagens, 11/06→07/07): 15 temas recorrentes mapeados; cada entrada do FAQ corresponde a uma dúvida real e repetida.

Merge: sessão dev (lane apenas prepara).