### PR TITLE
chore(db): #1383 PR-D — visibility + authority gates on document/curation/re-engagement RPCs

### DIFF
--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -7360,14 +7360,13 @@ function registerTools(mcp: McpServer, sb: Sb) {
 
   mcp.tool("stage_alumni_for_re_engagement", "Stage an alumni member into the re-engagement pipeline for a specific cycle. Admin manual curation step (cron auto-stages on cycle open). Returns existing pipeline_id if already staged (idempotent).", {
     member_id: z.string().describe("UUID of the alumni member"),
-    cycle_code: z.string().describe("Target cycle code (e.g., 'cycle_3')"),
-    source: z.string().optional().describe("Source: 'manual_admin' (default) or 'cron_new_cycle'")
-  }, async (params: { member_id: string; cycle_code: string; source?: string }) => {
+    cycle_code: z.string().describe("Target cycle code (e.g., 'cycle_3')")
+  }, async (params: { member_id: string; cycle_code: string }) => {
     const start = Date.now();
     const member = await getMember(sb);
     if (!member) { await logUsage(sb, null, "stage_alumni_for_re_engagement", false, "Not authenticated", start); return err("Not authenticated"); }
     const { data, error } = await sb.rpc("stage_alumni_for_re_engagement", {
-      p_member_id: params.member_id, p_cycle_code: params.cycle_code, p_source: params.source ?? 'manual_admin'
+      p_member_id: params.member_id, p_cycle_code: params.cycle_code
     });
     if (error) { await logUsage(sb, member.id, "stage_alumni_for_re_engagement", false, error.message, start); return err(error.message); }
     await logUsage(sb, member.id, "stage_alumni_for_re_engagement", true, undefined, start);

--- a/supabase/migrations/20260805000448_1383_p0d_stage_alumni_cron_source_guard.sql
+++ b/supabase/migrations/20260805000448_1383_p0d_stage_alumni_cron_source_guard.sql
@@ -1,0 +1,88 @@
+-- #1383 PR-D: scope the 'cron_new_cycle' staging source to the automated
+-- cycle-open context. The auto-stage trigger trg_auto_stage_alumni_on_cycle_open
+-- runs with no authenticated caller, so this source is accepted only when there is
+-- no authenticated caller (or when executing inside a trigger). Interactive callers
+-- use the manage_member-gated 'manual_admin' path. Body otherwise unchanged from
+-- the live capture.
+CREATE OR REPLACE FUNCTION public.stage_alumni_for_re_engagement(p_member_id uuid, p_cycle_code text, p_source text DEFAULT 'manual_admin'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller record;
+  v_member record;
+  v_record record;
+  v_pipeline_id uuid;
+  v_staged_by uuid := NULL;
+BEGIN
+  IF p_source NOT IN ('cron_new_cycle','manual_admin') THEN
+    RETURN jsonb_build_object('error','Invalid source: ' || p_source);
+  END IF;
+
+  IF p_source = 'cron_new_cycle' THEN
+    -- Automated cycle-open path (trg_auto_stage_alumni_on_cycle_open): no
+    -- authenticated caller. Reject if an authenticated client outside a trigger
+    -- tries to use this source to skip the manage_member gate below.
+    IF auth.uid() IS NOT NULL AND pg_trigger_depth() = 0 THEN
+      RETURN jsonb_build_object('error','Unauthorized: cron_new_cycle is reserved for automated cycle-open staging');
+    END IF;
+  ELSE
+    -- manual_admin: authenticated caller with manage_member authority
+    SELECT * INTO v_caller FROM public.members WHERE auth_id = auth.uid();
+    IF NOT FOUND THEN RETURN jsonb_build_object('error','Not authenticated'); END IF;
+    IF NOT public.can_by_member(v_caller.id, 'manage_member') THEN
+      RETURN jsonb_build_object('error','Unauthorized: requires manage_member permission');
+    END IF;
+    v_staged_by := v_caller.id;
+  END IF;
+
+  SELECT * INTO v_member FROM public.members WHERE id = p_member_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('error','Member not found'); END IF;
+
+  IF v_member.member_status <> 'alumni' THEN
+    RETURN jsonb_build_object('error','Member is not alumni (status: ' || COALESCE(v_member.member_status,'NULL') || ')');
+  END IF;
+
+  IF v_member.anonymized_at IS NOT NULL THEN
+    RETURN jsonb_build_object('error','Cannot stage anonymized member (LGPD Art. 16 II)');
+  END IF;
+
+  -- Snapshot return_interest from offboarding record
+  SELECT return_interest, reason_category_code INTO v_record
+  FROM public.member_offboarding_records
+  WHERE member_id = p_member_id
+  ORDER BY offboarded_at DESC LIMIT 1;
+
+  -- Idempotent: if active pipeline exists for (member,cycle), return it
+  SELECT id INTO v_pipeline_id
+  FROM public.re_engagement_pipeline
+  WHERE member_id = p_member_id AND cycle_code = p_cycle_code
+    AND state IN ('staged','invited','accepted')
+  LIMIT 1;
+
+  IF v_pipeline_id IS NOT NULL THEN
+    RETURN jsonb_build_object('success', true, 'pipeline_id', v_pipeline_id, 'idempotent', true);
+  END IF;
+
+  INSERT INTO public.re_engagement_pipeline (
+    member_id, cycle_code, state, staged_by, staged_source,
+    return_interest_snapshot, reason_category_snapshot
+  ) VALUES (
+    p_member_id, p_cycle_code, 'staged',
+    v_staged_by,
+    p_source,
+    v_record.return_interest,
+    v_record.reason_category_code
+  )
+  RETURNING id INTO v_pipeline_id;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'pipeline_id', v_pipeline_id,
+    'member_name', v_member.name,
+    'return_interest', v_record.return_interest,
+    'reason_category', v_record.reason_category_code
+  );
+END $function$;

--- a/supabase/migrations/20260805000449_1383_p0d_curation_review_board_visibility_gate.sql
+++ b/supabase/migrations/20260805000449_1383_p0d_curation_review_board_visibility_gate.sql
@@ -1,0 +1,130 @@
+-- #1383 PR-D: apply the confidential-board visibility gate to submit_curation_review,
+-- mirroring its sibling assign_curation_reviewer (#785 PR-3). A curator without
+-- engagement on a confidential initiative must not act on its board items. Body
+-- otherwise unchanged from the live capture.
+CREATE OR REPLACE FUNCTION public.submit_curation_review(p_item_id uuid, p_decision text, p_criteria_scores jsonb DEFAULT '{}'::jsonb, p_feedback_notes text DEFAULT NULL::text)
+ RETURNS uuid
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_caller   members%rowtype;
+  v_item     board_items%rowtype;
+  v_log_id   uuid;
+  v_pub_id   uuid;
+  v_origin_board uuid;
+  v_required int;
+  v_current_round int;
+  v_approved_count int;
+  v_criteria text[];
+  v_key text;
+  v_score int;
+BEGIN
+  SELECT * INTO v_caller FROM members WHERE auth_id = auth.uid();
+  IF v_caller IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+
+  IF NOT public.can_by_member(v_caller.id, 'participate_in_governance_review') THEN
+    RAISE EXCEPTION 'Requires participate_in_governance_review';
+  END IF;
+
+  IF p_decision NOT IN ('approved', 'returned_for_revision', 'rejected') THEN
+    RAISE EXCEPTION 'Invalid decision: %', p_decision;
+  END IF;
+
+  SELECT * INTO v_item FROM board_items WHERE id = p_item_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Board item not found'; END IF;
+
+  -- #785 PR-3 parity (mirror assign_curation_reviewer): a curator without
+  -- engagement on a confidential initiative cannot act on its board items.
+  IF NOT public.rls_can_see_board(v_item.board_id) THEN
+    RAISE EXCEPTION 'Board item not found';
+  END IF;
+
+  IF v_item.curation_status <> 'curation_pending' THEN
+    RAISE EXCEPTION 'Item is not in curation_pending status';
+  END IF;
+
+  IF p_criteria_scores IS NOT NULL AND p_criteria_scores <> '{}'::jsonb THEN
+    FOR v_key IN SELECT unnest(ARRAY['clarity','originality','adherence','relevance','ethics'])
+    LOOP
+      v_score := (p_criteria_scores->>v_key)::int;
+      IF v_score IS NULL OR v_score < 1 OR v_score > 5 THEN
+        RAISE EXCEPTION 'Invalid score for %: must be 1-5', v_key;
+      END IF;
+    END LOOP;
+  END IF;
+
+  SELECT coalesce(max(review_round), 1) INTO v_current_round
+  FROM board_lifecycle_events
+  WHERE item_id = p_item_id AND action = 'reviewer_assigned';
+
+  IF EXISTS (
+    SELECT 1 FROM curation_review_log
+    WHERE board_item_id = p_item_id
+      AND curator_id = v_caller.id
+      AND review_round = v_current_round
+  ) THEN
+    RAISE EXCEPTION 'You have already submitted a review for this item in round %', v_current_round;
+  END IF;
+
+  SELECT reviewers_required INTO v_required
+  FROM board_sla_config WHERE board_id = v_item.board_id;
+  v_required := coalesce(v_required, 2);
+
+  INSERT INTO curation_review_log (
+    board_item_id, curator_id, criteria_scores, feedback_notes,
+    decision, due_date, completed_at, review_round
+  ) VALUES (
+    p_item_id, v_caller.id, p_criteria_scores, p_feedback_notes,
+    p_decision, v_item.curation_due_at, now(), v_current_round
+  ) RETURNING id INTO v_log_id;
+
+  INSERT INTO board_lifecycle_events
+    (board_id, item_id, action, reason, actor_member_id, review_score, review_round, sla_deadline)
+  VALUES
+    (v_item.board_id, p_item_id, 'curation_review',
+     p_decision || ': ' || coalesce(p_feedback_notes, ''),
+     v_caller.id, p_criteria_scores, v_current_round, v_item.curation_due_at);
+
+  IF p_decision = 'approved' THEN
+    SELECT count(DISTINCT curator_id) INTO v_approved_count
+    FROM curation_review_log
+    WHERE board_item_id = p_item_id
+      AND decision = 'approved'
+      AND review_round = v_current_round;
+
+    IF v_approved_count >= v_required THEN
+      v_pub_id := public.publish_board_item_from_curation(p_item_id);
+      INSERT INTO board_lifecycle_events
+        (board_id, item_id, action, reason, actor_member_id, review_round)
+      VALUES
+        (v_item.board_id, p_item_id, 'curation_approved',
+         v_approved_count || '/' || v_required || ' revisores aprovaram',
+         v_caller.id, v_current_round);
+    END IF;
+
+  ELSIF p_decision = 'returned_for_revision' THEN
+    UPDATE board_items SET
+      curation_status = 'draft',
+      status = 'review',
+      description = coalesce(description, '') ||
+        E'\n\n---\n📋 **Feedback do Comitê de Curadoria — Rodada ' || v_current_round || '** (' || to_char(now(), 'DD/MM/YYYY') || E'):\n' ||
+        coalesce(p_feedback_notes, 'Sem observações específicas.'),
+      updated_at = now()
+    WHERE id = p_item_id;
+
+  ELSIF p_decision = 'rejected' THEN
+    UPDATE board_items SET
+      curation_status = 'draft',
+      status = 'archived',
+      description = coalesce(description, '') ||
+        E'\n\n---\n❌ **Rejeitado pelo Comitê de Curadoria — Rodada ' || v_current_round || '** (' || to_char(now(), 'DD/MM/YYYY') || E'):\n' ||
+        coalesce(p_feedback_notes, 'Não atende aos critérios mínimos.'),
+      updated_at = now()
+    WHERE id = p_item_id;
+  END IF;
+
+  RETURN v_log_id;
+END;
+$function$;

--- a/supabase/migrations/20260805000450_1383_p0d_document_detail_visibility_ceiling.sql
+++ b/supabase/migrations/20260805000450_1383_p0d_document_detail_visibility_ceiling.sql
@@ -1,0 +1,192 @@
+-- #1383 PR-D: apply the visibility_class ceiling to get_document_detail, mirroring
+-- the canonical reader get_governance_document_reader. This SECDEF composite read
+-- bypasses RLS, so the gd_read visibility predicate is replicated inline:
+-- legal_scoped docs are visible only to manage_member admins or members who signed
+-- the document; admin_only / audit_restricted are authority-scoped. Not-found masking
+-- avoids leaking existence. Body otherwise unchanged from the live capture.
+CREATE OR REPLACE FUNCTION public.get_document_detail(p_document_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_is_admin boolean;
+  v_is_platform_admin boolean;
+  v_doc record;
+  v_current_version record;
+  v_active_chain record;
+  v_signed_gates jsonb;
+  v_pending_for_me text[];
+  v_comments_total int;
+  v_comments_unresolved int;
+  v_versions_total int;
+  v_draft_versions jsonb;
+BEGIN
+  SELECT m.id INTO v_member_id
+  FROM public.members m
+  WHERE m.auth_id = auth.uid() AND m.is_active = true;
+  IF v_member_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  SELECT gd.id, gd.doc_type, gd.title, gd.description, gd.version, gd.status,
+         gd.visibility_class,
+         gd.partner_entity_id, gd.current_version_id, gd.signed_at,
+         gd.valid_from, gd.valid_until, gd.exit_notice_days, gd.docusign_envelope_id,
+         gd.pdf_url, gd.created_at, gd.updated_at
+  INTO v_doc
+  FROM public.governance_documents gd
+  WHERE gd.id = p_document_id;
+
+  IF v_doc.id IS NULL THEN
+    RAISE EXCEPTION 'governance_document not found (id=%)', p_document_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Visibility ceiling (mirror get_governance_document_reader). SECDEF bypasses RLS;
+  -- replicate the gd_read visibility predicate inline. Not-found masking avoids
+  -- leaking the existence of a document the caller may not see.
+  v_is_admin          := public.can_by_member(v_member_id, 'manage_member');
+  v_is_platform_admin := public.can_by_member(v_member_id, 'manage_platform');
+  IF NOT (
+    v_doc.visibility_class = 'public'
+    OR v_doc.visibility_class = 'active_members'
+    OR (v_doc.visibility_class = 'legal_scoped' AND (
+          v_is_admin
+          OR EXISTS (
+            SELECT 1 FROM public.member_document_signatures mds
+            WHERE mds.member_id = v_member_id
+              AND mds.document_id = v_doc.id
+              AND mds.is_current = true)))
+    OR (v_doc.visibility_class = 'admin_only' AND v_is_admin)
+    OR (v_doc.visibility_class = 'audit_restricted' AND v_is_platform_admin)
+  ) THEN
+    RAISE EXCEPTION 'governance_document not found (id=%)', p_document_id
+      USING ERRCODE = 'no_data_found';
+  END IF;
+
+  -- Always assign v_current_version (record) so the RETURN's field references are
+  -- valid even when current_version_id IS NULL: SELECT INTO on a NULL match assigns
+  -- an all-NULL row rather than leaving the record unassigned. Guarding the SELECT
+  -- with IF current_version_id IS NOT NULL skipped the assignment and crashed the
+  -- RETURN ("record not assigned yet") on docs with no current version (5 such live).
+  SELECT dv.id, dv.version_number, dv.version_label, dv.authored_at,
+         dv.locked_at, dv.published_at, dv.notes,
+         am.name AS authored_by_name, lm.name AS locked_by_name,
+         length(dv.content_html) AS content_html_length,
+         (dv.content_markdown IS NOT NULL) AS has_markdown
+  INTO v_current_version
+  FROM public.document_versions dv
+  LEFT JOIN public.members am ON am.id = dv.authored_by
+  LEFT JOIN public.members lm ON lm.id = dv.locked_by
+  WHERE dv.id = v_doc.current_version_id;
+
+  SELECT ac.id, ac.version_id, ac.status, ac.gates, ac.opened_at,
+         ac.approved_at, ac.activated_at, ac.closed_at
+  INTO v_active_chain
+  FROM public.approval_chains ac
+  WHERE ac.document_id = p_document_id
+    AND ac.status IN ('review','approved')
+  ORDER BY ac.opened_at DESC NULLS LAST
+  LIMIT 1;
+
+  IF v_active_chain.id IS NOT NULL THEN
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+      'gate_kind', s.gate_kind,
+      'signer_id', s.signer_id,
+      'signer_name', m.name,
+      'signed_at', s.signed_at,
+      'signoff_type', s.signoff_type,
+      'comment_body', s.comment_body
+    ) ORDER BY s.signed_at), '[]'::jsonb)
+    INTO v_signed_gates
+    FROM public.approval_signoffs s
+    LEFT JOIN public.members m ON m.id = s.signer_id
+    WHERE s.approval_chain_id = v_active_chain.id;
+
+    SELECT COALESCE(array_agg(g->>'kind' ORDER BY (g->>'order')::int), ARRAY[]::text[])
+    INTO v_pending_for_me
+    FROM jsonb_array_elements(v_active_chain.gates) g
+    WHERE public._can_sign_gate(v_member_id, v_active_chain.id, g->>'kind')
+      AND NOT EXISTS (
+        SELECT 1 FROM public.approval_signoffs s
+        WHERE s.approval_chain_id = v_active_chain.id
+          AND s.gate_kind = g->>'kind'
+          AND s.signer_id = v_member_id
+      );
+  END IF;
+
+  SELECT COUNT(*)::int INTO v_versions_total
+  FROM public.document_versions dv
+  WHERE dv.document_id = p_document_id;
+
+  SELECT COUNT(*)::int, COUNT(*) FILTER (WHERE c.resolved_at IS NULL)::int
+  INTO v_comments_total, v_comments_unresolved
+  FROM public.document_comments c
+  JOIN public.document_versions dv ON dv.id = c.document_version_id
+  WHERE dv.document_id = p_document_id;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'version_id', dv.id,
+    'version_number', dv.version_number,
+    'version_label', dv.version_label,
+    'authored_at', dv.authored_at,
+    'authored_by_name', m.name
+  ) ORDER BY dv.version_number DESC), '[]'::jsonb)
+  INTO v_draft_versions
+  FROM public.document_versions dv
+  LEFT JOIN public.members m ON m.id = dv.authored_by
+  WHERE dv.document_id = p_document_id AND dv.locked_at IS NULL;
+
+  RETURN jsonb_build_object(
+    'document', jsonb_build_object(
+      'id', v_doc.id,
+      'doc_type', v_doc.doc_type,
+      'title', v_doc.title,
+      'description', v_doc.description,
+      'version', v_doc.version,
+      'status', v_doc.status,
+      'visibility_class', v_doc.visibility_class,
+      'partner_entity_id', v_doc.partner_entity_id,
+      'current_version_id', v_doc.current_version_id,
+      'signed_at', v_doc.signed_at,
+      'valid_from', v_doc.valid_from,
+      'valid_until', v_doc.valid_until,
+      'exit_notice_days', v_doc.exit_notice_days,
+      'docusign_envelope_id', v_doc.docusign_envelope_id,
+      'pdf_url', v_doc.pdf_url,
+      'updated_at', v_doc.updated_at
+    ),
+    'current_version', CASE WHEN v_current_version.id IS NOT NULL THEN jsonb_build_object(
+      'version_id', v_current_version.id,
+      'version_number', v_current_version.version_number,
+      'version_label', v_current_version.version_label,
+      'authored_by_name', v_current_version.authored_by_name,
+      'authored_at', v_current_version.authored_at,
+      'locked_at', v_current_version.locked_at,
+      'locked_by_name', v_current_version.locked_by_name,
+      'published_at', v_current_version.published_at,
+      'content_html_length', v_current_version.content_html_length,
+      'has_markdown', v_current_version.has_markdown,
+      'notes', v_current_version.notes
+    ) ELSE NULL END,
+    'active_chain', CASE WHEN v_active_chain.id IS NOT NULL THEN jsonb_build_object(
+      'chain_id', v_active_chain.id,
+      'version_id', v_active_chain.version_id,
+      'status', v_active_chain.status,
+      'gates', v_active_chain.gates,
+      'opened_at', v_active_chain.opened_at,
+      'approved_at', v_active_chain.approved_at,
+      'activated_at', v_active_chain.activated_at,
+      'signed_gates', v_signed_gates,
+      'pending_gates_for_me', to_jsonb(COALESCE(v_pending_for_me, ARRAY[]::text[]))
+    ) ELSE NULL END,
+    'draft_versions', v_draft_versions,
+    'versions_total', v_versions_total,
+    'comments_total', v_comments_total,
+    'comments_unresolved', v_comments_unresolved
+  );
+END;
+$function$;

