### PR TITLE
chore(tribes): #1247 aposenta legado select_tribe + #1249 testes de roster data-driven

### DIFF
--- a/docs/adr/ADR-0123-retire-legacy-select-tribe-write-path.md
+++ b/docs/adr/ADR-0123-retire-legacy-select-tribe-write-path.md
@@ -1,0 +1,44 @@
+# ADR-0123 - Aposentadoria do write-path legado select_tribe / deselect_tribe
+
+**Status:** Accepted (2026-07-09)
+**Relacionado:** #1247 (auditoria da jornada de entrada em tribo) · #1248 (fix do picker da landing) · #1138 (MCP do fluxo híbrido, gap) · #1249 (testes de roster frágeis) · memória `reference-tribe-selection-hybrid-journey` · PRs #793/#794/#795 (fluxo híbrido vivo)
+
+## Contexto
+
+A plataforma tem duas superfícies de entrada em tribo, e a legada é um write-path perigoso:
+
+1. **Legado (`select_tribe` / `deselect_tribe`):** grava `members.tribe_id` via `tribe_selections` + trigger `sync_tribe_id_from_selection`, **sem criar engagement e sem aprovação do líder**. Nasceu do modelo de seleção em lote (deadline `home_schedule.selection_deadline_at`), anterior ao Domain Model V4.
+2. **Vivo (híbrido, contínuo):** `request_tribe_assignment` (pedido) -> `review_tribe_request` do líder (aprovação) -> cria `engagements` -> trigger `_sync_tribe_id_from_engagement` grava `members.tribe_id`. Fonte de autoridade correta no V4 (engagement e o primitivo).
+
+No kickoff do Ciclo 4 (2026-07-09), vários pesquisadores relataram "Erro ao selecionar" ao usar o picker da landing (`TribesSection.astro`), que chamava `select_tribe`. A auditoria #1247 (grounding ao vivo) apurou que o erro era um composto, não só o deadline:
+
+- O frontend engolia a mensagem descritiva da RPC e pintava o toast genérico `tribes.errorSelect` = "Erro ao selecionar" para QUALQUER falha.
+- Falhas reais no kickoff: tribo lotada (tribos 1, 4, 6, 8 estavam em 7/7, limite = 7), termo de voluntário não assinado, e possivelmente deadline (que no momento da auditoria já estava estendido para 2026-07-18, aberto).
+
+Consequência arquitetural mais grave: o write-path legado produziu **12 memberships fantasma** (pesquisadores C4 com `members.tribe_id` setado mas SEM engagement V4), reconciliados na mesma sessão (engagement retroativo, drift 13 -> 1, restando apenas 1 chapter_liaison esperado).
+
+O PR #1248 já cortou o write-path do botão da landing (passou a redirecionar para `/workspace`). Faltava cortar as demais superfícies de escrita.
+
+## Decisão
+
+Aposentar o write-path legado de seleção de tribo, mantendo a RPC no banco.
+
+1. **Tools MCP `select_tribe` e `deselect_tribe` RETIRADAS** (`supabase/functions/nucleo-mcp/index.ts`). Eram os últimos consumidores de escrita do legado alcançáveis por um agente. O fluxo vivo (`request_tribe_assignment`) ainda NÃO tem tool MCP (gap #1138); a assimetria e assumida conscientemente ate #1138.
+2. **Entradas removidas do `src/lib/mcp-manifest.json`** (`select_tribe`, `deselect_tribe`).
+3. **Strings i18n órfãs removidas** nas 3 línguas (`tribes.errorSelect`, `tribes.selectedSuccess`) e no `TRIBES_MSG` do `TribesSection.astro` (inalcançáveis após o corte do write).
+4. **RPCs `select_tribe` / `deselect_tribe` / `sync_tribe_id_from_selection` NÃO são dropadas.** A migration `20260805000216` marca `select_tribe` como "LEGACY (frozen) - do NOT drop without a deprecation ADR": este e o ADR. Dropar exigiria remover o trigger `trg_sync_tribe_id` e migrar/limpar `tribe_selections` (43 linhas, 7 divergentes de `members.tribe_id`), fora do escopo do estanca-sangramento. Ficam inertes: sem superfície de escrita, ninguem mais as invoca.
+5. **`count_tribe_slots` MANTIDA.** E read-only (telemetria de ocupação por `members.tribe_id`), consumida pela vitrine da landing para pintar vagas. Não é write-path nem gera fantasma; remover degradaria a vitrine sem ganho de segurança.
+
+## Alternativas rejeitadas
+
+- **Drop total das RPCs legadas agora.** Rejeitada: exige desmontar o trigger de sync e uma migração de dados de `tribe_selections`, com risco em plena virada C4. O ganho (higiene) não justifica o risco no momento; as RPCs inertes não são footgun sem superfície de escrita.
+- **Reabrir o deadline de `select_tribe` como caminho oficial.** Rejeitada: mantém o defeito de raiz (membership sem engagement nem aprovação do líder), que é justamente o que produziu os 12 fantasma.
+- **Carve-out no `TribesSection` mantendo o botão escrever direto.** Rejeitada pelo #1248: a landing deve rotear para o fluxo vivo, não ser uma segunda fonte de escrita.
+
+## Consequências
+
+- Nenhuma superfície de escrita de tribo passa por fora do modelo V4. Novo membership de tribo só nasce de `request_tribe_assignment` -> `review_tribe_request` -> engagement (ou dos caminhos admin `admin_*_tribe`, que são governados).
+- **Gap remanescente (#1138):** o fluxo híbrido vivo não tem tool MCP. Um agente que precise "entrar em tribo" via MCP não tem mais o atalho legado (bom: era quebrado) nem um substituto vivo (pendente). Priorizar a tool `request_tribe_assignment` no #1138.
+- **Bug legado conhecido (não corrigido de propósito):** `deselect_tribe` fazia `DELETE FROM tribe_selections`, mas o trigger de sync só dispara em INSERT/UPDATE, então `members.tribe_id` ficava preso. Com a tool retirada e a RPC inerte, o bug não tem mais superfície de disparo; sera resolvido junto do drop futuro das RPCs, se e quando ocorrer.
+- **Pré-deploy MCP:** a retirada de 2 tools muda a contagem do `tools/list`; rodar `node scripts/audit-mcp-tool-matrix.mjs --runtime` após o deploy da EF `nucleo-mcp` para confirmar `runtime ≡ static` (sem drift).
+- **Follow-up:** limpeza de `tribe_selections` + drop das RPCs legadas + correção/remoção do trigger de sync legado, quando houver janela fora de virada de ciclo.

--- a/src/components/sections/TribesSection.astro
+++ b/src/components/sections/TribesSection.astro
@@ -147,8 +147,6 @@ const TRIBES_MSG = {
   selectionRemoved: t('tribes.selectionRemoved', lang),
   tribeFull: t('tribes.tribeFull', lang),
   errorRemove: t('tribes.errorRemove', lang),
-  errorSelect: t('tribes.errorSelect', lang),
-  selectedSuccess: t('tribes.selectedSuccess', lang),
   selectionUnavailable: t('tribes.selectionUnavailable', lang),
   selectBtn: t('tribes.select', lang),
   selected: t('tribes.selected', lang),

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -844,8 +844,6 @@ const enUS: Record<string, string> = {
   'tribes.selectionRemoved': 'Selection removed',
   'tribes.tribeFull': 'Stream is full!',
   'tribes.errorRemove': 'Error removing',
-  'tribes.errorSelect': 'Error selecting',
-  'tribes.selectedSuccess': 'Stream {id} selected! ✓',
   'tribes.loading': 'Loading...',
   'tribes.trailsUnavailable': 'Trail data temporarily unavailable. Refresh the page in a moment.',
 

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -844,8 +844,6 @@ const esLATAM: Record<string, string> = {
   'tribes.selectionRemoved': 'Selección removida',
   'tribes.tribeFull': '¡Línea completa!',
   'tribes.errorRemove': 'Error al remover',
-  'tribes.errorSelect': 'Error al seleccionar',
-  'tribes.selectedSuccess': '¡Línea {id} seleccionada! ✓',
   'tribes.loading': 'Cargando...',
   'tribes.trailsUnavailable': 'Datos de líneas temporalmente no disponibles. Actualiza la página en un momento.',
 

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -844,8 +844,6 @@ const ptBR: Record<string, string> = {
   'tribes.selectionRemoved': 'Seleção removida',
   'tribes.tribeFull': 'Tribo lotada!',
   'tribes.errorRemove': 'Erro ao remover',
-  'tribes.errorSelect': 'Erro ao selecionar',
-  'tribes.selectedSuccess': 'Tribo {id} selecionada! ✓',
   'tribes.loading': 'Carregando...',
   'tribes.trailsUnavailable': 'Dados de trilhas indisponíveis temporariamente. Atualize a página em alguns instantes.',
 

--- a/src/lib/mcp-manifest.json
+++ b/src/lib/mcp-manifest.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-07-09T12:01:02.386Z",
+  "generated_at": "2026-07-10T02:58:33.572Z",
   "source": "supabase/functions/nucleo-mcp/index.ts",
-  "total": 337,
+  "total": 335,
   "by_domain": {
     "personal": 22,
-    "tribe": 106,
+    "tribe": 104,
     "board": 70,
     "events": 15,
     "governance": 23,
@@ -17,7 +17,7 @@
     "health": 18
   },
   "by_permission": {
-    "read": 222,
+    "read": 220,
     "write": 106,
     "admin": 9
   },
@@ -201,13 +201,6 @@
     {
       "name": "compute_pert_cutoff",
       "description": "Admin trigger: recomputes the PERT cutoff for a selection cycle and persists target/band/cohort_n columns on every application. Two dimensions can be recomputed independently: objective (default; writes pert_target_score/pert_band_*/pert_cohort_n/pert_cutoff_method/pert_calc_at) and leader_extra (score_column='leader_extra_pert_score'; writes leader_extra_pert_target/band_*/cohort_n/cutoff_method/calc_at). Cohort = applicants approved + engaged as active volunteer in prior cycles, filtered by role. Method: dynamic (n>=10) | historical_fallback | disabled. Auth: manage_member. Logs to admin_audit_log. Note: the weekly cron recompute-pert-cutoffs-weekly already calls BOTH dimensions per active cycle — use this MCP tool only for on-demand admin recompute (e.g., before committee final decision).",
-      "domain": "tribe",
-      "permission": "read",
-      "is_sensitive": false
-    },
-    {
-      "name": "deselect_tribe",
-      "description": "Remove a seleção de tribe do caller. Wrap RPC existente.",
       "domain": "tribe",
       "permission": "read",
       "is_sensitive": false
@@ -649,13 +642,6 @@
     {
       "name": "search_members",
       "description": "Search members by name, filter by tribe, tier, or status. Admin/GP only.",
-      "domain": "tribe",
-      "permission": "read",
-      "is_sensitive": false
-    },
-    {
-      "name": "select_tribe",
-      "description": "Seleciona/atualiza tribe preferida do caller (candidato selecionado). Wrap RPC existente.",
       "domain": "tribe",
       "permission": "read",
       "is_sensitive": false

--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -2147,8 +2147,9 @@ function registerTools(mcp: McpServer, sb: Sb) {
     return ok(data);
   });
 
-  // ===== #87 CANDIDATO + COMMITTEE MCP JOURNEY (8 tools) =====
-  // 6 new RPCs + 2 wrappers around existing select_tribe/deselect_tribe RPCs
+  // ===== #87 CANDIDATO + COMMITTEE MCP JOURNEY =====
+  // 6 candidate/committee self-service RPCs. (The 2 legacy select_tribe/deselect_tribe
+  // wrappers that used to live here were retired in #1247 — see ADR-0123.)
 
   // update_my_application — patch own non-evaluator fields
   mcp.tool("update_my_application", "Atualiza campos do próprio application em ciclo ativo. Allowed: linkedin_url, resume_url, motivation_letter, areas_of_interest, leadership_experience, academic_background, non_pmi_experience, availability_declared, proposed_theme, credly_url, linkedin_relevant_posts, reason_for_applying, phone. Bloqueado durante evaluating/interviews/ranking phases.", {
@@ -2230,29 +2231,12 @@ function registerTools(mcp: McpServer, sb: Sb) {
     return ok(data);
   });
 
-  // select_tribe — wraps existing RPC (Tier 1 candidato selecionado)
-  mcp.tool("select_tribe", "Seleciona/atualiza tribe preferida do caller (candidato selecionado). Wrap RPC existente.", {
-    tribe_id: z.number().describe("Tribe ID (1-8)")
-  }, async (params: { tribe_id: number }) => {
-    const start = Date.now();
-    const member = await getMember(sb);
-    if (!member) { await logUsage(sb, null, "select_tribe", false, "Not authenticated", start); return err("Not authenticated"); }
-    const { data, error } = await sb.rpc("select_tribe", { p_tribe_id: params.tribe_id });
-    if (error) { await logUsage(sb, member.id, "select_tribe", false, error.message, start); return err(error.message); }
-    await logUsage(sb, member.id, "select_tribe", true, undefined, start);
-    return ok(data);
-  });
-
-  // deselect_tribe — wraps existing RPC
-  mcp.tool("deselect_tribe", "Remove a seleção de tribe do caller. Wrap RPC existente.", {}, async () => {
-    const start = Date.now();
-    const member = await getMember(sb);
-    if (!member) { await logUsage(sb, null, "deselect_tribe", false, "Not authenticated", start); return err("Not authenticated"); }
-    const { data, error } = await sb.rpc("deselect_tribe");
-    if (error) { await logUsage(sb, member.id, "deselect_tribe", false, error.message, start); return err(error.message); }
-    await logUsage(sb, member.id, "deselect_tribe", true, undefined, start);
-    return ok(data);
-  });
+  // #1247: select_tribe / deselect_tribe MCP tools RETIRED. They wrapped the legacy
+  // select_tribe/deselect_tribe RPCs, which write members.tribe_id via tribe_selections
+  // WITHOUT creating an engagement — the exact path that produced 12 phantom C4
+  // memberships (tribe_id set, no V4 engagement) reconciled in the #1247 audit. The
+  // live self-service path is request_tribe_assignment → leader review_tribe_request
+  // → engagement (no MCP tool yet; gap tracked in #1138). See ADR-0123.
 
   // TOOL 39: get_anomaly_report — Admin only
   mcp.tool("get_anomaly_report", "Returns data quality anomaly report: inconsistencies, duplicates, drift. Admin only.", {}, async () => {

--- a/tests/contracts/1080-cycle-xp-bucket-taxonomy.test.mjs
+++ b/tests/contracts/1080-cycle-xp-bucket-taxonomy.test.mjs
@@ -134,15 +134,26 @@ test('#1080 behavioural: pillar buckets partition cycle_points; showcase_* route
     }
 
     let checked = 0;
-    let showcaseCovered = false;
     for (const [mid, m] of agg) {
       const sum = m.presenca + m.trilha + m.cert + m.showcase + m.artifacts + m.bonus;
       assert.equal(sum, m.total, `buckets must sum to cycle_points for member ${mid}`);
-      if (m.showcase > 0) showcaseCovered = true;
       checked++;
     }
     assert.ok(checked > 0, 'at least one member with cycle XP was checked');
-    // Guards the regression: with the old bare-slug filter, granular showcase_* would land in bonus
-    // and no member would show showcase XP unless they had a legacy bare 'showcase' row.
-    assert.ok(showcaseCovered, 'at least one member routes producao showcase_* XP into cycle_showcase');
+
+    // #1249/#1123: the showcase_* routing regression is defended over the WHOLE ledger, not just the
+    // current cycle. A fresh cycle (C4) can carry zero showcase XP (data absence, not a routing bug),
+    // which used to red the assertion. Routing is cycle-independent, so re-aggregate showcase_* across
+    // all cycles; skip only if the platform has no showcase XP at all (nothing to defend).
+    const { data: allPts } = await sb.from('gamification_points').select('category,points,organization_id');
+    let showcaseTotal = 0, anyShowcaseCategory = false;
+    for (const p of allPts || []) {
+      if (!String(p.category).startsWith('showcase')) continue;
+      anyShowcaseCategory = true;
+      const pillar = pillarBySlugOrg.get(`${p.organization_id}:${p.category}`) ?? null;
+      // regression: with the old bare-slug filter, granular showcase_* resolved to pillar null → bonus.
+      if (pillar === 'producao') showcaseTotal += p.points;
+    }
+    if (!anyShowcaseCategory) { t.skip('no showcase_* XP in the ledger yet — routing regression not exercisable'); return; }
+    assert.ok(showcaseTotal > 0, 'showcase_* XP resolves to the producao pillar (routes to showcase, not bonus)');
   });

--- a/tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs
+++ b/tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs
@@ -32,6 +32,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
+import { rosterViewCount } from '../helpers/roster-oracle.mjs';
 
 const ROOT = process.cwd();
 const MIG = resolve(ROOT, 'supabase/migrations/20260805000089_p277_419_m4_gamification_cohort_roster.sql');
@@ -140,35 +141,38 @@ test('M4-gam DB: auth gate intact — no-auth caller gets in-band Unauthorized (
   assert.equal(di?.error, 'Unauthorized', 'get_initiative_gamification gate returns in-band Unauthorized for no-auth caller');
 });
 
-test('M4-gam DB: tribe-8 cohort == canonical roster == 5 (participants-only); the count get_tribe_gamification now returns', { skip: dbGated ? false : skipMsg }, async () => {
+test('M4-gam DB: tribe-8 cohort == canonical roster (single source)', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
   const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: TRIBE8 });
   const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
-  assert.equal(Number(roster), 5, 'tribe-8 canonical roster = 5 (mig 088: observer-kind curator Roberto excluded)');
+  const viewCount = await rosterViewCount(sb, initId);
+  // #1249: single-source (RPC == canonical view), not the dead absolute fixture (== 5).
+  assert.equal(Number(roster), viewCount, 'tribe-8 roster RPC == canonical view (single source)');
 });
 
-test('M4-gam DB: native forks KILLED — Mesa=4, LATAM=3, Grupo=3 (== get_initiative_stats == roster)', { skip: dbGated ? false : skipMsg }, async () => {
+test('M4-gam DB: native forks — get_initiative_stats.member_count == roster == canonical view (single source)', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
-  const expect = { [MESA]: 4, [LATAM]: 3, [GRUPO]: 3 };
-  for (const [id, n] of Object.entries(expect)) {
+  // #1249: the absolute fixtures (Mesa=4, LATAM=3, Grupo=3) are dead cohort snapshots — Grupo drifted
+  // to 5 as its study group grew. The durable contract: get_initiative_stats shares the roster, and
+  // both equal the canonical view. Observer-kind reviewers stay excluded (defended by the roster tests).
+  for (const id of [MESA, LATAM, GRUPO]) {
+    const viewCount = await rosterViewCount(sb, id);
     const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: id });
     const { data: stats } = await sb.rpc('get_initiative_stats', { p_initiative_id: id });
-    assert.equal(Number(roster), n, `roster(${id}) == ${n}`);
-    assert.equal(Number(stats.member_count), n,
-      `get_initiative_stats(${id}).member_count == ${n} — get_initiative_gamification now agrees (shares the roster)`);
+    assert.equal(Number(roster), viewCount, `roster(${id}) == canonical view`);
+    assert.equal(Number(stats.member_count), viewCount, `get_initiative_stats(${id}).member_count == canonical view (shares the roster)`);
   }
 });
 
-test('M4-gam DB: only tribe-8 changed — other tribes stable (drift-tolerant baselines)', { skip: dbGated ? false : skipMsg }, async () => {
+test('M4-gam DB: get_initiative_roster_count agrees with the canonical view across tribes (single source)', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
-  // tribe-6 6→5: offboarding legítimo de membro em 2026-06-11 (alumni, ROI & Portfólio)
-  // tribe-2 REMOVIDA da baseline em 2026-07-08: T2 arquivada no DIA 9 (líder → alumni,
-  // #1124) e o roster drena conforme os 3 órfãos re-selecionam tribo até 17/07 — não há
-  // valor estável para pinar (histórico: 5→4 com o offboard do Ricardo em 04/07).
-  const expect = { 1: 4, 6: 5 };
-  for (const [tid, n] of Object.entries(expect)) {
-    const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: Number(tid) });
+  // #1249: the migration-088 snapshot ({1:4,6:5}) was a dead cohort fixture, broken at the C4 kickoff
+  // (reorg + #1247 phantom-membership regularization). Durable invariant: the roster helper reads the
+  // canonical view for every tribe.
+  for (const tid of [1, 6, 8]) {
+    const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: tid });
+    const viewCount = await rosterViewCount(sb, initId);
     const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
-    assert.equal(Number(roster), n, `tribe ${tid} roster == ${n} (unchanged)`);
+    assert.equal(Number(roster), viewCount, `tribe ${tid} roster RPC == canonical view (single source)`);
   }
 });

--- a/tests/contracts/p277-419-m4a-roster-primitive.test.mjs
+++ b/tests/contracts/p277-419-m4a-roster-primitive.test.mjs
@@ -22,6 +22,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
+import { rosterViewCount } from '../helpers/roster-oracle.mjs';
 
 const ROOT = process.cwd();
 const MIG = resolve(ROOT, 'supabase/migrations/20260805000082_p277_419_m4a_initiative_roster_primitive.sql');
@@ -64,13 +65,14 @@ test('M4-A behavioural: tribe 8 roster = 5, EXCLUDES the observer-kind curator R
   assert.ifError(e0);
   const { data: count, error: e1 } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
   assert.ifError(e1);
-  // mig 088 (PM 2026-06-01) revised the canonical roster to PARTICIPANTS-ONLY (added kind<>'observer'):
-  // the observer-kind curator Roberto no longer counts as a member. tribe-8 6 → 5.
-  assert.equal(count, 5, 'tribe-8 canonical roster = 5 (participants-only; observers excluded)');
 
   const { data: rows, error: e2 } = await sb
     .from('v_initiative_roster').select('name, role, kind').eq('initiative_id', initId);
   assert.ifError(e2);
+  // #1249: the absolute fixture (tribe-8 == 5) died when the C4 cohort evolved (kickoff reorg +
+  // #1247 phantom-membership regularization). The DURABLE contract is participants-only + single
+  // source: the helper count equals the canonical view rows, and NO observer (role OR kind) survives.
+  assert.equal(Number(count), await rosterViewCount(sb, initId), 'helper count == distinct person over the canonical view (single source)');
   assert.ok(!rows.some((r) => r.name === 'Roberto Macêdo'),
     'the observer-kind curator Roberto (role=curator/kind=observer) is EXCLUDED — observers are not participating members');
   assert.equal(rows.filter((r) => r.role === 'observer' || r.kind === 'observer').length, 0, 'no observer rows (role OR kind)');
@@ -82,7 +84,7 @@ test('M4-A behavioural: helper count == COUNT(DISTINCT person) over the view, pe
   const { data: count } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
   const { data: rows } = await sb.from('v_initiative_roster').select('person_id').eq('initiative_id', initId);
   const distinct = new Set(rows.map((r) => r.person_id)).size;
-  assert.equal(Number(count), distinct, 'helper == distinct person over the view');
-  // 6→5 em 2026-06-11: offboarding legítimo (alumni, ROI & Portfólio)
-  assert.equal(Number(count), 5, 'tribe-6 canonical roster = 5');
+  // #1249: single-source contract (helper == distinct person over the view). The absolute tribe-6
+  // fixture (== 5) is a dead cohort snapshot, dropped when the C4 cohort evolved.
+  assert.equal(Number(count), distinct, 'helper == distinct person over the view (single source)');
 });

--- a/tests/contracts/p277-419-m4b-digest-roster.test.mjs
+++ b/tests/contracts/p277-419-m4b-digest-roster.test.mjs
@@ -60,8 +60,10 @@ test('M4-B behavioural: tribe-8 digest active_members == roster count (5, partic
   const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: 8 });
   const { data: rosterCount } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
 
-  assert.equal(active, Number(rosterCount), 'digest active_members == canonical roster count');
-  assert.equal(active, 5, 'tribe-8 active_members = 5 (participants-only, mig 088: observer-kind curator excluded; offboarded Maria also not counted)');
+  // #1249: the durable contract is single-source (digest == canonical roster count). The absolute
+  // fixture (== 5) died when the C4 cohort evolved (kickoff reorg + #1247 phantom-membership
+  // regularization); the participants-only invariant is defended structurally + by the roster tests.
+  assert.equal(active, Number(rosterCount), 'digest active_members == canonical roster count (single source)');
 
   // the rest of the digest still computes (a representative non-roster aggregate is present + numeric)
   assert.equal(typeof Number(digest.aggregates.cards_overdue_total), 'number', 'cards_overdue_total still computes');

--- a/tests/contracts/p277-419-m4c-clean-stats-cross-roster.test.mjs
+++ b/tests/contracts/p277-419-m4c-clean-stats-cross-roster.test.mjs
@@ -31,6 +31,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
+import { rosterViewCount } from '../helpers/roster-oracle.mjs';
 
 const ROOT = process.cwd();
 const MIG = resolve(ROOT, 'supabase/migrations/20260805000086_p277_419_m4c_clean_stats_cross_roster.sql');
@@ -122,7 +123,9 @@ test('M4-C-clean DB: get_tribe_stats(8).member_count == roster primitive == 5 (p
   const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: TRIBE8 });
   const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
   const { data: stats } = await sb.rpc('get_tribe_stats', { p_tribe_id: TRIBE8 });
-  assert.equal(Number(roster), 5, 'tribe-8 canonical roster = 5 (participants-only, mig 088: observer-kind curator excluded)');
+  const viewCount = await rosterViewCount(sb, initId);
+  // #1249: dead absolute fixture (== 5) removed; single-source instead (roster == view == stats).
+  assert.equal(Number(roster), viewCount, 'roster helper == canonical view (single source)');
   assert.equal(Number(stats.member_count), Number(roster), 'get_tribe_stats.member_count reads the primitive');
 });
 

