### PR TITLE
fix(members): #1197 chapter deriva da declaração da application; sem capítulo -> 'Outro'

### DIFF
--- a/supabase/migrations/20260805000374_1197_member_chapter_from_application_declaration.sql
+++ b/supabase/migrations/20260805000374_1197_member_chapter_from_application_declaration.sql
@@ -1,0 +1,320 @@
+-- #1197: members.chapter must derive from the APPLICANT'S declaration, never from the
+-- cycle's contracting chapter.
+--
+-- Root cause: approve_selection_application derived v_member_chapter as
+--   COALESCE(app.chapter, cycle.contracting_chapter, 'Nao informado')
+-- so an applicant who declared NO chapter affiliation ("ainda nao" / "Nao sou!",
+-- selection_applications.chapter = NULL) was provisioned with chapter='PMI-GO' (the cycle's
+-- CONTRACTING chapter — a legal/contract concept, not the member's own affiliation).
+-- On post-signature promotion (guest -> researcher) the invariant
+-- U_active_person_has_primary_chapter_affiliation exclusion lapses and fires: a
+-- registry-chaptered active member with zero primary affiliations (live incident 2026-07-08,
+-- Thiago Pimentel; data fixed same day, Thiago + Hector -> 'Outro').
+--
+-- Fix: fallback is 'Outro' — the canonical "active member without a chapter" value (also the
+-- members.chapter column default), which invariant U correctly excludes. The contracting
+-- chapter plays no role in member affiliation (PMI-GO stays the contracting party on the
+-- volunteer term regardless — by design, #1048).
+--
+-- finalize_decisions needs no change: its live body delegates approvals to this canonical RPC
+-- (p157 canonical sync) and no longer inserts members directly.
+--
+-- Rollback: restore body from
+-- supabase/migrations/20260805000134_fix_selection_approval_rpc_end_date_chapter.sql
+
+CREATE OR REPLACE FUNCTION public.approve_selection_application(p_application_id uuid, p_decision jsonb DEFAULT '{}'::jsonb)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id        uuid;
+  v_caller_name      text;
+  v_caller_person_id uuid;
+  v_caller_org_id    uuid;
+  v_app              record;
+  v_member_id        uuid;
+  v_person_id        uuid;
+  v_member_role      text;
+  v_member_status    text;
+  v_target_role      text;
+  v_engagement_role  text;
+  v_engagement_kind  text := 'volunteer';
+  v_legal_basis      text := 'contract';
+  v_cycle_end_date   date;
+  v_member_chapter   text;
+  v_default_days     int;
+  v_requires_agreement boolean;
+  v_engagement_id    uuid;
+  v_existing_engagement_id uuid;
+  v_seeded_count     int := 0;
+  v_promoted         boolean := false;
+  v_member_created   boolean := false;
+  v_person_created   boolean := false;
+  v_engagement_created boolean := false;
+BEGIN
+  SELECT id, name, person_id, organization_id
+    INTO v_caller_id, v_caller_name, v_caller_person_id, v_caller_org_id
+  FROM public.members WHERE auth_id = auth.uid();
+
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  IF NOT public.can_by_member(v_caller_id, 'manage_platform') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Unauthorized');
+  END IF;
+
+  SELECT * INTO v_app FROM public.selection_applications WHERE id = p_application_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Application not found');
+  END IF;
+  IF v_app.status NOT IN ('approved', 'converted') THEN
+    RETURN jsonb_build_object(
+      'success', false,
+      'error', 'Application status must be approved or converted',
+      'current_status', v_app.status
+    );
+  END IF;
+  IF v_app.email IS NULL OR length(trim(v_app.email)) = 0 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Application has no email');
+  END IF;
+
+  SELECT sc.close_date
+    INTO v_cycle_end_date
+  FROM public.selection_cycles sc
+  WHERE sc.id = v_app.cycle_id;
+
+  IF v_cycle_end_date IS NOT NULL AND v_cycle_end_date < CURRENT_DATE THEN
+    v_cycle_end_date := NULL;
+  END IF;
+
+  -- #1197: member affiliation comes from the applicant's own declaration; an applicant
+  -- without a chapter gets the canonical 'Outro' (never the cycle's contracting chapter).
+  v_member_chapter := COALESCE(
+    NULLIF(trim(v_app.chapter), ''),
+    'Outro'
+  );
+
+  v_target_role := CASE
+    WHEN v_app.role_applied = 'leader'     THEN 'tribe_leader'
+    WHEN v_app.role_applied = 'researcher' THEN 'researcher'
+    ELSE NULL
+  END;
+
+  SELECT id, person_id, operational_role, member_status
+    INTO v_member_id, v_person_id, v_member_role, v_member_status
+  FROM public.members WHERE lower(email) = lower(v_app.email) LIMIT 1;
+
+  IF v_member_id IS NULL THEN
+    INSERT INTO public.members (
+      organization_id,
+      name, email, pmi_id, chapter,
+      operational_role, is_active, current_cycle_active
+    )
+    VALUES (
+      v_app.organization_id,
+      v_app.applicant_name, v_app.email, v_app.pmi_id, v_member_chapter,
+      COALESCE(v_target_role, 'researcher'),
+      true, true
+    )
+    RETURNING id, person_id, operational_role, member_status
+      INTO v_member_id, v_person_id, v_member_role, v_member_status;
+    v_member_created := true;
+  ELSE
+    UPDATE public.members SET
+      is_active = true,
+      current_cycle_active = true,
+      updated_at = now()
+    WHERE id = v_member_id
+      AND (is_active = false OR current_cycle_active = false);
+
+    IF v_target_role IS NOT NULL
+       AND v_member_role IN ('observer', 'guest', 'none', 'alumni', 'inactive')
+       AND v_member_status = 'active'
+    THEN
+      UPDATE public.members
+      SET operational_role = v_target_role, updated_at = now()
+      WHERE id = v_member_id;
+      v_promoted := true;
+    END IF;
+  END IF;
+
+  IF v_person_id IS NULL THEN
+    SELECT id INTO v_person_id
+    FROM public.persons WHERE lower(email) = lower(v_app.email) LIMIT 1;
+
+    IF v_person_id IS NULL THEN
+      INSERT INTO public.persons (
+        organization_id, name, email, pmi_id, phone,
+        consent_status, legacy_member_id
+      )
+      VALUES (
+        v_app.organization_id,
+        v_app.applicant_name, v_app.email, v_app.pmi_id, v_app.phone,
+        'pending', v_member_id
+      )
+      RETURNING id INTO v_person_id;
+      v_person_created := true;
+    END IF;
+
+    UPDATE public.members SET person_id = v_person_id, updated_at = now()
+    WHERE id = v_member_id AND person_id IS NULL;
+  END IF;
+
+  v_engagement_role := CASE
+    WHEN v_app.role_applied IN ('leader', 'researcher', 'coordinator', 'manager') THEN v_app.role_applied
+    ELSE 'researcher'
+  END;
+
+  SELECT ek.default_duration_days, ek.requires_agreement
+    INTO v_default_days, v_requires_agreement
+  FROM public.engagement_kinds ek WHERE ek.slug = v_engagement_kind;
+
+  SELECT id INTO v_existing_engagement_id
+  FROM public.engagements
+  WHERE person_id = v_person_id
+    AND kind = v_engagement_kind
+    AND status = 'active'
+  ORDER BY start_date DESC
+  LIMIT 1;
+
+  IF v_existing_engagement_id IS NULL THEN
+    INSERT INTO public.engagements (
+      person_id, organization_id,
+      kind, role, status,
+      start_date, end_date,
+      legal_basis,
+      selection_application_id,
+      granted_by, granted_at,
+      metadata
+    )
+    VALUES (
+      v_person_id,
+      v_app.organization_id,
+      v_engagement_kind, v_engagement_role, 'active',
+      CURRENT_DATE,
+      COALESCE(
+        v_cycle_end_date,
+        CURRENT_DATE + (COALESCE(v_default_days, 180) || ' days')::interval
+      ),
+      v_legal_basis,
+      p_application_id,
+      v_caller_person_id,
+      now(),
+      jsonb_build_object(
+        'source', 'approve_selection_application',
+        'role_applied', v_app.role_applied,
+        'application_status', v_app.status,
+        'chapter_source', CASE
+          WHEN NULLIF(trim(v_app.chapter), '') IS NOT NULL THEN 'application'
+          ELSE 'no_chapter_declared'
+        END,
+        'member_chapter', v_member_chapter
+      )
+    )
+    RETURNING id INTO v_engagement_id;
+    v_engagement_created := true;
+  ELSE
+    UPDATE public.engagements
+    SET selection_application_id = p_application_id, updated_at = now()
+    WHERE id = v_existing_engagement_id AND selection_application_id IS NULL;
+    v_engagement_id := v_existing_engagement_id;
+  END IF;
+
+  -- #1103: only seed steps that apply to this member's role (tribe_leader gets the
+  -- leader steps + base steps; researcher gets base steps only).
+  INSERT INTO public.onboarding_progress (application_id, member_id, step_key, status, metadata)
+  SELECT p_application_id, v_member_id, s.id, 'pending', '{}'::jsonb
+  FROM public.onboarding_steps s
+  WHERE s.is_required = true
+    AND NOT (s.id = 'volunteer_term' AND NOT COALESCE(v_requires_agreement, FALSE))
+    AND public.onboarding_step_applies(s.applies_to_role, COALESCE(v_target_role, 'researcher'))
+    AND NOT EXISTS (
+      SELECT 1 FROM public.onboarding_progress op
+      WHERE op.member_id = v_member_id AND op.step_key = s.id
+    );
+  GET DIAGNOSTICS v_seeded_count = ROW_COUNT;
+
+  INSERT INTO public.onboarding_progress (application_id, member_id, step_key, status, sla_deadline)
+  SELECT p_application_id, v_member_id, (step->>'key'), 'pending',
+         now() + ((step->>'sla_days')::int || ' days')::interval
+  FROM public.selection_cycles sc, jsonb_array_elements(sc.onboarding_steps) AS step
+  WHERE sc.id = v_app.cycle_id
+    AND NOT EXISTS (
+      SELECT 1 FROM public.onboarding_progress
+      WHERE member_id = v_member_id AND step_key = (step->>'key')
+    );
+
+  PERFORM public.check_pre_onboarding_auto_steps(v_member_id);
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.notifications
+    WHERE recipient_id = v_member_id
+      AND type = 'selection_approved'
+      AND source_id = p_application_id
+  ) THEN
+    PERFORM public.create_notification(
+      v_member_id,
+      'selection_approved',
+      'Parabens! Voce foi aprovado no Nucleo IA',
+      'Sua candidatura foi aprovada. Acesse a plataforma para iniciar o onboarding.',
+      '/onboarding',
+      'selection_application',
+      p_application_id
+    );
+  END IF;
+
+  INSERT INTO public.data_anomaly_log (anomaly_type, severity, description, context)
+  VALUES (
+    'selection_approval_canonical',
+    'info',
+    'Canonical approval for ' || v_app.applicant_name || ' (' || v_app.status || ')',
+    jsonb_build_object(
+      'application_id',     p_application_id,
+      'application_status', v_app.status,
+      'actor_id',           v_caller_id,
+      'actor_name',         v_caller_name,
+      'member_id',          v_member_id,
+      'person_id',          v_person_id,
+      'engagement_id',      v_engagement_id,
+      'member_created',     v_member_created,
+      'person_created',     v_person_created,
+      'engagement_created', v_engagement_created,
+      'onboarding_seeded',  v_seeded_count,
+      'role_promoted',      v_promoted,
+      'promoted_to',        CASE WHEN v_promoted THEN v_target_role ELSE NULL END,
+      'requires_agreement', v_requires_agreement,
+      'agreement_pending',  v_requires_agreement,
+      'member_chapter',     v_member_chapter,
+      'chapter_source',     CASE
+        WHEN NULLIF(trim(v_app.chapter), '') IS NOT NULL THEN 'application'
+        ELSE 'no_chapter_declared'
+      END
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'success',            true,
+    'application_id',     p_application_id,
+    'member_id',          v_member_id,
+    'person_id',          v_person_id,
+    'engagement_id',      v_engagement_id,
+    'member_created',     v_member_created,
+    'person_created',     v_person_created,
+    'engagement_created', v_engagement_created,
+    'onboarding_seeded',  v_seeded_count,
+    'role_promoted',      v_promoted,
+    'promoted_to',        CASE WHEN v_promoted THEN v_target_role ELSE NULL END,
+    'agreement_pending',  v_requires_agreement,
+    'member_chapter',     v_member_chapter
+  );
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.approve_selection_application(uuid, jsonb) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.approve_selection_application(uuid, jsonb) TO authenticated, service_role;
+
+COMMENT ON FUNCTION public.approve_selection_application(uuid, jsonb) IS
+  'Canonical post-approval provisioning (member + person + engagement + onboarding). #1197: member chapter derives from the applicant''s declaration; no declared chapter -> ''Outro'' (never the cycle''s contracting chapter).';

--- a/tests/contracts/1197-member-chapter-declaration-fallback.test.mjs
+++ b/tests/contracts/1197-member-chapter-declaration-fallback.test.mjs
@@ -1,0 +1,80 @@
+/**
+ * #1197 — member chapter derives from the applicant's declaration; no chapter -> 'Outro'
+ *
+ * Migration 20260805000374 rewrites approve_selection_application's v_member_chapter
+ * derivation: COALESCE(app.chapter, 'Outro'). The cycle's contracting chapter (a
+ * legal/contract concept) must never leak into members.chapter as if it were the
+ * member's own affiliation — that was the live 2026-07-08 incident: a "no chapter"
+ * signer provisioned as PMI-GO tripped invariant U_active_person_has_primary_chapter_affiliation
+ * on promotion (registry-chaptered active member with zero primary affiliations).
+ *
+ * Source-contract assertions run offline; the DB-aware checks verify the live column
+ * default and that no regression case exists in the active cohort.
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const MIG = readFileSync(
+  fileURLToPath(new URL('../../supabase/migrations/20260805000374_1197_member_chapter_from_application_declaration.sql', import.meta.url)),
+  'utf8',
+);
+// Comment-stripped view — "must NOT appear" assertions target executable SQL, not the
+// header comments (which legitimately name the anti-pattern being removed).
+const CODE = MIG.replace(/--.*$/gm, '');
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const canRun = !!(SUPABASE_URL && SERVICE_ROLE_KEY);
+const skipMsg = 'Skipped: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required';
+
+async function rest(path) {
+  const res = await fetch(`${SUPABASE_URL}${path}`, {
+    headers: { apikey: SERVICE_ROLE_KEY, Authorization: `Bearer ${SERVICE_ROLE_KEY}` },
+  });
+  if (!res.ok) throw new Error(`GET ${path} HTTP ${res.status}: ${await res.text()}`);
+  return res.json();
+}
+
+// ── Source contract (offline) ───────────────────────────────────────────────
+test('1197: fallback for a no-chapter applicant is the canonical Outro', () => {
+  assert.match(
+    CODE,
+    /v_member_chapter\s*:=\s*COALESCE\(\s*NULLIF\(trim\(v_app\.chapter\),\s*''\),\s*'Outro'\s*\)/,
+    'v_member_chapter must COALESCE the application declaration straight to Outro',
+  );
+});
+
+test('1197: contracting chapter no longer feeds member affiliation', () => {
+  assert.doesNotMatch(
+    CODE,
+    /v_cycle_contracting_chapter/,
+    'the cycle contracting chapter must play no role in approve_selection_application',
+  );
+  assert.doesNotMatch(
+    CODE,
+    /'Nao informado'/,
+    'the legacy Nao informado fallback must be gone',
+  );
+});
+
+test('1197: chapter_source telemetry distinguishes application vs no declaration', () => {
+  assert.match(CODE, /'chapter_source'/, 'chapter_source key still emitted');
+  assert.match(CODE, /'application'/, 'application source bucket');
+  assert.match(CODE, /'no_chapter_declared'/, 'no_chapter_declared source bucket');
+  assert.doesNotMatch(CODE, /'cycle_contracting_chapter'/, 'cycle_contracting_chapter bucket removed');
+});
+
+// ── DB-aware (live) ─────────────────────────────────────────────────────────
+test('1197: members.chapter column default stays Outro (canonical no-chapter value)', { skip: canRun ? false : skipMsg }, async () => {
+  // information_schema is not exposed via REST; assert indirectly through a probe the
+  // migration relies on: the invariant suite must be green, i.e. no active
+  // registry-chaptered member without a primary affiliation slipped through provisioning.
+  const rows = await rest('/rest/v1/rpc/check_schema_invariants');
+  const u = (Array.isArray(rows) ? rows : []).find(
+    (r) => r.invariant === 'U_active_person_has_primary_chapter_affiliation',
+  );
+  assert.ok(u, 'invariant U present in suite');
+  assert.equal(Number(u.violation_count), 0, 'invariant U must have 0 violations');
+});

--- a/tests/contracts/1197-member-chapter-declaration-fallback.test.mjs
+++ b/tests/contracts/1197-member-chapter-declaration-fallback.test.mjs
@@ -73,7 +73,7 @@ test('1197: members.chapter column default stays Outro (canonical no-chapter val
   // registry-chaptered member without a primary affiliation slipped through provisioning.
   const rows = await rest('/rest/v1/rpc/check_schema_invariants');
   const u = (Array.isArray(rows) ? rows : []).find(
-    (r) => r.invariant === 'U_active_person_has_primary_chapter_affiliation',
+    (r) => r.invariant_name === 'U_active_person_has_primary_chapter_affiliation',
   );
   assert.ok(u, 'invariant U present in suite');
   assert.equal(Number(u.violation_count), 0, 'invariant U must have 0 violations');

--- a/tests/contracts/canonical-approval-orchestration.test.mjs
+++ b/tests/contracts/canonical-approval-orchestration.test.mjs
@@ -84,16 +84,22 @@ test('approve_selection_application upserts member via lower(email) lookup', () 
 
 test('approve_selection_application uses selection_cycles.close_date, not nonexistent end_date', () => {
   const body = findFunctionBody('approve_selection_application');
-  assert.ok(/SELECT\s+sc\.close_date,\s*sc\.contracting_chapter[\s\S]+?FROM public\.selection_cycles sc/.test(body),
-    'must read selection_cycles.close_date and contracting_chapter');
+  // #1197: contracting_chapter is no longer read — it must not feed member affiliation.
+  assert.ok(/SELECT\s+sc\.close_date[\s\S]+?FROM public\.selection_cycles sc/.test(body),
+    'must read selection_cycles.close_date');
   assert.ok(!/sc\.end_date/.test(body),
     'must not reference nonexistent selection_cycles.end_date');
 });
 
 test('approve_selection_application has safe member.chapter fallback for null imported chapters', () => {
   const body = findFunctionBody('approve_selection_application');
-  assert.ok(/v_member_chapter\s*:=\s*COALESCE\([\s\S]+?NULLIF\(trim\(v_app\.chapter\), ''\)[\s\S]+?NULLIF\(trim\(v_cycle_contracting_chapter\), ''\)[\s\S]+?'Nao informado'/.test(body),
-    'must derive v_member_chapter from application chapter, cycle contracting_chapter, then fallback');
+  // #1197: chapter derives from the applicant's declaration only; no declared chapter ->
+  // canonical 'Outro'. The cycle's contracting chapter (a legal/contract concept) must never
+  // leak into members.chapter — that provisioning path tripped invariant U live on 2026-07-08.
+  assert.ok(/v_member_chapter\s*:=\s*COALESCE\(\s*NULLIF\(trim\(v_app\.chapter\), ''\),\s*'Outro'\s*\)/.test(body),
+    'must derive v_member_chapter from the application declaration with Outro fallback');
+  assert.ok(!/v_cycle_contracting_chapter/.test(body),
+    'contracting chapter must not feed member affiliation (#1197)');
   assert.ok(/v_app\.applicant_name,\s*v_app\.email,\s*v_app\.pmi_id,\s*v_member_chapter/.test(body),
     'member INSERT must use v_member_chapter instead of raw nullable v_app.chapter');
 });

--- a/tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs
+++ b/tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs
@@ -162,8 +162,10 @@ test('M4-gam DB: native forks KILLED — Mesa=4, LATAM=3, Grupo=3 (== get_initia
 test('M4-gam DB: only tribe-8 changed — other tribes stable (drift-tolerant baselines)', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
   // tribe-6 6→5: offboarding legítimo de membro em 2026-06-11 (alumni, ROI & Portfólio)
-  // tribe-2 5→4: offboarding legítimo de Ricardo França em 2026-07-04 (alumni, external_priority)
-  const expect = { 1: 4, 2: 4, 6: 5 };
+  // tribe-2 REMOVIDA da baseline em 2026-07-08: T2 arquivada no DIA 9 (líder → alumni,
+  // #1124) e o roster drena conforme os 3 órfãos re-selecionam tribo até 17/07 — não há
+  // valor estável para pinar (histórico: 5→4 com o offboard do Ricardo em 04/07).
+  const expect = { 1: 4, 6: 5 };
   for (const [tid, n] of Object.entries(expect)) {
     const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: Number(tid) });
     const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });


### PR DESCRIPTION
Closes #1197

## Problema
`approve_selection_application` derivava `members.chapter` com fallback no `contracting_chapter` do ciclo (PMI-GO) e depois `'Nao informado'`. Aplicante que declara NÃO ter capítulo era provisionado como PMI-GO; na promoção pós-assinatura a exclusão da invariante U cai e ela dispara (incidente vivo 08/07, Thiago Pimentel; dados corrigidos no dia, Thiago + Hector -> 'Outro').

## Fix (mig `20260805000374`)
- `v_member_chapter := COALESCE(NULLIF(trim(v_app.chapter), ''), 'Outro')` - capítulo contratante é conceito jurídico (Termo segue com PMI-GO by design, #1048) e não afiliação do membro.
- Remove `v_cycle_contracting_chapter` e `'Nao informado'`; `chapter_source` vira `application | no_chapter_declared`.
- `finalize_decisions` não precisa de mudança: o corpo live delega ao RPC canônico (INSERT direto do arquivo p157 é versão morta).
- Base = `pg_get_functiondef` live (zero drift); REVOKE/GRANT/COMMENT reproduzidos.

## Estado do DB
Migration JÁ APLICADA via apply_migration + tracking registrado como `20260805000374` (phantom caçada por name=) + `NOTIFY pgrst`. Invariantes 0 violações.

## Testes
- Novo contract test `1197-member-chapter-declaration-fallback` (source offline + DB-aware invariante U): 4/4.
- `canonical-approval-orchestration` atualizado (pinava a semântica superada do #603).
- Baseline do roster p277-419: tribo 2 removida (T2 arquivada no DIA 9, #1124).
- Suíte completa: 5168 tests, fails restantes = 0 (preview-gate 57014 = flake conhecido, passou em re-run). `npx astro build` verde.