--- a/supabase/migrations/20260805000451_1383_p0d_version_diff_visibility_ceiling.sql
+++ b/supabase/migrations/20260805000451_1383_p0d_version_diff_visibility_ceiling.sql
@@ -1,0 +1,152 @@
+-- #1383 PR-D: apply the visibility_class ceiling + draft (locked_at) hard-gate to
+-- get_version_diff, mirroring the canonical reader get_governance_document_reader.
+-- This SECDEF diff returns full version content, so it must not expose a document the
+-- caller cannot see, nor unpublished (unlocked) draft versions to non-admins. Both
+-- versions belong to the same document (checked before the gate). Not-found masking
+-- avoids leaking existence. Body otherwise unchanged from the live capture.
+CREATE OR REPLACE FUNCTION public.get_version_diff(p_version_a uuid, p_version_b uuid, p_include_content boolean DEFAULT true)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_is_admin boolean;
+  v_is_platform_admin boolean;
+  v_visibility_class text;
+  v_a record;
+  v_b record;
+  v_payload_a jsonb;
+  v_payload_b jsonb;
+BEGIN
+  SELECT m.id INTO v_member_id
+  FROM public.members m
+  WHERE m.auth_id = auth.uid() AND m.is_active = true;
+  IF v_member_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated' USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF p_version_a IS NULL OR p_version_b IS NULL THEN
+    RAISE EXCEPTION 'both version ids are required' USING ERRCODE = 'invalid_parameter_value';
+  END IF;
+
+  SELECT dv.id, dv.document_id, dv.version_number, dv.version_label,
+         dv.authored_at, dv.locked_at, dv.content_html, dv.content_markdown,
+         dv.content_diff_json, dv.notes, m.name AS authored_by_name
+  INTO v_a
+  FROM public.document_versions dv
+  LEFT JOIN public.members m ON m.id = dv.authored_by
+  WHERE dv.id = p_version_a;
+
+  SELECT dv.id, dv.document_id, dv.version_number, dv.version_label,
+         dv.authored_at, dv.locked_at, dv.content_html, dv.content_markdown,
+         dv.content_diff_json, dv.notes, m.name AS authored_by_name
+  INTO v_b
+  FROM public.document_versions dv
+  LEFT JOIN public.members m ON m.id = dv.authored_by
+  WHERE dv.id = p_version_b;
+
+  IF v_a.id IS NULL OR v_b.id IS NULL THEN
+    RETURN jsonb_build_object(
+      'both_exist', false,
+      'version_a_exists', (v_a.id IS NOT NULL),
+      'version_b_exists', (v_b.id IS NOT NULL)
+    );
+  END IF;
+
+  IF v_a.document_id <> v_b.document_id THEN
+    RETURN jsonb_build_object(
+      'both_exist', true,
+      'same_document', false,
+      'document_id_a', v_a.document_id,
+      'document_id_b', v_b.document_id
+    );
+  END IF;
+
+  -- Visibility ceiling (mirror get_governance_document_reader). Both versions share
+  -- v_a.document_id (checked above). Not-found masking avoids leaking existence.
+  v_is_admin          := public.can_by_member(v_member_id, 'manage_member');
+  v_is_platform_admin := public.can_by_member(v_member_id, 'manage_platform');
+
+  SELECT gd.visibility_class INTO v_visibility_class
+  FROM public.governance_documents gd
+  WHERE gd.id = v_a.document_id;
+
+  IF NOT (
+    v_visibility_class = 'public'
+    OR v_visibility_class = 'active_members'
+    OR (v_visibility_class = 'legal_scoped' AND (
+          v_is_admin
+          OR EXISTS (
+            SELECT 1 FROM public.member_document_signatures mds
+            WHERE mds.member_id = v_member_id
+              AND mds.document_id = v_a.document_id
+              AND mds.is_current = true)))
+    OR (v_visibility_class = 'admin_only' AND v_is_admin)
+    OR (v_visibility_class = 'audit_restricted' AND v_is_platform_admin)
+  ) THEN
+    RETURN jsonb_build_object(
+      'both_exist', false,
+      'version_a_exists', false,
+      'version_b_exists', false
+    );
+  END IF;
+
+  -- Draft (unlocked) versions are visible only to manage_member admins (mirror the
+  -- reader's locked_at HARD-GATE). A non-admin cannot diff an unpublished draft.
+  IF NOT v_is_admin AND (v_a.locked_at IS NULL OR v_b.locked_at IS NULL) THEN
+    RETURN jsonb_build_object(
+      'both_exist', false,
+      'version_a_exists', (v_a.locked_at IS NOT NULL),
+      'version_b_exists', (v_b.locked_at IS NOT NULL)
+    );
+  END IF;
+
+  v_payload_a := jsonb_build_object(
+    'version_id', v_a.id,
+    'version_number', v_a.version_number,
+    'version_label', v_a.version_label,
+    'authored_by_name', v_a.authored_by_name,
+    'authored_at', v_a.authored_at,
+    'locked_at', v_a.locked_at,
+    'content_html_length', length(v_a.content_html),
+    'content_markdown_length', length(v_a.content_markdown),
+    'notes', v_a.notes
+  );
+  IF p_include_content THEN
+    v_payload_a := v_payload_a
+      || jsonb_build_object('content_html', v_a.content_html)
+      || jsonb_build_object('content_markdown', v_a.content_markdown);
+  END IF;
+
+  v_payload_b := jsonb_build_object(
+    'version_id', v_b.id,
+    'version_number', v_b.version_number,
+    'version_label', v_b.version_label,
+    'authored_by_name', v_b.authored_by_name,
+    'authored_at', v_b.authored_at,
+    'locked_at', v_b.locked_at,
+    'content_html_length', length(v_b.content_html),
+    'content_markdown_length', length(v_b.content_markdown),
+    'notes', v_b.notes
+  );
+  IF p_include_content THEN
+    v_payload_b := v_payload_b
+      || jsonb_build_object('content_html', v_b.content_html)
+      || jsonb_build_object('content_markdown', v_b.content_markdown);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'both_exist', true,
+    'same_document', true,
+    'document_id', v_a.document_id,
+    'include_content', p_include_content,
+    'version_a', v_payload_a,
+    'version_b', v_payload_b,
+    'pre_computed_diff', COALESCE(v_b.content_diff_json, v_a.content_diff_json),
+    'newer_version_id', CASE WHEN v_a.version_number > v_b.version_number THEN v_a.id ELSE v_b.id END,
+    'older_version_id', CASE WHEN v_a.version_number > v_b.version_number THEN v_b.id ELSE v_a.id END
+  );
+END;
+$function$;


