### PR TITLE
fix(edge): #1223 sync EFs use isServiceRoleToken (rotation-immune)

### DIFF
--- a/supabase/functions/sync-attendance-points/index.ts
+++ b/supabase/functions/sync-attendance-points/index.ts
@@ -1,6 +1,7 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 import { POINTS_PER_ATTENDANCE, ATTENDANCE_CATEGORY } from '../_shared/attendance-xp.ts'
+import { isServiceRoleToken } from '../_shared/service-auth.ts'
 
 const CATEGORY = ATTENDANCE_CATEGORY
 // Keep batch size small to avoid PostgREST URL length limits on .in() queries
@@ -36,7 +37,10 @@ Deno.serve(async (req) => {
   const token = authHeader.replace(/^Bearer\s+/i, '')
   if (!token) return jsonResponse({ success: false, error: 'Unauthorized' }, 401)
 
-  const isServiceRole = token === serviceRoleKey
+  // #1223: robust service-role check (PostgREST-verified) — a literal compare
+  // against the injected env key rejects the vault-stored key every pg_net cron
+  // sends, which diverged after the sb_secret_* key rotation. See _shared/service-auth.ts.
+  const isServiceRole = await isServiceRoleToken(supabaseUrl, token)
 
   const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey)
 

--- a/supabase/functions/sync-credly-all/index.ts
+++ b/supabase/functions/sync-credly-all/index.ts
@@ -1,6 +1,7 @@
 import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { corsHeaders } from '../_shared/cors.ts'
 import { classifyBadge, PMI_TRAIL_KEYWORDS, selectCanonicalCpmai } from '../_shared/classify-badge.ts'
+import { isServiceRoleToken } from '../_shared/service-auth.ts'
 
 interface CredlyBadge {
   badge_template: { name: string; vanity_slug?: string }
@@ -285,7 +286,10 @@ Deno.serve(async (req) => {
     const supabaseUrl = Deno.env.get('SUPABASE_URL')!
     const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
     const token = authHeader.replace(/^Bearer\s+/i, '')
-    const isServiceRole = token === serviceRoleKey
+    // #1223: robust service-role check (PostgREST-verified) — a literal compare
+    // against the injected env key rejects the vault-stored key every pg_net cron
+    // sends, which diverged after the sb_secret_* key rotation. See _shared/service-auth.ts.
+    const isServiceRole = await isServiceRoleToken(supabaseUrl, token)
 
     const sb = createClient<any, "public", any>(supabaseUrl, serviceRoleKey)
 


### PR DESCRIPTION
## Problema (#1223, aterrado ao vivo 2026-07-08→09)

`sync-credly-all` e `sync-attendance-points` autenticavam service-role por **exact-match** `token === SUPABASE_SERVICE_ROLE_KEY`. Com a migração do projeto para o novo sistema de secret keys (`sb_secret_*`), a env injetada na EF divergiu da key legada (JWT) guardada no `vault` que **todo cron `pg_net` envia** — o compare falhava, caía no `getUser()` (que rejeita um JWT service-role com `missing sub claim`) e retornava **401**.

Impacto: o cron `sync-credly-all` (`0 3 */5 * *`) estava 401-ando desde a rotação — badges Credly novos não sincronizavam e o display cache (`members.credly_badges`) não reconciliava. O `sync-attendance-points` tinha o mesmo padrão frágil.

## Fix

Ambas migram para o helper robusto **`isServiceRoleToken()`** (`_shared/service-auth.ts`, já usado por `send-campaign` + 15 EFs), que valida via PostgREST `current_caller_role()` em vez de comparar string — **imune à rotação**. Sweep repo-wide confirmou que estas eram as **2 únicas** EFs com o padrão frágil.

## Validação ao vivo

- `net.http_post` com a key do vault (caminho **exato** do cron) → antes: 401 imediato; agora: entra no sync (timeout do cliente pg_net aos 5s porque a EF roda >90s).
- Log da EF: `sync-credly-all POST | 200 | 94.6s | v54` (a invocação completou 200).
- Display cache reconciliado pós-deploy: **58 membros verificados** nos últimos 10min, 63/64 com badges — fecha o pendente do #1209.
- `verify-credly` auditada: **não tem gate de auth** (recebe `{member_id, credly_url}` direto), então não tinha o exact-match — fora de escopo.

Ambas as EFs **já deployadas em prod** (para a validação acima).

## Checks

- `npx astro build` ✓
- `npm test` ✓ (2 flakes transitórios de Cloudflare 522 ao Supabase, ambos passam no retry; `check_schema_invariants()` = 0 violações)
- 0 bypass · rebased em `origin/main` (bfa335f9)

Refs #1223, #1209, #1220