### PR TITLE
feat(filiacao): #1368 link PMI ID to the VEP profile for manual affiliation check

### DIFF
--- a/src/components/admin/AffiliationQueueIsland.tsx
+++ b/src/components/admin/AffiliationQueueIsland.tsx
@@ -14,7 +14,7 @@
 // #1041 expiry column/farol. Migrate from "verify everything by hand" → "review the auto-derived
 // and confirm exceptions" without loosening the write boundary (SPEC_996_FILIACAO_JOURNEY.md).
 import { useState, useEffect, useCallback, useRef, useMemo, Fragment } from 'react';
-import { Loader2, SearchCheck, CalendarClock, ShieldCheck, Info, ArrowUpDown, BadgeCheck, Filter, Search, ChevronDown, ChevronRight, IdCard } from 'lucide-react';
+import { Loader2, SearchCheck, CalendarClock, ShieldCheck, Info, ArrowUpDown, BadgeCheck, Filter, Search, ChevronDown, ChevronRight, IdCard, ExternalLink } from 'lucide-react';
 import { usePageI18n } from '../../i18n/usePageI18n';
 import { unifiedBrChapters, soonestChapterExpiry, type PmiMembershipEntry, type ChapterAffiliation } from '../../lib/affiliation-chapters';
 import { validityFarol, toneClasses, VEP_STATUS_TONE, COHORT_TONE } from '../../lib/statusFarol';
@@ -145,6 +145,11 @@ interface RegistryChapter { chapter_code: string; state: string; }
 // #1364 — per-chapter reconciliation row from get_affiliation_chapter_rollup(). `chapter` is
 // members.chapter ('PMI-XX', the /admin/members roster axis); in_queue mirrors this queue's cohort.
 interface ChapterRollupEntry { chapter: string; total_active: number; in_queue: number; verified_out: number; }
+
+// #1368 — deterministic PMI VEP profile URL by pmi_id (owner-confirmed pattern, 2026-07-13:
+// volunteer.pmi.org/profiles/<pmi_id>[/stub]). Lets the office jump straight to the source used
+// for affiliation enrichment to verify membership manually. Requires the caller to be logged in.
+const vepProfileUrl = (pmiId: string) => `https://volunteer.pmi.org/profiles/${encodeURIComponent(pmiId)}`;
 
 type SortKey = 'attention' | 'name' | 'expiry' | 'sync';
 
