### PR TITLE
ci(types): #1410 guard database.gen.ts against live-schema drift

### DIFF
--- a/.github/workflows/gen-types-drift.yml
+++ b/.github/workflows/gen-types-drift.yml
@@ -1,0 +1,75 @@
+name: DB Types Drift (#1410)
+
+# Guard: fails when src/lib/database.gen.ts drifts from the live schema.
+# Follow-up to #1393 (one-time resync) — stops the file re-accumulating drift
+# silently between manual `npm run db:types` runs.
+#
+# Method (owner decision 2026-07-17): `supabase gen types typescript --project-id <ref>`
+# (Management API), which is byte-identical to the `--linked` path `npm run db:types`
+# uses — verified this session (29362 lines, exact match). Needs only SUPABASE_ACCESS_TOKEN.
+#
+# CLI PIN IS MANDATORY: `supabase gen types` output changes between CLI versions, so the
+# guard pins the SAME version `db:types` is run with locally. Current pin: 2.109.0.
+# When you bump the CLI: regenerate the file (`npm run db:types`), commit it, AND bump
+# SUPABASE_CLI_VERSION below in the same PR — otherwise the guard reports false drift.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Daily at 07:15 UTC — catches drift introduced outside the PR flow (direct DDL,
+    # apply_migration via MCP that adds/renames columns without a matching type resync).
+    - cron: '15 7 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: gen-types-drift-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SUPABASE_CLI_VERSION: '2.109.0'
+  SUPABASE_PROJECT_ID: 'ldrfrvwhxsmgaabwmaik'
+
+jobs:
+  gen-types-drift:
+    runs-on: ubuntu-latest
+    timeout-minutes: 6
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Supabase CLI (pinned)
+        uses: supabase/setup-cli@v1
+        with:
+          version: ${{ env.SUPABASE_CLI_VERSION }}
+
+      - name: Regenerate types and diff against committed file
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::warning::SUPABASE_ACCESS_TOKEN secret not configured — drift guard skipped. Add it in repo Settings → Secrets → Actions to enable live-schema drift detection."
+            exit 0
+          fi
+          echo "Regenerating types with supabase CLI $(supabase --version) (pinned $SUPABASE_CLI_VERSION)..."
+          supabase gen types typescript --project-id "$SUPABASE_PROJECT_ID" > /tmp/database.gen.fresh.ts
+          if diff -u src/lib/database.gen.ts /tmp/database.gen.fresh.ts; then
+            echo "src/lib/database.gen.ts is in sync with the live schema."
+          else
+            echo "::error::src/lib/database.gen.ts is stale vs the live schema. Run \`npm run db:types\` and commit src/lib/database.gen.ts. (If this is a CLI-version bump, also update SUPABASE_CLI_VERSION in .github/workflows/gen-types-drift.yml.)"
+            exit 1
+          fi
+
+      - name: Summarize result
+        if: always()
+        run: |
+          echo "## DB Types Drift Guard (#1410)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -z "${{ secrets.SUPABASE_ACCESS_TOKEN }}" ]; then
+            echo ":warning: Skipped — \`SUPABASE_ACCESS_TOKEN\` secret not set." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "To enable: repo Settings → Secrets → Actions → New secret \`SUPABASE_ACCESS_TOKEN\` (Supabase Account → Access Tokens). The guard uses \`--project-id ${SUPABASE_PROJECT_ID}\` (Management API), pinned CLI \`${SUPABASE_CLI_VERSION}\`." >> $GITHUB_STEP_SUMMARY
+          else
+            echo ":white_check_mark: \`src/lib/database.gen.ts\` verified against live schema (CLI \`${SUPABASE_CLI_VERSION}\`, \`--project-id ${SUPABASE_PROJECT_ID}\`)." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ This file orients the AI assistant on the project so it can work effectively wit
 | Member fields         | `operational_role`, `designations` (`role`/`roles` dropped in Wave 8) |
 | History               | `member_cycle_history` |
 | Edge functions        | supabase/functions/ (~37 deployed, 4 with --no-verify-jwt) |
-| DB schema / types     | `src/lib/database.gen.ts` (run `npm run db:types` to refresh) |
+| DB schema / types     | `src/lib/database.gen.ts` (run `npm run db:types` to refresh — supabase CLI **pinned 2.109.0**; CI guard `gen-types-drift.yml` (#1410) fails on drift, so bump the pin there in the same PR when you upgrade the CLI) |
 | Data import scripts   | `scripts/` (trello, calendar, volunteer CSV, miro importers) |
 | Pre-push              | `npm test` + `npm run build` |
 | Pre-commit QA rules   | CLAUDE.md (GC-097) |


### PR DESCRIPTION
Follow-up to #1393 (PR #1409), a one-time resync of `src/lib/database.gen.ts`. Nothing stopped it re-accumulating drift between manual `npm run db:types` runs — this adds a guard so drift fails CI instead of piling up silently.

## What
New dedicated workflow `.github/workflows/gen-types-drift.yml` (mirrors the `invariants-check` / `advisors-check` lightweight-check pattern): regenerate types from the live schema, `diff` against the committed file, fail with an actionable message on drift.

## Design (grounded this session)
- **Method — `--project-id` (owner decision):** `supabase gen types typescript --project-id ldrfrvwhxsmgaabwmaik` (Management API). Verified **byte-identical** to the `--linked` path `db:types` uses today (both 29362 lines, exact `diff`). Needs only `SUPABASE_ACCESS_TOKEN`, not a DB password.
- **CLI pin mandatory:** gen-types output is version-sensitive, so `SUPABASE_CLI_VERSION` is pinned to **2.109.0** (the version that generates the committed file). Bump it in the same PR as any CLI upgrade + resync, or the guard reports false drift. Documented next to `db:types` in AGENTS.md.
- **DB-gated / skip-clean:** when `SUPABASE_ACCESS_TOKEN` is absent the job exits 0 with a warning (same pattern as the other DB-aware checks), so the offline baseline is unaffected. **This PR's own `gen-types-drift` check will show green-skipped** — proving the gate.

## ⚠️ Owner action to activate
The guard only detects drift once you add the **`SUPABASE_ACCESS_TOKEN`** secret (repo Settings → Secrets → Actions; value from Supabase Account → Access Tokens). Until then it is a no-op skip. Nothing else in CI needs this secret.

## Scope
Guard only — no schema/type changes. Local: `npm test` 5308 pass / 0 fail; guard core simulated locally (in-sync → PASS).

Refs #1393

Assisted-By: Claude (Anthropic)