### PR TITLE
fix(landing): "Playlist completa" aponta para a playlist do Ciclo 4

### DIFF
--- a/src/components/sections/TribesSection.astro
+++ b/src/components/sections/TribesSection.astro
@@ -320,7 +320,7 @@ const TRIBE_IDS = safeTribes.map(tr => tr.id);
     </div>
 
     <div class="text-center mt-6">
-      <a href="https://youtube.com/playlist?list=PLQJVKrw1fcrx3fD2ug1hnps6TklcMT1dc"
+      <a href="https://youtube.com/playlist?list=PLRexyUb8O7bo"
          target="_blank" rel="noopener"
          class="text-crimson font-bold text-[.95rem] no-underline hover:underline">
         {t('tribes.playlist', lang)}


### PR DESCRIPTION
## Problema

O link **"Playlist completa →"** na landing (seção de tribos/trilhas) ainda apontava para a playlist do **Ciclo 3** (`list=PLQJVKrw1fcrx3fD2ug1hnps6TklcMT1dc`). Reportado pelo PM com screenshot.

## Fix

`src/components/sections/TribesSection.astro` — troca para a playlist do **Ciclo 4**: `https://youtube.com/playlist?list=PLRexyUb8O7bo` ("Ciclo 4 (2026/2) - Introdução dos Líderes de Tribo", link verificado como válido). Removido o param de tracking `si`.

## Fora de escopo (flag)

O **mesmo ID antigo C3** persiste no rodapé (`BaseLayout.astro` → `footer.webinars`), mas é outro conceito (playlist de webinars, não trilhas). Deixado intacto até confirmação do PM se também deve mudar.

`astro build` verde.

Refs landing SSOT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)