@@ -714,7 +719,15 @@ export default function AffiliationQueueIsland() {
                           <div className="flex flex-wrap gap-x-8 gap-y-2 text-[12px]">
                             <div>
                               <div className="text-[.6rem] uppercase tracking-wider text-[var(--text-muted)] flex items-center gap-1"><IdCard size={11} /> {t('comp.affiliationQueue.panelPmiId', 'PMI ID')}</div>
-                              <div className="font-medium text-[var(--text-primary)]">{p.pmi_id || '—'}</div>
+                              {p.pmi_id ? (
+                                <a href={vepProfileUrl(p.pmi_id)} target="_blank" rel="noopener noreferrer"
+                                   title={t('comp.affiliationQueue.openVepProfile', 'Abrir perfil no PMI VEP (volunteer.pmi.org) para verificar a filiação')}
+                                   className="font-medium text-teal-700 hover:text-teal-800 hover:underline inline-flex items-center gap-1">
+                                  {p.pmi_id} <ExternalLink size={11} className="opacity-70" />
+                                </a>
+                              ) : (
+                                <div className="font-medium text-[var(--text-primary)]">—</div>
+                              )}
                             </div>
                             <div>
                               <div className="text-[.6rem] uppercase tracking-wider text-[var(--text-muted)]">{t('comp.affiliationQueue.panelSince', 'Membro desde')}</div>

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -7152,6 +7152,7 @@ const enUS: Record<string, string> = {
   'comp.affiliationQueue.sort_sync': 'Last sync',
   'comp.affiliationQueue.expandHint': 'View PMI identity',
   'comp.affiliationQueue.panelPmiId': 'PMI ID',
+  'comp.affiliationQueue.openVepProfile': 'Open the PMI VEP profile (volunteer.pmi.org) to verify affiliation',
   'comp.affiliationQueue.panelSince': 'Member since',
   'comp.affiliationQueue.panelUntil': 'Member until',
   'comp.affiliationQueue.panelVolunteer': 'PMI service records',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -7152,6 +7152,7 @@ const esLATAM: Record<string, string> = {
   'comp.affiliationQueue.sort_sync': 'Última sync',
   'comp.affiliationQueue.expandHint': 'Ver identidad PMI',
   'comp.affiliationQueue.panelPmiId': 'PMI ID',
+  'comp.affiliationQueue.openVepProfile': 'Abrir el perfil en PMI VEP (volunteer.pmi.org) para verificar la afiliación',
   'comp.affiliationQueue.panelSince': 'Miembro desde',
   'comp.affiliationQueue.panelUntil': 'Miembro hasta',
   'comp.affiliationQueue.panelVolunteer': 'Registros de servicio PMI',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -7159,6 +7159,7 @@ const ptBR: Record<string, string> = {
   'comp.affiliationQueue.sort_sync': 'Última sync',
   'comp.affiliationQueue.expandHint': 'Ver identidade PMI',
   'comp.affiliationQueue.panelPmiId': 'PMI ID',
+  'comp.affiliationQueue.openVepProfile': 'Abrir perfil no PMI VEP (volunteer.pmi.org) para verificar a filiação',
   'comp.affiliationQueue.panelSince': 'Membro desde',
   'comp.affiliationQueue.panelUntil': 'Membro até',
   'comp.affiliationQueue.panelVolunteer': 'Registros de serviço PMI',

--- a/tests/contracts/1364-chapter-vocabulary-single-source.test.mjs
+++ b/tests/contracts/1364-chapter-vocabulary-single-source.test.mjs
@@ -105,6 +105,21 @@ test('i18n: tabEveryone + loadingAll exist in all three dictionaries', () => {
   }
 });
 
+// ---------- #1368 — deterministic VEP profile link by pmi_id ----------
+
+test('FE links PMI ID to the deterministic volunteer.pmi.org profile (owner-confirmed pattern)', () => {
+  const src = read(ISLAND);
+  // pattern volunteer.pmi.org/profiles/<pmi_id> (owner-confirmed 2026-07-13), built from stored pmi_id
+  assert.match(src, /volunteer\.pmi\.org\/profiles\/\$\{encodeURIComponent\(pmiId\)\}/,
+    'must build the VEP profile URL from pmi_id (no re-sync, no hardcoded id)');
+  assert.match(src, /vepProfileUrl\(p\.pmi_id\)/, 'the PMI ID cell must link via vepProfileUrl');
+  assert.match(src, /target="_blank"/, 'the external link must open in a new tab');
+  for (const dict of ['pt-BR', 'en-US', 'es-LATAM']) {
+    assert.match(read(`src/i18n/${dict}.ts`), /'comp\.affiliationQueue\.openVepProfile':/,
+      `${dict} must define openVepProfile`);
+  }
+});
+
 // ---------- DB-aware (skipped without creds) ----------
 
 async function rest(path) {


### PR DESCRIPTION
The affiliation office verifies membership by opening a member's profile on the PMI enrichment source. You confirmed (2026-07-13) that this profile is **deterministic by pmi_id**: `https://volunteer.pmi.org/profiles/<pmi_id>` (tested with two ids). Since the queue RPC already returns `pmi_profile.pmi_id` per row, this is **FE-only** — no migration, no worker change, no re-sync, and it works immediately for every row that has a pmi_id.

## Change
- The PMI ID in the identity panel of `/admin/filiacao` becomes an external link (new tab, `rel=noopener`) to the VEP profile, built from the stored `pmi_id` (no hardcoded id).
- i18n `openVepProfile` in all 3 dictionaries.
- Guard test locks the owner-confirmed URL pattern + the link wiring.

## Why (and the Vinicyus finding)
This directly serves the case that motivated it: **Vinicyus** showed "não verificada" because his enrichment carries no `pmi_memberships`. Opening his VEP profile shows he has **no active membership listed** — so the farol is **correct, not a bug**. The link lets the office confirm exactly this per member. The broader enrichment gap (6 public profiles without memberships) is tracked in #1368; this PR delivers the manual-verification aid.

## Verification
`npx astro build` OK; `npm test` → **5612 pass / 0 fail / 1 skip**.

Refs #1368