### PR TITLE
fix(footer): webinars link points to correct YouTube playlist

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -311,7 +311,7 @@ const globalI18nBundle = buildPageI18n(['comp.globalSearch', 'comp.common'], lan
       <span class="text-white/20" aria-hidden="true">·</span>
       <a href={localePath('/blog', lang)} class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('nav.blog', lang)}</a>
       <span class="text-white/20" aria-hidden="true">·</span>
-      <a href="https://youtube.com/playlist?list=PLRexyUb8O7bo" target="_blank" rel="noopener noreferrer" class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('footer.webinars', lang)}</a>
+      <a href="https://www.youtube.com/playlist?list=PLQJVKrw1fcryumj-vbZYK7Q-zoeAGQCos" target="_blank" rel="noopener noreferrer" class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('footer.webinars', lang)}</a>
       <span class="text-white/20" aria-hidden="true">·</span>
       <a href="https://www.youtube.com/playlist?list=PLQJVKrw1fcrymIpRMT4efnR0G1TJRaMWI" target="_blank" rel="noopener noreferrer" class="text-white/55 no-underline hover:text-[#05BFE0] hover:underline">{t('footer.meetings', lang)}</a>
       <span class="text-white/20" aria-hidden="true">·</span>

--- a/tests/ui-stabilization.test.mjs
+++ b/tests/ui-stabilization.test.mjs
@@ -1056,7 +1056,7 @@ test('R5: public playlist moved to footer; ResourcesSection holds no deadline co
   assert.equal(resources.includes('formatPlaylistDeadline'), false);
   // O link público de webinars (playlist do YouTube) está no rodapé
   assert.equal(footer.includes("t('footer.webinars', lang)"), true);
-  assert.equal(footer.includes('PLRexyUb8O7bo'), true); // Ciclo 4 (era C3 PLQJVKrw1fcrx3fD2ug1hnps6TklcMT1dc)
+  assert.equal(footer.includes('PLQJVKrw1fcryumj-vbZYK7Q-zoeAGQCos'), true); // Ciclo 4 webinars playlist (corrigido de PLRexyUb8O7bo, id errado — owner 2026-07-20)
 });
 
 test('public home locale copy no longer hardcodes cycle 3 labels', () => {


### PR DESCRIPTION
## O que
O link "webinars" no rodapé (`src/layouts/BaseLayout.astro:314`) apontava para uma playlist com id truncado/errado (`PLRexyUb8O7bo`), levando ao destino errado. Corrigido para a playlist canônica de webinares.

- Antes: `https://youtube.com/playlist?list=PLRexyUb8O7bo`
- Depois: `https://www.youtube.com/playlist?list=PLQJVKrw1fcryumj-vbZYK7Q-zoeAGQCos`

A linha vizinha (`footer.meetings`, playlist de reuniões) não foi tocada.

## Verificação
- `npx astro build` passou (0 novos erros).

## Nota (fora de escopo, para follow-up)
Ainda há links de playlist/Meet hardcoded: `TribesSection.astro:321` usa o MESMO id errado `PLRexyUb8O7bo`, e `TribesSection.astro:82-95` tem mapa tribe→Meet cravado. Higiene de hardcoding a tratar separadamente.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>