### PR TITLE
fix(oauth): #1428 true Dynamic Client Registration (unblocks Perplexity + all non-Claude MCP clients)

### DIFF
--- a/src/pages/oauth/register.ts
+++ b/src/pages/oauth/register.ts
@@ -1,21 +1,32 @@
 // src/pages/oauth/register.ts
-// Dynamic Client Registration — RFC 7591
-// FIX: Returns a client_secret to avoid Supabase Auth admin panel crash
-// (NULL client_secret_hash causes Go sql.Scan error)
+// Dynamic Client Registration — RFC 7591 (TRUE DCR since #1428 member onboarding).
+//
+// HISTORY: this used to be a SHIM that returned a single shared, hardcoded client_id
+// (8636c0d0) and merely echoed the requested redirect_uris without persisting them.
+// GoTrue validates redirect_uri against that ONE client's fixed allow-list, so every
+// client whose callback was not pre-listed (Perplexity, Cursor, Manus, xAI, ...) failed
+// authorize with 400 invalid_redirect_uri. And Supabase's admin "update OAuth client"
+// endpoint is currently broken (500), so widening the shared allow-list is impossible.
+//
+// NOW: each registration CREATES a dedicated public OAuth client via the GoTrue admin
+// API (POST /auth/v1/admin/oauth/clients), persisting the client's own redirect_uris.
+// Admin CREATE + DELETE work (only UPDATE is broken), so per-client creation is the
+// clean path. Existing connectors on the old shared client keep working (create-only,
+// nothing is mutated). See memory reference-mcp-dcr-shim-fixed-client-redirect-allowlist.
+//
+// Security: DCR is an open, unauthenticated endpoint by design (MCP clients register
+// BEFORE the user logs in). A created client can do NOTHING until a real user completes
+// the consent flow and approves it — user auth + the consent screen remain the gate.
+// We validate redirect_uris (https, or http://localhost for dev) and cap the count to
+// limit spam value. Data access is never granted by registration alone.
 
 import type { APIRoute } from "astro";
-import { env } from "cloudflare:workers";
+import { env as cfEnv } from "cloudflare:workers";
 
-async function kvLog(_endpoint: string, _data: any) {
-  // No-op: KV debug logs disabled (free tier 1k writes/day protection).
-}
-
-// This is the Supabase Auth OAuth client ID registered for MCP
-const SUPABASE_CLIENT_ID = "8636c0d0-a359-45f5-a2a4-8097dbdaabd6";
-
-// Deterministic secret derived from client_id (not a real secret since this
-// is a public client, but prevents NULL columns in Supabase Auth)
-const CLIENT_SECRET_PLACEHOLDER = `mcp_pub_${SUPABASE_CLIENT_ID.replace(/-/g, "")}`;
+// Backward-compat fallback: the pre-existing shared client. Used only when the admin
+// API is unreachable (e.g. local dev without a service role key). Its fixed allow-list
+// (claude.ai, claude.com, chatgpt.com, localhost) still works for those callbacks.
+const FALLBACK_CLIENT_ID = "8636c0d0-a359-45f5-a2a4-8097dbdaabd6";
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",
@@ -23,28 +34,100 @@ const CORS = {
   "Access-Control-Allow-Headers": "Content-Type, Authorization",
 };
 
