### PR TITLE
fix(landing): #1239 hero deriva ciclo atual · retenção = última transição fechada · cap nas bolas do mapa

### DIFF
--- a/src/components/sections/HomepageHero.astro
+++ b/src/components/sections/HomepageHero.astro
@@ -1,9 +1,30 @@
 ---
 import { t, type Lang } from '../../i18n/utils';
+import { createClient } from '@supabase/supabase-js';
 
 interface Props { lang?: Lang; }
 const { lang = 'pt-BR' } = Astro.props;
 const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
+
+// #1239: derive the hero cycle badge + status from the CURRENT cycle (was hardcoded 'CICLO 3 · 2026').
+// Mirrors ChaptersSection's anon RPC fetch; get_current_cycle is anon-EXECUTE granted.
+let cycleNum = '';
+let cycleYear = '';
+try {
+  const sbAnon = createClient(import.meta.env.PUBLIC_SUPABASE_URL, import.meta.env.PUBLIC_SUPABASE_ANON_KEY);
+  const { data } = await sbAnon.rpc('get_current_cycle');
+  if (data) {
+    cycleNum = String((data as any).cycle_abbr ?? '').replace(/\D/g, '');
+    cycleYear = String((data as any).cycle_start ?? '').slice(0, 4);
+  }
+} catch { /* fall back to neutral i18n strings below */ }
+
+const heroBadge = cycleNum
+  ? t('hero.badge', lang).replace('{n}', cycleNum).replace('{year}', cycleYear)
+  : t('hero.badgeFallback', lang);
+const heroCycleActive = cycleNum
+  ? t('hero.cycleActive', lang).replace('{n}', cycleNum)
+  : t('hero.cycleActiveFallback', lang);
 ---
 
 <section class="hero relative min-h-screen flex items-center justify-center overflow-hidden pt-14" id="hero">
@@ -13,7 +34,7 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
   <!-- ═══ VISITOR HERO ═══ -->
   <div id="hero-visitor" class="relative z-10 text-center max-w-[900px] px-6 py-8">
     <div class="inline-block bg-orange/15 text-orange text-[.78rem] font-semibold px-5 py-1.5 rounded-full border border-orange/30 mb-6 tracking-wider uppercase">
-      {t('hero.badge', lang)}
+      {heroBadge}
     </div>
 
     <h1 class="text-[clamp(2rem,5vw,3.5rem)] font-extrabold text-white leading-[1.15] mb-2">
@@ -61,7 +82,7 @@ const langPrefix = lang === 'pt-BR' ? '' : lang === 'en-US' ? '/en' : '/es';
     <!-- Cycle status -->
     <div class="inline-flex items-center gap-2 text-[.82rem] text-white/60">
       <span class="w-2 h-2 rounded-full bg-green-400 animate-pulse"></span>
