### PR TITLE
docs(mcp): reground repo docs to the live 3-surface MCP + current infra counts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,10 +40,10 @@ This file orients the AI assistant on the project so it can work effectively wit
 | Charts    | Chart.js v4 (native)           |
 | Hosting   | Cloudflare Workers SSR         |
 | Database  | Supabase (PostgreSQL, auth, RLS) |
-| Backend   | Supabase Edge Functions (~37 deployed) |
+| Backend   | Supabase Edge Functions (46 deployed) |
 | Auth      | Google + LinkedIn (OIDC) + Microsoft (Azure) |
 | Env access | `import { env } from 'cloudflare:workers'` (NOT `locals.runtime.env`) |
-| MCP       | 300+ tools, OAuth 2.1, Streamable HTTP SSE, `nucleoia.vitormr.dev/mcp` |
+| MCP       | 3 surfaces (`/mcp` 342 · `/semantic` 52 · `/actions` 88), OAuth 2.1, native Streamable HTTP, `nucleoia.vitormr.dev/mcp` |
 | Observability | PostHog (custom events) + Sentry (global handlers) |
 | i18n      | PT-BR, EN, ES (keys in `src/i18n/`) |
 
@@ -92,7 +92,7 @@ Before changing behavior or schema, check these for constraints and current stat
    See CLAUDE.md for mandatory validation rules before any commit (SQL/RPC, i18n, routes, RPC signatures).
 
 10. **Database patterns**
-    ~795 RPCs / SECURITY DEFINER helpers, RLS recursion pattern (queries via RPCs, not `.from()` when possible). 12 tables have `rpc_only_deny_all` policies. ~34 pg_cron jobs active.
+    ~1,066 SECURITY DEFINER functions, RLS recursion pattern (queries via RPCs, not `.from()` when possible). 12 tables have `rpc_only_deny_all` policies. ~63 pg_cron jobs active.
 
 ## Local workflow
 