-export const POST: APIRoute = async ({ request }) => {
-  const rawBody = await request.text();
-  await kvLog("register", { method: request.method, body: rawBody, userAgent: request.headers.get("user-agent") });
-  const body = JSON.parse(rawBody || "{}") as any;
+const json = (obj: unknown, status = 201) =>
+  new Response(JSON.stringify(obj), {
+    status,
+    headers: { "Content-Type": "application/json", ...CORS },
+  });
 
-  return new Response(
-    JSON.stringify({
-      client_id: SUPABASE_CLIENT_ID,
-      client_secret: CLIENT_SECRET_PLACEHOLDER,
-      client_name: body.client_name || "mcp-client",
-      redirect_uris: body.redirect_uris || [],
-      grant_types: body.grant_types || ["authorization_code", "refresh_token"],
-      response_types: body.response_types || ["code"],
-      token_endpoint_auth_method: "none", // still public, secret is just placeholder
-      client_id_issued_at: Math.floor(Date.now() / 1000),
-      client_secret_expires_at: 0,
-    }),
-    {
-      status: 201,
-      headers: { "Content-Type": "application/json", ...CORS },
-    }
-  );
+// A public client never sends a secret (token_endpoint_auth_method: none), but we echo a
+// deterministic placeholder for clients that expect the field — it is ignored under PKCE.
+const placeholderSecret = (clientId: string) => `mcp_pub_${clientId.replace(/-/g, "")}`;
+
+function sanitizeRedirectUris(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  const out: string[] = [];
+  for (const raw of input) {
+    if (typeof raw !== "string" || out.length >= 5) continue;
+    try {
+      const u = new URL(raw);
+      const isHttpsProd = u.protocol === "https:";
+      const isLocalDev = u.protocol === "http:" && (u.hostname === "localhost" || u.hostname === "127.0.0.1");
+      if ((isHttpsProd || isLocalDev) && !out.includes(raw)) out.push(raw);
+    } catch { /* skip malformed URI */ }
+  }
+  return out;
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  let body: any = {};
+  try { body = JSON.parse((await request.text()) || "{}"); } catch { /* keep {} */ }
+
+  const redirectUris = sanitizeRedirectUris(body.redirect_uris);
+  const clientName = typeof body.client_name === "string" && body.client_name.trim()
+    ? body.client_name.trim().slice(0, 120)
+    : "mcp-client";
+  const grantTypes = Array.isArray(body.grant_types) && body.grant_types.length
+    ? body.grant_types
+    : ["authorization_code", "refresh_token"];
+  const responseTypes = Array.isArray(body.response_types) && body.response_types.length
+    ? body.response_types
+    : ["code"];
+
+  const supabaseUrl = (cfEnv as any)?.SUPABASE_URL || import.meta.env.PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = (cfEnv as any)?.SUPABASE_SERVICE_ROLE_KEY;
+
+  // TRUE DCR: mint a dedicated public client with the caller's own redirect_uris.
+  if (supabaseUrl && serviceRoleKey && redirectUris.length) {
+    try {
+      const resp = await fetch(`${supabaseUrl}/auth/v1/admin/oauth/clients`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${serviceRoleKey}`,
+          apikey: serviceRoleKey,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          client_name: clientName,
+          client_type: "public",
+          token_endpoint_auth_method: "none",
+          grant_types: grantTypes,
+          response_types: responseTypes,
+          redirect_uris: redirectUris,
+        }),
+      });
+
+      if (resp.ok) {
+        const created = (await resp.json()) as any;
+        return json({
+          client_id: created.client_id,
+          client_secret: placeholderSecret(created.client_id),
+          client_name: created.client_name ?? clientName,
+          redirect_uris: created.redirect_uris ?? redirectUris,
+          grant_types: created.grant_types ?? grantTypes,
+          response_types: created.response_types ?? responseTypes,
+          token_endpoint_auth_method: "none",
+          client_id_issued_at: Math.floor(Date.now() / 1000),
+          client_secret_expires_at: 0,
+        });
+      }
+      // Non-2xx from admin API → fall through to the shared-client fallback below.
+    } catch { /* network/parse error → fall through */ }
+  }
+
+  // Fallback (no service role, or admin API failed): return the shared client. Only its
+  // pre-registered callbacks will pass authorize — same behavior as before true DCR.
+  return json({
+    client_id: FALLBACK_CLIENT_ID,
+    client_secret: placeholderSecret(FALLBACK_CLIENT_ID),
+    client_name: clientName,
+    redirect_uris: body.redirect_uris || [],
+    grant_types: grantTypes,
+    response_types: responseTypes,
+    token_endpoint_auth_method: "none",
+    client_id_issued_at: Math.floor(Date.now() / 1000),
+    client_secret_expires_at: 0,
+  });
 };
 
 export const OPTIONS: APIRoute = () => {


### PR DESCRIPTION
## Problema
Conexão MCP nova de **qualquer cliente cujo callback não estava pré-listado** (Perplexity, Cursor, Manus, xAI) falhava com `400 invalid_redirect_uri`. Raiz: `/oauth/register` era um shim que devolvia um único client compartilhado fixo (`8636c0d0`) e só ecoava os `redirect_uris` sem persistir. O GoTrue valida o redirect contra o allow-list fixo desse client (só claude.ai/claude.com/chatgpt.com/localhost). E o endpoint admin de **update** de OAuth client está quebrado no Supabase (500), então alargar o allow-list é impossível.

## Fix
DCR real: cada registro **cria um OAuth client público dedicado** via admin API do GoTrue (`POST /auth/v1/admin/oauth/clients`), persistindo o `redirect_uri` do próprio cliente. CREATE + DELETE funcionam (validado ao vivo: create 201 → authorize 302 pro consent → delete 204); só UPDATE está bugado, e criar-por-cliente contorna. Conectores existentes no client compartilhado ficam intactos (só criamos, não mutamos). Fallback ao client compartilhado quando não há service role (dev local).

## Grounding (ao vivo nesta sessão)
- Admin list: 1 client `8636c0d0` (public), redirects = claude.ai, claude.com, chatgpt.com, localhost. Perplexity ausente.
- Update via dashboard **e** via API PUT → **500** (bug Supabase). Create 201 + authorize 302 + delete 204 ✅.

## Segurança
DCR é aberto por design (clientes MCP registram antes do login). Um client criado não acessa nada até um usuário real aprovar no consent (user auth + consent = gate). `redirect_uris` validados (https ou http://localhost), cap 5.

## Testes
`npx astro build` verde. `npm test`: 5333 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)