### PR TITLE
fix(tribes): sair da tribo não limpava members.tribe_id (dual-write re-derivava de initiative_id)

### DIFF
--- a/supabase/migrations/20260805000396_fix_leave_tribe_demotion_clears_initiative_id.sql
+++ b/supabase/migrations/20260805000396_fix_leave_tribe_demotion_clears_initiative_id.sql
@@ -1,0 +1,76 @@
+-- Fix: leave-tribe demotion must also clear members.initiative_id, not only tribe_id.
+--
+-- Root cause (found in live QA 2026-07-10, researcher Tiele Lara): withdraw_from_initiative
+-- offboards the tribe engagement and the AFTER trigger _sync_tribe_id_from_engagement clears
+-- members.tribe_id -- BUT members carries a dual-write pair (tribe_id + initiative_id, ADR-0005).
+-- The BEFORE-UPDATE bridge trigger sync_tribe_from_initiative re-derives tribe_id from the STILL-SET
+-- initiative_id (legacy_tribe_id lookup), so members.tribe_id was immediately re-set to its old value.
+-- Net effect: leaving a tribe never cleared members.tribe_id -> get_my_tribe_request_context kept
+-- returning has_tribe -> the picker never reopened (the researcher was stuck in the dead-end).
+--
+-- Fix: in the demotion branch, clear BOTH tribe_id AND initiative_id in the same UPDATE. With both
+-- NULL, both bridge triggers (sync_tribe_from_initiative / sync_initiative_from_tribe) no-op. We only
+-- null initiative_id when it currently references a research_tribe initiative, so a member's link to a
+-- NON-tribe initiative (if any) is preserved. The promotion branch and the atomic-switch path (#1263)
+-- are unchanged: activating a tribe engagement re-sets tribe_id and the bridge re-derives initiative_id.
+CREATE OR REPLACE FUNCTION public._sync_tribe_id_from_engagement()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_legacy_tribe_id integer;
+  v_member_id uuid;
+BEGIN
+  SELECT i.legacy_tribe_id INTO v_legacy_tribe_id
+  FROM public.initiatives i
+  WHERE i.id = NEW.initiative_id AND i.kind = 'research_tribe';
+
+  IF v_legacy_tribe_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  SELECT m.id INTO v_member_id
+  FROM public.members m
+  WHERE m.person_id = NEW.person_id;
+
+  IF v_member_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  IF NEW.status = 'active' THEN
+    UPDATE public.members
+       SET tribe_id = v_legacy_tribe_id
+     WHERE id = v_member_id
+       AND tribe_id IS DISTINCT FROM v_legacy_tribe_id;
+    RETURN NULL;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.status = 'active' AND NEW.status <> 'active' THEN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.engagements e2
+      JOIN public.initiatives i2 ON i2.id = e2.initiative_id AND i2.kind = 'research_tribe'
+      WHERE e2.person_id = NEW.person_id
+        AND e2.kind = 'volunteer'
+        AND e2.status = 'active'
+        AND e2.id <> NEW.id
+    ) THEN
+      UPDATE public.members m
+         SET tribe_id = NULL,
+             initiative_id = CASE
+               WHEN m.initiative_id IN (SELECT id FROM public.initiatives WHERE kind = 'research_tribe')
+                 THEN NULL
+               ELSE m.initiative_id
+             END
+       WHERE m.id = v_member_id
+         AND (
+           m.tribe_id IS NOT NULL
+           OR m.initiative_id IN (SELECT id FROM public.initiatives WHERE kind = 'research_tribe')
+         );
+    END IF;
+  END IF;
+
+  RETURN NULL;
+END; $function$;


### PR DESCRIPTION
**Bug P0 encontrado no QA ao vivo com usuária real** (Tiele Lara, 2026-07-10, testando o "sair da tribo → escolher outra").

## Sintoma
A Tiele clicou "Sair da tribo", escreveu a justificativa, e ao ir escolher a nova tribo **"diz q já estou na tribo"** — presa no beco.

## Root cause
`members` carrega o par **dual-write** `tribe_id` + `initiative_id` (ADR-0005). O fluxo:
1. `withdraw_from_initiative` offboarda a engagement.
2. Trigger AFTER `_sync_tribe_id_from_engagement` faz `UPDATE members SET tribe_id=NULL`.
3. Esse UPDATE dispara o trigger **BEFORE** `sync_tribe_from_initiative`, que vê `initiative_id != NULL AND tribe_id = NULL` e **re-deriva tribe_id de volta** (lookup `legacy_tribe_id`).
4. Net: `members.tribe_id` **nunca** era limpo → `get_my_tribe_request_context` seguia `has_tribe` → picker não reabria.

Afetava **todo voluntário com `initiative_id` setado** (todos de tribo via V4), não só a Tiele. A Wave 2 (#1256) não pegou: a invariante AH mede *engagements*, não a consistência do dual-write no `members`. Provado por reprodução rolled-back (`active→offboarded` deixava tribe_id=1).

## Fix
Migration `20260805000396`: no branch de demoção, limpar **as duas** colunas no mesmo UPDATE (com ambas NULL, os dois triggers-ponte viram no-op). `initiative_id` só é limpo quando aponta para uma iniciativa `research_tribe` (preserva vínculo a iniciativa NÃO-tribo). Promotion + troca atômica #1263 inalterados. Corpo baseado no vivo, byte-igual ao arquivo local.

## Validação (tool results ao vivo)
- Reprodução rolled-back: `active→offboarded` agora zera **tribe_id E initiative_id**.
- Gates DB-aware verdes: rpc-body-drift Phase C, rpc-migration-coverage, ADR-0097 (22/22).
- **Remediação de dados**: Tiele → `tribe_id/initiative_id=NULL`, `get_my_tribe_request_context.eligible=true` (12 tribos ofertadas). Ela já consegue escolher a nova.

## Follow-up
https://github.com/VitorMRodovalho/ai-pm-research-hub/issues/1269 — guard de regressão (teste/invariante) + reconciliar membros ativos com `tribe_id` órfão (ex.: Andre Abreu, classe #1247).

Migration já aplicada no remoto (fix vale em prod agora). Merge é da sessão dev.