### PR TITLE
feat(filiacao): #1364b "Todos" tab (full active roster) with chapter filter

### DIFF
--- a/src/components/admin/AffiliationQueueIsland.tsx
+++ b/src/components/admin/AffiliationQueueIsland.tsx
@@ -172,7 +172,10 @@ export default function AffiliationQueueIsland() {
   // #1129 — default to 'all' so the queue never silently hides the current-selection members who
   // are past pre-onboarding (10/45 were invisible under the old 'pre' default). Attention-sort still
   // floats pre-onboarding rows to the top, so nothing urgent is lost.
-  const [tab, setTab] = useState<'pre' | 'all'>('all');
+  // #1364b — three scopes: 'pre' (pre-onboarding), 'queue' (todos não-verificados = the queue), and
+  // 'all' (todos os ativos, verified + unverified — lazy-loaded via p_scope='all'). Default 'queue'
+  // preserves the prior landing view.
+  const [tab, setTab] = useState<'pre' | 'queue' | 'all'>('queue');
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
   const [bulkVerifying, setBulkVerifying] = useState(false);
@@ -185,6 +188,10 @@ export default function AffiliationQueueIsland() {
   const [search, setSearch] = useState('');
   const [registry, setRegistry] = useState<RegistryChapter[]>([]);               // #1192
   const [rollup, setRollup] = useState<ChapterRollupEntry[]>([]);                // #1364
+  const [allRows, setAllRows] = useState<QueueRow[]>([]);                        // #1364b full roster
+  const [allLoaded, setAllLoaded] = useState(false);                            // #1364b lazy-load latch
+  const [allLoading, setAllLoading] = useState(false);                          // #1364b
+  const allLoadedRef = useRef(false); allLoadedRef.current = allLoaded;
 
   // #1192 — chapter filter options come from chapter_registry (RLS: read-all for authenticated),
   // NOT from whatever the loaded rows happen to parse to (the old 5-of-15 bug).
@@ -203,24 +210,47 @@ export default function AffiliationQueueIsland() {
     return () => { cancelled = true; };
   }, [getSb]);
 
+  // ── load one scope of the queue RPC ('queue' = unverified cohort, 'all' = full active roster #1364b) ──
+  const loadScope = useCallback(async (scope: 'queue' | 'all'): Promise<QueueRow[] | null> => {
+    const sb = getSb();
+    if (!sb) return null;
+    const { data, error } = await sb.rpc(
+      'get_affiliation_verification_queue',
+      scope === 'all' ? { p_scope: 'all' } : undefined,
+    );
+    if (error) {
+      (window as any).toast?.(error.message || t('comp.affiliationQueue.loadError', 'Erro ao carregar a fila'), 'error');
+      return null;
+    }
+    return Array.isArray(data) ? data : [];
+  }, [getSb, t]);
+
   // ── load the queue (retry until Nav publishes the authed client) ──
   const fetchQueue = useCallback(async () => {
     const sb = getSb();
     if (!sb) { setTimeout(fetchQueue, 300); return; }
     setLoading(true);
-    const { data, error } = await sb.rpc('get_affiliation_verification_queue');
-    if (error) {
-      (window as any).toast?.(error.message || t('comp.affiliationQueue.loadError', 'Erro ao carregar a fila'), 'error');
-      setRows([]);
-    } else {
-      setRows(Array.isArray(data) ? data : []);
-    }
+    const q = await loadScope('queue');
+    if (q) setRows(q);
     // #1364 — per-chapter reconciliation (full roster vs this queue) for the chapter-filter banner.
     sb.rpc('get_affiliation_chapter_rollup')
       .then(({ data: rd }: any) => setRollup(Array.isArray(rd) ? rd : []))
       .catch(() => {});
     setLoading(false);
-  }, [getSb, t]);
+    // #1364b — keep the full-roster tab in sync after a verify/refresh, if it was already loaded.
+    if (allLoadedRef.current) { const a = await loadScope('all'); if (a) setAllRows(a); }
+  }, [getSb, t, loadScope]);
+
+  // #1364b — lazy-load the full active roster the first time the "Todos" tab is opened.
+  const fetchAll = useCallback(async () => {
+    setAllLoading(true);
+    const a = await loadScope('all');
+    if (a) { setAllRows(a); setAllLoaded(true); }
+    setAllLoading(false);
+  }, [loadScope]);
+  useEffect(() => {
+    if (tab === 'all' && !allLoaded && !allLoading) fetchAll();
+  }, [tab, allLoaded, allLoading, fetchAll]);
 
   const fetchRef = useRef(fetchQueue); fetchRef.current = fetchQueue;
   useEffect(() => {
@@ -356,7 +386,10 @@ export default function AffiliationQueueIsland() {
   }, [rows]);
 
   const visible = useMemo(() => {
-    let list = tab === 'pre' ? rows.filter(r => r.is_pre_onboarding) : rows.slice();
+    // #1364b — base set by tab: 'pre' = pre-onboarding subset, 'all' = full active roster, else the queue.
+    let list = tab === 'pre' ? rows.filter(r => r.is_pre_onboarding)
+             : tab === 'all' ? allRows.slice()
+             : rows.slice();
     if (statusFilter === 'action') list = list.filter(r => { const k = farol(r, t).key; return k === 'expired' || k === 'soon'; });
     else if (statusFilter === 'unverified') list = list.filter(r => farol(r, t).key === 'unverified');
     if (cohortFilter !== 'all') list = list.filter(r => r.cohort_class === cohortFilter);   // #1129
@@ -383,7 +416,7 @@ export default function AffiliationQueueIsland() {
       return ra !== rb ? ra - rb : a.name.localeCompare(b.name);
     });
     return list;
-  }, [rows, tab, statusFilter, cohortFilter, termFilter, chapterFilter, vepFilter, search, sortKey, t]);
+  }, [rows, allRows, tab, statusFilter, cohortFilter, termFilter, chapterFilter, vepFilter, search, sortKey, t]);
 
   const allVisibleSelected = visible.length > 0 && visible.every(r => selectedIds.has(r.member_id));
   const toggleAll = () =>
