### PR TITLE
test(ci): #1422 expand critical-invoker view guard to full sensitive set

### DIFF
--- a/tests/contracts/1422-critical-views-security-invoker.test.mjs
+++ b/tests/contracts/1422-critical-views-security-invoker.test.mjs
@@ -30,14 +30,25 @@ const SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const canRun = !!(SUPABASE_URL && SERVICE_ROLE_KEY);
 const skipMsg = 'Skipped: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY required';
 
-// Views over identity/authority data that MUST be invoker (never SECURITY DEFINER).
-// auth_engagements + v_active_members are the two #1422 flipped. The rest were flipped
-// in the Onda 1 security sweep (20260508030000) and read member/attendance data.
+// Views over identity/authority/attendance/cert data that MUST be invoker (never
+// SECURITY DEFINER) — a DEFINER regression makes them bypass the caller's RLS on the
+// underlying sensitive tables. auth_engagements + v_active_members are the two #1422
+// flipped; the rest were flipped in the Onda 1 security sweep (20260508030000 / p40).
+// NOT included: impact_hours_total + public_members — those are accepted-DEFINER
+// (ADR-0096 / issue #82), tracked in scripts/advisor_baseline.json instead.
+// This is the full set of sensitive-data views that are invoker as of #1422; keep it in
+// sync when a new sensitive view is intentionally flipped (query: public views with
+// reloptions security_invoker=true that read members/persons/engagements).
 const CRITICAL_INVOKER_VIEWS = [
   'auth_engagements',
   'v_active_members',
   'active_members',
   'impact_hours_summary',
+  'member_attendance_summary',
+  'members_public_safe',
+  'v_initiative_roster',
+  'vw_exec_cert_timeline',
+  'vw_exec_skills_radar',
 ];
 
 async function auditViews(views) {


### PR DESCRIPTION
Follow-up de higiene do #1422 (opcional aprovado). Amplia o guard de recorrência para cobrir TODAS as views sensíveis que hoje são invoker, não só as 4 iniciais.

## Mudança

`CRITICAL_INVOKER_VIEWS` (em `1422-critical-views-security-invoker.test.mjs`): 4 → 9. Adiciona `member_attendance_summary`, `members_public_safe`, `v_initiative_roster`, `vw_exec_cert_timeline`, `vw_exec_skills_radar` — todas flipadas para invoker na Onda 1 (`20260508030000` / p40) e que leem dados de identidade/presença/certificado.

**Fora (por design):** `impact_hours_total` + `public_members` = DEFINER **aceitos** (ADR-0096 / #82), rastreados em `scripts/advisor_baseline.json`.

## Verificação

- Lista derivada de query ao vivo: views públicas com `reloptions security_invoker=true` que leem `members`/`persons`/`engagements`/attendance/cert.
- Teste ao vivo: **9/9 invoker=true** (10 pass / 0 skip).
- Só o array do teste muda (sem DDL, sem migration; RPC `_audit_view_security_invoker` já existe do #1426).

Refs #1422