### PR TITLE
fix(footer): playlist "webinars" do rodapé aponta para o Ciclo 4

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -311,7 +311,7 @@ const globalI18nBundle = buildPageI18n(['comp.globalSearch', 'comp.common'], lan
       <span class="text-white/20" aria-hidden="true">·</span>
       <a href={localePath('/blog', lang)} class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('nav.blog', lang)}</a>
       <span class="text-white/20" aria-hidden="true">·</span>
-      <a href="https://youtube.com/playlist?list=PLQJVKrw1fcrx3fD2ug1hnps6TklcMT1dc" target="_blank" rel="noopener noreferrer" class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('footer.webinars', lang)}</a>
+      <a href="https://youtube.com/playlist?list=PLRexyUb8O7bo" target="_blank" rel="noopener noreferrer" class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('footer.webinars', lang)}</a>
       <span class="text-white/20" aria-hidden="true">·</span>
       <a href="https://www.youtube.com/playlist?list=PLQJVKrw1fcrymIpRMT4efnR0G1TJRaMWI" target="_blank" rel="noopener noreferrer" class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('footer.meetings', lang)}</a>
       <span class="text-white/20" aria-hidden="true">·</span>

--- a/tests/ui-stabilization.test.mjs
+++ b/tests/ui-stabilization.test.mjs
@@ -1056,7 +1056,7 @@ test('R5: public playlist moved to footer; ResourcesSection holds no deadline co
   assert.equal(resources.includes('formatPlaylistDeadline'), false);
   // O link público de webinars (playlist do YouTube) está no rodapé
   assert.equal(footer.includes("t('footer.webinars', lang)"), true);
-  assert.equal(footer.includes('PLQJVKrw1fcrx3fD2ug1hnps6TklcMT1dc'), true);
+  assert.equal(footer.includes('PLRexyUb8O7bo'), true); // Ciclo 4 (era C3 PLQJVKrw1fcrx3fD2ug1hnps6TklcMT1dc)
 });
 
 test('public home locale copy no longer hardcodes cycle 3 labels', () => {


### PR DESCRIPTION
Segue #1242: o mesmo ID da playlist C3 (`PLQJVKrw1fcrx3fD2ug1hnps6TklcMT1dc`) que estava na "Playlist completa" da landing também vivia no link **"webinars" do rodapé** (`BaseLayout.astro`). Troca para o Ciclo 4 (`list=PLRexyUb8O7bo`).

`footer.meetings` (playlist de reuniões, ID distinto) fica intacta. `astro build` verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)