### PR TITLE
chore(db): #1383 restore anon EXECUTE on exec_portfolio_health (public home-page KPI feed)

### DIFF
--- a/supabase/migrations/20260805000452_1383_followup_exec_portfolio_health_anon_regrant.sql
+++ b/supabase/migrations/20260805000452_1383_followup_exec_portfolio_health_anon_regrant.sql
@@ -1,0 +1,10 @@
+-- #1383 follow-up: restore anon EXECUTE on exec_portfolio_health.
+-- This SECURITY DEFINER function is the public home-page KPI feed: KpiSection and
+-- TrailRankingSection on index.astro (pt-BR / en / es) call it client-side to
+-- hydrate the live RAG progress bars + certification-trail %. It aggregates public
+-- impact metrics and OKR / quarterly targets, with confidential initiatives and
+-- boards excluded inline (NOT is_confidential_initiative / NOT is_confidential_board),
+-- so anonymous access is by design for the marketing page. It is read-only (STABLE,
+-- no INSERT/UPDATE/DELETE or http_post), so it stays outside the #965 anon-SECDEF
+-- side-effect sweep. authenticated keeps EXECUTE (mig 20260805000443).
+GRANT EXECUTE ON FUNCTION public.exec_portfolio_health(text) TO anon;


### PR DESCRIPTION
Follow-up to the #1383 hardening series (after PR-D #1386).

## Why
`exec_portfolio_health` is the **public landing-page KPI feed** — `KpiSection` + `TrailRankingSection` on `index.astro` (pt-BR/en/es) call it client-side to overlay the live RAG progress bars + certification-trail % onto the KPI cards. The A+B grant tidy (mig `20260805000443`) revoked its PUBLIC/anon EXECUTE, which silently dropped those live overlays for **logged-out visitors** (the static KPI values from `data/kpis` still render; the live health bars just stopped appearing). This restores anon access.

## Why it is safe
- **Confidential-safe:** the body excludes confidential initiatives/boards inline (`NOT is_confidential_initiative` / `NOT is_confidential_board`) — no confidential values reach the aggregates.
- **Read-only:** STABLE, no `INSERT/UPDATE/DELETE` or `http_post`, so it stays outside the #965 anon-SECDEF side-effect sweep. Verified live: `_audit_secdef_public_grant_drift()` returns **0** hits for it (set-equality holds).
- `authenticated` keeps EXECUTE (mig 443).

## Verification (live)
- anon `exec_portfolio_health()` → returns the **9 KPI cards** (was `permission denied`).
- Guard tests **79/79**: #965 grant-drift + #785 reader-gate + kpi-portfolio-health + rpc-acl.

## Note
Reclassifies the A+B "anon leak #2" for this function as **intended-public feed** after locating the home-page call sites — the values are confidential-safe marketing/transparency metrics the landing page is designed to show publicly.
