### PR TITLE
feat(lgpd): #1054 5y retention + anonymize permission_email in drive_offboarding_audit

### DIFF
--- a/docs/legal/RoPA_1054_DRIVE_OFFBOARDING.md
+++ b/docs/legal/RoPA_1054_DRIVE_OFFBOARDING.md
@@ -1,0 +1,82 @@
+# RoPA - Revogacao automatica de acesso ao Google Drive de alumni (#1054 / #1039)
+
+> **Registro de Operacoes de Tratamento (Art. 37 LGPD)** para a rotina de
+> revogacao automatica de acessos a arquivos do Google Drive de ex-voluntarios
+> apos o desligamento, com trilha de auditoria retida na plataforma Nucleo IA.
+>
+> **Status:** RASCUNHO para ratificacao do DPO/juridico (gerado 2026-07-11 com o
+> build do #1054). A retencao/anonimizacao ja esta implementada (mig
+> `20260805000425`); o go-live da revogacao automatica (kill-switch) permanece
+> pendente de aprovacao do owner/DPO.
+> **Controladora:** PMI Goias (CNPJ 06.065.645/0001-99). **Operadora:** plataforma
+> nucleoia.vitormr.dev. **DPO:** Ivan Lourenco Costa (titular) - Angeline Altair
+> Silva Prado (substituta) - dpo@pmigo.org.br.
+> **Refs:** ADR-0014 (politica de retencao de logs) - decisao de conselho Tier-3
+> `docs/council/decisions/2026-07-02-1039-drive-auto-revoke-alumni-only.md` (legal
+> COND-3) - migrations `20260805000425` (retencao) + fatia B do #1039 (deteccao/
+> revogacao) - tabela `drive_offboarding_audit`.
+
+---
+
+## 1. Registro da operacao de tratamento (Art. 37)
+
+| Campo | Conteudo |
+|---|---|
+| **Operacao** | Deteccao e revogacao das permissoes de acesso a arquivos/pastas do Google Drive institucional detidas por ex-voluntarios apos o desligamento, e registro (trilha de auditoria) de cada evento de revogacao. |
+| **Agente que trata** | Rotina automatizada da plataforma (cron/edge function), sob controle da GP/administracao, agindo em nome da controladora (PMI-GO). A revogacao efetiva depende de aprovacao (`approval_mode`) conforme a fatia B do #1039. |
+| **Categorias de dado (Art. 5)** | Identificacao: e-mail do ex-membro associado a permissao no Drive (`permission_email`). Metadados tecnicos: id/nome/URL do arquivo, tipo e papel da permissao, id da permissao, status e datas da revogacao. **Sem dado sensivel (Art. 5, II).** |
+| **Titulares** | Ex-voluntarios (alumni) do Programa Nucleo IA que detinham acesso a arquivos do Drive institucional. |
+| **Finalidade** | Seguranca da informacao - eliminar acessos remanescentes de quem deixou o Programa (principio do menor privilegio), reduzindo o risco de acesso indevido a dados institucionais e de terceiros apos o fim do vinculo. |
+| **Base legal do tratamento** | Art. 7, IX (legitimo interesse da controladora na seguranca da informacao e no controle de acessos - LIA resumida no par. 3) c/c Art. 7, V (execucao do Termo de Voluntariado, cujo fim do vinculo justifica a revogacao). Medidas de seguranca sob Art. 46/47/49. |
+| **Base legal da retencao da trilha (5 anos)** | Art. 16, I (guarda para cumprimento de obrigacao regulatoria e de prestacao de contas da controladora - a trilha e evidencia de que a revogacao ocorreu) e para exercicio regular de direitos (Art. 7, VI / Art. 10, par. 3). |
+| **Retencao** | Trilha de auditoria (`drive_offboarding_audit`) retida por **5 anos**. Ao completar 5 anos, o `permission_email` das linhas terminais (`revoked`/`failed`/`already_absent`/`skipped`) e **anonimizado** por pseudonimo estavel `sha256:<SHA-256(email + salt fixo)>` (hex). Metadados tecnicos do arquivo/permissao (nao PII do ex-membro) permanecem para a integridade do registro. Mecanismo: cron mensal `log-retention-monthly` (ADR-0014, funcao `purge_expired_logs`). |
+| **Destinatarios** | **Google LLC** (Google Workspace), como operador/suboperador, via a service account institucional `nucleoia@pmigo.org.br` que executa a leitura/revogacao das permissoes. Internamente: GP/administracao da sede. Sem compartilhamento nominal com terceiros alem do necessario a operacao. |
+| **Transferencia internacional** | Google Workspace (infraestrutura global). Coberta pelo inventario de suboperadores (`docs/legal/642_DPA_SUBPROCESSOR_INVENTORY.md`) e pelas salvaguardas contratuais do DPA controladora-operadora. |
+| **Medidas de seguranca (Art. 46)** | Tabela com RLS; escrita apenas por rotinas SECURITY DEFINER com gate de contexto de sistema; anonimizacao do e-mail apos 5 anos (minimizacao/limitacao temporal); trilha append-only; funcao de retencao restrita a `service_role`. |
+| **Transparencia (Art. 9)** | A ser informada ao titular no Termo de Voluntariado v2.8 (clausula informativa de revogacao de ferramentas ao termino do vinculo - REC-2, pendente do owner). |
+
+## 2. Direitos do titular (Art. 18)
+Acesso (II) e correcao (III) via canal do DPO. A trilha de revogacao integra os
+registros da controladora; a eliminacao (VI) e ponderada contra a retencao legal
+de 5 anos (Art. 16, I). Apos a anonimizacao, o `permission_email` deixa de ser
+dado pessoal identificavel diretamente (pseudonimo unidirecional com salt fixo).
+Oposicao/revisao (Art. 18 / Art. 20) ao legitimo interesse enderecada ao DPO.
+
+## 3. LIA - teste de legitimo interesse (Art. 7 IX c/c Art. 10)
+1. **Finalidade legitima e informada.** Revogar acessos remanescentes de ex-membros
+   e requisito de seguranca da informacao e de protecao dos dados institucionais e
+   de terceiros; finalidade institucional, nao comercial.
+2. **Necessidade (minimizacao).** Trata-se do minimo: o e-mail que identifica a
+   permissao a revogar e os metadados tecnicos do arquivo. Nao ha meio menos
+   invasivo de identificar e remover a permissao correta. A retencao da trilha e
+   limitada no tempo (5 anos) e o e-mail e anonimizado ao fim do prazo.
+3. **Balanceamento (expectativa legitima x direitos do titular).** O titular adere
+   a um programa de voluntariado sabendo que o acesso a ferramentas e vinculado ao
+   vinculo ativo; ha expectativa legitima de que o acesso seja revogado ao sair.
+   Salvaguardas que pendem a balanca para o titular: revogacao aprovada (nao
+   silenciosa), trilha auditavel, retencao limitada + anonimizacao apos 5 anos,
+   ausencia de dado sensivel, sem decisao automatizada com efeito juridico sobre o
+   titular. Risco residual baixo.
+
+**Conclusao:** legitimo interesse adequado como base (combinado com Art. 7, V para o
+fim do vinculo e Art. 16, I para a retencao da trilha), sujeito as salvaguardas
+acima. Ratificacao do DPO pendente.
+
+## 4. Pendencias owner-gated (NAO executadas por esta issue)
+- **REC-1:** informar o DPO (dpo@pmigo.org.br) da nova operacao automatizada e
+  obter a ratificacao deste RoPA.
+- **REC-2:** avaliar clausula informativa de revogacao de ferramentas no Termo de
+  Voluntario v2.8 (informativa, sem re-aceite - deferivel).
+- **Go-live:** flip do kill-switch `platform_settings.drive_auto_revoke_enabled`
+  (hoje OFF) apos codigo + ROPA prontos e ratificacao do DPO.
+
+## 5. Implementacao (referencia tecnica)
+- Anonimizacao: funcao `public.purge_expired_logs` (ADR-0014), categoria
+  `drive_offboarding_audit`, modo `anonymize` a 1825 dias. Migration
+  `supabase/migrations/20260805000425_1054_drive_offboarding_audit_retention.sql`.
+- Idempotencia: pseudonimo prefixado `sha256:` e excluido de novas execucoes.
+- Contrato: `tests/contracts/1054-drive-offboarding-retention.test.mjs` +
+  `tests/contracts/log-retention.test.mjs` (9a tabela coberta).
+- Salt: constante fixa documentada no corpo da funcao (D1, decisao do owner
+  2026-07-11). Threat model: re-identificacao casual apos 5 anos e aceitavel para
+  a finalidade de trilha; nao ha salt por-registro no v1.

