### PR TITLE
fix(tribes): #1247 landing picker roteia para /workspace (destrava 'Erro ao selecionar' no kickoff C4)

### DIFF
--- a/src/components/sections/TribesSection.astro
+++ b/src/components/sections/TribesSection.astro
@@ -451,53 +451,14 @@ const TRIBE_IDS = safeTribes.map(tr => tr.id);
       window.toast?.(TRIBES_MSG.leadersAssigned, 'info');
       return;
     }
-    // R3: QA bypass — high management can select tribes past deadline
-    var canBypassSchedule = isHighMgmt(member);
-    if (!DEADLINE && !canBypassSchedule) {
-      window.toast?.(TRIBES_MSG.selectionUnavailable, 'error');
-      return;
-    }
-    if (DEADLINE && new Date() > DEADLINE && !canBypassSchedule) {
-      window.toast?.(TRIBES_MSG.selectionClosed, 'error');
-      return;
-    }
-
-    // Deselect if clicking current tribe
-    if (userTribe === id) {
-      try {
-        const { data } = await sb.rpc('deselect_tribe');
-        if (data?.success) {
-          userTribe = null;
-          window.toast?.(TRIBES_MSG.selectionRemoved, 'info');
-          await loadTribeCounts();
-        } else {
-          window.toast?.(data?.error || TRIBES_MSG.errorRemove, 'error');
-        }
-      } catch (e) {
-        window.toast?.('Erro: ' + (e?.message || 'falha inesperada'), 'error');
-      }
-      return;
-    }
-
-    // Select / switch
-    const count = tribeCounts[id] || 0;
-    if (count >= MAX_SLOTS) {
-      window.toast?.(TRIBES_MSG.tribeFull, 'error');
-      return;
-    }
-
-    try {
-      const { data } = await sb.rpc('select_tribe', { p_tribe_id: id });
-      if (data?.success) {
-        userTribe = id;
-        window.toast?.(TRIBES_MSG.selectedSuccess.replace('{id}', String(id)), 'success');
-        await loadTribeCounts();
-      } else {
-        window.toast?.(data?.error || TRIBES_MSG.errorSelect, 'error');
-      }
-    } catch (e) {
-      window.toast?.('Erro: ' + (e?.message || 'falha inesperada'), 'error');
-    }
+    // #1247: the landing picker used the LEGACY `select_tribe` RPC, which is
+    // frozen past the tribe selection deadline (mig 20260309010000). Months past
+    // that deadline every C4 researcher clicking "Escolher esta Tribo" got
+    // "Erro ao selecionar" at the kickoff. The live path is the hybrid flow in
+    // /workspace (request_tribe_assignment -> leader approval -> engagement), so
+    // route there instead of writing through the dead legacy RPC. Full journey
+    // audit tracked in #1247.
+    window.location.assign('/workspace');
   }
 
   // ── Bind select buttons ──


### PR DESCRIPTION
## Incidente (kickoff Ciclo 4, 2026-07-09)
Vários pesquisadores C4 relataram "está dando erro ao selecionar" no kickoff; o print da plataforma mostra o toast **"Erro ao selecionar"** ao clicar em **Escolher esta Tribo** na landing.

## Root cause
O picker da landing (`src/components/sections/TribesSection.astro`) chamava a RPC **legada `select_tribe`**, congelada pelo deadline de seleção (`mig 20260309010000`, deadline estendido para 2026-03-14). Meses após o deadline, a RPC bloqueia todo membro não-`manage_platform` → o handler cai em `TRIBES_MSG.errorSelect` = "Erro ao selecionar".

O fluxo **vivo e correto** é o híbrido em `/workspace` (`TribeRequestBlock` → `request_tribe_assignment` → aprovação do líder → engagement, PRs #793/#794/#795).

## Fix (mínimo)
No handler `selectTribe` de `TribesSection`:
- **Mantidas** as guardas: não-logado → `open-auth`; guest → aviso; líder → aviso.
- **Removida** a ação de escrita legada (checagem de deadline + `deselect_tribe` + `select_tribe`) e substituída por `window.location.assign('/workspace')`.

Retira a RPC morta da landing e leva o membro ao fluxo que funciona. Mudança de troca de tribo segue GP-mediada (fora do self-service, como já era o modelo).

## Validação
`npx astro build` OK · `npm test` 4716 pass / 0 fail · sem chamadas `select_tribe`/`deselect_tribe` restantes no arquivo.

## Follow-up
Auditoria completa da jornada de entrada em tribo (inventário de superfícies, aposentar de vez o legado, guardas do fluxo vivo, i18n) em **#1247**.