--- a/tests/contracts/p277-419-m4c-exec-tribe-dashboard-roster.test.mjs
+++ b/tests/contracts/p277-419-m4c-exec-tribe-dashboard-roster.test.mjs
@@ -30,6 +30,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
+import { rosterViewCount } from '../helpers/roster-oracle.mjs';
 
 const ROOT = process.cwd();
 const MIG = resolve(ROOT, 'supabase/migrations/20260805000084_p277_419_m4c_exec_tribe_dashboard_roster.sql');
@@ -112,17 +113,20 @@ test('M4-C DB: tribe-8 canonical roster == 5 (participants-only, mig 088); the v
   assert.ifError(e0);
   const { data: roster, error: e1 } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
   assert.ifError(e1);
-  assert.equal(Number(roster), 5, 'tribe-8 canonical roster = 5 (participants-only, mig 088: observer-kind curator Roberto excluded)');
+  const viewCount = await rosterViewCount(sb, initId);
+  // #1249: single-source contract (RPC == canonical view), not the dead absolute fixture (== 5).
+  assert.equal(Number(roster), viewCount, 'get_initiative_roster_count == canonical view (single source)');
 });
 
-test('M4-C DB: only tribe 8 changed — other tribes stable (drift-tolerant)', { skip: dbGated ? false : skipMsg }, async () => {
+test('M4-C DB: get_initiative_roster_count agrees with the canonical view across tribes (single source)', { skip: dbGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SUPABASE_KEY, { auth: { persistSession: false } });
-  // canonical roster per tribe is what members.total now reads; assert the stable baselines hold
-  // tribe-6 6→5: offboarding legítimo de membro em 2026-06-11 (alumni, ROI & Portfólio)
-  const expect = { 1: 4, 6: 5 };
-  for (const [tid, n] of Object.entries(expect)) {
-    const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: Number(tid) });
+  // #1249: the migration-088 snapshot ({1:4,6:5}) was a dead cohort fixture — it broke at the C4
+  // kickoff (reorg + #1247 phantom-membership regularization). The durable invariant is that
+  // members.total (get_initiative_roster_count) reads the canonical view for EVERY tribe.
+  for (const tid of [1, 6, 8]) {
+    const { data: initId } = await sb.rpc('resolve_initiative_id', { p_tribe_id: tid });
+    const viewCount = await rosterViewCount(sb, initId);
     const { data: roster } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: initId });
-    assert.equal(Number(roster), n, `tribe ${tid} roster == ${n} (unchanged by PR4-C)`);
+    assert.equal(Number(roster), viewCount, `tribe ${tid} roster RPC == canonical view (single source)`);
   }
 });

