### PR TITLE
feat(tribes): #1267 pré-check de único-voluntário antes do formulário de saída

### DIFF
--- a/src/components/tribe/TribeRequestBlock.tsx
+++ b/src/components/tribe/TribeRequestBlock.tsx
@@ -63,6 +63,10 @@ interface Context {
   // initiative_id null = legacy-only tribe_id with no engagement to withdraw from -> hide leave action.
   current_tribe_id?: number | null;
   current_tribe_initiative_id?: string | null;
+  // #1267: pre-check of the sole-volunteer/leader safeguard (mirrors withdraw's remaining_of_kind).
+  // false = the caller is the only active volunteer of the tribe -> self-leave is blocked; route to GP
+  // BEFORE the reason form. undefined/null (older backend / non-has_tribe) is treated as "not blocked".
+  can_self_leave?: boolean | null;
   pending: PendingRequest | null;
   tribes: TribeOption[];
 }
@@ -487,12 +491,19 @@ export default function TribeRequestBlock({ lang = 'pt-BR' }: Props) {
       // #1256: offer self-service leave only when there is an ACTIVE engagement to withdraw from.
       // Legacy-only tribe_id (no initiative_id) falls back to the "contact coordination" message.
       const canLeave = !!ctx.current_tribe_initiative_id;
+      // #1267: sole-volunteer/leader pre-check. Server says the withdraw would block (can_self_leave=false)
+      // -> show the GP-routing message in place of the button, so the reason form never appears. Strict
+      // === false so undefined/null (older backend) still allows the button; the withdraw RPC remains the
+      // authoritative gate (the leave() handler still catches remaining_of_kind as defense-in-depth).
+      const blockedSole = canLeave && ctx.can_self_leave === false;
       return (
         <section role="region" aria-label={copy.ariaLabel} className="mb-6">
           <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)] p-5">
             <h2 className="text-base font-extrabold text-navy dark:text-teal">{copy.hasTribeTitle}</h2>
             {!canLeave ? (
               <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{copy.hasTribeBody(ctx.current_tribe_title || null)}</p>
+            ) : blockedSole ? (
+              <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{copy.leaveBlockedSoleVolunteer}</p>
             ) : (
               <>
                 <p className="text-sm text-[var(--text-secondary)] mt-1.5 leading-relaxed">{copy.leaveTribeBody(ctx.current_tribe_title || null)}</p>

--- a/supabase/migrations/20260805000399_1267_sole_volunteer_precheck_context.sql
+++ b/supabase/migrations/20260805000399_1267_sole_volunteer_precheck_context.sql
@@ -1,0 +1,165 @@
+-- #1267 (Tribe UX) — surface the sole-volunteer/leader safeguard BEFORE the leave form.
+--
+-- Today the researcher who is the only active volunteer of their tribe (or its leader) only learns
+-- they cannot self-leave AFTER writing a reason (>= 10 chars) and confirming — the block comes from
+-- withdraw_from_initiative's `remaining_of_kind` return. Avoidable friction ("wrote the reason for
+-- nothing"). This extends get_my_tribe_request_context (ADDITIVE) to expose `can_self_leave` on the
+-- has_tribe case so the FE renders the GP-routing message in place of the button.
+--
+-- can_self_leave mirrors withdraw_from_initiative's guard exactly: if 'volunteer' is a required
+-- engagement kind of research_tribe AND the caller is the only active/onboarding volunteer of the
+-- tribe, withdraw would block -> can_self_leave = false. Only computed when there is an active
+-- engagement to leave (current_tribe_initiative_id present); NULL otherwise (legacy/no-tribe cases,
+-- where the FE already hides the leave action). The server RPC stays the source of truth; this is a
+-- pre-check for UX, not a new authority path.
+CREATE OR REPLACE FUNCTION public.get_my_tribe_request_context()
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_person_id uuid;
+  v_member_status text;
+  v_is_active boolean;
+  v_tribe_id integer;
+  v_has_tribe_engagement boolean;
+  v_eligible boolean;
+  v_reason text;
+  v_current_tribe_title text;
+  v_current_tribe_id integer;
+  v_current_tribe_initiative_id uuid;
+  v_pending jsonb;
+  v_tribes jsonb;
+  v_deadline timestamptz;
+  v_window_closed boolean;
+  v_can_self_leave boolean;
+  v_kind_required text[];
+  v_active_vol_count integer;
+BEGIN
+  SELECT m.id, m.person_id, m.member_status, m.is_active, m.tribe_id
+    INTO v_member_id, v_person_id, v_member_status, v_is_active, v_tribe_id
+    FROM public.members m WHERE m.auth_id = auth.uid();
+
+  IF v_member_id IS NULL THEN
+    RETURN jsonb_build_object('eligible', false, 'ineligible_reason', 'no_member', 'current_tribe_title', NULL, 'current_tribe_id', NULL, 'current_tribe_initiative_id', NULL, 'can_self_leave', NULL, 'pending', NULL, 'tribes', '[]'::jsonb, 'deadline', NULL);
+  END IF;
+
+  -- Deadline SSOT (absent/null = open window). Surfaced in the payload + drives the window_closed reason.
+  v_deadline := (SELECT (value #>> '{}')::timestamptz FROM public.platform_settings WHERE key = 'tribe_request_deadline');
+  v_window_closed := v_deadline IS NOT NULL AND now() > v_deadline;
+
+  -- caller's pending research_tribe self-request (invitee == me), if any.
+  -- #1255: invitation_id added so the FE can cancel this exact pending request.
+  SELECT to_jsonb(p) INTO v_pending FROM (
+    SELECT ii.id AS invitation_id, i.legacy_tribe_id AS tribe_id, i.title, ii.message, ii.created_at, ii.expires_at
+    FROM public.initiative_invitations ii
+    JOIN public.initiatives i ON i.id = ii.initiative_id AND i.kind = 'research_tribe'
+    WHERE ii.invitee_member_id = v_member_id AND ii.status = 'pending'
+    ORDER BY ii.created_at DESC
+    LIMIT 1
+  ) p;
+
+  -- already in a tribe via an active engagement?
+  v_has_tribe_engagement := EXISTS (
+    SELECT 1 FROM public.engagements e
+    JOIN public.initiatives i ON i.id = e.initiative_id AND i.kind = 'research_tribe'
+    WHERE e.person_id = v_person_id AND e.kind = 'volunteer' AND e.status = 'active'
+  );
+
+  -- eligible to self-request: active, termed (not pre-onboarding), no tribe yet (mirrors request_tribe_assignment)
+  v_eligible := v_is_active IS TRUE
+    AND v_tribe_id IS NULL
+    AND NOT v_has_tribe_engagement
+    AND v_person_id IS NOT NULL
+    AND NOT public.member_is_pre_onboarding(v_person_id, v_member_status);
+
+  -- #1139 Item 1: surface WHY when ineligible so the FE renders an explicit empty-state instead of a
+  -- blank block. Priority mirrors request_tribe_assignment's guard sequence: inactive → has-tribe → term.
+  -- Deadline enforcement: if the window is closed and the caller has no tribe (so they would want to
+  -- request), window_closed outranks the term/eligible states — after the deadline there is nothing to
+  -- request. has_tribe callers keep their own state (the deadline is about joining, not their membership).
+  IF v_window_closed AND v_tribe_id IS NULL AND NOT v_has_tribe_engagement THEN
+    v_eligible := false;
+    v_reason := 'window_closed';
+  ELSIF v_eligible THEN
+    v_reason := NULL;
+  ELSIF v_person_id IS NULL THEN
+    v_reason := 'no_member';
+  ELSIF v_is_active IS DISTINCT FROM true THEN
+    v_reason := 'inactive';
+  ELSIF v_tribe_id IS NOT NULL OR v_has_tribe_engagement THEN
+    v_reason := 'has_tribe';
+  ELSIF public.member_is_pre_onboarding(v_person_id, v_member_status) THEN
+    v_reason := 'pending_term';
+  ELSE
+    v_reason := 'ineligible';
+  END IF;
+
+  -- #1256: for the has_tribe empty-state, prefer the initiative where the caller holds the ACTIVE
+  -- volunteer engagement — withdraw_from_initiative requires an active engagement on that initiative,
+  -- so the FE's "leave tribe" action targets it. Returns tribe_id + initiative_id + title together.
+  IF v_reason = 'has_tribe' THEN
+    SELECT i.id, i.legacy_tribe_id, i.title
+      INTO v_current_tribe_initiative_id, v_current_tribe_id, v_current_tribe_title
+    FROM public.initiatives i
+    JOIN public.engagements e ON e.initiative_id = i.id
+      AND e.person_id = v_person_id AND e.kind = 'volunteer' AND e.status = 'active'
+    WHERE i.kind = 'research_tribe'
+    ORDER BY (i.legacy_tribe_id = v_tribe_id) DESC NULLS LAST, e.start_date DESC, e.created_at DESC
+    LIMIT 1;
+
+    -- legacy-only fallback: tribe_id set but no active engagement (liaison / stale bridge). Keep the
+    -- title for the empty-state; leave initiative_id NULL so the FE hides the self-service leave action.
+    IF v_current_tribe_title IS NULL THEN
+      SELECT i.title, i.legacy_tribe_id INTO v_current_tribe_title, v_current_tribe_id
+      FROM public.initiatives i
+      WHERE i.kind = 'research_tribe' AND i.legacy_tribe_id = v_tribe_id
+      ORDER BY i.legacy_tribe_id
+      LIMIT 1;
+    END IF;
+
+    -- #1267: pre-check the sole-volunteer/leader safeguard so the FE routes to the GP BEFORE the reason
+    -- form. Mirrors withdraw_from_initiative: if 'volunteer' is a required kind of research_tribe and the
+    -- caller is the only active/onboarding volunteer of the tribe, withdraw would block. Only meaningful
+    -- when there is an active engagement to leave (initiative_id present); NULL otherwise.
+    IF v_current_tribe_initiative_id IS NOT NULL THEN
+      SELECT ik.required_engagement_kinds INTO v_kind_required
+      FROM public.initiative_kinds ik
+      WHERE ik.slug = 'research_tribe';
+
+      IF 'volunteer' = ANY(coalesce(v_kind_required, ARRAY[]::text[])) THEN
+        SELECT count(*) INTO v_active_vol_count
+        FROM public.engagements e
+        WHERE e.initiative_id = v_current_tribe_initiative_id
+          AND e.kind = 'volunteer'
+          AND e.status IN ('active', 'onboarding');
+        v_can_self_leave := v_active_vol_count > 1;
+      ELSE
+        v_can_self_leave := true;
+      END IF;
+    END IF;
+  END IF;
+
+  -- selectable active research_tribe tribes (single source of truth = initiatives, not static data)
+  SELECT coalesce(
+    jsonb_agg(jsonb_build_object('tribe_id', i.legacy_tribe_id, 'title', i.title) ORDER BY i.legacy_tribe_id),
+    '[]'::jsonb
+  ) INTO v_tribes
+  FROM public.initiatives i
+  WHERE i.kind = 'research_tribe' AND i.status = 'active' AND i.legacy_tribe_id IS NOT NULL;
+
+  RETURN jsonb_build_object(
+    'eligible', v_eligible,
+    'ineligible_reason', v_reason,
+    'current_tribe_title', v_current_tribe_title,
+    'current_tribe_id', v_current_tribe_id,
+    'current_tribe_initiative_id', v_current_tribe_initiative_id,
+    'can_self_leave', v_can_self_leave,
+    'pending', v_pending,
+    'tribes', v_tribes,
+    'deadline', v_deadline
+  );
+END;
+$function$;

--- a/tests/contracts/1267-sole-volunteer-precheck.test.mjs
+++ b/tests/contracts/1267-sole-volunteer-precheck.test.mjs
@@ -1,0 +1,81 @@
+// #1267 (Tribe UX) — surface the sole-volunteer/leader safeguard BEFORE the leave form. Extends
+// get_my_tribe_request_context (ADDITIVE) with `can_self_leave` on the has_tribe case, mirroring
+// withdraw_from_initiative's remaining_of_kind guard, so the FE routes to the GP without making the
+// researcher write a reason first. Static test over the migration + FE island; the body-drift gate
+// (Phase C) covers live drift. See #1267.
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MIG = join(
+  __dirname,
+  '../../supabase/migrations/20260805000399_1267_sole_volunteer_precheck_context.sql',
+);
+const TSX = join(__dirname, '../../src/components/tribe/TribeRequestBlock.tsx');
+const sql = readFileSync(MIG, 'utf8');
+const tsx = readFileSync(TSX, 'utf8');
+
+test('#1267: migration redefine get_my_tribe_request_context', () => {
+  assert.match(
+    sql,
+    /CREATE OR REPLACE FUNCTION public\.get_my_tribe_request_context\(\)/,
+    'a migration deve redefinir get_my_tribe_request_context',
+  );
+});
+
+test('#1267: extensão é ADITIVA (mantém as chaves de #1256 intactas)', () => {
+  for (const key of ['eligible', 'ineligible_reason', 'current_tribe_title', 'current_tribe_id', 'current_tribe_initiative_id', 'pending', 'tribes', 'deadline']) {
+    assert.match(sql, new RegExp(`'${key}',`), `chave ${key} deve continuar no RETURN`);
+  }
+});
+
+test('#1267: RETURN expõe can_self_leave', () => {
+  assert.match(sql, /'can_self_leave', v_can_self_leave/, 'expõe can_self_leave no payload');
+});
+
+test('#1267: can_self_leave espelha o guard do withdraw (required kind + contagem do mesmo kind)', () => {
+  // required_engagement_kinds de research_tribe, como no withdraw_from_initiative
+  assert.match(sql, /required_engagement_kinds INTO v_kind_required/, 'lê required_engagement_kinds de research_tribe');
+  assert.match(sql, /'volunteer' = ANY\(coalesce\(v_kind_required, ARRAY\[\]::text\[\]\)\)/, 'só bloqueia se volunteer for required kind');
+  // conta ativos/onboarding do mesmo kind na MESMA initiative que o FE vai deixar
+  assert.match(
+    sql,
+    /count\(\*\) INTO v_active_vol_count[\s\S]*?e\.initiative_id = v_current_tribe_initiative_id[\s\S]*?e\.kind = 'volunteer'[\s\S]*?e\.status IN \('active', 'onboarding'\)/,
+    'conta voluntários ativos/onboarding da tribo-alvo',
+  );
+  assert.match(sql, /v_can_self_leave := v_active_vol_count > 1;/, 'sole volunteer (<=1) => can_self_leave=false');
+});
+
+test('#1267: can_self_leave só é computado quando há engagement ativo (initiative_id presente)', () => {
+  assert.match(
+    sql,
+    /IF v_current_tribe_initiative_id IS NOT NULL THEN[\s\S]*?v_can_self_leave/,
+    'o pré-check roda dentro do guard de initiative_id não-nulo',
+  );
+});
+
+// --- FE island (TribeRequestBlock.tsx) ---
+
+test('#1267: o FE lê can_self_leave do contexto', () => {
+  assert.match(tsx, /can_self_leave\?: boolean \| null;/, 'a interface Context declara can_self_leave');
+  assert.match(tsx, /const blockedSole = canLeave && ctx\.can_self_leave === false;/, 'deriva blockedSole com === false (undefined/null não bloqueia)');
+});
+
+test('#1267: quando bloqueado, o FE mostra a mensagem de rota ao GP no lugar do botão', () => {
+  assert.match(
+    tsx,
+    /blockedSole \? \([\s\S]*?copy\.leaveBlockedSoleVolunteer[\s\S]*?\) : \(/,
+    'branch blockedSole renderiza a mensagem de rota ao GP antes do formulário',
+  );
+});
+
+test('#1267: o safeguard server-side (remaining_of_kind) segue como defesa em profundidade no leave()', () => {
+  assert.match(
+    tsx,
+    /typeof data\.remaining_of_kind === 'number'[\s\S]*?setLeaveBlocked\(copy\.leaveBlockedSoleVolunteer\)/,
+    'o handler de leave mantém o fallback do retorno remaining_of_kind',
+  );
+});


### PR DESCRIPTION
## Contexto
Fecha #1267 (validação stakeholder-persona / active-volunteer do arco de tribo, pós-#1258).

## Problema
No card "Sair da tribo" (`TribeRequestBlock.tsx`, caso `has_tribe`), o voluntário que é o **único voluntário ativo** da tribo (ou o líder) só descobria que **não pode sair** DEPOIS de escrever o motivo (>= 10 chars) e confirmar — o bloqueio vinha do retorno `remaining_of_kind` do `withdraw_from_initiative`. Atrito evitável.

## O que mudou
- **DDL (aditivo, mig `20260805000399`):** `get_my_tribe_request_context` expõe `can_self_leave` no caso `has_tribe`. Espelha **fielmente** o guard do `withdraw_from_initiative`: se `volunteer` é required kind de `research_tribe` E o caller é o único voluntário `active`/`onboarding` da tribo → `can_self_leave=false`. Só computado quando há engagement ativo (`current_tribe_initiative_id` presente); `NULL` caso contrário. A RPC de escrita segue como fonte de verdade — isto é pré-check de UX, não novo caminho de autoridade.
- **FE:** quando `can_self_leave === false`, o card mostra a mensagem de rota ao GP no lugar do botão "Sair da tribo" (formulário nunca aparece). Estrito `=== false` → backend antigo (`undefined`/`null`) não bloqueia. O handler `leave()` mantém o fallback do `remaining_of_kind` como defesa em profundidade.

## Validação
- Ao vivo (impersonando via JWT claim, rolled-back): sole volunteer (tribo 5) → `false`; multi-voluntário (tribo 4) → `true`.
- Body-hash da função bate com a migration (Phase C sem drift).
- Contract test `1267-sole-volunteer-precheck` (9 casos) + `npm test` (4758 pass / 0 fail) + `astro build` verdes.

## Notas
- Migration já aplicada ao remoto compartilhado via `apply_migration`; tracking regularizado para a série `20260805000399` (phantom renomeado).

Closes #1267