### PR TITLE
fix(chapter): renomeia PMI-AM para "PMI Amazônia" (pedido do presidente do capítulo)

### DIFF
--- a/supabase/migrations/20260805000390_rename_am_chapter_to_amazonia.sql
+++ b/supabase/migrations/20260805000390_rename_am_chapter_to_amazonia.sql
@@ -1,0 +1,25 @@
+-- Renomeia o capítulo PMI-AM para "PMI Amazônia" a pedido do presidente do capítulo
+-- João Leite (Presidente PMI Amazônia), 2026-07-09: "o nosso é PMI Amazônia, não é só Amazonas".
+--
+-- O capítulo cobre a região Amazônia, não só o estado do Amazonas. Corrige TODAS as telas:
+--   - legal_name (dropdowns/tooltips, via get_active_chapters)
+--   - state (card de afiliação do /perfil exibe este campo: "PMI-AM · <state>")
+-- Mantém a resolução VEP robusta nos dois sentidos: vep_name_aliases guarda as variantes
+-- "Amazônia Chapter" (o que o PMI Community realmente emite, caso-índice #1175) E "Amazonas,
+-- Brazil Chapter"/"Amazonas Chapter" como rede de segurança agora que state deixou de ser
+-- "Amazonas" (a convenção "<state>, Brazil Chapter" passou a gerar "Amazônia, Brazil Chapter").
+--
+-- Sem risco geográfico: worldMap.ts e os mapas de state-reach têm seus próprios dicionários
+-- chaveados em "amazonas" e NÃO leem chapter_registry.state. O único consumidor SQL de
+-- chapter_registry.state é resolve_br_chapter_code (coberto pelos aliases acima).
+--
+-- Verificado ao vivo (2026-07-09): get_active_chapters mostra "PMI Amazônia, Brazil Chapter";
+-- perfil mostra "Amazônia"; resolve_br_chapter_code('Amazônia Chapter' | 'Amazonas, Brazil
+-- Chapter' | 'Amazônia, Brazil Chapter' | 'Amazonia Chapter') = 'AM' nas 4 formas.
+
+UPDATE public.chapter_registry
+SET legal_name = 'PMI Amazônia, Brazil Chapter',
+    state = 'Amazônia',
+    vep_name_aliases = ARRAY['Amazônia Chapter','Amazonia Chapter','Amazonas, Brazil Chapter','Amazonas Chapter'],
+    updated_at = now()
+WHERE chapter_code = 'AM';


### PR DESCRIPTION
## Contexto
O presidente do capítulo, **João Leite (Presidente PMI Amazônia)**, sinalizou (2026-07-09) que o nome do capítulo é **PMI Amazônia** (cobre a região), não "Amazonas" (só o estado).

## O que muda (mig `20260805000390`, data-only em `chapter_registry`, código AM)
| campo | antes | depois |
|---|---|---|
| `legal_name` | PMI **Amazonas**, Brazil Chapter | **PMI Amazônia, Brazil Chapter** |
| `state` | Amazonas | **Amazônia** |
| `vep_name_aliases` | {Amazônia Chapter, Amazonia Chapter} | + {Amazonas, Brazil Chapter; Amazonas Chapter} |

Corrige **todas as telas**: dropdowns/tooltips (via `get_active_chapters`) e o card de afiliação do `/perfil` (que exibe o campo `state`, motivo provável da reclamação).

## Segurança da resolução VEP
Verificado ao vivo que `resolve_br_chapter_code` retorna `AM` nas 4 variantes: `Amazônia Chapter` (o que o PMI Community emite, caso-índice #1175), `Amazonas, Brazil Chapter`, `Amazônia, Brazil Chapter`, `Amazonia Chapter`. Os aliases "Amazonas" foram adicionados como rede de segurança já que `state` deixou de ser "Amazonas".

**Sem risco geográfico:** `worldMap.ts` e os mapas de state-reach têm dicionários próprios chaveados em "amazonas" e não leem `chapter_registry.state`; o único consumidor SQL desse campo é `resolve_br_chapter_code` (coberto pelos aliases).

## Follow-up (fora de escopo)
O fallback hardcoded em `src/lib/chapters.ts` só tem 13 capítulos (GO..SE) e **não inclui AM nem PB** desde que foram adicionados. Lacuna pré-existente, só afeta quando `get_active_chapters` está indisponível. Não tocado aqui.

## Validação
`npx astro build` OK · `npm test` 4716 pass / 0 fail · sem hardcode de "PMI Amazonas" em tests/src.