### PR TITLE
chore(db): #1383 confidential-visibility carve-outs for checklists + drive/comms readers

### DIFF
--- a/supabase/migrations/20260805000445_1383_p0c_checklists_confidential_rls.sql
+++ b/supabase/migrations/20260805000445_1383_p0c_checklists_confidential_rls.sql
@@ -1,0 +1,30 @@
+-- #785: add the confidential visibility carve-out to board_item_checklists.
+--
+-- The parent table board_items has a RESTRICTIVE SELECT policy
+-- (board_items_confidential_visibility = rls_can_see_board(board_id)) that ANDs on top
+-- of its permissive read. board_item_checklists had only the permissive
+-- checklists_read_members (rls_is_authoritative_member), so its checklist rows were not
+-- covered by the confidential visibility gate the parent board_items carries.
+--
+-- Fix: a RESTRICTIVE SELECT policy that mirrors the tested sibling board_item_comments
+-- pattern — an EXISTS over board_items (whose own RESTRICTIVE policy already hides
+-- confidential items), so a checklist row is selectable only when its parent board_item
+-- is visible to the caller. RESTRICTIVE ANDs with the permissive read; the confidential
+-- gate is inherited transitively through board_items' RLS (no scalar-subquery NULL trap).
+--
+-- Applied via apply_migration, then registered + NOTIFY per Track Q-C / GC-097.
+
+CREATE POLICY checklists_confidential_visibility
+  ON public.board_item_checklists
+  AS RESTRICTIVE
+  FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1
+      FROM public.board_items bi
+      JOIN public.project_boards pb ON pb.id = bi.board_id
+      WHERE bi.id = board_item_checklists.board_item_id
+    )
+  );
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260805000446_1383_p0c_list_drive_discoveries_confidential_gate.sql
+++ b/supabase/migrations/20260805000446_1383_p0c_list_drive_discoveries_confidential_gate.sql
@@ -1,0 +1,117 @@
+-- #785: gate list_drive_discoveries to the initiatives the caller may see (+ fix a
+-- pre-existing aggregate/pagination bug surfaced while gating it).
+--
+-- The function is gated by view_internal_analytics but listed drive-file discoveries for
+-- any initiative regardless of its visibility. The prior structural containment ("the
+-- confidential initiative has 0 drive links") no longer holds: initiative Drive
+-- provisioning (#1376 / ADR-0124) created a drive link for the confidential committee,
+-- so a file discovered under it would otherwise be listed without a visibility check.
+--
+-- Fix 1 (security): AND public.rls_can_see_initiative(l.initiative_id) into both the count
+-- and the returned rows. rls_can_see_initiative returns true for non-confidential
+-- initiatives and for engaged members / GP, so ordinary analytics viewers keep seeing all
+-- non-confidential discoveries; only the confidential initiative is filtered from
+-- non-engaged callers.
+--
+-- Fix 2 (pre-existing bug): the live body aggregated with jsonb_agg while applying
+-- `ORDER BY d.discovered_at DESC LIMIT/OFFSET` at the OUTER level of that aggregate query
+-- (no GROUP BY) -> "column d.discovered_at must appear in the GROUP BY clause". The
+-- function errored on every call that reached the row aggregation (it was in the
+-- never-called set, so this went unnoticed). Restructured to ORDER/LIMIT/OFFSET the rows
+-- in a subquery and aggregate its output, preserving the same shape and ordering.
+--
+-- Apply + register + NOTIFY per Track Q-C / GC-097.
+
+CREATE OR REPLACE FUNCTION public.list_drive_discoveries(p_initiative_id uuid DEFAULT NULL::uuid, p_status_filter text DEFAULT 'all'::text, p_limit integer DEFAULT 50, p_offset integer DEFAULT 0)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO ''
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_rows jsonb;
+  v_total integer;
+  v_limit integer := least(greatest(coalesce(p_limit, 50), 1), 200);
+  v_offset integer := greatest(coalesce(p_offset, 0), 0);
+BEGIN
+  SELECT m.id INTO v_caller_id FROM public.members m WHERE m.auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Not authenticated');
+  END IF;
+  IF NOT public.can_by_member(v_caller_id, 'view_internal_analytics') THEN
+    RETURN jsonb_build_object('error', 'Not authorized: requires view_internal_analytics');
+  END IF;
+  IF p_status_filter NOT IN ('all', 'unmatched', 'unpromoted', 'promoted') THEN
+    RETURN jsonb_build_object('error', 'Invalid status_filter. Use: all | unmatched | unpromoted | promoted');
+  END IF;
+
+  WITH base AS (
+    SELECT d.id
+    FROM public.drive_file_discoveries d
+    INNER JOIN public.initiative_drive_links l ON l.id = d.initiative_drive_link_id
+    WHERE (p_initiative_id IS NULL OR l.initiative_id = p_initiative_id)
+      AND public.rls_can_see_initiative(l.initiative_id)
+      AND (
+        p_status_filter = 'all'
+        OR (p_status_filter = 'unmatched' AND d.matched_event_id IS NULL)
+        OR (p_status_filter = 'unpromoted' AND d.matched_event_id IS NOT NULL AND d.promoted_to_minutes_url = false)
+        OR (p_status_filter = 'promoted' AND d.promoted_to_minutes_url = true)
+      )
+  )
+  SELECT count(*) INTO v_total FROM base;
+
+  SELECT coalesce(jsonb_agg(elem ORDER BY disc DESC), '[]'::jsonb)
+  INTO v_rows
+  FROM (
+    SELECT
+      jsonb_build_object(
+        'id', d.id,
+        'initiative_id', l.initiative_id,
+        'initiative_title', i.title,
+        'drive_folder_name', l.drive_folder_name,
+        'drive_file_id', d.drive_file_id,
+        'drive_file_url', d.drive_file_url,
+        'filename', d.filename,
+        'mime_type', d.mime_type,
+        'size_bytes', d.size_bytes,
+        'drive_modified_at', d.drive_modified_at,
+        'discovered_at', d.discovered_at,
+        'matched_event_id', d.matched_event_id,
+        'matched_event_title', e.title,
+        'matched_event_date', e.date,
+        'match_strategy', d.match_strategy,
+        'match_confidence', d.match_confidence,
+        'promoted_to_minutes_url', d.promoted_to_minutes_url,
+        'promoted_at', d.promoted_at,
+        'promoted_by_name', m.name
+      ) AS elem,
+      d.discovered_at AS disc
+    FROM public.drive_file_discoveries d
+    INNER JOIN public.initiative_drive_links l ON l.id = d.initiative_drive_link_id
+    LEFT JOIN public.initiatives i ON i.id = l.initiative_id
+    LEFT JOIN public.events e ON e.id = d.matched_event_id
+    LEFT JOIN public.members m ON m.id = d.promoted_by
+    WHERE (p_initiative_id IS NULL OR l.initiative_id = p_initiative_id)
+      AND public.rls_can_see_initiative(l.initiative_id)
+      AND (
+        p_status_filter = 'all'
+        OR (p_status_filter = 'unmatched' AND d.matched_event_id IS NULL)
+        OR (p_status_filter = 'unpromoted' AND d.matched_event_id IS NOT NULL AND d.promoted_to_minutes_url = false)
+        OR (p_status_filter = 'promoted' AND d.promoted_to_minutes_url = true)
+      )
+    ORDER BY d.discovered_at DESC
+    LIMIT v_limit OFFSET v_offset
+  ) sub;
+
+  RETURN jsonb_build_object(
+    'total', v_total,
+    'limit', v_limit,
+    'offset', v_offset,
+    'discoveries', v_rows,
+    'fetched_at', now()
+  );
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/supabase/migrations/20260805000447_1383_p0c_member_comms_card_confidential_roles.sql
+++ b/supabase/migrations/20260805000447_1383_p0c_member_comms_card_confidential_roles.sql
@@ -1,0 +1,154 @@
+-- #785: keep confidential-initiative membership out of the comms card.
+--
+-- get_member_comms_card (gated by manage_event OR manage_member) returns a target
+-- person's active engagements as `roles` (initiative title + kind + role) without a
+-- visibility check, so a confidential-initiative role could appear in the card. The card
+-- is a publicity aid, so confidential-initiative roles have no place in it.
+--
+-- Fix: exclude visibility = 'confidential' initiatives from the roles subselect. GP still
+-- reads confidential board/committee content through the initiative surfaces; the comms
+-- card simply never advertises a confidential role.
+--
+-- Live body (pg_get_functiondef, 2026-07-15) with only the roles predicate added, so the
+-- drift-gate captures it byte-for-byte (GC-097 / #965). Apply + register + NOTIFY.
+
+CREATE OR REPLACE FUNCTION public.get_member_comms_card(p_query text DEFAULT NULL::text, p_person_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_person_id uuid;
+  v_can boolean;
+  v_target uuid;
+  v_match_count int;
+  v_matches jsonb;
+  v_member_id uuid;
+  v_member_status text;
+  v_clear boolean;
+  v_reason text;
+  v_like text;
+BEGIN
+  -- Auth. Resolve the caller's person_id: can() keys on auth_engagements.person_id
+  -- (= persons.id), NOT auth.uid() — so the gate MUST pass a person_id.
+  SELECT id INTO v_caller_person_id FROM public.persons WHERE auth_id = auth.uid();
+  IF v_caller_person_id IS NULL THEN
+    RETURN jsonb_build_object('error', 'Not authenticated');
+  END IF;
+
+  -- Authority gate: comms/event leaders + admin/GP
+  v_can := public.can(v_caller_person_id, 'manage_event', NULL, NULL)
+        OR public.can(v_caller_person_id, 'manage_member', NULL, NULL);
+  IF NOT v_can THEN
+    RETURN jsonb_build_object('error', 'Unauthorized: requires manage_event or manage_member');
+  END IF;
+
+  -- Resolve target person
+  IF p_person_id IS NOT NULL THEN
+    v_target := p_person_id;
+  ELSIF p_query IS NOT NULL AND length(trim(p_query)) >= 2 THEN
+    -- Escape LIKE wildcards so a caller cannot pass '%'/'_' to enumerate the directory.
+    v_like := '%' || replace(replace(replace(trim(p_query), '\', '\\'), '%', '\%'), '_', '\_') || '%';
+
+    SELECT count(*) INTO v_match_count
+    FROM public.persons p
+    WHERE p.anonymized_at IS NULL
+      AND p.name ILIKE v_like ESCAPE '\';
+
+    IF v_match_count = 0 THEN
+      RETURN jsonb_build_object('error', 'No person found matching query');
+    ELSIF v_match_count > 1 THEN
+      SELECT jsonb_agg(jsonb_build_object(
+               'person_id', p.id,
+               'name', p.name,
+               'has_photo', (p.photo_url IS NOT NULL)
+             ) ORDER BY p.name)
+        INTO v_matches
+      FROM public.persons p
+      WHERE p.anonymized_at IS NULL
+        AND p.name ILIKE v_like ESCAPE '\';
+      RETURN jsonb_build_object('ambiguous', true, 'match_count', v_match_count, 'matches', v_matches);
+    ELSE
+      SELECT p.id INTO v_target
+      FROM public.persons p
+      WHERE p.anonymized_at IS NULL
+        AND p.name ILIKE v_like ESCAPE '\';
+    END IF;
+  ELSE
+    RETURN jsonb_build_object('error', 'Provide person_id or query (min 2 chars)');
+  END IF;
+
+  -- Target must exist and not be anonymized
+  IF NOT EXISTS (SELECT 1 FROM public.persons WHERE id = v_target AND anonymized_at IS NULL) THEN
+    RETURN jsonb_build_object('error', 'Person not found');
+  END IF;
+
+  -- Comms clearance (Cláusula 11): signed term = NOT pre-onboarding for the linked member.
+  SELECT m.id, m.member_status INTO v_member_id, v_member_status
+  FROM public.members m
+  JOIN public.persons p ON p.legacy_member_id = m.id
+  WHERE p.id = v_target;
+
+  IF v_member_id IS NULL THEN
+    v_clear := false;
+    v_reason := 'no_member_record';
+  ELSIF public.member_is_pre_onboarding(v_target, v_member_status) THEN
+    v_clear := false;
+    v_reason := 'pre_onboarding';
+  -- #729: honor an image/voice publicity consent REVOCATION (#570 SSOT, consent_records).
+  -- "Currently revoked" = a revoked image_voice_publicity consent with NO later active opt-in.
+  -- Behavior-neutral today (0 rows; #570 dormant). At #570 go-live, tighten to REQUIRE an
+  -- active opt-in rather than only blocking on an explicit revocation (see header note).
+  ELSIF EXISTS (
+      SELECT 1 FROM public.consent_records cr
+      WHERE cr.member_id = v_member_id
+        AND cr.policy_type = 'image_voice_publicity'
+        AND cr.revoked_at IS NOT NULL
+    ) AND NOT EXISTS (
+      SELECT 1 FROM public.consent_records cr
+      WHERE cr.member_id = v_member_id
+        AND cr.policy_type = 'image_voice_publicity'
+        AND cr.revoked_at IS NULL
+    ) THEN
+    v_clear := false;
+    v_reason := 'image_consent_revoked';
+  ELSE
+    v_clear := true;
+    v_reason := 'signed_term';
+  END IF;
+
+  -- Build the comms card
+  RETURN (
+    SELECT jsonb_build_object(
+      'person_id', p.id,
+      'display_name', p.name,
+      'headshot_url', p.photo_url,
+      'linkedin_url', p.linkedin_url,
+      'credly_url', p.credly_url,
+      'credentials', COALESCE((
+        SELECT jsonb_agg(b->>'name' ORDER BY (b->>'issued_at') DESC)
+        FROM jsonb_array_elements(COALESCE(p.credly_badges, '[]'::jsonb)) b
+        WHERE b->>'name' IS NOT NULL
+      ), '[]'::jsonb),
+      'roles', COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'initiative', i.title,
+                 'kind', e.kind,
+                 'role', e.role
+               ) ORDER BY e.granted_at DESC)
+        FROM public.engagements e
+        JOIN public.initiatives i ON i.id = e.initiative_id
+        WHERE e.person_id = p.id AND e.status = 'active'
+          AND i.visibility IS DISTINCT FROM 'confidential'
+      ), '[]'::jsonb),
+      'comms_clearance', v_clear,
+      'clearance_reason', v_reason
+    )
+    FROM public.persons p
+    WHERE p.id = v_target
+  );
+END;
+$function$;
+
+NOTIFY pgrst, 'reload schema';

--- a/tests/contracts/785-secdef-reader-confidential-gate.test.mjs
+++ b/tests/contracts/785-secdef-reader-confidential-gate.test.mjs
@@ -125,13 +125,16 @@ const ALLOWLIST = {
   get_event_attendance_health: 'gated (view_internal_analytics OR view_chapter_dashboards)',
   get_event_champion_suggestions: 'gated (manage_event OR award_champion) + caller-org check',
   get_gp_cohort_health: 'gated (manage_member OR view_internal_analytics); logic filters kind=research_tribe (excludes governance)',
-  get_member_comms_card: 'gated (manage_event OR manage_member)',
+  // get_member_comms_card: gated in mig 447 (#1383) — excludes visibility='confidential'
+  //   initiatives from the roles list; now references a gate, removed from this allowlist.
   get_member_detail: 'analytics-gated (view_internal_analytics entry gate)',
   get_pending_agreement_engagements: 'gated (manage_member)',
   get_platform_usage: 'gp-only (manage_platform entry gate)',
   get_recurring_meeting_admin_list: 'gp-only (manage_platform entry gate)',
   get_recurring_meeting_drift: 'gp-only (manage_platform entry gate)',
-  list_drive_discoveries: 'gated (view_internal_analytics); confidential initiative has 0 drive_links',
+  // list_drive_discoveries: gated in mig 446 (#1383) — rls_can_see_initiative(l.initiative_id)
+  //   on both the count and the rows (the "0 drive_links" containment lapsed once #1376
+  //   provisioned a link for the confidential committee); now gated, removed from this allowlist.
   list_orphan_interview_events: 'gp-only (manage_platform entry gate)',
   offboard_member_with_handoffs: 'gated (manage_member) member-lifecycle write, GP-only (board-flagged, pre-existing)',
   // -- self-scoped (auth.uid own data; a non-engaged caller only ever sees their own rows)
@@ -325,4 +328,36 @@ test('#1063 static: get_meeting_notes_compliance excludes confidential in mig 42
   assert.ok(block, 'get_meeting_notes_compliance must be CREATE OR REPLACE\'d in migration 426');
   assert.ok(/visibility IS DISTINCT FROM 'confidential'/.test(block),
     'get_meeting_notes_compliance must exclude confidential initiatives from the rollup');
+});
+
+// --- #1383 PR-C (2026-07-15): board_item_checklists RLS carve-out + two SECDEF reader gates.
+// Static guards so a future rewrite cannot silently drop the confidential protection. The
+// DB-aware guard above already keeps the two functions out of the ungated set; these lock
+// the migration bodies, and cover the RLS policy (which the SECDEF audit does not track).
+const MIG_CHK = 'supabase/migrations/20260805000445_1383_p0c_checklists_confidential_rls.sql';
+const MIG_DRV = 'supabase/migrations/20260805000446_1383_p0c_list_drive_discoveries_confidential_gate.sql';
+const MIG_CMC = 'supabase/migrations/20260805000447_1383_p0c_member_comms_card_confidential_roles.sql';
+
+test('#1383 static: board_item_checklists gains a RESTRICTIVE confidential SELECT policy in mig 445', () => {
+  const sql = readFileSync(resolve(process.cwd(), MIG_CHK), 'utf8');
+  assert.ok(/CREATE POLICY checklists_confidential_visibility/.test(sql),
+    'mig 445 must create the checklists_confidential_visibility policy');
+  assert.ok(/AS RESTRICTIVE/i.test(sql) && /FOR SELECT/i.test(sql),
+    'the checklist policy must be RESTRICTIVE FOR SELECT');
+  assert.ok(/FROM public\.board_items bi/.test(sql),
+    'the checklist policy must gate through board_items (inherits its confidential RLS)');
+});
+
+test('#1383 static: list_drive_discoveries applies rls_can_see_initiative in mig 446', () => {
+  const block = migBlock(MIG_DRV, 'list_drive_discoveries');
+  assert.ok(block, 'list_drive_discoveries must be CREATE OR REPLACE\'d in migration 446');
+  assert.ok(/rls_can_see_initiative\(l\.initiative_id\)/.test(block),
+    'list_drive_discoveries must gate discoveries via rls_can_see_initiative');
+});
+
+test('#1383 static: get_member_comms_card excludes confidential roles in mig 447', () => {
+  const block = migBlock(MIG_CMC, 'get_member_comms_card');
+  assert.ok(block, 'get_member_comms_card must be CREATE OR REPLACE\'d in migration 447');
+  assert.ok(/visibility IS DISTINCT FROM 'confidential'/.test(block),
+    'get_member_comms_card must exclude confidential initiatives from the roles list');
 });


### PR DESCRIPTION
## What

Three #785 confidential-visibility carve-outs (re-proven live against the one confidential initiative):

- **board_item_checklists**: add a RESTRICTIVE `SELECT` policy that inherits the parent `board_items` confidential gate through an `EXISTS` (the tested `board_item_comments` pattern). Its checklist rows were only covered by the permissive `rls_is_authoritative_member` read.
- **list_drive_discoveries**: `AND rls_can_see_initiative(l.initiative_id)` on the count and the rows (the "0 confidential drive links" structural containment lapsed once #1376/ADR-0124 provisioned a link for the committee). Also fixes a pre-existing aggregate `ORDER BY … LIMIT` error that made the RPC fail on every call that returned rows.
- **get_member_comms_card**: exclude `visibility='confidential'` initiatives from the `roles` list.
- **#785 guard**: the two now-gated readers move out of the allowlist; add static recurrence guards for all three fixes.

The other candidate readers were re-proven safe and left as-is: `get_portfolio_planned_vs_actual` / `get_portfolio_timeline` (structurally exclude the NULL-tribe confidential initiative), `get_comms_pipeline` (gated + 0 confidential webinars).

## State

- Applied to remote via `apply_migration` + registered in `schema_migrations` + `NOTIFY pgrst` (GC-097 / Track Q-C).
- Verified live via impersonation: a non-engaged member sees **0** of the 13 confidential checklist rows (and **504** non-confidential ones — no over-blocking); GP sees all 13. The comms card drops the confidential role while keeping non-confidential roles; the drive reader gates confidential and runs clean.
- Green locally: `785-secdef-reader-confidential-gate` (DB-aware + static), `rpc-migration-coverage` (Phase C body-drift, ADR-0097), `rpc-acl`.