-      {t('hero.cycleActive', lang)}
+      {heroCycleActive}
     </div>
 
     <div class="flex flex-col items-center gap-1 mt-5">

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -34,7 +34,8 @@ const enUS: Record<string, string> = {
   'nav.attendance': 'Attendance',
   'nav.gamification': '🏆 Gamification',
   'nav.reunioesGerais': '⭐ General Meetings',
-  'hero.cycleActive': 'Cycle 4 In Progress',
+  'hero.cycleActive': 'Cycle {n} In Progress',
+  'hero.cycleActiveFallback': 'Cycle In Progress',
   'hero.cycleTribes': 'active tribes',
   'hero.cycleMembers': 'researchers',
   'tribe.lgpdMask': 'Data protected by LGPD',
@@ -639,7 +640,8 @@ const enUS: Record<string, string> = {
   'nav.menu': 'Menu',
 
   // ── Hero ──
-  'hero.badge': 'CYCLE 3 · 2026',
+  'hero.badge': 'CYCLE {n} · {year}',
+  'hero.badgeFallback': 'CURRENT CYCLE',
   'hero.title.line1': 'Study and Research Hub in',
   'hero.title.accent': 'Artificial Intelligence',
   'hero.title.line3': 'and Project Management',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -34,7 +34,8 @@ const esLATAM: Record<string, string> = {
   'nav.attendance': 'Asistencia',
   'nav.gamification': '🏆 Gamificación',
   'nav.reunioesGerais': '⭐ Reuniones Generales',
-  'hero.cycleActive': 'Ciclo 4 en Curso',
+  'hero.cycleActive': 'Ciclo {n} en Curso',
+  'hero.cycleActiveFallback': 'Ciclo en Curso',
   'hero.cycleTribes': 'tribus activas',
   'hero.cycleMembers': 'investigadores',
   'tribe.lgpdMask': 'Datos protegidos por LGPD',
@@ -639,7 +640,8 @@ const esLATAM: Record<string, string> = {
   'nav.menu': 'Menú',
 
   // ── Hero ──
-  'hero.badge': 'CICLO 3 · 2026',
+  'hero.badge': 'CICLO {n} · {year}',
+  'hero.badgeFallback': 'CICLO ACTUAL',
   'hero.title.line1': 'Núcleo de Estudios e Investigación en',
   'hero.title.accent': 'Inteligencia Artificial',
   'hero.title.line3': 'y Gestión de Proyectos',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -34,7 +34,8 @@ const ptBR: Record<string, string> = {
   'nav.attendance': 'Presença',
   'nav.gamification': '🏆 Gamificação',
   'nav.reunioesGerais': '⭐ Reuniões Gerais',
-  'hero.cycleActive': 'Ciclo 4 em Andamento',
+  'hero.cycleActive': 'Ciclo {n} em Andamento',
+  'hero.cycleActiveFallback': 'Ciclo em Andamento',
   'hero.cycleTribes': 'tribos ativas',
   'hero.cycleMembers': 'pesquisadores',
   'tribe.lgpdMask': 'Dados protegidos por LGPD',
@@ -639,7 +640,8 @@ const ptBR: Record<string, string> = {
   'nav.menu': 'Menu',
 
   // ── Hero ──
-  'hero.badge': 'CICLO 3 · 2026',
+  'hero.badge': 'CICLO {n} · {year}',
+  'hero.badgeFallback': 'CICLO ATUAL',
   'hero.title.line1': 'Núcleo de Estudos e Pesquisa em',
   'hero.title.accent': 'Inteligência Artificial',
   'hero.title.line3': '& Gestão de Projetos',

--- a/src/lib/worldMap.ts
+++ b/src/lib/worldMap.ts
@@ -184,5 +184,9 @@ export function buildGeoPins(
 export function pinDiameter(kind: 'country' | 'state' | 'continent', count: number): number {
   const base = kind === 'state' ? 15 : 20;
   const k = kind === 'state' ? 2.6 : 4.2;
-  return Math.round(base + k * Math.sqrt(Math.max(count, 1)));
+  // #1239: the count is rendered INSIDE the pin, so magnitude does not need to be
+  // encoded by area too. Cap the diameter so a large cohort (e.g. Brazil) stays a
+  // subtle hierarchy cue instead of ballooning and covering neighbouring pins.
+  const cap = kind === 'state' ? 30 : 38;
+  return Math.min(Math.round(base + k * Math.sqrt(Math.max(count, 1))), cap);
 }

--- a/supabase/migrations/20260805000385_1239_retention_headline_last_closed_transition.sql
+++ b/supabase/migrations/20260805000385_1239_retention_headline_last_closed_transition.sql
@@ -1,0 +1,62 @@
+-- #1239 (option A): retention headline = last CLOSED cohort transition.
+-- The homepage "Taxa de Retenção" reads get_member_retention_canonical()->headline, which picked the
+-- LAST transition unconditionally (ORDER BY rn DESC LIMIT 1). Once C4 opened (2026-07-09) that headline
+-- became C3->C4 (47.6%) -- retention measured INTO the current, still-forming cohort, which understates
+-- it (denominator complete, numerator incomplete). The function's own definition already said "last
+-- closed transition"; this makes the code match it by excluding the current open cycle as the target.
+-- The in-progress transition stays in `transitions` (full history). Falls back to the latest transition
+-- if every transition targets the current cycle (edge case at a brand-new program).
+CREATE OR REPLACE FUNCTION public.get_member_retention_canonical()
+ RETURNS jsonb
+ LANGUAGE sql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  WITH cyc AS (
+    SELECT cycle_code, min(cycle_start) AS cstart, min(cycle_label) AS clabel
+    FROM public.member_cycle_history
+    GROUP BY cycle_code
+  ),
+  ordered AS (
+    SELECT cycle_code, clabel, cstart, row_number() OVER (ORDER BY cstart) AS rn FROM cyc
+  ),
+  pairs AS (
+    SELECT a.cycle_code AS from_code, a.clabel AS from_label,
+           b.cycle_code AS to_code, b.clabel AS to_label, a.rn AS rn
+    FROM ordered a JOIN ordered b ON b.rn = a.rn + 1
+  ),
+  computed AS (
+    SELECT p.rn, p.from_code, p.from_label, p.to_code, p.to_label,
+      (SELECT count(DISTINCT member_id) FROM public.member_cycle_history WHERE cycle_code = p.from_code) AS cohort_n,
+      (SELECT count(DISTINCT mh1.member_id) FROM public.member_cycle_history mh1
+         WHERE mh1.cycle_code = p.from_code
+           AND EXISTS (SELECT 1 FROM public.member_cycle_history mh2
+                       WHERE mh2.member_id = mh1.member_id AND mh2.cycle_code = p.to_code)) AS survived
+    FROM pairs p
+  ),
+  withpct AS (
+    SELECT *, ROUND(survived::numeric * 100 / NULLIF(cohort_n, 0), 1) AS survival_pct FROM computed
+  )
+  SELECT jsonb_build_object(
+    'metric', 'cohort_survival',
+    'definition', 'Share of cycle N members (distinct member_id in member_cycle_history) who return in cycle N+1. Headline = last CLOSED transition (excludes the current open cycle as target; the in-progress transition stays in transitions).',
+    'transitions', COALESCE((SELECT jsonb_agg(jsonb_build_object(
+        'from_code', from_code, 'from_label', from_label, 'to_code', to_code, 'to_label', to_label,
+        'cohort_n', cohort_n, 'survived', survived, 'survival_pct', survival_pct) ORDER BY rn) FROM withpct), '[]'::jsonb),
+    'headline', COALESCE(
+      (SELECT jsonb_build_object(
+        'from_code', from_code, 'from_label', from_label, 'to_code', to_code, 'to_label', to_label,
+        'cohort_n', cohort_n, 'survived', survived, 'survival_pct', survival_pct,
+        'basis', replace(from_code, 'cycle_', 'C') || '->' || replace(to_code, 'cycle_', 'C')
+      ) FROM withpct
+      WHERE to_code IS DISTINCT FROM (SELECT cycle_code FROM public.cycles WHERE is_current LIMIT 1)
+      ORDER BY rn DESC LIMIT 1),
+      (SELECT jsonb_build_object(
+        'from_code', from_code, 'from_label', from_label, 'to_code', to_code, 'to_label', to_label,
+        'cohort_n', cohort_n, 'survived', survived, 'survival_pct', survival_pct,
+        'basis', replace(from_code, 'cycle_', 'C') || '->' || replace(to_code, 'cycle_', 'C')
+      ) FROM withpct ORDER BY rn DESC LIMIT 1)
+    ),
+    'computed_at', now()
+  );
+$function$;


### PR DESCRIPTION
Três correções de frontend na landing pública (`nucleoia.vitormr.dev`), aterradas em dado vivo. Closes #1239.

## 1. Hero "CICLO 3 · 2026" hardcoded → deriva do ciclo atual
`hero.badge`/`hero.cycleActive` eram strings estáticas nos 3 dicionários (o "em Andamento" só estava certo por sorte). Agora `HomepageHero.astro` faz fetch de `get_current_cycle` (anon-EXECUTE, mesmo padrão do ChaptersSection) e monta o badge + status via template i18n (`CICLO {n} · {year}`), com fallback neutro se o fetch falhar. `HeroSection.astro` (que também usava a chave) está morto (nenhum import).

## 2. Taxa de Retenção subestimada (47,6%) → última transição FECHADA (96,8%)
`get_member_retention_canonical()->headline` pegava a última transição com `ORDER BY rn DESC LIMIT 1` **sem filtrar coorte fechada**. Ao abrir o C4 (2026-07-09), o headline virou **C3→C4 = 47,6%** — retenção medida PARA DENTRO de um ciclo em formação (denominador completo, numerador incompleto). A própria `definition` da função já dizia *"last closed transition"*; a migration `20260805000385` alinha o código: headline = última transição cujo `to_code` != ciclo corrente (`cycles.is_current`), com fallback. **Agora C2→C3 = 96,8%** (verificado ao vivo, incl. `get_public_platform_stats.retention_rate`). A transição em formação C3→C4 continua no array `transitions` (histórico).

## 3. Bolas do mapa crescem demais
`pinDiameter = base + k·√count` sem teto → Brasil ~59px cobrindo vizinhos, sendo que o número já está dentro da bola. Adiciona cap (38 country/continent, 30 state) em `worldMap.ts`.

## Validação
- Migration byte-fiel via apply_migration + `migration repair --status applied 20260805000385` + `NOTIFY pgrst`.
- Retenção viva: `basis=C2->C3`, `survival_pct=96.8`, `retention_rate=96.8`.
- `npx astro build` verde.