--- a/README.es.md
+++ b/README.es.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-320%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
+[![MCP](https://img.shields.io/badge/MCP-3%20Surfaces-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracion-con-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,10 +43,10 @@ Fundado en 2024 como piloto en PMI Goias, el proyecto evoluciono hacia una alian
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de gobernanza | 160+ |
 | Posts en el blog | 9 |
-| Herramientas MCP | 320+ |
-| Edge Functions | 38 |
-| Claves i18n | 6.200+ (3 idiomas) |
-| Tests | 1.418 pasando (1.456 con service-role) |
+| Superficies MCP | `/mcp` 342 · `/semantic` 52 · `/actions` 88 |
+| Edge Functions | 46 |
+| Claves i18n | 6.700+ (3 idiomas) |
+| Tests | 5.306 pasando (5.839 total; suite DB-aware con service-role) |
 | Costo mensual | $0 |
 
 ---
@@ -80,9 +80,9 @@ graph LR
 
     subgraph "Supabase"
         G --> H[Auth<br/>Google · LinkedIn · Microsoft]
-        E --> I[PostgreSQL<br/>795 RPC · RLS]
-        F --> J[Edge Functions<br/>38 deployed]
-        I --> K[pg_cron<br/>34 jobs]
+        E --> I[PostgreSQL<br/>1.066 SECDEF · RLS]
+        F --> J[Edge Functions<br/>46 deployed]
+        I --> K[pg_cron<br/>63 jobs]
     end
 
     subgraph "Observability"
@@ -106,13 +106,13 @@ graph LR
 |------|-----------|---------|
 | **Frontend** | Astro 6 + React 19 + Tailwind 4 | SSR con island architecture, trilingue |
 | **Hospedaje** | Cloudflare Workers | SSR en el edge, proxy OAuth, proxy MCP |
-| **Base de Datos** | Supabase PostgreSQL | 795 RPCs y helpers SECURITY DEFINER, RLS |
+| **Base de Datos** | Supabase PostgreSQL | 1.066 funciones SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor personalizado (320+ herramientas) | Asistentes de IA consultan la plataforma via lenguaje natural |
-| **Logica Server** | Supabase Edge Functions (38) | Sync Credly, asistencia, MCP, campañas, PostHog proxy, AI/video |
+| **MCP** | Servidor personalizado, 3 superficies | `/mcp` (342 registro) · `/semantic` (52 de intención, SPEC-280) · `/actions` (88 overflow del tope de 256/conector) |
+| **Logica Server** | Supabase Edge Functions (46) | Sync Credly, asistencia, MCP, campañas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de producto, session replay |
 | **Errores** | Sentry | Monitoreo de errores en tiempo real |
-| **Cron** | pg_cron (34 jobs) | Sync Credly, asistencia, alertas detractores, recordatorios, LGPD, AI/video y digests |
+| **Cron** | pg_cron (63 jobs) | Sync Credly, asistencia, alertas detractores, recordatorios, LGPD, AI/video y digests |
 | **DnD** | @dnd-kit | BoardEngine Kanban |
 | **Rich Text** | TipTap | Actas de reunion, editor de blog |
 
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracion con IA
 
-Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. 320+ herramientas autenticadas via OAuth 2.1 con Row Level Security. Auto-refresh server-side mantiene sesiones activas por hasta 30 dias sin reconexion manual. Capa de conocimiento dinamica adapta orientaciones al rol y permisos de cada miembro.
+Cualquier miembro puede conectar Claude, ChatGPT, Perplexity, Cursor o VS Code a la plataforma via Model Context Protocol. Las tools se autentican via OAuth 2.1 (servidor OAuth nativo de Supabase, #1210 - el cliente de IA renueva directo en Supabase Auth, independiente de la sesion del navegador) con Row Level Security. El servidor expone tres superficies: `/mcp` (342 registro completo), `/semantic` (52 de intencion, SPEC-280) y `/actions` (88 overflow del tope de 256/conector). Conteos en vivo en `/health`; `tools/list` es la fuente de verdad.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -229,7 +229,7 @@ npm test
 ├── supabase/
 │   ├── functions/      # 38 Edge Functions
 │   └── migrations/     # Migraciones de base de datos
-├── tests/              # 1.418 tests pasando
+├── tests/              # 5.306 tests pasando
 ├── docs/               # Gobernanza, guias, specs
 └── scripts/            # Scripts de auditoria y utilitarios
 ```

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-320%2B%20Tools-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
+[![MCP](https://img.shields.io/badge/MCP-3%20Surfaces-D97757?logo=claude&logoColor=white)](#mcp-server--ai-integration)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -44,12 +44,12 @@ Founded in 2024 as a pilot within PMI Goiás, the initiative has grown into a st
 | Events held | 209 |
 | Governance entries | 141+ (GC-001 → GC-141+) |
 | Blog posts | 9 |
-| MCP tools | 320+ |
-| Edge Functions | 38 |
-| pg_cron jobs | 34 |
-| RPCs (SECURITY DEFINER + helpers) | 795 |
-| i18n keys | 6,200+ (3 locales) |
-| Tests | 1,449 passing (1,501 with service-role env) |
+| MCP surfaces | `/mcp` 342 registry · `/semantic` 52 intent · `/actions` 88 overflow |
+| Edge Functions | 46 |
+| pg_cron jobs | 63 |
+| RPCs (SECURITY DEFINER) | 1,066 (1,228 public functions total) |
+| i18n keys | 6,700+ (3 locales) |
+| Tests | 5,306 passing (5,839 total; DB-aware suite runs with service-role env) |
 | Monthly cost | $0 |
 
 ---
@@ -76,16 +76,16 @@ graph LR
 
     subgraph "Cloudflare Workers"
         B --> E[Pages + API Routes]
-        D --> F["/mcp Proxy"]
+        D --> F["/mcp · /semantic · /actions"]
         E --> G[OAuth 2.1 Server]
         F --> G
     end
 
     subgraph "Supabase"
         G --> H[Auth<br/>Google · LinkedIn · Microsoft]
-        E --> I[PostgreSQL<br/>795 RPC · RLS]
-        F --> J[Edge Functions<br/>38 deployed]
-        I --> K[pg_cron<br/>34 jobs]
+        E --> I[PostgreSQL<br/>1,066 SECDEF · RLS]
+        F --> J[Edge Functions<br/>46 deployed]
+        I --> K[pg_cron<br/>63 jobs]
     end
 
     subgraph "Observability"
@@ -109,13 +109,13 @@ graph LR
 |-------|-----------|---------|
 | **Frontend** | Astro 6 + React 19 + Tailwind 4 | SSR with island architecture, trilingual |
 | **Hosting** | Cloudflare Workers | Edge SSR, OAuth proxy, MCP proxy |
-| **Database** | Supabase PostgreSQL | 200+ SECURITY DEFINER functions, RLS |
-| **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, dynamic client registration |
-| **MCP** | Custom server (320+ tools) | AI assistants query platform via natural language |
-| **Server Logic** | Supabase Edge Functions (38) | Credly sync, attendance, MCP, campaigns, Artia sync, PostHog proxy, AI triage |
+| **Database** | Supabase PostgreSQL | 1,066 SECURITY DEFINER functions, RLS |
+| **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, native Supabase OAuth server (#1210) |
+| **MCP** | Custom server, 3 surfaces | `/mcp` (342 registry) · `/semantic` (52 intent-level, SPEC-280) · `/actions` (88 overflow for the 256/connector cap) |
+| **Server Logic** | Supabase Edge Functions (46) | Credly sync, attendance, MCP, campaigns, Artia sync, PostHog proxy, AI triage |
 | **Analytics** | PostHog | Product analytics, session replay |
 | **Errors** | Sentry | Real-time error monitoring |
-| **Cron** | pg_cron (34 jobs) | Credly sync, attendance batch, detractor alerts, weekly digests (member · leader · tribe), MCP anomaly detection, LGPD anonymize, log retention, R2 backup, AI retry queues, Artia sync, drive-discover-atas, V4 engagement expiry/anonymize |
+| **Cron** | pg_cron (63 jobs) | Credly sync, attendance batch, detractor alerts, weekly digests (member · leader · tribe), MCP anomaly detection, LGPD anonymize, log retention, R2 backup, AI retry queues, Artia sync, drive-discover-atas, V4 engagement expiry/anonymize |
 | **DnD** | @dnd-kit | BoardEngine Kanban |
 | **Rich Text** | TipTap | Meeting minutes, blog editor |
 
@@ -123,7 +123,15 @@ graph LR
 
 ## MCP Server — AI Integration
 
-Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. 320+ tools authenticated via OAuth 2.1 with full Row Level Security enforcement. Server-side auto-refresh keeps sessions alive for up to 30 days without manual reconnection. Dynamic knowledge layer adapts guidance to each member's role and permissions.
+Any member can connect Claude, ChatGPT, Perplexity, Cursor, or VS Code to the platform via the Model Context Protocol. All tools are authenticated via OAuth 2.1 (Supabase's native OAuth server, #1210 — the AI client refreshes directly against Supabase Auth on a client-scoped chain, independent of the browser session) with full Row Level Security enforcement.
+
+The server exposes **three surfaces** (live counts at `/health`; the `tools/list` response is the source of truth, never pin a number):
+
+| Surface | URL | Tools | Purpose |
+|---------|-----|-------|---------|
+| **`/mcp`** | `nucleoia.vitormr.dev/mcp` | 342 | Full internal capability registry. Default for clients that accept large catalogs. |
+| **`/semantic`** | `nucleoia.vitormr.dev/mcp/semantic` | 52 | Intent-level semantic gateway (SPEC-280 / #1383). One tool per user intent (~7:1 consolidation) with a stable envelope `{ok,data,summary,warnings,next_actions,audit}`; writes carry authority + confidential-visibility gates as a contract. Use when a strict client rejects the full catalog. |
+| **`/actions`** | `nucleoia.vitormr.dev/mcp/actions` | 88 | Overflow surface for the Claude connector's 256-tool-per-connector cap (#1377) — re-exposes the write/action tail the alphabetical cut would drop. Consumed alongside `/mcp` as a second connector. |
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -144,15 +152,10 @@ sequenceDiagram
     W->>S: Login (Google/LinkedIn/MS)
     S-->>W: JWT
     W-->>User: authorization code
-    User->>W: POST /oauth/token (PKCE)
-    W-->>User: access_token + refresh_token
-    Note over W: Stores refresh_token in KV (30d TTL)
+    User->>S: POST /auth/v1/oauth/token (PKCE)
+    S-->>User: access_token + refresh_token
+    Note over User,S: Client refreshes directly against GoTrue (#1210)<br/>client-scoped chain; the Worker never refreshes
     User->>W: POST /mcp + Bearer token
-    W->>W: Check JWT exp (5min buffer)
-    alt Token expired
-        W->>S: Refresh via stored token
-        S-->>W: New JWT
-    end
     W->>EF: Proxy with valid JWT
     EF->>EF: RLS-enforced query
     EF-->>User: Tool result
@@ -236,9 +239,9 @@ npm test
 │   ├── lib/            # Supabase client, auth, utilities
 │   └── middleware/      # CSP, auth, i18n
 ├── supabase/
-│   ├── functions/      # 38 Edge Functions
+│   ├── functions/      # 46 Edge Functions
 │   └── migrations/     # Database migrations
-├── tests/              # 1,383 passing tests
+├── tests/              # 5,306 passing tests
 ├── docs/               # Governance, guides, specs
 └── scripts/            # Audit and utility scripts
 ```

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -11,7 +11,7 @@
 [![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=white)](https://react.dev)
 [![Supabase](https://img.shields.io/badge/Supabase-PostgreSQL-3FCF8E?logo=supabase&logoColor=white)](https://supabase.com)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare-Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com)
-[![MCP](https://img.shields.io/badge/MCP-320%2B%20Tools-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
+[![MCP](https://img.shields.io/badge/MCP-3%20Surfaces-D97757?logo=claude&logoColor=white)](#servidor-mcp--integracao-com-ia)
 [![PostHog](https://img.shields.io/badge/PostHog-Analytics-F9BD2B?logo=posthog&logoColor=white)](https://posthog.com)
 [![Sentry](https://img.shields.io/badge/Sentry-Monitoring-362D59?logo=sentry&logoColor=white)](https://sentry.io)
 [![Cost](https://img.shields.io/badge/Infra%20Cost-%240%2Fmo-brightgreen)]()
@@ -43,10 +43,10 @@ Fundado em 2024 como piloto no PMI Goias, o projeto evoluiu para uma alianca est
 | Capitulos PMI | 5 (GO · CE · DF · MG · RS) |
 | Entradas de governanca | 160+ |
 | Posts no blog | 9 |
-| Ferramentas MCP | 320+ |
-| Edge Functions | 38 |
-| Chaves i18n | 6.200+ (3 idiomas) |
-| Testes | 1.418 passando (1.456 com service-role) |
+| Superfícies MCP | `/mcp` 342 · `/semantic` 52 · `/actions` 88 |
+| Edge Functions | 46 |
+| Chaves i18n | 6.700+ (3 idiomas) |
+| Testes | 5.306 passando (5.839 total; suite DB-aware com service-role) |
 | Custo mensal | $0 |
 
 ---
@@ -80,9 +80,9 @@ graph LR
 
     subgraph "Supabase"
         G --> H[Auth<br/>Google · LinkedIn · Microsoft]
-        E --> I[PostgreSQL<br/>795 RPC · RLS]
-        F --> J[Edge Functions<br/>38 deployed]
-        I --> K[pg_cron<br/>34 jobs]
+        E --> I[PostgreSQL<br/>1.066 SECDEF · RLS]
+        F --> J[Edge Functions<br/>46 deployed]
+        I --> K[pg_cron<br/>63 jobs]
     end
 
     subgraph "Observability"
@@ -106,13 +106,13 @@ graph LR
 |--------|-----------|---------|
 | **Frontend** | Astro 6 + React 19 + Tailwind 4 | SSR com island architecture, trilingue |
 | **Hospedagem** | Cloudflare Workers | SSR na edge, proxy OAuth, proxy MCP |
-| **Banco de Dados** | Supabase PostgreSQL | 795 RPCs e helpers SECURITY DEFINER, RLS |
+| **Banco de Dados** | Supabase PostgreSQL | 1.066 funções SECURITY DEFINER, RLS |
 | **Auth** | Google + LinkedIn + Microsoft | OAuth 2.1, PKCE, registro dinamico de clientes |
-| **MCP** | Servidor customizado (320+ ferramentas) | Assistentes de IA consultam a plataforma via linguagem natural |
-| **Logica Server** | Supabase Edge Functions (38) | Sync Credly, presenca, MCP, campanhas, PostHog proxy, AI/video |
+| **MCP** | Servidor customizado, 3 superfícies | `/mcp` (342 registro) · `/semantic` (52 intencionais, SPEC-280) · `/actions` (88 overflow do cap de 256/conector) |
+| **Logica Server** | Supabase Edge Functions (46) | Sync Credly, presenca, MCP, campanhas, PostHog proxy, AI/video |
 | **Analytics** | PostHog | Analytics de produto, session replay |
 | **Erros** | Sentry | Monitoramento de erros em tempo real |
-| **Cron** | pg_cron (34 jobs) | Sync Credly, presenca, alertas detratores, lembretes, LGPD, AI/video e digests |
+| **Cron** | pg_cron (63 jobs) | Sync Credly, presenca, alertas detratores, lembretes, LGPD, AI/video e digests |
 | **DnD** | @dnd-kit | BoardEngine Kanban |
 | **Rich Text** | TipTap | Atas de reuniao, editor de blog |
 
@@ -120,7 +120,7 @@ graph LR
 
 ## Servidor MCP — Integracao com IA
 
-Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. 320+ ferramentas autenticadas via OAuth 2.1 com Row Level Security. Auto-refresh server-side mantem sessoes ativas por ate 30 dias sem reconexao manual. Camada de conhecimento dinamica adapta orientacoes ao papel e permissoes de cada membro.
+Qualquer membro pode conectar Claude, ChatGPT, Perplexity, Cursor ou VS Code a plataforma via Model Context Protocol. As tools sao autenticadas via OAuth 2.1 (servidor OAuth nativo do Supabase, #1210 - o cliente de IA renova direto no Supabase Auth, independente da sessao do navegador) com Row Level Security. O servidor expoe tres superficies: `/mcp` (342 registro completo), `/semantic` (52 de intencao, SPEC-280) e `/actions` (88 overflow do cap de 256/conector). Contagens ao vivo em `/health`; `tools/list` e a fonte de verdade.
 
 ```
 https://nucleoia.vitormr.dev/mcp
@@ -229,7 +229,7 @@ npm test
 ├── supabase/
 │   ├── functions/      # 38 Edge Functions
 │   └── migrations/     # Migracoes do banco de dados
-├── tests/              # 1.418 testes passando
+├── tests/              # 5.306 testes passando
 ├── docs/               # Governanca, guias, specs
 └── scripts/            # Scripts de auditoria e utilitarios
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,7 +57,7 @@
 
 **Astro 6** opera em modo SSR via Cloudflare Workers adapter (`@astrojs/cloudflare` v13). Env access via `import { env } from 'cloudflare:workers'` (NOT `locals.runtime.env`). Páginas são `.astro` files que podem conter React islands para interatividade.
 
-**MCP Server:** OAuth 2.1-authenticated MCP endpoint at `nucleoia.vitormr.dev/mcp` with 15 tools (10 read + 5 write). See `docs/MCP_SETUP_GUIDE.md`.
+**MCP Server:** OAuth 2.1-authenticated MCP server at `nucleoia.vitormr.dev/mcp` with 3 surfaces — `/mcp` (342 raw registry) · `/semantic` (52 intent-level, SPEC-280 / #1383) · `/actions` (88 overflow for the 256/connector cap, #1377). See `docs/MCP_SETUP_GUIDE.md`. _(This file's per-subsystem counts below are mid-refresh under #1183.)_
 
 **CSP Middleware:** Content Security Policy headers applied via Astro middleware (`src/middleware.ts`), not via `_headers` file.
 
@@ -124,13 +124,13 @@ Jobs cron usam funções `_cron` separadas (sem `auth.uid()` check) com `REVOKE`
 
 ### 4. Edge Functions
 
-17 Edge Functions (Deno runtime no Supabase):
+46 Edge Functions (Deno runtime no Supabase; amostra representativa abaixo, refresh completo em #1183):
 
 | Categoria | Functions | Notas |
 |-----------|-----------|-------|
 | Credly sync | sync-credly-all, verify-credly, sync-attendance-points | 3 com `--no-verify-jwt` |
 | Email/Campaign | send-campaign, send-global-onboarding, send-allocation-notify | Via Resend API |
-| MCP | nucleo-mcp | OAuth 2.1, 15 tools |
+| MCP | nucleo-mcp | OAuth 2.1, 3 surfaces (342 / 52 / 88) |
 | Utility | detect-detractors, attendance-reminders, etc. | 1 com `--no-verify-jwt` |
 | Legacy | 2 não-deployed | Mantidas por referência |
 

--- a/docs/MCP_ORG_CONNECTOR_ENABLEMENT.md
+++ b/docs/MCP_ORG_CONNECTOR_ENABLEMENT.md
@@ -29,7 +29,7 @@ valid as the **Team/Enterprise playbook** if the org ever upgrades.
 |---|---|
 | **Current path (individual plan)** | Distribute the **member self-add** instruction (§3b): each member adds `https://nucleoia.vitormr.dev/mcp` in *Customize → Connectors*. RLS scopes each user. |
 | **Team/Enterprise playbook** (if upgraded) | PM adds the server in **Organization settings → Connectors** (§1/§3); members enable individually. |
-| **What's done (platform side)** | OAuth 2.1 DCR + PKCE, server-side auto-refresh (KV, 30-day TTL), `offline_access`+`refresh_token` advertised live, docs corrected, decision recorded. **Personal connector verified working live (308 tools).** |
+| **What's done (platform side)** | OAuth 2.1 DCR + PKCE, native Supabase OAuth server with per-client refresh chains (#1210 — the earlier KV/server-side auto-refresh model was retired), `offline_access`+`refresh_token` advertised live, docs corrected, decision recorded. **Personal connector verified working live.** |
 | **Risk** | Low. No code change. The connector already works as a per-user custom connector today. |
 
 ---
@@ -95,13 +95,20 @@ GET https://nucleoia.vitormr.dev/.well-known/oauth-protected-resource
   scopes_supported      : [ "mcp:tools", "offline_access" ]
 ```
 
-**Server-side auto-refresh is real** (verified in code, this session):
+> **⚠️ SUPERSEDED by #1210 (native Supabase OAuth server).** The server-side / proxy auto-refresh model
+> described below was **retired**: the AI client now refreshes directly against GoTrue's
+> `/auth/v1/oauth/token` on its own client-scoped chain, and the Worker proxies MUST NOT refresh (a second
+> refresher was the #1053 re-login bug). `src/pages/oauth/token.ts` is now a retired stub and the KV
+> refresh entries are dead (left to expire by TTL). See `.claude/rules/mcp.md` (§ OAuth Flow / Token refresh).
+> The historical description is kept below for context only.
 
-- `src/pages/mcp.ts` and `src/pages/mcp/semantic.ts` decode the JWT `exp`, and within a 5-minute window look up
-  `mcp_refresh:{sub}` from KV and renew against Supabase Auth — transparent to the MCP host.
-- `src/pages/oauth/token.ts` stores the `refresh_token` in KV with a **30-day TTL** on both the
+**Server-side auto-refresh (HISTORICAL, retired by #1210):**
+
+- `src/pages/mcp.ts` and `src/pages/mcp/semantic.ts` decoded the JWT `exp`, and within a 5-minute window looked up
+  `mcp_refresh:{sub}` from KV and renewed against Supabase Auth — transparent to the MCP host.
+- `src/pages/oauth/token.ts` stored the `refresh_token` in KV with a **30-day TTL** on both the
   `authorization_code` and `refresh_token` grants.
-- Net effect on the **happy path**: a Claude.ai connector stays alive well beyond 7 days without manual relogin.
+- Net effect on the **happy path** (pre-#1210): a Claude.ai connector stayed alive well beyond 7 days without manual relogin.
 
 > **Known robustness gap (low severity, tracked separately):** the proxy's KV re-store at `mcp.ts:62` /
 > `semantic.ts:60` is gated on `if (data.refresh_token)` and lacks the `|| oldRefreshToken` fallback that

--- a/docs/MCP_SETUP_GUIDE.md
+++ b/docs/MCP_SETUP_GUIDE.md
@@ -2,22 +2,28 @@
 
 ## What is MCP?
 
-MCP (Model Context Protocol) is an open protocol that allows AI assistants to interact with external services. The Núcleo server exposes two surfaces: `/mcp` (the full implementation-tool catalog for verified clients) and `/mcp/semantic` (a smaller, bridge-first semantic gateway for strict MCP clients). Both surfaces let you query and manage project data from your AI assistant using natural language. A dynamic knowledge layer adapts guidance to each member's role and permissions.
+MCP (Model Context Protocol) is an open protocol that allows AI assistants to interact with external services. The Núcleo server exposes **three surfaces**: `/mcp` (the full internal capability registry), `/mcp/semantic` (an intent-level semantic gateway with a stable envelope), and `/mcp/actions` (an overflow surface for connectors with a per-connector tool cap). All surfaces let you query and manage project data from your AI assistant using natural language. A dynamic knowledge layer adapts guidance to each member's role and permissions.
 
 ## Endpoints
 
+Live counts are at `/health`; the `tools/list` response is the source of truth. Never pin a number, query it.
+
 | Endpoint | Tools | Purpose | Recommended clients |
 |----------|-------|---------|---------------------|
-| `https://nucleoia.vitormr.dev/mcp` | Full catalog | Full internal capability registry. Stable for clients that accept large catalogs. | Claude.ai, Claude Code, Cursor / VS Code, ChatGPT developer mode, Manus AI |
-| `https://nucleoia.vitormr.dev/mcp/semantic` | 4 | **Bridge-first semantic gateway (p222 #280 alpha).** Compact, review-ready public contract over the internal registry. Stable envelope `{ok,data,summary,warnings,next_actions,audit}`. Use when a strict client rejects the full catalog. | Perplexity, OpenAI Apps SDK review, Anthropic Connectors Directory review, future store/directory submissions |
+| `https://nucleoia.vitormr.dev/mcp` | 342 | Full internal capability registry. Default for clients that accept large catalogs. | Claude.ai, Claude Code, Cursor / VS Code, ChatGPT developer mode, Manus AI |
+| `https://nucleoia.vitormr.dev/mcp/semantic` | 52 | **Intent-level semantic gateway (SPEC-280 / #1383, `nucleo-ia-semantic` v0.9.0).** One tool per user intent (~7:1 consolidation over the raw registry) with a stable envelope `{ok,data,summary,warnings,next_actions,audit}`; write tools carry authority + confidential-visibility (#785) gates as a contract. Use when a strict client rejects the full catalog. | Perplexity, OpenAI Apps SDK review, Anthropic Connectors Directory review, future store/directory submissions |
+| `https://nucleoia.vitormr.dev/mcp/actions` | 88 | **Overflow surface (#1377).** The Claude connector ingests at most 256 tools per connector, alphabetically, dropping the write/action tail. `/actions` re-exposes that dropped tail as a second connector, reusing the same tool definitions. | Claude.ai / Claude Code, consumed alongside `/mcp` as a second connector |
 
-Both endpoints share the same OAuth 2.1 flow (same account, same login). Pick the endpoint that matches your client's catalog tolerance — most clients should still default to `/mcp`.
+All endpoints share the same OAuth 2.1 flow (same account, same login). Pick the endpoint that matches your client's catalog tolerance — most clients default to `/mcp`; add `/actions` as a second connector if you need the write tail; use `/semantic` for strict clients or a bounded, review-ready contract.
 
-Semantic tools (read-only):
-- `get_my_context` — compact self-scope context (profile, current cycle, gamification, upcoming events, certificates). *(wave-1)*
-- `search_nucleo_knowledge` — bounded multi-source search across hub resources + wiki + knowledge_assets. *(wave-1)*
-- `get_board_or_initiative_context` — initiative/board/tribe one-shot summary. *(wave-1)*
-- `get_operational_status` — composite operational summary (admin/GP only, `manage_platform`-gated, PII-clean). *(wave-2, v0.2.0)*
+The 52 semantic tools cover seven intent domains (full catalog: [`docs/reference/SEMANTIC_TOOL_CATALOG.md`](reference/SEMANTIC_TOOL_CATALOG.md)):
+- **Boards & cards** — `board_overview`, `card_search`, `card_get`, `card_write`, `card_checklist`, `card_comment`, `portfolio_report`, `platform_context`.
+- **Members, engagements & initiatives** — `member_search`, `member_get`, `member_emails`, `member_lifecycle`, `engagement_write`, `initiative_roster`, `initiative_directory`, `initiative_report`, `my_status`.
+- **Events, attendance & meetings** — `event_search`, `event_write`, `attendance_record`, `attendance_report`, `meeting_minutes`, `meeting_actions`.
+- **Selection & evaluation** — `selection_dashboard`, `application_get`, `evaluation_submit`, `interview_manage`, `selection_decide`, `visitor_leads`.
+- **Governance, documents & certificates** — `document_get`, `document_version_write`, `document_comment`, `change_request`, `signature_flow`, `certificate_manage`, `ip_exclusion`.
+- **Comms, Drive & partners** — `comms_report`, `comms_post`, `webinar_manage`, `idea_pipeline`, `drive_links`, `drive_access_admin`, `partner_crm`.
+- **Knowledge, gamification & admin** — `search_nucleo_knowledge`, `gamification_report`, `champion_award`, `admin_dashboard`, `audit_log`, `lgpd_admin`, plus the bridge tools `get_my_context`, `get_board_or_initiative_context`, `get_operational_status`.
 
 ## Compatibility
 
@@ -90,7 +96,7 @@ Manual bearer tokens copied into Claude Code expire in 1 hour. Prefer the OAuth 
 
 ## Representative Tools
 
-The live source of truth is the MCP `tools/list` response (or the `/health` endpoint for a per-surface count). The examples below cover the most common member and operator workflows; the full runtime inventory currently exposes 300+ tools — never pin the exact number, query it live.
+The live source of truth is the MCP `tools/list` response (or the `/health` endpoint for a per-surface count). The examples below cover the most common member and operator workflows on the raw `/mcp` registry (342 tools); prefer the 52 intent-level `/semantic` tools where your client supports them. Never pin the exact number, query it live.
 
 For the **complete machine-generated contract matrix** (tool → domain → RPC dependencies → tables → canV4 gate → external fetches → service_role usage), see:
 
@@ -179,7 +185,9 @@ Your AI Client → Workers Proxy → Supabase Edge Function (nucleo-mcp)
 ```
 
 The Workers proxy at `nucleoia.vitormr.dev` routes:
-- `/mcp` → Supabase Edge Function `nucleo-mcp`
+- `/mcp` → Supabase Edge Function `nucleo-mcp` (`/nucleo-mcp/mcp`)
+- `/mcp/semantic` → `nucleo-mcp` `/nucleo-mcp/semantic` (semantic gateway)
+- `/mcp/actions` → `nucleo-mcp` `/nucleo-mcp/actions` (overflow surface)
 - `/.well-known/oauth-authorization-server` → OAuth discovery JSON
 
 This ensures OAuth discovery is at the domain root (required by some clients like ChatGPT).


### PR DESCRIPTION
**Item 1 of the post-#1383 docs pass.** All numbers re-grounded **live this session** (health/`tools/list`, `pg_proc`, `cron.job`, `list_edge_functions`); the semantic layer is documented for the first time.

## Live regrounding
| Metric | Was | Now (live) |
|---|---|---|
| MCP surfaces | "320+ tools" | `/mcp` 342 · `/semantic` 52 · `/actions` 88 |
| Edge Functions | 38 | 46 |
| pg_cron jobs | 34 | 63 |
| SECURITY DEFINER fns | 795 / 200+ | 1,066 (1,228 public total) |
| Tests | 1,449 / 1,383 / 1,418 | 5,306 passing (5,839 total) |
| i18n keys | 6,200+ | 6,700+ |

## Substantive fixes (beyond numbers)
- **Documents the 3-surface architecture** for the first time (`/mcp` registry · `/semantic` intent gateway SPEC-280 · `/actions` overflow #1377) across README (EN/pt/es), MCP_SETUP_GUIDE, AGENTS, ARCHITECTURE.
- **Corrects the retired OAuth model**: the "server-side auto-refresh, 30-day KV" claim is gone/marked superseded by the native Supabase OAuth server (#1210 — client refreshes directly against GoTrue; proxies must not refresh). Fixed in README (3 langs), the README sequence diagram, and MCP_ORG_CONNECTOR_ENABLEMENT.
- **MCP_SETUP_GUIDE**: two→three surfaces; `/semantic` 4→52 (v0.9.0) with the 7 intent domains listed; `/actions` endpoint + proxy routes added.

## Scope
- Historical/audit docs under `docs/audit`, `docs/strategy`, `docs/project-governance` left untouched (dated records — not rewriting history).
- Full `ARCHITECTURE.md` per-subsystem refresh stays **#1183** (a note points to it).
- Program/domain metrics (researchers, events, governance entries) not touched in this infra-focused pass.

Docs-only. `Refs #1383, #1183, #1392`.