@@ -414,9 +447,15 @@ export default function AffiliationQueueIsland() {
           className={`px-3 py-1.5 text-[13px] rounded-lg border cursor-pointer ${tab === 'pre' ? 'bg-teal-600 text-white border-teal-600' : 'bg-transparent text-[var(--text-secondary)] border-[var(--border-default)] hover:bg-[var(--surface-hover)]'}`}>
           {t('comp.affiliationQueue.tabPre', 'Pré-onboarding')} ({preCount})
         </button>
+        <button onClick={() => setTab('queue')}
+          className={`px-3 py-1.5 text-[13px] rounded-lg border cursor-pointer ${tab === 'queue' ? 'bg-teal-600 text-white border-teal-600' : 'bg-transparent text-[var(--text-secondary)] border-[var(--border-default)] hover:bg-[var(--surface-hover)]'}`}>
+          {t('comp.affiliationQueue.tabAll', 'Todos não-verificados')} ({rows.length})
+        </button>
+        {/* #1364b — full active roster (verified + unverified) so the office can filter a chapter and
+            see every member linked to it with each one's status. Lazy-loaded on first open. */}
         <button onClick={() => setTab('all')}
           className={`px-3 py-1.5 text-[13px] rounded-lg border cursor-pointer ${tab === 'all' ? 'bg-teal-600 text-white border-teal-600' : 'bg-transparent text-[var(--text-secondary)] border-[var(--border-default)] hover:bg-[var(--surface-hover)]'}`}>
-          {t('comp.affiliationQueue.tabAll', 'Todos não-verificados')} ({rows.length})
+          {t('comp.affiliationQueue.tabEveryone', 'Todos')}{allLoaded ? ` (${allRows.length})` : ''}
         </button>
       </div>
 
@@ -494,7 +533,7 @@ export default function AffiliationQueueIsland() {
           so a chapter here shows FEWER people than the same chapter on /membros: the difference is the
           already-verified members, who correctly leave the queue. Surfaced so the two screens reconcile
           at a glance and the old "PMI-RS shows 16 there but 3 here" reads as by-design, not a bug. */}
-      {chapterFilter !== 'all' && (() => {
+      {tab !== 'all' && chapterFilter !== 'all' && (() => {
         const r = rollup.find(x => x.chapter === `PMI-${chapterFilter}`);
         if (!r) return null;
         const label = registry.find(c => c.chapter_code === chapterFilter)?.state || `PMI-${chapterFilter}`;
@@ -523,7 +562,11 @@ export default function AffiliationQueueIsland() {
         </div>
       )}
 
-      {visible.length === 0 ? (
+      {tab === 'all' && allLoading && !allLoaded ? (
+        <div className="flex items-center justify-center py-16 text-[var(--text-muted)]">
+          <Loader2 size={20} className="animate-spin mr-2" /> {t('comp.affiliationQueue.loadingAll', 'Carregando todos os membros…')}
+        </div>
+      ) : visible.length === 0 ? (
         <div className="text-center py-16 text-[var(--text-muted)]">{t('comp.affiliationQueue.empty', 'Nenhum membro pendente de verificação.')}</div>
       ) : (
         <div className="overflow-x-auto rounded-xl border border-[var(--border-default)]">

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -7091,6 +7091,8 @@ const enUS: Record<string, string> = {
   'comp.affiliationQueue.intro': 'Verify members\' PMI affiliation: (1) active membership and (2) an in-good-standing Brazilian chapter affiliation. VEP affiliation data is shown when available; when a candidate keeps their PMI community private or is not yet affiliated, fill it in manually.',
   'comp.affiliationQueue.tabPre': 'Pre-onboarding',
   'comp.affiliationQueue.tabAll': 'All unverified',
+  'comp.affiliationQueue.tabEveryone': 'Everyone',
+  'comp.affiliationQueue.loadingAll': 'Loading all members…',
   'comp.affiliationQueue.selected': 'selected',
   'comp.affiliationQueue.selectAll': 'Select all',
   'comp.affiliationQueue.bulkVerifyVep': 'Verify via VEP (active membership)',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -7091,6 +7091,8 @@ const esLATAM: Record<string, string> = {
   'comp.affiliationQueue.intro': 'Verifique la afiliación PMI de los miembros: (1) membresía activa y (2) afiliación a un capítulo brasileño vigente. El dato de afiliación del VEP se muestra cuando está disponible; cuando el candidato mantiene la comunidad PMI privada o aún no está afiliado, complete manualmente.',
   'comp.affiliationQueue.tabPre': 'Pre-onboarding',
   'comp.affiliationQueue.tabAll': 'Todos sin verificar',
+  'comp.affiliationQueue.tabEveryone': 'Todos',
+  'comp.affiliationQueue.loadingAll': 'Cargando todos los miembros…',
   'comp.affiliationQueue.selected': 'seleccionado(s)',
   'comp.affiliationQueue.selectAll': 'Seleccionar todos',
   'comp.affiliationQueue.bulkVerifyVep': 'Verificar vía VEP (membresía activa)',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -7098,6 +7098,8 @@ const ptBR: Record<string, string> = {
   'comp.affiliationQueue.intro': 'Verifique a filiação PMI dos membros: (1) membresia ativa e (2) filiação a um capítulo brasileiro em dia. O dado de filiação do VEP é exibido quando disponível; quando o candidato mantém a comunidade PMI privada ou ainda não é filiado, preencha manualmente.',
   'comp.affiliationQueue.tabPre': 'Pré-onboarding',
   'comp.affiliationQueue.tabAll': 'Todos não-verificados',
+  'comp.affiliationQueue.tabEveryone': 'Todos',
+  'comp.affiliationQueue.loadingAll': 'Carregando todos os membros…',
   'comp.affiliationQueue.selected': 'selecionado(s)',
   'comp.affiliationQueue.selectAll': 'Selecionar todos',
   'comp.affiliationQueue.bulkVerifyVep': 'Verificar via VEP (membresia ativa)',

--- a/supabase/migrations/20260805000437_1364b_affiliation_queue_scope_all.sql
+++ b/supabase/migrations/20260805000437_1364b_affiliation_queue_scope_all.sql
@@ -1,0 +1,284 @@
+-- #1364b — /admin/filiacao gains a third tab "Todos" (full active roster), so the office can filter
+-- a chapter (e.g. RS) and see EVERY member linked to it with each one's status/situation, not only the
+-- unverified queue. Rather than duplicate the rich per-row shape (chapter_affiliations, VEP, term,
+-- cohort, latest_verification) in a second RPC (drift risk), the queue RPC gains a p_scope param that
+-- relaxes the cohort WHERE: p_scope='all' returns all active members; default 'queue' is unchanged.
+--
+-- DROP + CREATE (not CREATE OR REPLACE) because the argument count changes (GC-097). Body is the LIVE
+-- definition verbatim with only two edits: the signature and the cohort WHERE. Grants re-applied.
+
+DROP FUNCTION IF EXISTS public.get_affiliation_verification_queue();
+
+CREATE OR REPLACE FUNCTION public.get_affiliation_verification_queue(p_scope text DEFAULT 'queue')
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id           uuid;
+  v_caller_designations text[];
+  v_result              jsonb;
+  v_member_ids          uuid[];
+  v_current_cycle_id    uuid;
+  v_term_soon_days      int := 180;  -- ~one renewal cycle (cycle_4.cycle_end open); raw date also surfaced
+BEGIN
+  -- Auth-resolve + function-anchored gate (mirror verify_member_affiliation, mig 148).
+  SELECT m.id, m.designations INTO v_caller_id, v_caller_designations
+  FROM public.members m WHERE m.auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'Forbidden: authentication required';
+  END IF;
+
+  -- Least-privilege: read audience == write audience (filiacao_director OR manage_member).
+  IF NOT ('filiacao_director' = ANY(COALESCE(v_caller_designations, '{}'::text[])))
+     AND NOT public.can_by_member(v_caller_id, 'manage_member') THEN
+    RAISE EXCEPTION 'Forbidden: requires filiacao_director designation or platform manager authority';
+  END IF;
+
+  -- Current selection cycle, tied to the current operational cycle by number (dynamic — no hardcoded
+  -- cycle_code; survives C4→C5). selection_cycles has no is_current column; two selection rows can be
+  -- status='open' at once, so we anchor on cycles.is_current, then take the latest open_date.
+  SELECT sc.id INTO v_current_cycle_id
+  FROM public.selection_cycles sc
+  WHERE regexp_replace(sc.cycle_code, '\D', '', 'g')
+        LIKE (SELECT regexp_replace(c.cycle_code, '\D', '', 'g') FROM public.cycles c WHERE c.is_current LIMIT 1) || '%'
+  ORDER BY sc.open_date DESC NULLS LAST
+  LIMIT 1;
+
+  WITH cohort AS (
+    SELECT
+      m.id  AS member_id,
+      m.name,
+      m.email,
+      m.chapter,
+      m.operational_role,
+      m.pmi_id_verified,
+      COALESCE(pre.flag, false)  AS is_pre_onboarding,
+      vep.vep_status_raw,
+      vep.vep_last_seen_at,
+      vep.pmi_memberships,
+      vep.pmi_id,
+      vep.service_first_start_date,
+      vep.service_latest_end_date,
+      vep.service_history_count,
+      vep.pmi_data_fetched_at,
+      aff.created_at            AS aff_created_at,
+      aff.membership_active     AS aff_membership_active,
+      aff.membership_expires_on AS aff_membership_expires_on,
+      aff.method                AS aff_method,
+      aff.chapter_verified      AS aff_chapter_verified,
+      -- #1129 cohort (by email set; current-cycle preferred)
+      sel.sel_cycle_code,
+      sel.sel_role,
+      sel.sel_is_current,
+      sel.has_selection,
+      -- #1129 term validity
+      term.term_end_date,
+      -- #1192 SSOT chapter read-through
+      aff2.chapter_affiliations
+    FROM public.members m
+    -- VEP + PMI membership detail from the latest matching application (shape from admin_list_members).
+    LEFT JOIN LATERAL (
+      SELECT a.vep_status_raw, a.vep_last_seen_at, a.pmi_memberships,
+             a.pmi_id, a.service_first_start_date, a.service_latest_end_date,
+             a.service_history_count, a.pmi_data_fetched_at
+      FROM public.selection_applications a
+      WHERE lower(a.email) = lower(m.email)
+        AND a.vep_status_raw IS NOT NULL
+      ORDER BY a.vep_last_seen_at DESC NULLS LAST
+      LIMIT 1
+    ) vep ON true
+    -- #625 C0 pre-onboarding flag — VERBATIM from admin_list_members (mig 148).
+    LEFT JOIN LATERAL (
+      SELECT (
+        m.member_status = 'active'
+        AND EXISTS (
+          SELECT 1 FROM public.engagements e
+          WHERE e.person_id = m.person_id AND e.status = 'active'
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM public.engagements e
+          JOIN public.engagement_kinds ek ON ek.slug = e.kind
+          WHERE e.person_id = m.person_id AND e.status = 'active'
+            AND (ek.requires_agreement IS NOT TRUE OR e.agreement_certificate_id IS NOT NULL)
+        )
+      ) AS flag
+    ) pre ON true
+    -- Latest verification from the append-only trail.
+    LEFT JOIN LATERAL (
+      SELECT mav.created_at, mav.membership_active, mav.membership_expires_on,
+             mav.method, mav.chapter_verified
+      FROM public.member_affiliation_verifications mav
+      WHERE mav.member_id = m.id
+      ORDER BY mav.created_at DESC
+      LIMIT 1
+    ) aff ON true
+    -- #1129 cohort: most-relevant approved/converted selection application across the member's full
+    -- email set (primary + member_emails), preferring the current cycle. NULL row ⇒ non_selection.
+    LEFT JOIN LATERAL (
+      SELECT sc.cycle_code                     AS sel_cycle_code,
+             a.role_applied                    AS sel_role,
+             (a.cycle_id = v_current_cycle_id) AS sel_is_current,
+             true                              AS has_selection
+      FROM public.selection_applications a
+      JOIN public.selection_cycles sc ON sc.id = a.cycle_id
+      WHERE a.status IN ('approved','converted')
+        AND ( lower(a.email) = lower(m.email)
+              OR lower(a.email) IN (SELECT lower(me.email) FROM public.member_emails me WHERE me.member_id = m.id) )
+      ORDER BY (a.cycle_id = v_current_cycle_id) DESC, sc.open_date DESC NULLS LAST
+      LIMIT 1
+    ) sel ON true
+    -- #1129 term boundary: the active agreement-requiring engagement's end_date (volunteer term).
+    LEFT JOIN LATERAL (
+      SELECT e.end_date AS term_end_date
+      FROM public.engagements e
+      JOIN public.engagement_kinds ek ON ek.slug = e.kind
+      WHERE e.person_id = m.person_id
+        AND e.status = 'active'
+        AND ek.requires_agreement = true
+      ORDER BY e.end_date DESC NULLS LAST
+      LIMIT 1
+    ) term ON true
+    -- #1192 chapter_affiliations: SSOT rows (member_chapter_affiliations × chapter_registry) with the
+    -- matching raw membership's expiry paired via resolve_br_chapter_code, UNION raw names that resolve
+    -- via the registry but have no SSOT row yet ('vep_raw', provisional). ALL name→code resolution runs
+    -- here, in the one SSOT resolver — the client never re-parses names to decide anything.
+    LEFT JOIN LATERAL (
+      SELECT jsonb_agg(x.obj ORDER BY x.is_primary DESC, x.chapter_code) AS chapter_affiliations
+      FROM (
+        SELECT mca.chapter_code, mca.is_primary,
+               jsonb_build_object(
+                 'chapter_code', mca.chapter_code,
+                 'chapter_label', cr.state,
+                 'source', mca.source,
+                 'verified_at', mca.verified_at,
+                 'is_primary', mca.is_primary,
+                 'raw_name', raw.raw_name,
+                 'expiry', raw.expiry
+               ) AS obj
+        FROM public.member_chapter_affiliations mca
+        JOIN public.chapter_registry cr
+          ON cr.chapter_code = mca.chapter_code AND cr.is_active = true
+        LEFT JOIN LATERAL (
+          SELECT CASE WHEN jsonb_typeof(e) = 'string' THEN e #>> '{}' ELSE e->>'chapterName' END AS raw_name,
+                 CASE WHEN jsonb_typeof(e) = 'string' THEN NULL ELSE e->>'expiryDate' END AS expiry
+          FROM jsonb_array_elements(COALESCE(vep.pmi_memberships, '[]'::jsonb)) e
+          WHERE public.resolve_br_chapter_code(
+                  CASE WHEN jsonb_typeof(e) = 'string' THEN e #>> '{}' ELSE e->>'chapterName' END
+                ) = mca.chapter_code
+          LIMIT 1
+        ) raw ON true
+        WHERE mca.person_id = m.person_id
+        UNION ALL
+        SELECT rr.code, false,
+               jsonb_build_object(
+                 'chapter_code', rr.code,
+                 'chapter_label', cr2.state,
+                 'source', 'vep_raw',
+                 'verified_at', NULL,
+                 'is_primary', false,
+                 'raw_name', rr.raw_name,
+                 'expiry', rr.expiry
+               )
+        FROM (
+          SELECT DISTINCT ON (t.code) t.code, t.raw_name, t.expiry
+          FROM (
+            SELECT public.resolve_br_chapter_code(CASE WHEN jsonb_typeof(e) = 'string' THEN e #>> '{}' ELSE e->>'chapterName' END) AS code,
+                   CASE WHEN jsonb_typeof(e) = 'string' THEN e #>> '{}' ELSE e->>'chapterName' END AS raw_name,
+                   CASE WHEN jsonb_typeof(e) = 'string' THEN NULL ELSE e->>'expiryDate' END AS expiry
+            FROM jsonb_array_elements(COALESCE(vep.pmi_memberships, '[]'::jsonb)) e
+          ) t
+          WHERE t.code IS NOT NULL
+          ORDER BY t.code, (t.expiry IS NULL)
+        ) rr
+        JOIN public.chapter_registry cr2 ON cr2.chapter_code = rr.code AND cr2.is_active = true
+        WHERE NOT EXISTS (
+          SELECT 1 FROM public.member_chapter_affiliations mca2
+          WHERE mca2.person_id = m.person_id AND mca2.chapter_code = rr.code)
+      ) x
+    ) aff2 ON true
+    WHERE m.member_status = 'active'
+      AND (
+        p_scope = 'all'                                                -- #1364b full roster (verified + unverified)
+        OR COALESCE(pre.flag, false)                                   -- pre-onboarding (urgent)
+        OR COALESCE(m.pmi_id_verified, false) = false                  -- cache says unverified
+        OR NOT EXISTS (                                                -- never verified at all
+          SELECT 1 FROM public.member_affiliation_verifications mv
+          WHERE mv.member_id = m.id
+        )
+      )
+  )
+  SELECT
+    COALESCE(jsonb_agg(jsonb_build_object(
+      'member_id', c.member_id,
+      'name', c.name,
+      'email', c.email,
+      'chapter', c.chapter,
+      'operational_role', c.operational_role,
+      'is_pre_onboarding', c.is_pre_onboarding,
+      'pmi_id_verified', COALESCE(c.pmi_id_verified, false),
+      'vep_status_raw', c.vep_status_raw,
+      'vep_last_seen_at', c.vep_last_seen_at,
+      'pmi_memberships', COALESCE(c.pmi_memberships, '[]'::jsonb),
+      -- #1192 SSOT chapter read-through (see lateral above)
+      'chapter_affiliations', COALESCE(c.chapter_affiliations, '[]'::jsonb),
+      'pmi_profile', CASE
+        WHEN c.pmi_id IS NULL AND c.service_first_start_date IS NULL
+             AND c.service_latest_end_date IS NULL AND c.service_history_count IS NULL
+             AND c.pmi_data_fetched_at IS NULL
+        THEN NULL
+        ELSE jsonb_build_object(
+          'pmi_id', c.pmi_id,
+          'member_since', c.service_first_start_date,
+          'member_until', c.service_latest_end_date,
+          'volunteer_count', c.service_history_count,
+          'last_sync', c.pmi_data_fetched_at
+        )
+      END,
+      -- #1129 cohort + volunteer-term validity
+      'cohort_class', CASE
+        WHEN NOT COALESCE(c.has_selection, false) THEN 'non_selection'
+        WHEN c.sel_is_current THEN 'current_selection'
+        ELSE 'carryover'
+      END,
+      'cohort_cycle_code', c.sel_cycle_code,
+      'cohort_role', c.sel_role,
+      'term_end_date', c.term_end_date,
+      'term_status', CASE
+        WHEN c.term_end_date IS NULL THEN 'none'
+        WHEN c.term_end_date < CURRENT_DATE THEN 'expired'
+        WHEN c.term_end_date <= CURRENT_DATE + (v_term_soon_days || ' days')::interval THEN 'expiring'
+        ELSE 'valid'
+      END,
+      'latest_verification', CASE WHEN c.aff_created_at IS NULL THEN NULL ELSE jsonb_build_object(
+        'created_at', c.aff_created_at,
+        'membership_active', c.aff_membership_active,
+        'membership_expires_on', c.aff_membership_expires_on,
+        'method', c.aff_method,
+        'chapter_verified', c.aff_chapter_verified
+      ) END
+    ) ORDER BY c.is_pre_onboarding DESC, c.name),
+    '[]'::jsonb),
+    ARRAY_AGG(c.member_id)
+  INTO v_result, v_member_ids
+  FROM cohort c;
+
+  -- LGPD Art. 37 — nominal read of affiliation data by the office (SPEC §6.2.3(4)). cohort/term/
+  -- chapter_affiliations are derived from selection/engagement/affiliation data the office already
+  -- reads; no new raw identity column ('chapter' + 'membership_dates' cover the read-through).
+  PERFORM public.log_pii_access_batch(
+    v_member_ids,
+    ARRAY['pmi_id','chapter','membership_status','membership_dates'],
+    'affiliation_verification_queue',
+    'Diretoria de Filiação — leitura da fila de verificação de filiação');
+
+  RETURN v_result;
+END;
+$function$;
+
+-- Grants (defense in depth — internal gate already bars unauthorized callers).
+REVOKE ALL ON FUNCTION public.get_affiliation_verification_queue(text) FROM public, anon;
+GRANT EXECUTE ON FUNCTION public.get_affiliation_verification_queue(text) TO authenticated, service_role;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/1364-chapter-vocabulary-single-source.test.mjs
+++ b/tests/contracts/1364-chapter-vocabulary-single-source.test.mjs
@@ -29,6 +29,7 @@ const REPO_ROOT = join(__dirname, '..', '..');
 const read = (p) => readFileSync(join(REPO_ROOT, p), 'utf8');
 
 const MIGRATION = 'supabase/migrations/20260805000436_1364_affiliation_chapter_rollup.sql';
+const MIGRATION_SCOPE = 'supabase/migrations/20260805000437_1364b_affiliation_queue_scope_all.sql';
 const ISLAND = 'src/components/admin/AffiliationQueueIsland.tsx';
 
 // ---------- static (offline) ----------
@@ -66,6 +67,41 @@ test('i18n: chapterReconcile exists in all three dictionaries', () => {
     const src = read(`src/i18n/${dict}.ts`);
     assert.match(src, /'comp\.affiliationQueue\.chapterReconcile':/,
       `${dict} must define comp.affiliationQueue.chapterReconcile`);
+  }
+});
+
+// ---------- #1364b — "Todos" tab (full active roster) ----------
+
+test('scope migration adds p_scope via DROP+CREATE without losing the queue shape', () => {
+  const src = read(MIGRATION_SCOPE);
+  // arg count changed -> must DROP then re-CREATE (GC-097), not a bare CREATE OR REPLACE of the 0-arg
+  assert.match(src, /DROP FUNCTION IF EXISTS public\.get_affiliation_verification_queue\(\);/,
+    'must DROP the 0-arg function before recreating with the new signature');
+  assert.match(src, /CREATE OR REPLACE FUNCTION public\.get_affiliation_verification_queue\(p_scope text DEFAULT 'queue'\)/,
+    'must recreate with p_scope defaulting to queue (back-compatible)');
+  // p_scope='all' relaxes the cohort; the rich per-row shape is preserved (single source, not duplicated)
+  assert.match(src, /p_scope = 'all'/, "p_scope='all' must relax the cohort WHERE");
+  assert.match(src, /chapter_affiliations/, 'the SSOT chapter read-through shape must be preserved');
+  assert.match(src, /PERFORM public\.log_pii_access_batch/, 'nominal PII read logging must be preserved');
+  // grants re-applied on the NEW (text) signature
+  assert.match(src, /REVOKE ALL ON FUNCTION public\.get_affiliation_verification_queue\(text\) FROM public, anon;/,
+    'must revoke the new (text) signature from public, anon');
+  assert.match(src, /GRANT EXECUTE ON FUNCTION public\.get_affiliation_verification_queue\(text\) TO authenticated, service_role;/,
+    'must grant the new (text) signature to authenticated, service_role');
+});
+
+test('FE has a third "Todos" tab that loads the full roster via p_scope=all', () => {
+  const src = read(ISLAND);
+  assert.match(src, /'pre' \| 'queue' \| 'all'/, 'tab state must be the three scopes');
+  assert.match(src, /p_scope: 'all'/, 'the Todos tab must request the full-roster scope');
+  assert.match(src, /comp\.affiliationQueue\.tabEveryone/, 'must render the "Todos" tab label');
+});
+
+test('i18n: tabEveryone + loadingAll exist in all three dictionaries', () => {
+  for (const dict of ['pt-BR', 'en-US', 'es-LATAM']) {
+    const src = read(`src/i18n/${dict}.ts`);
+    assert.match(src, /'comp\.affiliationQueue\.tabEveryone':/, `${dict} must define tabEveryone`);
+    assert.match(src, /'comp\.affiliationQueue\.loadingAll':/, `${dict} must define loadingAll`);
   }
 });
 


### PR DESCRIPTION
Follow-up to #1364 (PR #1366, already merged). Owner request: on `/admin/filiacao`, filter a chapter (e.g. RS) and see **every** member linked to it with each one's status/situation, not only the unverified verification queue. The two existing tabs (Pré-onboarding, Todos não-verificados) are both subsets of the queue.

## Approach (no duplicated logic)

Rather than a second RPC duplicating the rich per-row shape (`chapter_affiliations`, VEP, term, cohort, `latest_verification`), the queue RPC gains a scope param:

`get_affiliation_verification_queue(p_scope text DEFAULT 'queue')`

- `p_scope='all'` relaxes the cohort WHERE to return **all active members** (verified + unverified).
- Default `'queue'` is unchanged — existing no-arg callers keep working (back-compatible).
- `DROP + CREATE` because the arg count changed (GC-097). Body is the **live** definition verbatim with only the signature and the cohort WHERE edited; grants re-applied on the `(text)` signature.

## FE

- Third tab **"Todos"**, lazy-loaded on first open (avoids logging a full-roster PII read until the tab is used), kept in sync after a verify.
- All existing filters (chapter, cohort, term, VEP, status, search) + sort work over it unchanged — so filtering RS on "Todos" shows all 16 RS members with their farol/status.
- The #1364 reconciliation banner is hidden on this tab (everyone is already shown).
- i18n `tabEveryone` / `loadingAll` in all 3 dictionaries.
- Guard test `1364-*` extended to lock the DROP+CREATE, `p_scope='all'`, the preserved shape/grants, and the FE tab wiring.

## Verification

- Impersonated smoke: default scope -> **47** rows (unchanged); `p_scope='all'` -> **99** (full active roster); filtering RS on "Todos" -> **16** members.
- Affiliation-queue contract tests (659/996/1129/1192) still green with the new signature.
- `npx astro build` OK; `npm test` -> **5611 pass / 0 fail / 1 skip**.

Closes #1364