### PR TITLE
fix(ux): #1287 dismiss affordance do AnnouncementBanner + retira kickoff vencido

### DIFF
--- a/src/components/ui/AnnouncementBanner.astro
+++ b/src/components/ui/AnnouncementBanner.astro
@@ -42,6 +42,10 @@
     if (docLang === 'en' || docLang.startsWith('en')) pathLang = 'en';
     else if (docLang === 'es' || docLang.startsWith('es')) pathLang = 'es';
 
+    // #1287: localized, high-contrast dismiss affordance (opacity-40 ✕ read as non-dismissable
+    // by a mobile user at the C4 kickoff; dismiss already persists via localStorage #518).
+    const dismissLabel = pathLang === 'en' ? 'Dismiss' : pathLang === 'es' ? 'Cerrar' : 'Fechar';
+
     area.innerHTML = visible.map((a: any) => {
       const s = TYPE_STYLES[a.type] || TYPE_STYLES.info;
       // Translate common link_text values
@@ -62,7 +66,7 @@
           ${msg ? `<span class="ml-1 opacity-80">${escapeHtml(msg)}</span>` : ''}
           ${link}
         </div>
-        <button type="button" class="ann-dismiss flex-shrink-0 text-current opacity-40 hover:opacity-80 bg-transparent border-0 cursor-pointer text-base px-1" data-ann-id="${escapeHtml(String(a.id))}" title="Fechar">✕</button>
+        <button type="button" class="ann-dismiss flex-shrink-0 flex items-center justify-center w-6 h-6 rounded-full text-current opacity-70 hover:opacity-100 hover:bg-black/10 bg-transparent border-0 cursor-pointer text-base leading-none" data-ann-id="${escapeHtml(String(a.id))}" title="${escapeHtml(dismissLabel)}" aria-label="${escapeHtml(dismissLabel)}">✕</button>
       </div>`;
     }).join('');
 


### PR DESCRIPTION
## Contexto
#1287 — Jhonatan reportou (print ao owner) que o alerta de kickoff no topo da home "não é dismissável e reaparece a cada re-entrada".

## Diagnóstico (grounded ao vivo)
- Único banner de topo no `BaseLayout` = `AnnouncementBanner.astro`, que **já é dismissível** (✕ + `localStorage` por UUID, #518) e **já auto-expira** por `ends_at`.
- O row de kickoff (`Kick-off do Ciclo 4`) tinha `ends_at = 2026-07-10 02:00 UTC` → já filtrado hoje (07-11). O print do Jhonatan é da janela ativa (07-10).
- Causa da percepção "não-dismissável": o ✕ tinha `opacity-40` e sem hover-bg → em mobile/touch lê como decorativo, não como botão.

## Mudança
- **Código:** ✕ com alvo de toque 24px, `opacity-70→100`, hover-bg circular, `aria-label` e rótulo localizado (Fechar/Dismiss/Cerrar). Comportamento de dismiss inalterado (localStorage #518).
- **Dado (já aplicado em prod via DML):** `announcements` `is_active=true` já vencidos por `ends_at` desativados (kickoff C4 + ranking 06-18). Aftershow (17/07) segue ativo.

## Validação
- `npx astro build` ✓
- `npm test` → 5353 pass / 0 fail / 1 skip

🤖 Generated with [Claude Code](https://claude.com/claude-code)