### PR TITLE
fix(ci): #1422 repair advisor-check API path + remediate the drift it surfaced

### DIFF
--- a/scripts/advisor_baseline.json
+++ b/scripts/advisor_baseline.json
@@ -11,6 +11,10 @@
       {
         "cache_key": "security_definer_view_public_gamification_leaderboard",
         "rationale": "Public leaderboard — 3 callsites in /gamification.astro consume 20+ columns (cycle_*, category breakdowns). get_public_leaderboard() RPC returns subset; either extend RPC OR verify RLS permits full breakdown after invoker flip. Onda 3 product+UX decision (issue #82)."
+      },
+      {
+        "cache_key": "security_definer_view_public_impact_hours_total",
+        "rationale": "SECURITY DEFINER accepted risk per ADR-0096 (p223 audit MED #10, migration 20260805000002). anon SELECT REVOKE'd (authenticated/service_role only); content is scalar platform-wide YTD aggregates with no per-row PII. Documented via COMMENT ON VIEW (canonical p170 BUG-HOI formula). Never surfaced in CI before #1422 because the advisor check ran with a stale API path + no token. Distinct from impact_hours_summary/active_members, which were flipped to invoker in Onda 1 (20260508030000)."
       }
     ],
     "accepted_warnings": [

--- a/scripts/check_advisors.mjs
+++ b/scripts/check_advisors.mjs
@@ -2,7 +2,7 @@
 /**
  * Supabase Advisor drift check (preventive)
  *
- * Calls the Supabase management API for `/projects/{ref}/advisors?type=security`
+ * Calls the Supabase management API for `/projects/{ref}/advisors/security`
  * and diffs results against `scripts/advisor_baseline.json`. Exits non-zero if
  * any ERROR-level finding is NOT in the baseline allowlist — meaning a new
  * security issue was introduced since baseline snapshot.
@@ -40,7 +40,9 @@ if (!TOKEN) {
 }
 
 async function fetchAdvisors(type) {
-  const url = `https://api.supabase.com/v1/projects/${PROJECT_REF}/advisors?type=${type}`;
+  // Management API moved the advisor type from a `?type=` query param to a path
+  // segment (`/advisors/{type}`) on 2026-07-18; the old query form now 404s (#1422).
+  const url = `https://api.supabase.com/v1/projects/${PROJECT_REF}/advisors/${type}`;
   const res = await fetch(url, {
     headers: {
       Authorization: `Bearer ${TOKEN}`,

--- a/supabase/migrations/20260805000465_1422_restore_security_invoker_auth_engagements_v_active_members.sql
+++ b/supabase/migrations/20260805000465_1422_restore_security_invoker_auth_engagements_v_active_members.sql
@@ -1,0 +1,28 @@
+-- #1422 — restore security_invoker on two SECURITY DEFINER views flagged by the
+-- (now-working) Supabase advisor check. Both are consumed only by postgres-owned
+-- SECURITY DEFINER functions (invoker is functionally identical inside them) and by
+-- zero direct frontend callsites; neither grants SELECT to anon. No RLS policy
+-- references either view, so there is no security_invoker-view-in-RLS recursion risk.
+--
+-- auth_engagements: regressed to DEFINER because 20260805000341 (interim leader grant)
+--   used CREATE OR REPLACE VIEW without restating the reloption, silently dropping the
+--   security_invoker=true set in 20260508030000 (Onda 1). This restores that known-good
+--   state (~3 months in prod) while keeping the interim-grant column logic intact.
+-- v_active_members: DEFINER since creation (20260805000062), never flipped. As DEFINER +
+--   authenticated write grants it bypassed the members_read hardening (20260805000243)
+--   AND, being auto-updatable (single-table, simple WHERE), exposed a live UPDATE/DELETE
+--   primitive over members that ran as postgres and bypassed members write RLS. The flip
+--   bounds reads/writes to the caller's members RLS; the REVOKE below removes the write
+--   surface entirely (defense-in-depth on a read-only reporting view).
+--
+-- Rollback:
+--   ALTER VIEW public.auth_engagements SET (security_invoker = false);
+--   ALTER VIEW public.v_active_members  SET (security_invoker = false);
+--   GRANT INSERT, UPDATE, DELETE ON public.v_active_members TO authenticated;
+
+ALTER VIEW public.auth_engagements SET (security_invoker = true);
+ALTER VIEW public.v_active_members  SET (security_invoker = true);
+
+-- v_active_members is a read-only reporting view over members; authenticated has no
+-- legitimate reason to write through it (all 5 real callers are SECDEF/postgres).
+REVOKE INSERT, UPDATE, DELETE ON public.v_active_members FROM authenticated;


### PR DESCRIPTION
## Contexto

`scripts/check_advisors.mjs` batia em `/v1/projects/{ref}/advisors?type=security`. A Supabase Management API moveu o tipo de query param para path segment (`/advisors/{type}`) em 2026-07-18; a forma antiga passou a retornar 404 (quebrando todo PR, embora non-required). Fix do path: uma linha em `fetchAdvisors()`.

## O que a auditoria revelou

O check **nunca havia rodado de fato em CI** (pulava por falta de token, depois 404). Exercitá-lo pela 1ª vez expôs **3 ERROS SECURITY DEFINER reais**, cada um tratado conforme sua natureza:

| View | Diagnóstico | Ação |
|------|-------------|------|
| `impact_hours_total` | Risco **aceito** (ADR-0096 / p223 MED #10): anon revogado, só agregados escalares sem PII | → baseline allowlist com rationale |
| `auth_engagements` | **Regressão acidental**: `20260805000341` (interim leader grant) usou `CREATE OR REPLACE VIEW` sem restatar o reloption, dropando o `security_invoker=true` da Onda 1 (`20260508030000`) | → mig 465 restaura estado known-good (~3 meses em prod) |
| `v_active_members` | DEFINER desde a criação, nunca flipada; bypassava o hardening de leitura de `members` (`20260805000243`) **e** — sendo auto-updatable com grants de escrita p/ `authenticated` — expunha um primitivo UPDATE/DELETE vivo sobre `members` que rodava como postgres | → mig 465 flipa p/ invoker + REVOKE INSERT/UPDATE/DELETE de authenticated |

## Segurança

- **Review do security-engineer (council): GO.** Nenhuma policy RLS referencia as views (sem risco de recursão); nenhuma dá SELECT a anon.
- Todos os callers reais são funções SECDEF owned by postgres (invoker ≡ definer dentro delas): 8 da cadeia de autoridade p/ `auth_engagements`, 5 de relatório p/ `v_active_members`. 0 callsites frontend diretos.
- **QA impersonado (rolled-back):** ghost autenticado agora vê **0** linhas em `v_active_members` (antes, como DEFINER, veria as 98); callers SECDEF seguem vendo 98.

## Verificação

- advisor-check: exit **0**, 0 ERROS inesperados, lints 1433→1431, baseline 7→8
- `npx astro build`: limpo
- `npm test`: **5333 pass / 0 fail** (533 skip DB-aware, esperado)
- Ritual GC-097 completo: apply_migration → phantom-row delete (versão exata) → `migration repair` 465 → NOTIFY pgrst

## Notas / follow-ups (fora de escopo, rastreados à parte)

1. **Recorrência**: só o advisor-check (não-required) detecta um futuro reset do reloption. Recomendo torná-lo **required** na branch protection - decisão do owner.
2. **Achado do security-engineer (verificado ao vivo — FALSO ALARME)**: o agente leu só o arquivo `20260413310000` (`persons/engagements_select_authenticated USING(true)`) e concluiu "sem gate". Ao vivo existe também a policy **RESTRICTIVE** `..._org_scope` (`organization_id = auth_org() OR org IS NULL`): um ghost autenticado vê **0 linhas** (auth_org()=NULL). A invariante "ghost não vê PII" está intacta. Não há issue a abrir. (Resta apenas o design pré-existente V4 de org-scoping para membros autenticados - decisão de produto/LGPD, não bug.)
3. Os 1419 WARN `function_search_path_mutable` são pré-existentes e non-blocking (script só falha em ERROR).

Closes #1422
