### PR TITLE
gov(bypass-audit): #1182 métrica conta só push sem PR mergeado + fallback rewrite-proof (ADR-0122)

### DIFF
--- a/.claude/rules/bypass-protocol.md
+++ b/.claude/rules/bypass-protocol.md
@@ -2,6 +2,7 @@
 
 **Status:** active since 2026-05-21 (p209 close, WATCH-207.D resolution path C — Híbrido)
 **Threshold:** **2 bypass events / 7-day window** before mandatory pause + audit
+**Metric (ADR-0122, 2026-07-08):** bypass event = `--admin` merge OR push to main with NO merged PR associated (direct association + rewrite-proof `(#N)` subject fallback). PR-backed squash-merges are listed informationally and do NOT count. Context: the W28 "73 events" alert (#1142) was 69 false positives from the 2026-07-04 history-rewrite orphaning commit↔PR associations; the real count was 4.
 **Audit cron:** `.github/workflows/bypass-audit-weekly.yml` (Mondays 10:00 UTC, opens issue with previous week's bypass count + breakdown)
 
 ## Background

--- a/.github/workflows/bypass-audit-weekly.yml
+++ b/.github/workflows/bypass-audit-weekly.yml
@@ -1,8 +1,9 @@
 name: Bypass Audit (weekly)
 
 # Tripwire automation per .claude/rules/bypass-protocol.md (Option C — Híbrido).
-# Lists --admin merges + direct pushes to main from last 7 days.
-# If >2: labels output issue with 'requires-review' for PM reflection.
+# Metric (ADR-0122): bypass = --admin merges + pushes to main with NO merged PR.
+# PR-backed pushes (squash merges) are listed informationally, not counted.
+# If counted total >2: labels output issue with 'requires-review' for PM reflection.
 
 on:
   schedule:
@@ -65,26 +66,62 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SINCE: ${{ steps.window.outputs.since }}
         run: |
-          # List commits on main from last 7 days that are NOT merge commits (direct push pattern)
-          # Heuristic: parent count == 1 (merges have 2 parents in --first-parent view)
-          DIRECT_LINES=""
-          DIRECT_COUNT=0
+          # Classify every non-merge commit on main (parent count == 1) into two buckets
+          # (ADR-0122): PR-BACKED (squash merge of a merged PR - informational, NO threshold)
+          # vs NO-PR (true direct push - the bypass signal, thresholded).
+          #
+          # PR association is checked two ways, because a history rewrite (force-push) remaps
+          # main's SHAs and orphans the commit<->PR association on GitHub's side (root cause of
+          # the W28 2026 false-positive blowup, issue #1142 - 73 flagged, 4 real):
+          #   1. GET /commits/{sha}/pulls (authoritative when history is intact)
+          #   2. Fallback: trailing "(#N)" squash reference in the subject, verified against a
+          #      MERGED pull request via the API (rewrite-proof)
+          # An association-check API error marks the commit "(association check failed)" and
+          # counts it in the NO-PR bucket - fail loud toward review, never silently skip.
+          NOPR_LINES=""
+          NOPR_COUNT=0
+          WITHPR_LINES=""
+          WITHPR_COUNT=0
 
-          for SHA in $(gh api "repos/$GITHUB_REPOSITORY/commits?sha=main&since=$SINCE&per_page=100" --jq '.[] | select(.parents | length == 1) | .sha'); do
-            # Skip if this commit is on any PR (would be a squash merge commit)
-            PR_FOR_COMMIT=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/pulls" --jq '[.[] | select(.merged_at)] | length' 2>/dev/null || echo 0)
-            if [ "$PR_FOR_COMMIT" = "0" ]; then
-              MSG=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA" --jq '.commit.message' | head -1)
-              AUTHOR=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA" --jq '.commit.author.name')
-              DIRECT_LINES="$DIRECT_LINES- \`${SHA:0:8}\` ($AUTHOR) — $MSG\n"
-              DIRECT_COUNT=$((DIRECT_COUNT + 1))
+          for SHA in $(gh api "repos/$GITHUB_REPOSITORY/commits?sha=main&since=$SINCE&per_page=100" --paginate --jq '.[] | select(.parents | length == 1) | .sha'); do
+            MSG=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA" --jq '.commit.message' | head -1)
+            AUTHOR=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA" --jq '.commit.author.name')
+
+            # 1) direct commit<->PR association
+            ASSOC=$(gh api "repos/$GITHUB_REPOSITORY/commits/$SHA/pulls" --jq '[.[] | select(.merged_at)] | first | .number // empty' 2>/dev/null) || ASSOC="__ERR__"
+            if [ "$ASSOC" != "__ERR__" ] && [ -n "$ASSOC" ]; then
+              WITHPR_LINES="$WITHPR_LINES- \`${SHA:0:8}\` (PR #$ASSOC) ($AUTHOR) - $MSG\n"
+              WITHPR_COUNT=$((WITHPR_COUNT + 1))
+              continue
             fi
+
+            # 2) fallback: trailing (#N) squash reference, verified as a MERGED PR
+            PRNUM=$(printf '%s' "$MSG" | grep -oE '\(#[0-9]+\)' | tail -1 | tr -d '(#)')
+            if [ -n "$PRNUM" ]; then
+              MERGED_AT=$(gh api "repos/$GITHUB_REPOSITORY/pulls/$PRNUM" --jq '.merged_at // empty' 2>/dev/null || echo "")
+              if [ -n "$MERGED_AT" ]; then
+                WITHPR_LINES="$WITHPR_LINES- \`${SHA:0:8}\` (PR #$PRNUM via subject ref) ($AUTHOR) - $MSG\n"
+                WITHPR_COUNT=$((WITHPR_COUNT + 1))
+                continue
+              fi
+            fi
+
+            NOTE=""
+            if [ "$ASSOC" = "__ERR__" ]; then NOTE=" **(association check failed)**"; fi
+            NOPR_LINES="$NOPR_LINES- \`${SHA:0:8}\` ($AUTHOR) - $MSG$NOTE\n"
+            NOPR_COUNT=$((NOPR_COUNT + 1))
           done
 
-          echo "count=$DIRECT_COUNT" >> $GITHUB_OUTPUT
+          echo "count=$NOPR_COUNT" >> $GITHUB_OUTPUT
+          echo "withpr_count=$WITHPR_COUNT" >> $GITHUB_OUTPUT
           {
             echo 'commits<<BYPASS_EOF'
-            echo -e "$DIRECT_LINES"
+            echo -e "$NOPR_LINES"
+            echo 'BYPASS_EOF'
+          } >> $GITHUB_OUTPUT
+          {
+            echo 'withpr_commits<<BYPASS_EOF'
+            echo -e "$WITHPR_LINES"
             echo 'BYPASS_EOF'
           } >> $GITHUB_OUTPUT
 
@@ -95,6 +132,8 @@ jobs:
           DIRECT_COUNT: ${{ steps.direct_pushes.outputs.count }}
           WEEK: ${{ steps.window.outputs.week_label }}
         run: |
+          # Threshold counts ONLY real bypass events: --admin merges + pushes with NO merged PR.
+          # PR-backed pushes (squash merges) are informational (ADR-0122).
           TOTAL=$((ADMIN_COUNT + DIRECT_COUNT))
           THRESHOLD=2
 
@@ -133,20 +172,29 @@ jobs:
           ADMIN_PRS: ${{ steps.admin_merges.outputs.prs }}
           DIRECT_COUNT: ${{ steps.direct_pushes.outputs.count }}
           DIRECT_COMMITS: ${{ steps.direct_pushes.outputs.commits }}
+          WITHPR_COUNT: ${{ steps.direct_pushes.outputs.withpr_count }}
+          WITHPR_COMMITS: ${{ steps.direct_pushes.outputs.withpr_commits }}
         run: |
           cat <<EOF > /tmp/issue-body.md
           ## Week $WEEK — Bypass Audit
 
           **Status:** $STATUS
-          **Total events:** $TOTAL (threshold: 2)
+          **Total bypass events:** $TOTAL (threshold: 2 = --admin merges + pushes without PR)
 
           ### --admin PR merges ($ADMIN_COUNT)
 
           $ADMIN_PRS
 
-          ### Direct pushes to main ($DIRECT_COUNT)
+          ### Direct pushes to main WITHOUT a merged PR ($DIRECT_COUNT) - counted
 
           $DIRECT_COMMITS
+
+          <details>
+          <summary>PR-backed pushes ($WITHPR_COUNT) - informational, not counted (ADR-0122)</summary>
+
+          $WITHPR_COMMITS
+
+          </details>
 
           ### Action required
 
@@ -155,9 +203,10 @@ jobs:
           ### Reference
 
           - Protocol: \`.claude/rules/bypass-protocol.md\`
+          - Metric definition: \`docs/adr/ADR-0122-bypass-audit-metric-no-pr-pushes.md\`
           - Cron: \`.github/workflows/bypass-audit-weekly.yml\`
           - Origin: WATCH-207.D + WATCH-209.C (P162 log)
-          - Decision: p209 close — Option C Híbrido
+          - Decision: p209 close — Option C Híbrido · re-scoped by ADR-0122 (#1182/#1142)
 
           🤖 Generated by bypass-audit-weekly workflow
           EOF

--- a/docs/adr/ADR-0122-bypass-audit-metric-no-pr-pushes.md
+++ b/docs/adr/ADR-0122-bypass-audit-metric-no-pr-pushes.md
@@ -1,0 +1,40 @@
+# ADR-0122 - Métrica do bypass-audit: contar só push na main sem PR mergeado
+
+**Status:** Accepted (2026-07-08)
+**Relacionado:** `.claude/rules/bypass-protocol.md` (Option C - Híbrido, p209) · #1142 (audit W28, 73 eventos) · #1182 (diagnóstico + spec) · `.github/workflows/bypass-audit-weekly.yml`
+
+## Contexto
+
+A auditoria semanal de bypass (W28, issue #1142) acusou **73 eventos contra limiar 2**. A inspeção (#1182 + re-contagem ao vivo em 08/07) mostrou que **69 dos 73 eram squash-merges de PRs revisados e mergeados** - falsos positivos. Só **4 eram pushes diretos reais** (3 commits docs de governança + 1 feat governado pelo ADR-0121, todos autorizados pelo owner na semana da virada C4).
+
+A causa raiz NÃO era a definição da métrica: o workflow já tentava excluir squash-merges consultando `GET /commits/{sha}/pulls`. O que quebrou foi a **associação commit↔PR no GitHub após o history-rewrite + force-push de 04/07** (scrub do ADR-0120): os SHAs da main foram remapeados e os PRs continuam apontando os SHAs antigos pendurados, então a consulta retorna vazio para todo commit remapeado. Verificado ao vivo em 08/07: commits pós-rewrite (ex. PRs #1194/#1196) associam normalmente; commits remapeados retornam `[]`.
+
+Agravante silencioso: o passo usava `2>/dev/null || echo 0`, tratando erro de API como "sem PR" sem qualquer sinal no report.
+
+## Decisão
+
+**Opção (a) do #1182: o bucket com threshold conta apenas commit na main SEM PR mergeado associado.** O report semanal passa a ter 3 buckets:
+
+1. **`--admin` merges** - contam no threshold (inalterado).
+2. **Pushes diretos SEM PR mergeado** - contam no threshold (limiar mantido em 2/semana).
+3. **Pushes PR-backed** (squash-merges) - listados em `<details>` informativo, NÃO contam.
+
+A associação commit→PR é resolvida em duas camadas, para ser robusta a history-rewrite:
+
+1. `GET /commits/{sha}/pulls` filtrando PRs com `merged_at` (autoritativa com histórico intacto);
+2. **Fallback rewrite-proof:** última referência `(#N)` no subject do commit (convenção do squash-merge do GitHub), verificada contra a API como PR realmente `merged`. Referência a issue (não-PR ou PR aberto) não passa na verificação e o commit cai no bucket contado.
+
+Erro de API na checagem de associação agora **conta no bucket com threshold com a marca "(association check failed)"** - falha ruidosa na direção da revisão, nunca skip silencioso.
+
+## Alternativa rejeitada
+
+**Opção (b): require-PR via ruleset do GitHub.** Rejeitada pelo PMO (2026-07-07): repositório de dev solo onde os PRs já existem e são revisados; um ruleset só adicionaria atrito sem ganho de controle, e mataria a válvula de emergência que o Option C preserva deliberadamente.
+
+**Condição de reversão explícita:** se entrar um segundo committer regular no repositório, reavaliar require-PR via ruleset (a premissa "dev solo com disciplina de PR" deixa de valer).
+
+## Consequências
+
+- O alerta semanal volta a significar alguma coisa: bucket contado = eventos que o protocolo realmente governa (`--admin` + push sem PR). W28 real: 4 eventos (ainda acima do limiar 2; parecer registrado no #1142 - semana excepcional da virada C4 + scrub, todos os 4 autorizados pelo owner).
+- O audit fica imune a history-rewrites futuros (o fallback por subject não depende da associação do GitHub).
+- Pushes docs-only continuam contando: o protocolo não tem carve-out por tipo de arquivo, e criar um aqui seria escopo além do #1182. Se o padrão "3 docs-push/semana" persistir fora de semanas excepcionais, tratar em decisão própria.
+- Validação pendente: W29 deve sair com o bucket contado limpo (critério de aceite do #1182).


### PR DESCRIPTION
## O que

Redefine a métrica do bypass-audit semanal (spec do #1182, opção a) e a torna imune a history-rewrites:

- **3 buckets no report:** `--admin` merges + **pushes sem PR mergeado** contam no threshold (2/semana); pushes PR-backed (squash-merges) viram `<details>` informativo, sem threshold.
- **Associação commit→PR em 2 camadas:** `GET /commits/{sha}/pulls` (autoritativa) + fallback pela última referência `(#N)` do subject, verificada via API como PR realmente merged (**rewrite-proof**).
- **Fail-loud:** erro de API na checagem conta no bucket com threshold com a marca "(association check failed)" (o código antigo fazia `|| echo 0` silencioso).
- **ADR-0122** registra a decisão, a rejeição do require-PR ruleset (dev solo) e a condição de reversão (segundo committer regular).
- `bypass-protocol.md` ganha a linha de métrica + cross-ref.

## Por que

O audit W28 (#1142) acusou **73 eventos contra limiar 2**. Re-contagem ao vivo (08/07): **69 falsos positivos** — o history-rewrite de 04/07 (scrub ADR-0120) remapeou os SHAs da main e órfãou a associação commit↔PR no GitHub (PRs apontam os SHAs antigos pendurados), então o skip de squash-merges retornava `[]` para todo commit remapeado. Verificado: commits pós-rewrite (#1194/#1196) associam normalmente.

## Validação

Dry-run local da lógica nova sobre a janela exata da W28 (29/06 10:00Z → 06/07 10:00Z): **78 PR-backed / 4 sem PR** (3 docs de governança + 1 feat ADR-0121, todos owner-authorized). Parecer completo vai no fechamento do #1142. YAML validado. Critério de aceite restante (#1182): W29 sair limpa no bucket contado.

Closes #1182