--- a/tests/contracts/p277-419-roster-participants-only.test.mjs
+++ b/tests/contracts/p277-419-roster-participants-only.test.mjs
@@ -27,6 +27,7 @@ import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
 import { attendanceCycleStart } from '../helpers/reference-cycle.mjs';
+import { rosterViewCount } from '../helpers/roster-oracle.mjs';
 
 const ROOT = process.cwd();
 const MIG = resolve(ROOT, 'supabase/migrations/20260805000088_p277_419_roster_participants_only.sql');
@@ -68,15 +69,15 @@ test('roster participants-only forward-defense: this migration does NOT touch ge
 test('roster participants-only DB: tribe-8 = 5, natives LATAM = 3 / Grupo = 3 / Mesa = 4', { skip: svcGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false } });
   const { data: t8Init } = await sb.rpc('resolve_initiative_id', { p_tribe_id: 8 });
-  const counts = {};
-  for (const [k, id] of Object.entries({ tribe8: t8Init, LATAM, GRUPO: GRUPO, MESA })) {
-    const { data } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: id });
-    counts[k] = Number(data);
+  // #1249: the absolute fixtures (tribe8=5, LATAM=3, Grupo=3, Mesa=4) are dead cohort snapshots — the
+  // C4 kickoff reorg + #1247 phantom-membership regularization moved tribe-8 to 7, Grupo grew to 5.
+  // Durable contract: get_initiative_roster_count == the canonical view for each initiative (single
+  // source). The observers-excluded invariant is asserted in the next test + the m4a/static tests.
+  for (const id of [t8Init, LATAM, GRUPO, MESA]) {
+    const { data: rpcCount } = await sb.rpc('get_initiative_roster_count', { p_initiative_id: id });
+    const viewCount = await rosterViewCount(sb, id);
+    assert.equal(Number(rpcCount), viewCount, `roster(${id}) RPC == canonical view (single source)`);
   }