--- a/supabase/migrations/20260805000425_1054_drive_offboarding_audit_retention.sql
+++ b/supabase/migrations/20260805000425_1054_drive_offboarding_audit_retention.sql
@@ -1,0 +1,335 @@
+-- ============================================================
+-- #1054 — LGPD retention for drive_offboarding_audit (ADR-0014 extension)
+--
+-- Pre-GO-LIVE follow-up of #1039 (drive auto-revoke kill-switch). Council
+-- Tier-3 2026-07-02 / legal COND-3 gate the flip of
+-- platform_settings.drive_auto_revoke_enabled on this retention rule existing.
+--
+-- Adds a 9th category to public.purge_expired_logs:
+--   drive_offboarding_audit: 5y (1825d) anonymize of permission_email
+--   (email of the ex-member whose Drive access was revoked) on TERMINAL
+--   rows (status in revoked/failed/already_absent/skipped). The email is
+--   replaced by 'sha256:' || SHA-256(email || fixed_salt) in hex — a stable
+--   pseudonym that preserves statistical uniqueness for the compliance trail
+--   (evidence that offboarding ran) while removing the plaintext PII.
+--   drive_file_id / drive_file_name / permission_role stay (not ex-member PII).
+--
+-- Idempotent: the 'sha256:' sentinel prefix is excluded from the WHERE, so a
+-- re-run never re-hashes an already-anonymized value.
+--
+-- D1 (owner 2026-07-11): hash + fixed salt constant (not NULL — the column is
+--   citext NOT NULL, and the trail keeps evidentiary value). Threat model:
+--   casual re-identification after 5y is acceptable for a fixed documented salt.
+-- ROPA: docs/legal/RoPA_1054_DRIVE_OFFBOARDING.md (D2, owner 2026-07-11).
+--
+-- Reuses the existing cron 'log-retention-monthly' (pg_cron jobid 22) — NO new
+-- cron. Signature unchanged (CREATE OR REPLACE preserves grants); base is the
+-- LIVE body (pg_get_functiondef), only the drive_offboarding_audit block +
+-- retention constants are added.
+--
+-- Rollback: re-apply 20260427010000_log_retention_policy.sql (prior body).
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION public.purge_expired_logs(p_dry_run boolean DEFAULT true, p_limit integer DEFAULT 10000)
+ RETURNS TABLE(table_name text, purge_mode text, rows_affected bigint, oldest_row_kept timestamp with time zone)
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  -- Retention constants (days). Change here to adjust policy.
+  v_mcp_retention_days          constant integer := 90;
+  v_email_webhook_retention_days constant integer := 180;
+  v_broadcast_retention_days    constant integer := 730;
+  v_data_anomaly_resolved_days  constant integer := 180;
+  v_comms_ingestion_retention_days constant integer := 90;
+  v_knowledge_ingestion_retention_days constant integer := 90;
+  v_pii_access_anonymize_days   constant integer := 1825;
+  v_pii_access_drop_days        constant integer := 2190;
+  v_admin_audit_archive_days    constant integer := 1825;
+  v_admin_audit_drop_days       constant integer := 2555;
+  -- #1054: drive_offboarding_audit permission_email anonymization (5y)
+  v_drive_audit_anonymize_days  constant integer := 1825;
+  v_drive_audit_salt            constant text := 'nucleoia-drive-offboarding-audit-anon-v1';
+  v_count bigint;
+  v_oldest timestamptz;
+BEGIN
+  -- Auth: GRANT-based only. Function EXECUTE is granted to service_role
+  -- exclusively (see GRANT at migration tail). Callers without the grant
+  -- receive Postgres-level 'permission denied for function' error directly.
+  -- This is an infrastructure RPC (log retention) — ADR-0011 can_by_member
+  -- pattern applies to domain RPCs with user-level authority derivation.
+
+  -- mcp_usage_log (90d drop)
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.mcp_usage_log
+      WHERE created_at < now() - (v_mcp_retention_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM public.mcp_usage_log WHERE id IN (
+          SELECT id FROM public.mcp_usage_log
+          WHERE created_at < now() - (v_mcp_retention_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(created_at) INTO v_oldest FROM public.mcp_usage_log;
+    RETURN QUERY SELECT 'mcp_usage_log'::text, 'drop'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'mcp_usage_log purge failed: %', SQLERRM;
+    RETURN QUERY SELECT 'mcp_usage_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- comms_metrics_ingestion_log (90d drop)
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.comms_metrics_ingestion_log
+      WHERE created_at < now() - (v_comms_ingestion_retention_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM public.comms_metrics_ingestion_log WHERE id IN (
+          SELECT id FROM public.comms_metrics_ingestion_log
+          WHERE created_at < now() - (v_comms_ingestion_retention_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(created_at) INTO v_oldest FROM public.comms_metrics_ingestion_log;
+    RETURN QUERY SELECT 'comms_metrics_ingestion_log'::text, 'drop'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'comms_metrics_ingestion_log purge failed: %', SQLERRM;
+    RETURN QUERY SELECT 'comms_metrics_ingestion_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- knowledge_insights_ingestion_log (90d drop)
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.knowledge_insights_ingestion_log
+      WHERE created_at < now() - (v_knowledge_ingestion_retention_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM public.knowledge_insights_ingestion_log WHERE id IN (
+          SELECT id FROM public.knowledge_insights_ingestion_log
+          WHERE created_at < now() - (v_knowledge_ingestion_retention_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(created_at) INTO v_oldest FROM public.knowledge_insights_ingestion_log;
+    RETURN QUERY SELECT 'knowledge_insights_ingestion_log'::text, 'drop'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'knowledge_insights_ingestion_log purge failed: %', SQLERRM;
+    RETURN QUERY SELECT 'knowledge_insights_ingestion_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- data_anomaly_log (180d after resolved)
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.data_anomaly_log
+      WHERE fixed_at IS NOT NULL
+        AND fixed_at < now() - (v_data_anomaly_resolved_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM public.data_anomaly_log WHERE id IN (
+          SELECT id FROM public.data_anomaly_log
+          WHERE fixed_at IS NOT NULL
+            AND fixed_at < now() - (v_data_anomaly_resolved_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(detected_at) INTO v_oldest FROM public.data_anomaly_log;
+    RETURN QUERY SELECT 'data_anomaly_log'::text, 'drop_resolved'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'data_anomaly_log purge failed: %', SQLERRM;
+    RETURN QUERY SELECT 'data_anomaly_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- email_webhook_events (180d drop)
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.email_webhook_events
+      WHERE created_at < now() - (v_email_webhook_retention_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM public.email_webhook_events WHERE id IN (
+          SELECT id FROM public.email_webhook_events
+          WHERE created_at < now() - (v_email_webhook_retention_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(created_at) INTO v_oldest FROM public.email_webhook_events;
+    RETURN QUERY SELECT 'email_webhook_events'::text, 'drop'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'email_webhook_events purge failed: %', SQLERRM;
+    RETURN QUERY SELECT 'email_webhook_events'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- broadcast_log (2y drop)
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.broadcast_log
+      WHERE sent_at < now() - (v_broadcast_retention_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM public.broadcast_log WHERE id IN (
+          SELECT id FROM public.broadcast_log
+          WHERE sent_at < now() - (v_broadcast_retention_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(sent_at) INTO v_oldest FROM public.broadcast_log;
+    RETURN QUERY SELECT 'broadcast_log'::text, 'drop'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'broadcast_log purge failed: %', SQLERRM;
+    RETURN QUERY SELECT 'broadcast_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- pii_access_log: 5y anonymize
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.pii_access_log
+      WHERE accessed_at < now() - (v_pii_access_anonymize_days || ' days')::interval
+        AND accessed_at >= now() - (v_pii_access_drop_days || ' days')::interval
+        AND accessor_id IS NOT NULL;
+    ELSE
+      WITH upd AS (
+        UPDATE public.pii_access_log
+        SET accessor_id = NULL,
+            reason = CASE WHEN reason IS NOT NULL THEN 'anonymized' ELSE reason END
+        WHERE id IN (
+          SELECT id FROM public.pii_access_log
+          WHERE accessed_at < now() - (v_pii_access_anonymize_days || ' days')::interval
+            AND accessed_at >= now() - (v_pii_access_drop_days || ' days')::interval
+            AND accessor_id IS NOT NULL
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM upd;
+    END IF;
+    SELECT min(accessed_at) INTO v_oldest FROM public.pii_access_log;
+    RETURN QUERY SELECT 'pii_access_log'::text, 'anonymize'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'pii_access_log anonymize failed: %', SQLERRM;
+    RETURN QUERY SELECT 'pii_access_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- pii_access_log: 6y drop
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.pii_access_log
+      WHERE accessed_at < now() - (v_pii_access_drop_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM public.pii_access_log WHERE id IN (
+          SELECT id FROM public.pii_access_log
+          WHERE accessed_at < now() - (v_pii_access_drop_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    RETURN QUERY SELECT 'pii_access_log'::text, 'drop'::text, v_count, NULL::timestamptz;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'pii_access_log drop failed: %', SQLERRM;
+    RETURN QUERY SELECT 'pii_access_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- admin_audit_log: 5y archive
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.admin_audit_log
+      WHERE created_at < now() - (v_admin_audit_archive_days || ' days')::interval;
+    ELSE
+      WITH moved AS (
+        INSERT INTO z_archive.admin_audit_log
+          (id, actor_id, action, target_type, target_id, changes, metadata, created_at)
+        SELECT id, actor_id, action, target_type, target_id, changes, metadata, created_at
+        FROM public.admin_audit_log
+        WHERE id IN (
+          SELECT id FROM public.admin_audit_log
+          WHERE created_at < now() - (v_admin_audit_archive_days || ' days')::interval
+          LIMIT p_limit
+        )
+        ON CONFLICT (id) DO NOTHING
+        RETURNING id
+      ), del AS (
+        DELETE FROM public.admin_audit_log WHERE id IN (SELECT id FROM moved)
+        RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(created_at) INTO v_oldest FROM public.admin_audit_log;
+    RETURN QUERY SELECT 'admin_audit_log'::text, 'archive'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'admin_audit_log archive failed: %', SQLERRM;
+    RETURN QUERY SELECT 'admin_audit_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- z_archive.admin_audit_log: 7y drop
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM z_archive.admin_audit_log
+      WHERE created_at < now() - (v_admin_audit_drop_days || ' days')::interval;
+    ELSE
+      WITH del AS (
+        DELETE FROM z_archive.admin_audit_log WHERE id IN (
+          SELECT id FROM z_archive.admin_audit_log
+          WHERE created_at < now() - (v_admin_audit_drop_days || ' days')::interval
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM del;
+    END IF;
+    SELECT min(created_at) INTO v_oldest FROM z_archive.admin_audit_log;
+    RETURN QUERY SELECT 'z_archive.admin_audit_log'::text, 'drop'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'z_archive.admin_audit_log drop failed: %', SQLERRM;
+    RETURN QUERY SELECT 'z_archive.admin_audit_log'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- drive_offboarding_audit: 5y anonymize permission_email (#1054)
+  -- Terminal rows only. SHA-256 + fixed salt (extensions.digest), hex,
+  -- 'sha256:' sentinel prefix -> idempotent (re-run skips already-anonymized).
+  BEGIN
+    IF p_dry_run THEN
+      SELECT count(*) INTO v_count FROM public.drive_offboarding_audit
+      WHERE created_at < now() - (v_drive_audit_anonymize_days || ' days')::interval
+        AND status IN ('revoked','failed','already_absent','skipped')
+        AND permission_email NOT LIKE 'sha256:%';
+    ELSE
+      WITH upd AS (
+        UPDATE public.drive_offboarding_audit
+        SET permission_email = 'sha256:' || encode(extensions.digest(permission_email::text || v_drive_audit_salt, 'sha256'), 'hex')
+        WHERE id IN (
+          SELECT id FROM public.drive_offboarding_audit
+          WHERE created_at < now() - (v_drive_audit_anonymize_days || ' days')::interval
+            AND status IN ('revoked','failed','already_absent','skipped')
+            AND permission_email NOT LIKE 'sha256:%'
+          LIMIT p_limit
+        ) RETURNING 1
+      ) SELECT count(*) INTO v_count FROM upd;
+    END IF;
+    SELECT min(created_at) INTO v_oldest FROM public.drive_offboarding_audit;
+    RETURN QUERY SELECT 'drive_offboarding_audit'::text, 'anonymize'::text, v_count, v_oldest;
+  EXCEPTION WHEN OTHERS THEN
+    RAISE WARNING 'drive_offboarding_audit anonymize failed: %', SQLERRM;
+    RETURN QUERY SELECT 'drive_offboarding_audit'::text, 'error'::text, 0::bigint, NULL::timestamptz;
+  END;
+
+  -- Meta-log
+  IF NOT p_dry_run THEN
+    BEGIN
+      INSERT INTO public.admin_audit_log (
+        actor_id, action, target_type, target_id, changes, metadata
+      ) VALUES (
+        NULL, 'platform.log_retention_run', 'system', NULL, NULL,
+        jsonb_build_object('executed_at', now(), 'p_limit', p_limit, 'source', 'purge_expired_logs')
+      );
+    EXCEPTION WHEN OTHERS THEN
+      RAISE WARNING 'meta-log insert failed: %', SQLERRM;
+    END;
+  END IF;
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/1054-drive-offboarding-retention.test.mjs
+++ b/tests/contracts/1054-drive-offboarding-retention.test.mjs
@@ -1,0 +1,122 @@
+/**
+ * #1054 — LGPD 5y retention + anonymization of permission_email in
+ * drive_offboarding_audit (ADR-0014 extension of purge_expired_logs).
+ *
+ * Pre-GO-LIVE follow-up of #1039 (drive auto-revoke kill-switch).
+ *
+ * Static assertions (always run) parse the migration that (re)defines
+ * purge_expired_logs and pin the anonymization contract:
+ *   - a drive_offboarding_audit block anonymizes (not drops) at 5y (1825d)
+ *   - only TERMINAL rows (revoked/failed/already_absent/skipped) are touched
+ *   - SHA-256 + fixed salt via extensions.digest, hex-encoded
+ *   - 'sha256:' sentinel prefix + NOT LIKE guard => idempotent re-runs
+ *
+ * The destructive runtime path (old→hashed, recent/pending→intact, stable
+ * across re-runs) was verified live in-session with a rolled-back DO block.
+ *
+ * DB-aware assertion (needs SUPABASE_URL + SERVICE_ROLE_KEY) calls the RPC
+ * dry-run and asserts drive_offboarding_audit surfaces with mode 'anonymize'
+ * and no error. Dry-run is read-only.
+ *
+ * ⚠️ Known infra flake: the audit RPC path through Cloudflare occasionally
+ * returns an error page; a rerun / isolated run resolves it (not a regression).
+ */
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = join(__dirname, '..', '..');
+const MIG_DIR = join(REPO_ROOT, 'supabase/migrations');
+
+// Latest migration that (re)defines purge_expired_logs.
+function latestPurgeMigration() {
+  const files = readdirSync(MIG_DIR).filter((f) => f.endsWith('.sql')).sort();
+  let src = null;
+  for (const f of files) {
+    const s = readFileSync(join(MIG_DIR, f), 'utf8');
+    if (s.includes('FUNCTION public.purge_expired_logs(')) src = s;
+  }
+  return src;
+}
+
+// Slice the drive_offboarding_audit BEGIN…END anonymize block out of the body.
+function driveBlock(src) {
+  const anchor = src.indexOf('drive_offboarding_audit: 5y anonymize');
+  if (anchor === -1) return null;
+  const end = src.indexOf('-- Meta-log', anchor);
+  return end === -1 ? src.slice(anchor) : src.slice(anchor, end);
+}
+
+test('#1054: latest purge_expired_logs migration defines the drive block', () => {
+  const src = latestPurgeMigration();
+  assert.ok(src, 'a migration must (re)define purge_expired_logs');
+  const block = driveBlock(src);
+  assert.ok(block, 'the drive_offboarding_audit anonymize block must exist');
+});
+
+test('#1054: anonymizes (not drops) at 5y on terminal rows only', () => {
+  const block = driveBlock(latestPurgeMigration());
+  assert.match(block, /v_drive_audit_anonymize_days/, 'uses the 5y retention constant');
+  assert.match(
+    block,
+    /status IN \('revoked','failed','already_absent','skipped'\)/,
+    'restricts to terminal statuses',
+  );
+  assert.match(block, /RETURN QUERY SELECT 'drive_offboarding_audit'::text, 'anonymize'::text/,
+    'reports purge_mode anonymize');
+  assert.doesNotMatch(block, /DELETE FROM public\.drive_offboarding_audit/,
+    'must not DELETE audit rows (anonymize-in-place)');
+});
+
+test('#1054: hashes with SHA-256 + salt via extensions.digest (not NULL, not plaintext)', () => {
+  const src = latestPurgeMigration();
+  const block = driveBlock(src);
+  assert.match(src, /v_drive_audit_salt\s+constant text/, 'declares a fixed salt constant');
+  assert.match(
+    block,
+    /encode\(extensions\.digest\(permission_email::text \|\| v_drive_audit_salt, 'sha256'\), 'hex'\)/,
+    'SHA-256(email||salt) hex via schema-qualified extensions.digest',
+  );
+});
+
+test('#1054: sentinel prefix makes anonymization idempotent', () => {
+  const block = driveBlock(latestPurgeMigration());
+  assert.match(block, /'sha256:' \|\| encode\(/, "prefixes the pseudonym with 'sha256:'");
+  const guards = block.match(/permission_email NOT LIKE 'sha256:%'/g) || [];
+  assert.ok(guards.length >= 2,
+    "both the dry-run count and the UPDATE must exclude already-anonymized rows");
+});
+
+test('#1054: retention window is 1825 days (5 years)', () => {
+  const src = latestPurgeMigration();
+  assert.match(src, /v_drive_audit_anonymize_days\s+constant integer := 1825;/,
+    '5y = 1825 days');
+});
+
+// ---- DB-aware dry-run (optional) --------------------------------------------
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
+const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const canRun = !!(SUPABASE_URL && SERVICE_ROLE_KEY);
+const skipMsg = 'Skipped: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required';
+
+test('#1054: live dry-run surfaces drive_offboarding_audit as anonymize (no error)',
+  { skip: !canRun && skipMsg }, async () => {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/purge_expired_logs`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': SERVICE_ROLE_KEY,
+        'Authorization': `Bearer ${SERVICE_ROLE_KEY}`,
+      },
+      body: JSON.stringify({ p_dry_run: true, p_limit: 10000 }),
+    });
+    assert.ok(res.ok, `RPC dry-run must succeed (HTTP ${res.status})`);
+    const rows = await res.json();
+    const drive = rows.filter((r) => r.table_name === 'drive_offboarding_audit');
+    assert.strictEqual(drive.length, 1, 'exactly one drive_offboarding_audit row');
+    assert.strictEqual(drive[0].purge_mode, 'anonymize', 'mode must be anonymize');
+    assert.notStrictEqual(drive[0].purge_mode, 'error', 'block must not error');
+  });

--- a/tests/contracts/log-retention.test.mjs
+++ b/tests/contracts/log-retention.test.mjs
@@ -8,7 +8,7 @@
  * This test does NOT verify actual purge writes (cron does that monthly).
  * It verifies:
  *   1. RPC signature exists and returns expected shape
- *   2. All 8 covered tables appear in the output
+ *   2. All 9 covered tables appear in the output
  *   3. pii_access_log appears twice (anonymize + drop phases)
  *   4. admin_audit_log pair appears (archive live + drop z_archive)
  *   5. purge_mode enum matches spec (drop|archive|anonymize|drop_resolved|error)
@@ -37,6 +37,7 @@ const EXPECTED_TABLES = [
   'pii_access_log',             // appears 2x (anonymize + drop)
   'admin_audit_log',
   'z_archive.admin_audit_log',
+  'drive_offboarding_audit',    // #1054: 5y anonymize of permission_email (8 → 9 log tables)
 ];
 
 async function callPurgeDryRun() {
@@ -57,7 +58,7 @@ async function callPurgeDryRun() {
   return res.json();
 }
 
-test('ADR-0014: purge_expired_logs covers all 8 log tables', { skip: !canRun && skipMsg }, async () => {
+test('ADR-0014: purge_expired_logs covers all 9 log tables', { skip: !canRun && skipMsg }, async () => {
   const rows = await callPurgeDryRun();
 
   assert.ok(Array.isArray(rows), 'RPC must return an array');


### PR DESCRIPTION
## O que

Follow-up PRE-GO-LIVE do #1039 (kill-switch de auto-revogacao de acesso Drive; council Tier-3 2026-07-02, legal COND-3). Estende `purge_expired_logs` (ADR-0014) com uma 9a categoria: `drive_offboarding_audit` anonimiza `permission_email` a 5 anos (1825d) nas linhas terminais.

## Como

- **Anonimizacao (D1, owner 2026-07-11):** `permission_email` (citext NOT NULL) vira pseudonimo estavel `sha256:<SHA-256(email || salt fixo)>` em hex, via `extensions.digest`. Preserva unicidade estatistica (trilha como evidencia de cumprimento) e remove a PII em claro. `drive_file_id`/`name`/`role` permanecem (nao sao PII do ex-membro). NULL foi descartado: a coluna e NOT NULL e perderia valor probatorio.
- **Idempotente:** prefixo sentinela `sha256:` e excluido de novas execucoes (`NOT LIKE 'sha256:%'`).
- **Reuso do cron** `log-retention-monthly` (pg_cron jobid 22), sem cron novo.
- **DDL:** `CREATE OR REPLACE` baseado no corpo VIVO (`pg_get_functiondef`), so o bloco novo + 2 constantes adicionadas. Body-drift gate (Phase C) verde.

## Grounding (ao vivo, 2026-07-11)

- `drive_offboarding_audit`: 14 linhas, 12 terminais (todas `revoked`), **0 > 5 anos** (tabela tem ~2 semanas). O cron nao tera nada a processar por anos; e mecanismo que so age a 5y.
- `pgcrypto.digest` no schema `extensions` (qualificado na funcao).
- kill-switch `drive_auto_revoke_enabled` = OFF (go-live pendente, correto).

## QA runtime (bloco DO rolled-back, revertido)

| Linha sintetica | Resultado |
|---|---|
| terminal `revoked`, 6 anos | `sha256:8af98a71...` (anonimizada) |
| terminal `revoked`, recente | plaintext intacto |
| `pending_revoke` (nao-terminal), 6 anos | plaintext intacto |
| 2a execucao sobre linha ja anonimizada | estavel (idempotente) |

Nada persistiu (tabela = 14 linhas, 0 anonimizadas, 0 leftovers apos os blocos).

## Testes

- `tests/contracts/1054-drive-offboarding-retention.test.mjs` (novo): 5 estaticos + 1 DB-aware dry-run. 6/6 pass.
- `tests/contracts/log-retention.test.mjs`: 8 -> 9 tabelas cobertas.
- `npx astro build` verde; `npm test` = 5412 pass / 0 fail / 1 skip.

## ROPA (D2)

`docs/legal/RoPA_1054_DRIVE_OFFBOARDING.md` (doc proprio): base Art. 16 I (retencao da trilha 5y), destinatario Google Workspace SA `nucleoia@pmigo.org.br`, LIA.

## Owner-gated (NAO neste PR)

- **REC-1:** informar o DPO (dpo@pmigo.org.br) e obter ratificacao do RoPA.
- **REC-2:** clausula informativa de revogacao de ferramentas no Termo v2.8 (deferivel).
- **Go-live:** flip do kill-switch `drive_auto_revoke_enabled` apos ratificacao do DPO.

Closes #1054

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>