### PR TITLE
fix(ui): #1235 helper flutuante não fica mais atrás do 'Modo Apresentação'

### DIFF
--- a/src/components/ui/PresentationLayer.astro
+++ b/src/components/ui/PresentationLayer.astro
@@ -39,7 +39,12 @@ const PRES_I18N = {
 ---
 
 <!-- Presentation Toggle -->
-<div id="pres-toggle-container" class="hidden fixed bottom-6 right-6 z-50">
+<!-- #1235: stacked ABOVE the HelpFloatingButton (which owns the bottom-right corner —
+     BaseLayout convention, others clear it). At bottom-6/right-6 this pill (z-50) sat on top of
+     the help FAB (bottom-4/right-4/z-40), hiding it. bottom-20/right-4 aligns the right edge with
+     the FAB and stacks clear above it. Only eligible presenters see this pill, so the FAB stays
+     put for everyone else. -->
+<div id="pres-toggle-container" class="hidden fixed bottom-20 right-4 z-50">
   <button id="pres-toggle-btn"
     class="flex items-center gap-2 px-4 py-2.5 bg-navy text-white rounded-xl text-[.78rem] font-bold shadow-lg cursor-pointer border-2 border-[#05BFE0]/30 hover:border-[#05BFE0] transition-all">
     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"/></svg>


### PR DESCRIPTION
Closes #1235.

## Bug
O botão flutuante de ajuda (o "magic icon") aparecia parcialmente **atrás** do pill "Modo Apresentação" no canto inferior direito (foto do PM 2026-07-09).

## Causa
Dois flutuantes no mesmo canto, o de apresentação por cima:
- `HelpFloatingButton.tsx:382` — `fixed bottom-4 right-4 z-40` (FAB de ajuda, global p/ autenticados)
- `PresentationLayer.astro:42` — `#pres-toggle-container` `fixed bottom-6 right-6 z-50` (pill, só apresentadores)

`BaseLayout.astro:277` já documenta a convenção: **o HelpFloatingButton é dono do canto inferior direito** (o `MilestoneCelebration` fica à esquerda pra clarear). O pill violava isso.

## Fix
Pill → `bottom-20 right-4`: alinha a borda direita com o FAB e empilha **acima** dele (folga de 16px — o FAB ocupa 16–64px do fundo; o pill começa em 80px). Só apresentadores elegíveis veem o pill, então o FAB não muda de lugar para o resto dos usuários. 1 linha, sem coordenação cross-componente, sem mudança de z-index.

## Validação
- `npx astro build` verde.
- Geometria determinística (sem sobreposição) + convenção do canto (BaseLayout).
- ⚠️ Repro visual fiel exige sessão de **apresentador autenticado** (o pill é JS-gated); recomenda-se um olhar no deploy preview desta branch.

🤖 Assisted-By: Claude (Anthropic)