-  assert.equal(counts.tribe8, 5, 'tribe-8 = 5 (curator Roberto excluded)');
-  assert.equal(counts.LATAM, 3, 'LATAM = 3 (Fabricio + Sarah observer-kind reviewers excluded)');
-  assert.equal(counts.GRUPO, 3, 'Grupo = 3 (Welma observer-kind reviewer excluded)');
-  assert.equal(counts.MESA, 4, 'Mesa = 4 (unchanged — its observers were already role=observer)');
 });
 
 test('roster participants-only DB: no observer rows (role OR kind) survive in any roster', { skip: svcGated ? false : skipMsg }, async () => {
@@ -87,22 +88,33 @@ test('roster participants-only DB: no observer rows (role OR kind) survive in an
     'no row has role=observer OR kind=observer');
 });
 
-test('roster participants-only DB: single-source propagation — get_tribe_stats(8) == digest == 5', { skip: svcGated ? false : skipMsg }, async () => {
+test('roster participants-only DB: single-source propagation — get_tribe_stats(8) == digest == canonical view', { skip: svcGated ? false : skipMsg }, async () => {
   const sb = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false } });
+  const { data: t8Init } = await sb.rpc('resolve_initiative_id', { p_tribe_id: 8 });
+  const viewCount = await rosterViewCount(sb, t8Init);
   const { data: stats } = await sb.rpc('get_tribe_stats', { p_tribe_id: 8 });
   const { data: digest } = await sb.rpc('get_weekly_tribe_digest', { p_tribe_id: 8 });
-  assert.equal(Number(stats.member_count), 5, 'get_tribe_stats tribe-8 member_count = 5 (via primitive)');
-  assert.equal(Number(digest.aggregates.active_members), 5, 'weekly digest tribe-8 active_members = 5 (via primitive)');
+  // #1249: single-source propagation — both surfaces read the same primitive (== canonical view),
+  // not a dead absolute fixture (== 5).
+  assert.equal(Number(stats.member_count), viewCount, 'get_tribe_stats tribe-8 member_count == canonical view');
+  assert.equal(Number(digest.aggregates.active_members), viewCount, 'weekly digest tribe-8 active_members == canonical view');
 });
 
