### PR TITLE
feat(picker): #1227 LinkedIn+vídeo da tribo do SSOT (DB); #1228 salas de kickoff time-boxed

### DIFF
--- a/src/components/sections/TribesSection.astro
+++ b/src/components/sections/TribesSection.astro
@@ -44,8 +44,56 @@ const QUAD_COLORS: Record<string, string> = {
 
 const viewModel = buildTribesViewModel(lang);
 const safeQuadrants = viewModel.quadrants;
-const safeTribes = viewModel.tribes;
+let safeTribes = viewModel.tribes;
 const viewWarnings = viewModel.warnings;
+
+// #1227: leader LinkedIn + explainer video derive from the DB SSOT, not the static
+// tribes.ts. The SSOT is tribes.video_url/video_duration + tribes.leader_member_id →
+// members.linkedin_url, surfaced via the SECURITY DEFINER RPC get_tribe_picker_cards
+// (tribes is not anon-readable). The hardcoded tribes.ts values remain only as a fallback
+// if the RPC fails. This is what lights up the newly-formed C4 tribes (9-14), whose
+// leaderLinkedIn/videoUrl are empty in tribes.ts but present/fillable in the DB.
+try {
+  const { data: cards } = await sbAnonForStats.rpc('get_tribe_picker_cards');
+  if (Array.isArray(cards) && cards.length) {
+    const cardById = new Map<number, { leader_linkedin: string | null; video_url: string | null; video_duration: string | null }>(
+      cards.map((c: any) => [Number(c.tribe_id), c])
+    );
+    const pick = (dbVal: unknown, fallback: string): string =>
+      (typeof dbVal === 'string' && dbVal.trim().length > 0) ? dbVal : fallback;
+    safeTribes = safeTribes.map((tr) => {
+      const db = cardById.get(tr.id);
+      if (!db) return tr;
+      return {
+        ...tr,
+        leaderLinkedIn: pick(db.leader_linkedin, tr.leaderLinkedIn),
+        videoUrl: pick(db.video_url, tr.videoUrl),
+        videoDuration: pick(db.video_duration, tr.videoDuration),
+      };
+    });
+  }
+} catch {}
+
+// #1228: ephemeral kickoff Q&A rooms (Ciclo 4 kickoff, 2026-07-09 20h00 BRT). A per-tribe
+// Google Meet where the leader takes questions during the final 30 min. Deliberately a
+// date-gated hardcode with an EXPLICIT expiry — NOT a permanent field. Auto-hides after the
+// window closes (2026-07-11 00:00 BRT). Remove this block once the kickoff window passes.
+const KICKOFF_ROOMS_EXPIRY = new Date('2026-07-11T00:00:00-03:00');
+const KICKOFF_ROOMS: Record<number, string> = {
+  1: 'https://meet.google.com/xhd-dyym-ckc',
+  4: 'https://meet.google.com/cqs-jcko-zsf',
+  5: 'https://meet.google.com/fko-xbom-wyg',
+  6: 'https://meet.google.com/axp-fvig-oau',
+  7: 'https://meet.google.com/xhg-iwzp-jzr',
+  8: 'https://meet.google.com/zqf-jiju-ddt',
+  9: 'https://meet.google.com/mxi-crmn-vrb',
+  10: 'https://meet.google.com/bho-jayj-qvf',
+  11: 'https://meet.google.com/gea-mzor-chh',
+  12: 'https://meet.google.com/dvz-mfdg-ecs',
+  13: 'https://meet.google.com/rgj-mepi-yzz',
+  14: 'https://meet.google.com/faw-wkux-jgz',
+};
+const showKickoffRooms = new Date() < KICKOFF_ROOMS_EXPIRY;
 const parsedDeadline = typeof deadlineProp === 'string' && !Number.isNaN(new Date(deadlineProp).getTime())
   ? deadlineProp
   : null;
@@ -236,6 +284,15 @@ const TRIBE_IDS = safeTribes.map(tr => tr.id);
                                   hover:opacity-85 transition-opacity"
                            data-stop-propagation>
                           ▶ {t('tribes.video', lang)} ({tr.videoDuration})
+                        </a>
+                      )}
+                      {showKickoffRooms && KICKOFF_ROOMS[tr.id] && (
+                        <a href={KICKOFF_ROOMS[tr.id]} target="_blank" rel="noopener"
+                           class="inline-flex items-center gap-1.5 bg-[#1a365d] text-white px-4 py-2
+                                  rounded-xl no-underline text-[.82rem] font-semibold
+                                  hover:opacity-85 transition-opacity"
+                           data-stop-propagation>
+                          🎥 {t('tribes.kickoffRoom', lang)}
                         </a>
                       )}
                       <button class="tribe-select-btn w-full sm:w-auto px-4 py-2.5 rounded-xl

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -828,6 +828,7 @@ const enUS: Record<string, string> = {
   'tribes.deliverables': 'Cycle Deliverables:',
   'tribes.meetings': '📅 Meetings:',
   'tribes.video': 'Video',
+  'tribes.kickoffRoom': 'Live Q&A room with the leader',
   'tribes.select': 'Choose This Stream',
   'tribes.selected': '✓ Selected (click to switch)',
   'tribes.full': 'Full',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -828,6 +828,7 @@ const esLATAM: Record<string, string> = {
   'tribes.deliverables': 'Entregables del Ciclo:',
   'tribes.meetings': '📅 Reuniones:',
   'tribes.video': 'Video',
+  'tribes.kickoffRoom': 'Sala de dudas con el líder',
   'tribes.select': 'Elegir esta Línea',
   'tribes.selected': '✓ Seleccionada (haz clic para cambiar)',
   'tribes.full': 'Completa',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -828,6 +828,7 @@ const ptBR: Record<string, string> = {
   'tribes.deliverables': 'Entregáveis do Ciclo:',
   'tribes.meetings': '📅 Encontros:',
   'tribes.video': 'Vídeo',
+  'tribes.kickoffRoom': 'Sala de tira-dúvida com o líder',
   'tribes.select': 'Escolher esta Tribo',
   'tribes.selected': '✓ Selecionada (clique para trocar)',
   'tribes.full': 'Lotada',

--- a/supabase/migrations/20260805000382_1227_get_tribe_picker_cards.sql
+++ b/supabase/migrations/20260805000382_1227_get_tribe_picker_cards.sql
@@ -1,0 +1,22 @@
+-- #1227: expose the tribe-picker per-card public metadata (leader LinkedIn + explainer
+-- video) that the picker (TribesSection) currently hardcodes in src/data/tribes.ts. The
+-- SSOT already lives in the DB — tribes.video_url/video_duration + tribes.leader_member_id →
+-- members.linkedin_url — but `tribes` is not anon-readable (RLS), so the SSR frontmatter
+-- cannot read it directly. This SECURITY DEFINER RPC returns ONLY public professional data
+-- (LinkedIn + YouTube video), the same class already public via public_members / the homepage.
+-- No PII (email/phone/pmi_id). Anon-safe (LGPD GC-162 / Key Architecture Decision #6).
+CREATE OR REPLACE FUNCTION public.get_tribe_picker_cards()
+ RETURNS TABLE(tribe_id integer, leader_linkedin text, video_url text, video_duration text)
+ LANGUAGE sql
+ STABLE
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT t.id, m.linkedin_url, t.video_url, t.video_duration
+  FROM public.tribes t
+  LEFT JOIN public.members m ON m.id = t.leader_member_id
+  WHERE t.is_active = true;
+$function$;
+
+REVOKE EXECUTE ON FUNCTION public.get_tribe_picker_cards() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_tribe_picker_cards() TO anon, authenticated, service_role;


### PR DESCRIPTION
## #1227 — mata o hardcode drift de LinkedIn/vídeo no picker

O picker de escolha de tribo (`TribesSection`, na home em modo autenticado) renderizava LinkedIn do líder e vídeo de intro do **`src/data/tribes.ts` estático** — vazio para as tribos novas do C4 (T9-T14 sem LinkedIn/vídeo; T6 sem LinkedIn). O SSOT já vive no DB: `tribes.video_url`/`video_duration` + `tribes.leader_member_id` → `members.linkedin_url`. A **foto** já era derivada do DB; LinkedIn/vídeo ficaram no hardcode = duplicação-drift.

**Fix:** RPC SECURITY DEFINER `get_tribe_picker_cards()` (mig 382) devolve, por tribo ativa, só dado profissional **público** (LinkedIn + vídeo). Necessária porque `tribes` não é anon-readable (RLS). O frontmatter mescla no view-model no SSR, com `tribes.ts` como fallback.

Resultado: LinkedIn acende para as **12** tribos (DB já tem todos, inclusive novos líderes); vídeo para **11/12** (T9 legitimamente NULL, sem gravação).

## Fonte canônica (#1229)

A RPC lê de `tribes` (Fonte B, "é dela que o app lê hoje"). Vídeo é **dual-write** hoje (`tribes` + `initiatives.metadata`). Quando o hub decidir a fonte canônica (#1229), o único ponto a re-apontar é o corpo da RPC — frontend não muda. Sincronizado 09/07: T10-T14 + T06(errata) preenchidos, T05 troca hoje, T9 NULL.

## #1228 — salas de tira-dúvida do kickoff (time-boxed)

Botão por tribo com o Meet da sala de tira-dúvida (kickoff C4, 09/07 20h BRT). Mapa date-gated com expiry **explícito** (auto-some após 2026-07-11); NÃO é campo permanente. Chave i18n `tribes.kickoffRoom` nos 3 dicts.

## Checks
- `npx astro build` ✓ · `npm test` ✓ (4 flakes CF-522 passam no retry; i18n 3-dict ✓; ADR-0097 ✓)
- `check_schema_invariants()` = 0 · 0 bypass
- Limpeza phantom: `apply_migration` do MCP auto-registrou `20260709111032` (fora da convenção); removida por versão exata, mantida `20260805000382` (arquivo local)

Refs #1227, #1228, #1229