### PR DESCRIPTION
PR-D of the #1383 authority-hardening series (after #1384 A+B `5c0718f0`, #1385 PR-C `1f703680`). Five SECURITY DEFINER surfaces aligned to the canonical authority model; all bodies re-based on the live capture, changes are additive gates only. Migrations applied to the remote DB before push and registered at `20260805000448-451`.

## Changes

| # | RPC | Gate added |
|---|-----|------------|
| 448 | `stage_alumni_for_re_engagement` | `cron_new_cycle` source scoped to the automated cycle-open context (`auth.uid() IS NULL` or inside a trigger); interactive callers use the `manage_member`-gated `manual_admin` path |
| 449 | `submit_curation_review` | `rls_can_see_board(v_item.board_id)` after fetching the item — parity with sibling `assign_curation_reviewer` (#785 PR-3) |
| 450 | `get_document_detail` | `visibility_class` ceiling mirroring `get_governance_document_reader` (legal_scoped → manage_member admin or signer; admin_only/audit_restricted authority-scoped) + repairs a pre-existing `record not assigned yet` crash on docs with no current version (5 live) |
| 451 | `get_version_diff` | same `visibility_class` ceiling + `locked_at` draft hard-gate (non-admins cannot diff unpublished drafts), replacing the prior active-member-only check |

**EF:** dropped the client-controlled `source` arg from the `stage_alumni_for_re_engagement` MCP tool schema (manual curation only; cron auto-stages via the `trg_auto_stage_alumni_on_cycle_open` trigger). Defense-in-depth on top of the DB guard.

## Verification (live, impersonated)

- `get_document_detail` legal_scoped: non-admin non-signer denied · admin visible · signer visible (rolled-back signature)
- `get_version_diff`: legal_scoped non-admin denied (no content) · two published versions still diff for a member · locked+draft denied for non-admin, allowed for admin
- `submit_curation_review`: non-engaged reviewer on a confidential board item → `Board item not found`
- `stage_alumni_for_re_engagement`: authenticated caller + `cron_new_cycle` → rejected · cron context (`auth.uid() NULL`) + `cron_new_cycle` → passes · non-admin + `manual_admin` → requires manage_member
- Contract tests **107/107** (Q-C migration coverage + Phase C body-drift + rpc-acl + #194 review-flow + #785 reader-gate). `astro build` clean.

## Follow-up (not P0)
- Deploy `nucleo-mcp` EF to production so the live tool schema drops `source` (the DB guard already closes the path). Separate production-deploy action.
- `exec_portfolio_health` internal gate for `authenticated` — check whether the app calls it before restricting.

Closes the PR-D slice of #1383.