-test('roster participants-only DB: metric-3 is INDEPENDENT — get_member_tribe still kind-based (M4-F not applied)', { skip: svcGated ? false : skipMsg }, async (t) => {
+test('roster participants-only DB: metric-3 is INDEPENDENT — get_member_tribe drives the attendance cohort, not the roster', { skip: svcGated ? false : skipMsg }, async (t) => {
   const sb = createClient(SUPABASE_URL, SERVICE_KEY, { auth: { persistSession: false } });
   // Roberto's get_member_tribe stays NULL (his tribe-8 engagement is kind=observer) → he is NOT pulled into
-  // the tribe-8 attendance cohort. tribe-8 engagement cohort_n stays 5 (unchanged by the roster revision).
+  // the tribe-8 attendance cohort. #1249: the absolute fixture (cohort_n == 5) died when #1247 regularized
+  // 2 phantom tribe-8 memberships (their new engagements gave them get_member_tribe=8). The durable
+  // contract: the attendance cohort is the get_member_tribe axis — active researchers/leaders whose
+  // engagement resolves to tribe-8 — and it EXCLUDES the observer-kind liaison (get_member_tribe NULL).
   const cs = await attendanceCycleStart(sb); // most recent populated cycle (#1123)
   if (!cs) { t.skip('no populated attendance cohort — cycle turnover (#1234)'); return; }
   const { data: t8eng } = await sb.rpc('get_attendance_engagement_summary', { p_scope: 'tribe', p_scope_id: 8, p_cycle_start: cs });
-  assert.equal(Number(t8eng.cohort_n), 5, 'metric-3 tribe-8 cohort_n = 5 (unchanged — reads operational_role + get_member_tribe, not the roster)');
+  const { count: cohortExpected } = await sb.from('members')
+    .select('*', { count: 'exact', head: true })
+    .eq('tribe_id', 8).eq('is_active', true).in('operational_role', ['researcher', 'tribe_leader']);
+  assert.equal(Number(t8eng.cohort_n), cohortExpected,
+    'metric-3 cohort_n == active researchers/leaders resolving to tribe-8 (get_member_tribe axis, observers excluded)');
 });
 
 test('roster participants-only DB: anon CANNOT SELECT the view (mig-085 lockdown intact)', { skip: anonGated ? false : 'anon key required' }, async () => {

--- a/tests/helpers/roster-oracle.mjs
+++ b/tests/helpers/roster-oracle.mjs
@@ -1,0 +1,19 @@
+/**
+ * Independent oracle for the canonical roster count (#1249).
+ *
+ * get_initiative_roster_count is COUNT(DISTINCT person_id) over v_initiative_roster (a person with two
+ * engagements on the same initiative — e.g. volunteer + speaker — is ONE roster member). Single-source
+ * contract tests derive the expected count from the view with the SAME distinct-person definition, so
+ * they compare the RPC against the view without hardcoding a cohort fixture that dies at every cohort
+ * change (kickoff reorg, #1247 phantom-membership regularization).
+ *
+ * Cross-ref: issue #1249; SPEC p277/#419 (participants-only roster).
+ */
+export async function rosterViewCount(sb, initiativeId) {
+  const { data, error } = await sb
+    .from('v_initiative_roster')
+    .select('person_id')
+    .eq('initiative_id', initiativeId);
+  if (error) throw error;
+  return new Set((data || []).map((r) => r.person_id)).size;
+}


### PR DESCRIPTION
## Auditoria da jornada de entrada em tribo (#1247) — inventário ponta-a-ponta + aposentadoria do legado

Fecha #1247 e #1249. O PR #1248 foi o estanca-sangramento da landing; este é o inventário completo + a decisão de aposentar o legado + a reconciliação de dados que a auditoria expôs.

### Root cause do "Erro ao selecionar" (reinterpretado com grounding vivo)
Foi um **composto**, não só o deadline. O `TribesSection` chamava `select_tribe` e, em QUALQUER falha, pintava o toast genérico `tribes.errorSelect`, engolindo a mensagem descritiva da RPC. Falhas reais no kickoff: tribo **lotada** (tribos 1/4/6/8 em 7/7, limite 7), **termo não assinado**, e possivelmente o deadline (que ao vivo já estava estendido para 2026-07-18). Independente disso, `select_tribe` é arquiteturalmente errado: grava `members.tribe_id` sem engagement nem aprovação do líder.

### Achados
1. **Membership fantasma — 12 pesquisadores C4** com `tribe_id` mas SEM engagement V4 (8 via select_tribe legado, 4 movidos à mão na reorg, incluindo 2 das reclamantes do WhatsApp). Mérito/roster V4 não computavam.
2. **`deselect_tribe` bug**: trigger de sync só em INSERT/UPDATE, não DELETE → sair não limpa `tribe_id`.
3. **Assimetria de superfícies**: MCP só expunha o legado; o fluxo vivo (`request_tribe_assignment`) não tem tool (gap #1138).
4. **Lixo do legado**: i18n órfãos, tools no manifest.

**São (verificado):** guardas do `request_tribe_assignment` com mensagens descritivas; empty-state #1139; `review_tribe_request` com deep-link `?tab=members`; invariantes AG/AH intactos.

### Ações desta sessão
- **Regularização (DML já aplicado ao DB vivo):** 12 engagements `volunteer/participant/active` retroativos (`metadata.source=audit_1247_regularize_phantom`), welcome-notify suprimida no mesmo bloco transacional. Antes→depois: drift 13→1 (resta só o chapter_liaison Roberto, esperado), 0 welcome vazada, `check_schema_invariants()` = 0 violações.
- **Neutralização do legado (commit 1, ADR-0123):** tools MCP `select_tribe`/`deselect_tribe` retiradas, manifest regenerado (335 tools), i18n órfãos removidos nas 3 línguas. RPC mantida no banco (sem drop).
- **Testes de roster data-driven (commit 2, #1249):** a regularização mudou rosters vivos e deixou 13 testes-fixture vermelhos (a main já estava vermelha no CI Validate desde #1248). Refatorados para single-source (RPC == canonical view; helper `rosterViewCount` = distinct person), preservando os invariantes (observers excluídos, anon lockdown, forward-defense da migration). #1080: regressão showcase defendida all-time (ciclo C4 novo sem showcase XP).

### Validação
- `npx astro build`: OK.
- `npm test` (com DB): **5252 pass, 0 fail, 1 skip.**
- Manifest fresh test: OK (335).

### Follow-up (pós-merge)
- Deploy da EF `nucleo-mcp` + `audit-mcp-tool-matrix --runtime` (runtime ≡ static).
- #1138: tool MCP para o fluxo vivo `request_tribe_assignment`.
- Drop futuro das RPCs legadas + limpeza de `tribe_selections` fora de virada de ciclo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)