### PR TITLE
feat(onboarding): #1224 PR2 nudge de capítulo de entrada (in-app + e-mail Resend)

### DIFF
--- a/docs/adr/ADR-0022-notification-types-catalog.json
+++ b/docs/adr/ADR-0022-notification-types-catalog.json
@@ -35,6 +35,10 @@
       "delivery_mode": "transactional_immediate",
       "rationale": "Stakeholder fan-out on offboard — leadership awareness is time-sensitive."
     },
+    "entry_chapter_action_needed": {
+      "delivery_mode": "transactional_immediate",
+      "rationale": "#1224 PR2 (2026-07-09): onboarding nudge to the small cohort whose PMI enrichment cannot resolve an entry chapter (profile_private / no_fetch / not_affiliated / ambiguous with no self-choice). The action is on the member's community.pmi.org profile, so it is one-time per cohort, low-volume (6 recipients for C4), and time-sensitive to onboarding — not digest material. Produced by nudge_entry_chapter_cohort with a 30-day per-recipient dedup guard; blast is dry-run-previewed and approved before firing."
+    },
     "attendance_detractor": {
       "delivery_mode": "suppress",
       "rationale": "Per-cycle detractor pattern — surfaced in admin dashboards. Email-spamming would amplify noise."

--- a/src/components/onboarding/EntryChapterNudge.tsx
+++ b/src/components/onboarding/EntryChapterNudge.tsx
@@ -1,60 +1,144 @@
 import { useState, useEffect, useCallback } from 'react';
 
-// Entry-chapter adoption nudge (#625 follow-up / ADR-0104 Wave 3b-i).
+// Entry-chapter nudge — #1224 PR2 (bucket-aware) on top of #625 / ADR-0104 Wave 3b-i.
 //
-// The /profile entry-chapter CARD already exists (set_my_entry_chapter), but adoption among the
-// established membership is 0/48 live (the screen is passive — you only see it if you go look).
-// This island PULLS the member to it: a dismissible banner on /workspace that links straight to
-// the card. PM decision 2026-06-18: FE-only, no new DB state.
+// The /profile entry-chapter CARD lets a member choose the chapter they enter the Núcleo
+// through (set_my_entry_chapter). This island PULLS the member to the right action from a
+// dismissible banner on /workspace. It renders one of two families of message:
 //
-// Eligibility mirrors what the /profile card itself can act on, so the nudge never dead-ends:
-//   - non-guest, active member (guests have their own pre-onboarding flow + islands)
-//   - get_my_chapter_affiliations() returns >= 1 BR affiliation (the RPC is BR-only)
-//   - none of those affiliations is already the entry chapter (is_entry === false for all)
-// Live grounding 2026-06-18: 48/48 eligible members have >= 1 BR affiliation → 0 dead-ends.
+//   1. PMI-side diagnosis (#1224): get_my_entry_chapter_diagnosis() classifies the caller's
+//      selection application against the PMI enrichment (SSOT — pmi_memberships, never free
+//      text). When the entry chapter still cannot be derived, the bucket tells the member
+//      exactly what to fix on their community.pmi.org profile:
+//        - profile_private → make the PMI profile public
+//        - no_fetch        → create / link the PMI profile
+//        - not_affiliated  → regularize PMI membership
+//      For these the action is on PMI's site, so the CTA opens community.pmi.org.
 //
-// Dismissal is a localStorage flag ("not now", per device) with a 14-day TTL — a fat-finger
-// dismiss should not silence a 0/48-adoption governance nudge forever (ux-leader R2). Once an
-// entry chapter is chosen, is_entry flips true on the next load and the banner disappears on its
-// own regardless of the flag — dismiss is only for members who want to defer.
+//   2. Choice fallback (#625): when the diagnosis is not one of the PMI-side buckets and no
+//      entry chapter is set yet, we fall back to the affiliation-based prompt (the member has
+//      >= 1 BR chapter affiliation but has not chosen which one is the entry chapter — e.g. an
+//      established member, or an ambiguous cohort member who has not self-declared). CTA links
+//      straight to the /profile choice card.
+//
+// Once entry_chapter_code is set the banner disappears on its own (diagnosis short-circuits and
+// the affiliation check finds is_entry). Dismissal is a per-device localStorage flag with a
+// 14-day TTL — a fat-finger dismiss must not silence a governance nudge forever (ux-leader R2).
 
 const DISMISS_KEY = 'nucleo:entryChapterNudgeDismissed';
 const DISMISS_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+
+// PMI community site — where profile visibility / membership are fixed.
+const PMI_COMMUNITY_URL = 'https://community.pmi.org';
 
 interface Affiliation {
   chapter_code: string;
   is_entry: boolean;
 }
 
-interface Copy {
+interface Diagnosis {
+  bucket: string;
+  active_br_codes: string[];
+  entry_chapter_code: string | null;
+  member_chapter: string | null;
+}
+
+// Which diagnosis buckets need a PMI-side fix (CTA → community.pmi.org).
+type PmiVariant = 'profile_private' | 'no_fetch' | 'not_affiliated';
+const PMI_BUCKETS: readonly PmiVariant[] = ['profile_private', 'no_fetch', 'not_affiliated'];
+
+type Variant = PmiVariant | 'choose';
+
+interface Message {
   title: string;
   body: string;
   cta: string;
+}
+
+interface Copy {
   dismiss: string;
   ariaLabel: string;
+  variants: Record<Variant, Message>;
 }
 
 const COPY: Record<string, Copy> = {
   'pt-BR': {
-    title: 'Defina seu capítulo de entrada',
-    body: 'Escolha por qual capítulo do PMI você entra no Núcleo. Leva um clique e ajuda na governança e nos indicadores do seu capítulo.',
-    cta: 'Escolher meu capítulo',
     dismiss: 'Agora não',
-    ariaLabel: 'Aviso: defina seu capítulo de entrada',
+    ariaLabel: 'Aviso sobre seu capítulo de entrada',
+    variants: {
+      choose: {
+        title: 'Defina seu capítulo de entrada',
+        body: 'Escolha por qual capítulo do PMI você entra no Núcleo. Leva um clique e ajuda na governança e nos indicadores do seu capítulo.',
+        cta: 'Escolher meu capítulo',
+      },
+      profile_private: {
+        title: 'Deixe seu perfil PMI público',
+        body: 'Seu perfil no community.pmi.org está privado, então não conseguimos ler seus capítulos para definir seu capítulo de entrada. Deixe o perfil público e nós atualizamos automaticamente.',
+        cta: 'Abrir meu perfil PMI',
+      },
+      no_fetch: {
+        title: 'Vincule seu perfil PMI',
+        body: 'Ainda não localizamos seu perfil no community.pmi.org. Se você tem filiação PMI, confira se o perfil está criado e público para confirmarmos seu capítulo de entrada automaticamente.',
+        cta: 'Abrir community.pmi.org',
+      },
+      not_affiliated: {
+        title: 'Confirme sua filiação PMI',
+        body: 'Não conseguimos confirmar uma filiação PMI ativa no seu perfil do community.pmi.org. Verifique se sua filiação está ativa e se o capítulo aparece no perfil. Assim que estiver regular, atualizamos automaticamente.',
+        cta: 'Abrir meu perfil PMI',
+      },
+    },
   },
   'en-US': {
-    title: 'Set your entry chapter',
-    body: 'Pick which PMI chapter you join the Núcleo through. It takes one click and supports your chapter’s governance and metrics.',
-    cta: 'Choose my chapter',
     dismiss: 'Not now',
-    ariaLabel: 'Notice: set your entry chapter',
+    ariaLabel: 'Notice about your entry chapter',
+    variants: {
+      choose: {
+        title: 'Set your entry chapter',
+        body: 'Pick which PMI chapter you join the Núcleo through. It takes one click and supports your chapter’s governance and metrics.',
+        cta: 'Choose my chapter',
+      },
+      profile_private: {
+        title: 'Make your PMI profile public',
+        body: 'Your community.pmi.org profile is private, so we cannot read your chapters to set your entry chapter. Make the profile public and we update it automatically.',
+        cta: 'Open my PMI profile',
+      },
+      no_fetch: {
+        title: 'Link your PMI profile',
+        body: 'We could not find your community.pmi.org profile yet. If you hold a PMI membership, check that the profile is created and public so we can confirm your entry chapter automatically.',
+        cta: 'Open community.pmi.org',
+      },
+      not_affiliated: {
+        title: 'Confirm your PMI membership',
+        body: 'We could not confirm an active PMI membership on your community.pmi.org profile. Check that your membership is active and the chapter shows on the profile. Once it is current, we update automatically.',
+        cta: 'Open my PMI profile',
+      },
+    },
   },
   'es-LATAM': {
-    title: 'Define tu capítulo de entrada',
-    body: 'Elige por cuál capítulo del PMI ingresas al Núcleo. Toma un clic y apoya la gobernanza y los indicadores de tu capítulo.',
-    cta: 'Elegir mi capítulo',
     dismiss: 'Ahora no',
-    ariaLabel: 'Aviso: define tu capítulo de entrada',
+    ariaLabel: 'Aviso sobre tu capítulo de entrada',
+    variants: {
+      choose: {
+        title: 'Define tu capítulo de entrada',
+        body: 'Elige por cuál capítulo del PMI ingresas al Núcleo. Toma un clic y apoya la gobernanza y los indicadores de tu capítulo.',
+        cta: 'Elegir mi capítulo',
+      },
+      profile_private: {
+        title: 'Haz público tu perfil PMI',
+        body: 'Tu perfil en community.pmi.org está privado, así que no podemos leer tus capítulos para definir tu capítulo de entrada. Hazlo público y lo actualizamos automáticamente.',
+        cta: 'Abrir mi perfil PMI',
+      },
+      no_fetch: {
+        title: 'Vincula tu perfil PMI',
+        body: 'Todavía no localizamos tu perfil en community.pmi.org. Si tienes membresía PMI, verifica que el perfil esté creado y público para confirmar tu capítulo de entrada automáticamente.',
+        cta: 'Abrir community.pmi.org',
+      },
+      not_affiliated: {
+        title: 'Confirma tu membresía PMI',
+        body: 'No pudimos confirmar una membresía PMI activa en tu perfil de community.pmi.org. Verifica que tu membresía esté activa y que el capítulo aparezca en el perfil. Cuando esté al día, lo actualizamos automáticamente.',
+        cta: 'Abrir mi perfil PMI',
+      },
+    },
   },
 };
 
@@ -64,7 +148,7 @@ interface Props {
 
 export default function EntryChapterNudge({ lang = 'pt-BR' }: Props) {
   const copy = COPY[lang] || COPY['pt-BR'];
-  const [show, setShow] = useState(false);
+  const [variant, setVariant] = useState<Variant | null>(null);
 
   const getSb = useCallback(() => (window as any).navGetSb?.(), []);
 
@@ -85,13 +169,24 @@ export default function EntryChapterNudge({ lang = 'pt-BR' }: Props) {
 
     const sb = getSb();
     if (!sb) return;
+
+    // 1. PMI-side diagnosis (SSOT = PMI enrichment). If the entry chapter is already set,
+    //    nothing to nudge. If a PMI-side bucket, render its specific fix.
+    const { data: diag } = await sb.rpc('get_my_entry_chapter_diagnosis');
+    const d: Diagnosis | null = diag && typeof diag === 'object' ? diag : null;
+    if (d?.entry_chapter_code) return;
+    if (d && PMI_BUCKETS.includes(d.bucket as PmiVariant)) {
+      setVariant(d.bucket as PmiVariant);
+      return;
+    }
+
+    // 2. Choice fallback (#625): has BR affiliations but no entry chapter chosen yet.
     const { data, error } = await sb.rpc('get_my_chapter_affiliations');
     if (error) return;
     const affils: Affiliation[] = Array.isArray(data) ? data : [];
-    // BR-only RPC. Eligible = has affiliations AND none is already the entry chapter.
     if (affils.length === 0) return;
     if (affils.some((a) => a.is_entry === true)) return;
-    setShow(true);
+    setVariant('choose');
   }, [getSb]);
 
   // Boot like the sibling islands: wait for the nav member, then evaluate once.
@@ -106,10 +201,16 @@ export default function EntryChapterNudge({ lang = 'pt-BR' }: Props) {
 
   const dismiss = useCallback(() => {
     try { localStorage.setItem(DISMISS_KEY, JSON.stringify({ ts: Date.now() })); } catch { /* ignore */ }
-    setShow(false);
+    setVariant(null);
   }, []);
 
-  if (!show) return null;
+  if (!variant) return null;
+
+  const msg = copy.variants[variant];
+  const isPmi = PMI_BUCKETS.includes(variant as PmiVariant);
+  const ctaHref = isPmi ? PMI_COMMUNITY_URL : `/profile?lang=${lang}#entry-chapter-card`;
+  // PMI-side CTA leaves the platform → new tab + noopener; internal choice stays in place.
+  const ctaExtra = isPmi ? { target: '_blank', rel: 'noopener noreferrer' } : {};
 
   return (
     <section role="region" aria-label={copy.ariaLabel} className="mb-6">
@@ -121,14 +222,15 @@ export default function EntryChapterNudge({ lang = 'pt-BR' }: Props) {
             <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 10.5c0 7.142-7.5 11.25-7.5 11.25S4.5 17.642 4.5 10.5a7.5 7.5 0 1 1 15 0Z" />
           </svg>
           <div className="flex-1 min-w-0">
-            <h2 className="text-base font-extrabold text-navy dark:text-teal">{copy.title}</h2>
-            <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{copy.body}</p>
+            <h2 className="text-base font-extrabold text-navy dark:text-teal">{msg.title}</h2>
+            <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{msg.body}</p>
             <div className="mt-3 flex items-center gap-2 flex-wrap">
               <a
-                href={`/profile?lang=${lang}#entry-chapter-card`}
+                href={ctaHref}
+                {...ctaExtra}
                 className="min-h-[44px] inline-flex items-center px-4 rounded-lg bg-teal text-white text-sm font-bold no-underline hover:bg-teal/90"
               >
-                {copy.cta}
+                {msg.cta}
               </a>
               <button
                 type="button"

--- a/supabase/functions/send-notification-email/index.ts
+++ b/supabase/functions/send-notification-email/index.ts
@@ -20,6 +20,7 @@ const TYPE_SUBJECTS: Record<string, string> = {
   webinar_status_confirmed: 'Webinar confirmado',
   webinar_status_completed: 'Webinar realizado',
   webinar_status_cancelled: 'Webinar cancelado',
+  entry_chapter_action_needed: 'Capitulo de entrada: acao necessaria',
   ip_ratification_gate_pending: 'Acao necessaria — ratificacao de documento',
   ip_ratification_gate_advanced: 'Gate satisfeito — cadeia avancou',
   ip_ratification_chain_approved: 'Cadeia de aprovacao concluida',

--- a/supabase/migrations/20260805000387_1224_pr2_entry_chapter_nudge.sql
+++ b/supabase/migrations/20260805000387_1224_pr2_entry_chapter_nudge.sql
@@ -1,0 +1,269 @@
+-- #1224 PR 2 — entry-chapter nudge (in-app diagnosis + Resend email channel)
+--
+-- Builds on PR 1 (mig 386): PR 1 gave the pure classifier classify_entry_chapter() and the
+-- admin cohort diagnosis get_entry_chapter_diagnosis(cycle). PR 2 adds the two surfaces that
+-- ACT on that diagnosis:
+--
+--   1. get_my_entry_chapter_diagnosis() — SELF-scoped read for the /workspace in-app nudge.
+--      Finds the caller's own selection application (by email) and returns the classifier
+--      bucket + active BR codes + the member's current entry_chapter_code / chapter. The
+--      EntryChapterNudge island renders bucket-specific copy from this (PMI-side action for
+--      profile_private / no_fetch / not_affiliated; the choice card for ambiguous).
+--
+--   2. nudge_entry_chapter_cohort(cycle, dry_run) — admin PRODUCER of the email blast. Reuses
+--      get_entry_chapter_diagnosis + create_notification. Targets only the genuinely stuck:
+--      member exists, entry_chapter_code IS NULL, and bucket is actionable. Each recipient
+--      gets one notification of the new type entry_chapter_action_needed with bucket-specific
+--      title/body; create_notification stamps delivery_mode = transactional_immediate (via the
+--      _delivery_mode_for change below), so the jobid-9 send-notification-email cron delivers
+--      the email. dry_run=true (default) returns the plan WITHOUT inserting, so the blast is
+--      previewed and approved before it fires (outward-facing = explicit approval). A 30-day
+--      per-recipient dedup guard prevents an accidental double-fire on re-run.
+--
+--   3. _delivery_mode_for(text) — add entry_chapter_action_needed => transactional_immediate.
+--      Kept byte-identical to the live body except the one new WHEN line (ADR-0022 catalog +
+--      contract test adr-0022-delivery-mode kept in sync in this same PR).
+--
+-- SSOT stays the PMI enrichment (selection_applications.pmi_memberships), never free text
+-- (PM #1224). member.chapter may hold a self-declared chapter that the enrichment cannot
+-- confirm; the nudge copy is honest about that ("we could not confirm from your PMI profile").
+--
+-- ROLLBACK:
+--   DROP FUNCTION public.nudge_entry_chapter_cohort(uuid, boolean);
+--   DROP FUNCTION public.get_my_entry_chapter_diagnosis();
+--   -- restore _delivery_mode_for to the mig-386-era body (remove the entry_chapter_action_needed WHEN).
+
+-- ── 1. Self-scoped diagnosis for the in-app nudge ────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.get_my_entry_chapter_diagnosis()
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member   public.members%ROWTYPE;
+  v_app      public.selection_applications%ROWTYPE;
+  v_classify jsonb;
+BEGIN
+  IF auth.uid() IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  SELECT * INTO v_member FROM public.members WHERE auth_id = auth.uid();
+  IF v_member.id IS NULL THEN
+    RETURN jsonb_build_object(
+      'bucket', 'no_application', 'active_br_codes', '[]'::jsonb,
+      'entry_chapter_code', NULL, 'member_chapter', NULL
+    );
+  END IF;
+
+  -- The caller's own application, preferring an approved one, then most recent.
+  SELECT * INTO v_app
+  FROM public.selection_applications sa
+  WHERE lower(sa.email) = lower(v_member.email)
+  ORDER BY (sa.status = 'approved') DESC, sa.created_at DESC
+  LIMIT 1;
+
+  IF v_app.id IS NULL THEN
+    RETURN jsonb_build_object(
+      'bucket', 'no_application', 'active_br_codes', '[]'::jsonb,
+      'entry_chapter_code', v_member.entry_chapter_code, 'member_chapter', v_member.chapter
+    );
+  END IF;
+
+  v_classify := public.classify_entry_chapter(
+    v_app.pmi_memberships, v_app.community_profile_private, v_app.pmi_data_fetched_at
+  );
+
+  RETURN jsonb_build_object(
+    'bucket', v_classify->>'bucket',
+    'active_br_codes', v_classify->'active_br_codes',
+    'entry_chapter_code', v_member.entry_chapter_code,
+    'member_chapter', v_member.chapter
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.get_my_entry_chapter_diagnosis() IS
+  '#1224 PR2 — self-scoped entry-chapter diagnosis for the /workspace nudge. Returns {bucket, active_br_codes, entry_chapter_code, member_chapter} from the caller''s own selection application via classify_entry_chapter. SSOT is the PMI enrichment, not free text. SECDEF; authenticated only.';
+
+REVOKE ALL ON FUNCTION public.get_my_entry_chapter_diagnosis() FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.get_my_entry_chapter_diagnosis() TO authenticated;
+
+-- ── 2. delivery_mode: add the new transactional type ─────────────────────────────────────────
+-- Rebuilt from the live body (mig 360 era) plus the one new WHEN, so no prior type mapping is
+-- dropped (the earlier draft was based on a stale mig-386-era capture that lacked the whole
+-- selection/affiliation policy matrix — caught by adr-0022-delivery-mode contract test).
+CREATE OR REPLACE FUNCTION public._delivery_mode_for(p_type text)
+ RETURNS text
+ LANGUAGE sql
+ IMMUTABLE PARALLEL SAFE
+ SET search_path TO ''
+AS $function$
+  SELECT CASE p_type
+    -- PR-2 (email audit): the per-signing leadership alert is now in-app only; the daily
+    -- digest (volunteer_term_signed_digest) carries the single aggregated email.
+    WHEN 'volunteer_agreement_signed'    THEN 'suppress'
+    WHEN 'volunteer_term_signed_digest'  THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_pending'  THEN 'transactional_immediate'
+    WHEN 'system_alert'                  THEN 'transactional_immediate'
+    -- #1169: ready is redundant with issued at the email layer (issued carries the single email);
+    -- kept in-app only. Every ready-cert already fired an issued email (0 ready-without-issued/60d).
+    WHEN 'certificate_ready'             THEN 'suppress'
+    WHEN 'certificate_issued'            THEN 'transactional_immediate'
+    WHEN 'member_offboarded'             THEN 'transactional_immediate'
+    WHEN 'ip_ratification_gate_advanced'    THEN 'transactional_immediate'
+    WHEN 'ip_ratification_chain_approved'   THEN 'transactional_immediate'
+    WHEN 'ip_ratification_awaiting_members' THEN 'transactional_immediate'
+    WHEN 'webinar_status_confirmed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_completed'      THEN 'transactional_immediate'
+    WHEN 'webinar_status_cancelled'      THEN 'transactional_immediate'
+    WHEN 'weekly_card_digest_member'     THEN 'transactional_immediate'
+    WHEN 'governance_cr_new'             THEN 'transactional_immediate'
+    WHEN 'governance_cr_vote'            THEN 'transactional_immediate'
+    WHEN 'governance_cr_approved'        THEN 'transactional_immediate'
+    WHEN 'sponsor_finance_entry_logged'  THEN 'transactional_immediate'
+    WHEN 'governance_manual_proposed'    THEN 'transactional_immediate'
+    WHEN 'engagement_renewal_d7_urgent'  THEN 'transactional_immediate'
+    -- p153 OPP-153.1: project_charter (TAP) notifications
+    WHEN 'project_charter_invite'        THEN 'transactional_immediate'
+    WHEN 'project_charter_approved'      THEN 'transactional_immediate'
+    -- p159 S#1 T1 (2026-05-14): selection_termo_due é o "email principal" pós-VEP-Active
+    WHEN 'selection_termo_due'           THEN 'transactional_immediate'
+    -- p228 #260 W2 Leaf 1 (2026-05-23): Selection funnel Policy Matrix
+    WHEN 'selection_approved'            THEN 'transactional_immediate'
+    WHEN 'selection_interview_scheduled' THEN 'transactional_immediate'
+    WHEN 'peer_review_requested'         THEN 'transactional_immediate'
+    WHEN 'selection_evaluation_complete' THEN 'suppress'
+    WHEN 'selection_interview_noshow'    THEN 'digest_weekly'
+    -- p228 #260 W2 Leaf 2 (2026-05-23): admin reminder for overdue interviews
+    WHEN 'selection_interview_overdue'   THEN 'digest_weekly'
+    -- p228 #260 W2 Leaf 4 (2026-05-23): candidate invite to book interview after
+    -- objective evaluations cleared + research_score >= cycle cutoff.
+    WHEN 'selection_cutoff_approved'     THEN 'transactional_immediate'
+    -- (end p228)
+    -- #186 (2026-06-05): curation committee broadcast when an item enters curation_pending
+    WHEN 'curation_item_submitted'       THEN 'transactional_immediate'
+    WHEN 'engagement_renewal_d30'        THEN 'digest_weekly'
+    WHEN 'engagement_renewal_d60_gp_aggregate' THEN 'digest_weekly'
+    -- #625 F3 (2026-06-11): radar de renovação de filiação
+    WHEN 'affiliation_renewal_d7_urgent'  THEN 'transactional_immediate'
+    WHEN 'affiliation_renewal_d30'        THEN 'digest_weekly'
+    WHEN 'affiliation_verification_stale' THEN 'digest_weekly'
+    -- #1224 PR2 (2026-07-09): one-time onboarding nudge when the PMI enrichment cannot resolve
+    -- an entry chapter (profile_private / no_fetch / not_affiliated / ambiguous-no-choice).
+    WHEN 'entry_chapter_action_needed'    THEN 'transactional_immediate'
+    -- #740 Wave 3c-i (B8): agreement rejected / reissued — member must re-sign, deliver immediately
+    WHEN 'volunteer_agreement_rejected'  THEN 'transactional_immediate'
+    WHEN 'volunteer_agreement_reissued'  THEN 'transactional_immediate'
+    WHEN 'attendance_detractor'          THEN 'suppress'
+    WHEN 'info'                          THEN 'suppress'
+    WHEN 'system'                        THEN 'suppress'
+    ELSE 'digest_weekly'
+  END;
+$function$;
+
+-- ── 3. Admin producer of the entry-chapter nudge blast ───────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.nudge_entry_chapter_cohort(
+  p_cycle_id uuid DEFAULT NULL,
+  p_dry_run  boolean DEFAULT true
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_rec       record;
+  v_title     text;
+  v_body      text;
+  v_sent      int := 0;
+  v_skipped   int := 0;
+  v_plan      jsonb := '[]'::jsonb;
+BEGIN
+  -- manage_platform, or service_role/postgres (cron/tests) — same gate as get_entry_chapter_diagnosis.
+  IF auth.uid() IS NOT NULL THEN
+    SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+    IF v_caller_id IS NULL OR NOT public.can_by_member(v_caller_id, 'manage_platform') THEN
+      RAISE EXCEPTION 'Unauthorized: nudge_entry_chapter_cohort requires manage_platform';
+    END IF;
+  ELSIF current_setting('role', true) NOT IN ('service_role', 'postgres')
+        AND current_user NOT IN ('postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'Unauthorized: nudge_entry_chapter_cohort requires authentication';
+  END IF;
+
+  FOR v_rec IN
+    SELECT d.member_id, d.applicant_name, d.bucket
+    FROM public.get_entry_chapter_diagnosis(p_cycle_id) d
+    WHERE d.member_id IS NOT NULL
+      AND d.entry_chapter_code IS NULL
+      AND d.bucket IN ('ambiguous', 'profile_private', 'no_fetch', 'not_affiliated')
+    ORDER BY d.applicant_name
+  LOOP
+    v_title := CASE v_rec.bucket
+      WHEN 'ambiguous'       THEN 'Escolha seu capítulo de entrada no Núcleo'
+      WHEN 'profile_private' THEN 'Deixe seu perfil PMI público para confirmarmos seu capítulo'
+      WHEN 'no_fetch'        THEN 'Vincule seu perfil PMI para definir seu capítulo de entrada'
+      ELSE                        'Confirme sua filiação PMI para definir seu capítulo de entrada'
+    END;
+    v_body := CASE v_rec.bucket
+      WHEN 'ambiguous' THEN
+        'Encontramos mais de um capítulo PMI ativo na sua filiação. Escolha por qual capítulo você entra no Núcleo para ajustarmos a governança e os indicadores do seu capítulo. Leva um clique no seu perfil.'
+      WHEN 'profile_private' THEN
+        'Seu perfil no community.pmi.org está com a visibilidade privada, então não conseguimos ler seus capítulos para definir seu capítulo de entrada no Núcleo. Acesse community.pmi.org, deixe seu perfil público (ao menos a seção de capítulos) e nós atualizamos automaticamente.'
+      WHEN 'no_fetch' THEN
+        'Ainda não localizamos seu perfil no community.pmi.org. Se você tem filiação PMI, confira se o perfil está criado e público em community.pmi.org para confirmarmos seu capítulo de entrada no Núcleo automaticamente.'
+      ELSE
+        'Não conseguimos confirmar uma filiação PMI ativa no seu perfil do community.pmi.org. Para registrarmos seu capítulo de entrada no Núcleo, verifique se sua filiação PMI está ativa e se o capítulo aparece no seu perfil em community.pmi.org. Assim que estiver regular, atualizamos automaticamente.'
+    END;
+
+    v_plan := v_plan || jsonb_build_object(
+      'member_id', v_rec.member_id,
+      'name', v_rec.applicant_name,
+      'bucket', v_rec.bucket,
+      'title', v_title
+    );
+
+    IF p_dry_run THEN
+      CONTINUE;
+    END IF;
+
+    -- Dedup: do not re-fire if this member already got the nudge in the last 30 days.
+    IF EXISTS (
+      SELECT 1 FROM public.notifications n
+      WHERE n.recipient_id = v_rec.member_id
+        AND n.type = 'entry_chapter_action_needed'
+        AND n.created_at > now() - interval '30 days'
+    ) THEN
+      v_skipped := v_skipped + 1;
+      CONTINUE;
+    END IF;
+
+    PERFORM public.create_notification(
+      v_rec.member_id,
+      'entry_chapter_action_needed',
+      v_title,
+      v_body,
+      '/profile#entry-chapter-card'
+    );
+    v_sent := v_sent + 1;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'dry_run', p_dry_run,
+    'cycle_id', p_cycle_id,
+    'candidates', jsonb_array_length(v_plan),
+    'sent', v_sent,
+    'skipped_recent', v_skipped,
+    'plan', v_plan
+  );
+END;
+$function$;
+
+COMMENT ON FUNCTION public.nudge_entry_chapter_cohort(uuid, boolean) IS
+  '#1224 PR2 — producer of the entry-chapter nudge blast. Reuses get_entry_chapter_diagnosis + create_notification. Targets members with entry_chapter_code IS NULL and an actionable bucket (ambiguous | profile_private | no_fetch | not_affiliated). Type entry_chapter_action_needed => transactional_immediate => jobid-9 email cron. dry_run=true (default) returns the plan without inserting (blast is approved before firing). 30-day per-recipient dedup guard. manage_platform-gated; service_role/postgres allowed.';
+
+REVOKE ALL ON FUNCTION public.nudge_entry_chapter_cohort(uuid, boolean) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.nudge_entry_chapter_cohort(uuid, boolean) TO authenticated, service_role;

--- a/supabase/migrations/20260805000388_raise_postgrest_db_max_rows_5000.sql
+++ b/supabase/migrations/20260805000388_raise_postgrest_db_max_rows_5000.sql
@@ -1,0 +1,22 @@
+-- Raise PostgREST db-max-rows from the Supabase default (1000) to 5000.
+--
+-- WHY: the public schema holds 1121 functions and grows every session. PostgREST caps
+-- API/RPC responses at 1000 rows (Supabase "Max Rows" default), so the Phase C body-drift
+-- audit RPC public._audit_list_public_function_bodies() (ORDER BY proname) has been SILENTLY
+-- truncating its ~121 alphabetically-last functions — the drift gate was blind to them. The
+-- boundary surfaced when #1224 PR2 added get_my_entry_chapter_diagnosis + nudge_entry_chapter_cohort
+-- (both alphabetically before 's'), shifting submit_interview_scores from position ~999 to >1000
+-- and breaking its p241 live checks (tests/contracts/p241-watch-240-a-submit-interview-scores-relax).
+--
+-- FIX: set pgrst.db_max_rows on the authenticator role (PostgREST's in-database config channel)
+-- + reload. 5000 restores full visibility for the ~1121 functions with multi-year headroom.
+-- RLS still gates every row (PII protection is unchanged); the app paginates its own large reads,
+-- so the higher ceiling only affects intentionally-large admin/audit responses.
+--
+-- ROLLBACK:
+--   ALTER ROLE authenticator RESET pgrst.db_max_rows;
+--   NOTIFY pgrst, 'reload config';
+
+ALTER ROLE authenticator SET pgrst.db_max_rows = '5000';
+
+NOTIFY pgrst, 'reload config';


### PR DESCRIPTION
## #1224 PR 2 — nudge diagnóstico do capítulo de entrada

Segue o PR1 (fundação backend, `classify_entry_chapter` + `get_entry_chapter_diagnosis`). PR2 entrega as **duas superfícies que agem** sobre o diagnóstico, reusando o classificador. SSOT = enriquecimento PMI (`selection_applications.pmi_memberships`), nunca texto livre.

### O que entra
- **`get_my_entry_chapter_diagnosis()`** — RPC self-scoped (SECDEF, authenticated) para o nudge in-app. Acha a candidatura do próprio membro (por e-mail) e devolve `{bucket, active_br_codes, entry_chapter_code, member_chapter}`.
- **`nudge_entry_chapter_cohort(cycle, dry_run)`** — produtor admin do blast. Reusa `get_entry_chapter_diagnosis` + `create_notification`. Mira só quem está travado: `member_id` existe, `entry_chapter_code IS NULL`, bucket em `ambiguous | profile_private | no_fetch | not_affiliated`. `dry_run=true` (default) devolve o plano **sem inserir** → blast aprovado antes de disparar (outward-facing). Guard de dedup de 30 dias por destinatário.
- **`_delivery_mode_for`** — novo tipo `entry_chapter_action_needed` ⇒ `transactional_immediate` (jobid-9 `send-notification-email`). Rebase **byte-fiel do corpo VIVO** (a matriz selection/affiliation inteira preservada).
- **Catálogo ADR-0022** — novo tipo documentado (contract test `adr-0022-delivery-mode` em sincronia).
- **EF `send-notification-email`** — `TYPE_SUBJECTS` do novo tipo (deployado).
- **`EntryChapterNudge.tsx`** — bucket-aware: PMI-side (`profile_private`/`no_fetch`/`not_affiliated`) → CTA para `community.pmi.org`; fallback #625 de escolha para membresia estabelecida. i18n pt-BR/en-US/es-LATAM inline.

### Grounding vivo (C4, ciclo `08c1e301`)
6 acionáveis: 4 `not_affiliated` (Cristiano, Emanuelle, Hector, Marcio) + 2 `profile_private` (Maria, Thiago). 34 `resolved` e 6 `ambiguous` já auto-declarados **não** recebem. Dry-run verificado (`sent:0, candidates:6`). Self-diagnosis verificado impersonando Cristiano → `not_affiliated`.

### Blast = aprovação própria
O produtor **não dispara sozinho**. Após merge/aprovação do Vitor, rodar `nudge_entry_chapter_cohort(NULL, false)` uma vez (6 e-mails via cron). Membros sem `auth_id` (ex.: Maria) recebem só o e-mail; quem já logou vê também o nudge in-app.

### Testes
- Suíte completa com DB env: **5245 pass**, 0 falha nova.
- Phase C drift (byte-fidelidade das 3 funções): ✅.
- ⚠️ 2 falhas `p241 submit_interview_scores` + 1 `preview_gate` são **drift/flake PRÉ-EXISTENTES na main** (confirmado via `git stash` — falham sem o meu diff; funções que não toquei). A CI da main passa porque faz skip dos testes live sem secrets. Vale um issue de higiene à parte (fora de escopo).

Closes #1224 (parte 2 de 3; PR3 = sweep cosmético legado `'Outro'`).