### PR TITLE
fix(gamification): #1448 conquistas vitalícias (certs/badges) sempre contam na visão de ciclo

### DIFF
--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -5624,6 +5624,8 @@ const enUS: Record<string, string> = {
   'profile.xp.variableNote': '(variable: 15–25 pts by type)',
   'profile.xp.tabLifetime': 'All-time',
   'profile.xp.tabCycle': 'Current cycle',
+  'profile.xp.lifetimeTag': 'lifetime',
+  'profile.xp.lifetimeTagTip': 'Permanent achievement (certifications and badges) — always counts, even in the current-cycle view.',
   'profile.xp.ofTotal': '% of total',
   'profile.xp.triggerTipManual': 'Manual recognition by leadership',
   'profile.xp.triggerTipAuto': 'Automatic when source action happens',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -5625,6 +5625,8 @@ const esLATAM: Record<string, string> = {
   'profile.xp.variableNote': '(variable: 15–25 pts por tipo)',
   'profile.xp.tabLifetime': 'Histórico',
   'profile.xp.tabCycle': 'Ciclo actual',
+  'profile.xp.lifetimeTag': 'vitalicio',
+  'profile.xp.lifetimeTagTip': 'Logro permanente (certificaciones e insignias) — siempre cuenta, incluso en la vista del ciclo actual.',
   'profile.xp.ofTotal': '% del total',
   'profile.xp.triggerTipManual': 'Reconocimiento manual por liderazgo',
   'profile.xp.triggerTipAuto': 'Automático cuando la acción fuente ocurre',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -5630,6 +5630,8 @@ const ptBR: Record<string, string> = {
   'profile.xp.variableNote': '(variável: 15–25 pts por tipo)',
   'profile.xp.tabLifetime': 'Vida toda',
   'profile.xp.tabCycle': 'Ciclo atual',
+  'profile.xp.lifetimeTag': 'vitalício',
+  'profile.xp.lifetimeTagTip': 'Conquista permanente (certificações e badges) — conta sempre, mesmo na visão do ciclo atual.',
   'profile.xp.ofTotal': '% do total',
   'profile.xp.triggerTipManual': 'Reconhecimento manual por liderança',
   'profile.xp.triggerTipAuto': 'Automático quando a ação-fonte acontece',

--- a/src/pages/profile.astro
+++ b/src/pages/profile.astro
@@ -1128,10 +1128,18 @@ const PROFILE_I18N = {
     const tabCycleI18n = t('profile.xp.tabCycle', lang) + cycleSuffix;
     const ofTotalI18n = t('profile.xp.ofTotal', lang);
 
+    const lifetimeTagI18n = t('profile.xp.lifetimeTag', lang);
     const cardsHtml = pillars.map((p: any) => {
       const rules: any[] = p.rules || [];
       const pillarRulesId = `pillar-rules-${p.pillar}-${currentXpScope}`;
       const hasPts = p.total_pts > 0;
+      // #1448: conquistas vitalícias (certificações/badges) sempre contam com valor vitalício,
+      // mesmo no escopo ciclo. Marca o pilar e usa histórico unscoped no drilldown.
+      const pillarIsLifetime = !!p.is_lifetime;
+      const earnSource = (isLifetime || pillarIsLifetime) ? allGamificationPoints : scopedPoints;
+      const lifetimeTagHtml = (pillarIsLifetime && !isLifetime)
+        ? `<span class="ml-1 align-middle text-[.5rem] px-1 py-0.5 rounded bg-amber-100 text-amber-800 font-bold uppercase tracking-wide" title="${escapeHtmlSafe(t('profile.xp.lifetimeTagTip', lang))}">∞ ${lifetimeTagI18n}</span>`
+        : '';
       const headerColor = hasPts ? 'text-navy' : 'text-[var(--text-secondary)]';
       const pillarPct = totalPts > 0 ? Math.round((p.total_pts / totalPts) * 100) : 0;
       const barColor = hasPts ? 'bg-teal' : 'bg-[var(--border-default)]';
@@ -1172,7 +1180,7 @@ const PROFILE_I18N = {
 
         let detailHtml = '';
         if (r.pts > 0) {
-          const earnings = scopedPoints.filter((gp: any) => gp.category === r.slug);
+          const earnings = earnSource.filter((gp: any) => gp.category === r.slug);
           if (earnings.length > 0) {
             const shown = earnings.slice(0, 30);
             const overflow = earnings.length - shown.length;
@@ -1215,7 +1223,7 @@ const PROFILE_I18N = {
       return `
         <div class="bg-[var(--surface-base)] rounded-xl border border-[var(--border-default)] p-3 flex flex-col">
           <div class="flex items-center justify-between mb-1">
-            <div class="font-bold text-[.78rem] ${headerColor}">${pillarEmoji(p.pillar)} ${pillarLabel(p.pillar)}</div>
+            <div class="font-bold text-[.78rem] ${headerColor}">${pillarEmoji(p.pillar)} ${pillarLabel(p.pillar)}${lifetimeTagHtml}</div>
             <div class="text-xl font-black text-navy">${p.total_pts}</div>
           </div>
           <div class="text-[.62rem] text-[var(--text-muted)] mb-1">
@@ -1321,7 +1329,7 @@ const PROFILE_I18N = {
             ${initiative ? `<span class="text-[.6rem] text-[var(--text-muted)]">${initiative}</span>` : ''}
           </div>
           <p class="text-[.7rem] text-[var(--text-secondary)] italic">"${safeJust}"</p>
-          <p class="text-[.6rem] text-[var(--text-muted)] mt-1">— ${awarder} · ${criteriaLabel}: ${(c.criteria_met || []).join(', ')}</p>
+          <p class="text-[.6rem] text-[var(--text-muted)] mt-1">— ${awarder}${c.awarded_at ? ` · ${formatDateShort(c.awarded_at)}` : ''} · ${criteriaLabel}: ${(c.criteria_met || []).join(', ')}</p>
         </div>`;
     }).join('');
 

--- a/supabase/migrations/20260805000472_1448_lifetime_achievements_always_count_in_cycle_pillars.sql
+++ b/supabase/migrations/20260805000472_1448_lifetime_achievements_always_count_in_cycle_pillars.sql
@@ -1,0 +1,174 @@
+-- #1448: conquistas vitalícias (certificações + badges Credly) somem na visão "Ciclo Atual".
+--
+-- Causa: get_member_xp_pillars janela TODOS os gamification_points por created_at >= cycle_start.
+-- Certs/badges recebem created_at da data de importação (ex.: uma CPMAI de 2025), então caem
+-- fora do ciclo corrente e o card de "Certificações" mostra 0 — o membro acha que "não pontua".
+--
+-- Decisão de produto (sessão dedicada 2026-07-21, híbrido surface-aware):
+--   - PERFIL/pilares: o pilar `certificacoes` (badge + cert_*) SEMPRE conta com valor vitalício,
+--     mesmo no escopo 'cycle'. Só XP de fluxo (presença/champions/curadoria/trilha/produção) é
+--     janelado por ciclo. Marcamos o pilar com is_lifetime=true para a UI rotular "vitalício".
+--   - RANKING: usa get_gamification_leaderboard (RPC distinta, cycle-scoped) — INTOCADO por design;
+--     estoque de certs de anos anteriores não deve inflar o ranking competitivo do ciclo.
+--
+-- Nenhuma mudança de assinatura; CREATE OR REPLACE preserva grants existentes.
+
+CREATE OR REPLACE FUNCTION public.get_member_xp_pillars(p_member_id uuid DEFAULT NULL::uuid, p_cycle_code text DEFAULT NULL::text, p_scope text DEFAULT 'lifetime'::text)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller members%ROWTYPE;
+  v_target_id uuid;
+  v_target members%ROWTYPE;
+  v_is_self boolean;
+  v_can_view_pii boolean;
+  v_scope text;
+  v_cycle_code text;
+  v_cycle_start timestamptz;
+  v_cycle_end timestamptz;
+  v_result jsonb;
+BEGIN
+  SELECT * INTO v_caller FROM members WHERE auth_id = auth.uid();
+  IF v_caller.id IS NULL THEN
+    RETURN jsonb_build_object('error','not_authenticated');
+  END IF;
+
+  IF p_scope NOT IN ('cycle','lifetime') THEN
+    RETURN jsonb_build_object('error','invalid_scope','detail','must be cycle or lifetime');
+  END IF;
+
+  v_target_id := COALESCE(p_member_id, v_caller.id);
+  v_is_self := (v_target_id = v_caller.id);
+
+  SELECT * INTO v_target FROM members WHERE id = v_target_id;
+  IF v_target.id IS NULL THEN
+    RETURN jsonb_build_object('error','member_not_found');
+  END IF;
+  IF v_target.organization_id != v_caller.organization_id THEN
+    RETURN jsonb_build_object('error','member_not_in_org');
+  END IF;
+
+  IF NOT v_is_self THEN
+    v_can_view_pii := public.can_by_member(v_caller.id, 'view_pii'::text);
+    -- FU-2 Slice C: an org-scoped view_pii grant must not elevate a chapter-restricted caller
+    -- (partner-chapter leader) past another chapter's gamification opt-out. GP/sede (scope NULL)
+    -- keep the elevation; everyone else falls back to the public/opt-out path cross-chapter.
+    v_scope := public.caller_chapter_scope();
+    IF v_can_view_pii AND v_scope IS NOT NULL AND v_target.chapter IS DISTINCT FROM v_scope THEN
+      v_can_view_pii := false;
+    END IF;
+    IF NOT v_can_view_pii AND COALESCE(v_target.gamification_opt_out, false) THEN
+      RETURN jsonb_build_object('error','member_opted_out_from_public');
+    END IF;
+  END IF;
+
+  IF p_scope = 'cycle' THEN
+    IF p_cycle_code IS NULL THEN
+      SELECT cycle_code, cycle_start::timestamptz, cycle_end::timestamptz
+        INTO v_cycle_code, v_cycle_start, v_cycle_end
+      FROM cycles WHERE is_current = true LIMIT 1;
+    ELSE
+      SELECT cycle_code, cycle_start::timestamptz, cycle_end::timestamptz
+        INTO v_cycle_code, v_cycle_start, v_cycle_end
+      FROM cycles WHERE cycle_code = p_cycle_code LIMIT 1;
+      IF v_cycle_code IS NULL THEN
+        RETURN jsonb_build_object('error','cycle_not_found');
+      END IF;
+    END IF;
+  END IF;
+  -- lifetime: v_cycle_* stay NULL
+
+  WITH points_filtered AS (
+    SELECT gp.category, gp.points
+    FROM gamification_points gp
+    WHERE gp.member_id = v_target_id
+      AND gp.organization_id = v_caller.organization_id
+      AND (
+        p_scope = 'lifetime'
+        -- #1448: conquistas vitalícias (pilar certificacoes = badges + cert_*) sempre contam,
+        -- mesmo na visão de ciclo. Só XP de fluxo é janelado por created_at.
+        OR EXISTS (
+          SELECT 1 FROM gamification_rules r_win
+          WHERE r_win.organization_id = gp.organization_id
+            AND r_win.slug = gp.category
+            AND r_win.pillar = 'certificacoes'
+        )
+        OR (gp.created_at >= v_cycle_start
+            AND (v_cycle_end IS NULL OR gp.created_at < (v_cycle_end + interval '1 day')))
+      )
+  ),
+  rule_breakdown AS (
+    SELECT
+      r.pillar,
+      r.slug,
+      r.display_name_i18n,
+      r.description_i18n,
+      r.base_points,
+      r.cap_points,
+      r.trigger_source,
+      COALESCE(SUM(p.points), 0)::int AS pts,
+      -- #1087 Onda 3: estorno (points < 0) não conta como "earned"; pts segue SUM cru (net).
+      (COUNT(p.points) FILTER (WHERE p.points > 0))::int AS earned_count
+    FROM gamification_rules r
+    LEFT JOIN points_filtered p ON p.category = r.slug
+    WHERE r.organization_id = v_caller.organization_id
+      AND r.active = true
+    GROUP BY r.pillar, r.slug, r.display_name_i18n, r.description_i18n, r.base_points, r.cap_points, r.trigger_source
+  ),
+  pillar_agg AS (
+    SELECT
+      pillar,
+      SUM(pts)::int AS total_pts,
+      SUM(earned_count)::int AS earned_count,
+      jsonb_agg(
+        jsonb_build_object(
+          'slug', slug,
+          'display_name_i18n', display_name_i18n,
+          'description_i18n', description_i18n,
+          'base_points', base_points,
+          'cap_points', cap_points,
+          'trigger_source', trigger_source,
+          'pts', pts,
+          'count', earned_count
+        ) ORDER BY pts DESC, slug
+      ) AS rules
+    FROM rule_breakdown
+    GROUP BY pillar
+  )
+  SELECT jsonb_build_object(
+    'member_id', v_target_id,
+    'member_name', v_target.name,
+    'is_self', v_is_self,
+    'scope', p_scope,
+    'cycle_code', v_cycle_code,
+    'cycle_start', v_cycle_start,
+    'cycle_end', v_cycle_end,
+    'total_pts', COALESCE((SELECT SUM(total_pts)::int FROM pillar_agg), 0),
+    'pillars', COALESCE((
+      SELECT jsonb_agg(
+        jsonb_build_object(
+          'pillar', pillar,
+          'total_pts', total_pts,
+          'earned_count', earned_count,
+          -- #1448: pilar vitalício (não janelado por ciclo) — UI rotula "vitalício" no modo ciclo.
+          'is_lifetime', (pillar = 'certificacoes'),
+          'rules', rules
+        )
+        ORDER BY CASE pillar
+          WHEN 'presenca' THEN 1
+          WHEN 'trilha' THEN 2
+          WHEN 'certificacoes' THEN 3
+          WHEN 'producao' THEN 4
+          WHEN 'curadoria' THEN 5
+          WHEN 'champions' THEN 6
+        END
+      ) FROM pillar_agg
+    ), '[]'::jsonb)
+  ) INTO v_result;
+
+  RETURN v_result;
+END;
+$function$;


### PR DESCRIPTION
Resolve a parte de dados/UX do #1448 (sessão dedicada de gamificação, 2026-07-21). **Auditoria ao vivo primeiro, fix depois.**

## Root-cause (aterrado no DB)

`get_member_xp_pillars` janelava TODOS os `gamification_points` por `created_at >= cycle_start`. Certs/badges recebem `created_at` da data de importação (ex.: uma CPMAI de 2025), então caíam fora do Ciclo 4 (`cycle_start=2026-07-09`) → o card "Certificações" mostrava 0, e o membro achava que "não pontua".

**Henrique (`2bbbe245…`), aterrado ao vivo:** 30 pts de fluxo no Ciclo 4 (3× presença) + 270 pts de certificação, TODOS pré-ciclo.

## Fix — híbrido surface-aware (decisão de produto)

- **RPC `get_member_xp_pillars`:** o pilar `certificacoes` (badge + cert_*) agora conta SEMPRE com valor vitalício, mesmo no escopo `cycle`. Só XP de fluxo (presença/champions/curadoria/trilha/produção) segue janelado. Pilar marcado com `is_lifetime=true`. Validado ao vivo pós-fix: `certificacoes=270`, `presenca=30`.
- **Ranking INTOCADO por design:** `get_gamification_leaderboard` é uma RPC distinta e cycle-scoped — estoque de certs de anos anteriores não infla o ranking competitivo do ciclo.
- **`profile.astro`:** tag "vitalício" no pilar em modo ciclo; drilldown usa histórico unscoped para pilares vitalícios; card de champions agora mostra a **data de concessão** (faceta 2 — o champion antigo do Jefferson não parece mais "atual").
- **i18n:** `profile.xp.lifetimeTag` + `lifetimeTagTip` nos 3 dicionários.

## Facetas do issue

1. Certs somem no ciclo → **corrigido** (acima).
2. Champion "no Ciclo 4" → backend estava **correto** (created_at 03/07 = Ciclo 3; as RPCs de ciclo já o excluem). A surface `get_member_champions_history` é unscoped/vitalícia — não há divergência de fontes. UI agora mostra a data.
3. "scope=lifetime num call de cycle" → **não era bug**: é o smart-default do `profile.astro`.

## GC-097

Migration `20260805000472` aplicada via `apply_migration`; phantom tracking row (`20260721135411`) removida por versão exata; canônica registrada via `migration repair`; `NOTIFY pgrst`.

## Testes

`npx astro build` ✅ · `npm test` ✅ **5980/5981 pass, 0 fail, 1 skip**.

Segue #1449 (tooltip de breakdown): consome a mesma RPC e herda o `is_lifetime`.