### PR TITLE
docs(planning): versiona briefs de arranque de sessão

### DIFF
--- a/docs/planning/2026-07-21_decisoes_humanas_fila_wave2.md
+++ b/docs/planning/2026-07-21_decisoes_humanas_fila_wave2.md
@@ -1,0 +1,210 @@
+# Decisoes humanas pendentes na fila (Wave 2 + follow-ups)
+
+> **RATIFICADO pelo owner em 2026-07-21: em acordo com as 6 recomendacoes abaixo.**
+> Direcoes travadas (nao re-litigar). Execucao segue a "Nota de processo" no fim.
+>
+> Aterrado ao vivo em 2026-07-21 (HEAD `171b721a`, `main ≡ prod`). Estados dos issues
+> confirmados via `gh issue view` na mesma sessao. Isto separa o que EU posso executar
+> (codigo, SPEC, rascunho) do que depende de decisao SUA (ou de PMI-GO / legal / produto).
+> Para cada decisao: quem decide, contexto, cenarios e recomendacao com justificativa.
+
+## Matriz rapida
+
+| # | Decisao | Quem decide | Bloqueia | Minha recomendacao | Urgencia |
+|---|---------|-------------|----------|--------------------|----------|
+| 1 | #1008 - ratificacao do nome "AI Community Day" + PDU/certificado | Presidencia PMI-GO + legal-counsel + c-level | Divulgacao de qualquer material publico do ACD | Postura conservadora: ratificacao escrita ANTES de publicar; certificado sem claim de PDU | Alta (dependencia externa; recorrente) |
+| 2 | #1152 - mapa funcao->gate (Ivan vs Lorena) + committee_majority stub | Voce + confirmacao Ivan/Lorena | Trilha de lock da Politica (Termo e contornavel) | Ratificar leitura do issue: Lorena = contraparte pos-aprovacao, nao gate de versao; policy com cadeia custom explicita | Media |
+| 3 | #1424 Fase D - reclassificar tipos imediatos para digest | Voce (produto/UX) | Nada critico (A/B/C sao a alavanca real) | ADIAR D ate a medicao de sabado 25/07; nao mover certificado/welcome | Baixa-media |
+| 4 | #1358 - "stakeholder de capitulo" vs "ponto focal do nucleo" | Voce (tem a lista nominal) | Corretude de rosters/campanhas (grupos WhatsApp C4) | Adotar o split de 3 categorias; voce confirma o mapa nominal; eu implemento (so rotulo, sem mudar autoridade) | Media |
+| 5 | #1014 - mecanismo de convite de signup direcionado | Voce (produto) + security-engineer | Remediacao do dia-9 a cada virada de ciclo | Comecar por "nudge-to-signup" (a); magic-link (b) so se nudge nao bastar | Media (workaround manual existe) |
+| 6 | #485 - modelo de recorrencia + escopo | Voce/PM | Nada (deferred, low) | Estender rows materializadas com frequencia/intervalo; adiar tz selector e GCal sync | Baixa |
+
+---
+
+## 1. #1008 - Ratificacao do nome "AI Community Day" + linguagem de PDU/certificado
+
+**Quem decide:** Presidencia de PMI-GO (ratificacao do nome), com review obrigatorio de
+legal-counsel (linguagem) e c-level-advisor (enquadramento vs PMI). Nao e decisao unilateral
+do Nucleo. **Meu papel:** preparar os rascunhos; a publicacao e gated por esses reviews (criterio
+de aceite do proprio issue).
+
+**Contexto (aterrado no issue, origem council-review 2026-07-01):** coincidencia de nome + data +
+tema com o AI Community Day GLOBAL do PMI cria **implied endorsement** (parceiros/imprensa presumem
+chancela oficial ou guarda-chuva do novo AI Standard). PMI-GO e a parte contratante (ADR-0104) e a
+entidade mais exposta. Reivindicar PDU sem habilitacao formal e o item que pode **fechar o Path A**
+(PMI-internal spinoff). O evento de 16/07 ja passou, entao a urgencia aguda caiu, mas nome + PDU e
+**recorrente** para ACDs futuros e continua sendo blocker de divulgacao padrao.
+
+**Decisao 1a - ratificacao do nome.**
+- Cenario A (conservador): exigir ratificacao escrita da Presidencia PMI-GO antes de qualquer
+  material publico usar "AI Community Day".
+- Cenario B (permissivo): seguir usando o nome, tratando como uso local obvio, sem ratificacao formal.
+- **Recomendacao: A.** A assimetria decide: o custo de pedir e um atraso curto; o custo de nao pedir
+  e risco institucional ao Path A e a PMI-GO (a entidade mais exposta). Risco reputacional
+  irreversivel nao se troca por conveniencia de calendario.
+
+**Decisao 1b - linguagem do certificado / PDU.**
+- Cenario A: "Certificado de participacao emitido pelo Nucleo IA & GP"; NUNCA "concede N PDUs"; se
+  aplicavel, "PDU pode ser autodeclarado pelo participante conforme a categoria [X] do PMI CCR".
+- Cenario B: certificado com mencao a PDUs concedidas (posicionamento mais forte de valor).
+- **Recomendacao: A.** Sob o PMI CCR, PDU de educacao pode ser **autodeclarado** pelo participante,
+  isso e factual e seguro. "Concede N PDUs" implica autoridade emissora que o Nucleo nao tem, e e
+  exatamente o claim que ameaca o Path A. Ganha-se o valor (o participante registra a PDU) sem o risco.
+
+**Decisao 1c - enquadramento do evento.**
+- Cenario A: "aftershow / extensao noturna" do ACD (slot 19-21h BRT; o PMI global roda 10-17h BRT).
+- Cenario B: "evento paralelo" ou "edicao local oficial".
+- **Recomendacao: A.** O slot noturno e a brecha real e verdadeira; posiciona como complementar, nao
+  concorrente nem oficial. Evita o implied endorsement e ainda e um enquadramento honesto.
+
+**Decisao 1d - timing / recorte desta rodada.**
+Como 16/07 passou, o recorte muda de "blocker desta semana" para: (1) **higiene retroativa** - auditar
+se algum material do 16/07 com linguagem arriscada ainda esta publico e ajustar; (2) **politica
+forward** - a consulta escrita a PMI-GO/PMI Latam vira politica-padrao para ACDs futuros.
+- **Recomendacao:** fazer os dois. Eu preparo (i) o rascunho da consulta a PMI-GO/PMI Latam
+  (autorizacao do nome + referencia ao Standard sem parecer emissor + limites de PDU) e (ii) a copy
+  travada de certificado e convite. Ambos passam por legal-counsel antes de publicar (gate duro).
+
+---
+
+## 2. #1152 - Mapa funcao->gate (fusao Ivan/Lorena) + committee_majority stub
+
+**Quem decide:** Voce, com confirmacao de Ivan/Lorena sobre a semantica da contraparte. **Meu papel:**
+propor o mapa e implementar em `_can_sign_gate` apos ratificado (seguindo o procedimento de 4 etapas
+do `docs/reference/V4_AUTHORITY_MODEL.md` antes de qualquer DDL de gate).
+
+**Contexto (aterrado no corpo do issue, schema live 06/07):** o gate `president_go` do
+`volunteer_term_template` hoje e satisfeito por duas funcoes distintas via predicado de designacao
+sobreposto: Ivan (`legal_signer`, presidente/SEDE) e Lorena (`voluntariado_director`, diretora de
+voluntariado). O carve-out `voluntariado_director` dentro de `president_go` funde **aprovacao da
+versao do documento** com **assinatura da contraparte da entidade em cada Termo executado**.
+
+**Decisao 2a - a funcao da Lorena e gate de versao ou contraparte por-instrumento?**
+- Cenario A (leitura do issue): a assinatura da Lorena e a **contraparte da entidade promotora em
+  cada Termo executado** (mecanica pos-aprovacao, por adesao individual), NAO um gate de aprovacao de
+  versao. Remover o carve-out `voluntariado_director` de `president_go`.
+- Cenario B: manter como esta (ambos satisfazem o gate de versao).
+- **Recomendacao: A.** Aprovar a VERSAO do template (vira vigente) e um ato de governanca documental;
+  assinar a contraparte de cada Termo executado e outra coisa (por-adesao, pos-aprovacao). Alinha com
+  [[reference-volunteer-term-countersign-lorena]] (a contra-assinatura e ato exclusivo da Lorena,
+  roteado como fila, nao como gate). Corrige tambem um cheiro de segregacao de funcoes.
+
+**Decisao 2b - segregacao de funcoes.**
+- Cenario A: proibir que a mesma pessoa aprove o template E assine a contraparte.
+- Cenario B: nao restringir.
+- **Recomendacao: A.** Controle interno basico. Custo zero na pratica (ja sao pessoas diferentes:
+  Ivan aprova, Lorena assina a contraparte). Trava o precedente antes de virar problema.
+
+**Decisao 2c - committee_majority stub trava o lock da Politica.**
+`resolve_default_gates('policy')` devolve `committee_majority` (retorna FALSE ate o roster do Comite
+de Curadoria ser definido em §7.1) no gate 1, entao a Politica nunca atinge maioria e fica presa.
+- Cenario A: destravar o roster do Comite de Curadoria (§7.1) agora.
+- Cenario B: travar a policy com uma cadeia custom explicita (ex.: Ivan `president_go` +
+  `partner_consultation` consultivo), deixando `committee_majority` de fora ate §7.1 existir.
+- **Recomendacao: B, a menos que o Comite ja esteja de fato constituido.** Um stub que retorna FALSE
+  nunca atinge maioria: depender dele bloqueia a trilha da Politica indefinidamente. Uma cadeia
+  custom e honesta sobre quem realmente aprova hoje. Nao afeta a Onda 1 (Termo), que segue contornavel
+  (threshold 1, Ivan assina a SEDE).
+
+---
+
+## 3. #1424 Fase D - Reclassificar tipos de e-mail imediatos para digest
+
+**Quem decide:** Voce (produto/UX). **Meu papel:** implementar apos a decisao; Fases A/B/C sao da lane
+dev independentemente.
+
+**Contexto:** as Fases A (agrupar por destinatario) + B (cap diario compartilhado) + C (escalonar o
+digest de sabado) atacam a raiz do estouro da cota Resend. A Fase D e incremental: mover tipos nao-
+urgentes de alto volume (`volunteer_agreement_signed`, `certificate_issued`, `certificate_ready`,
+`engagement_welcome`) de `transactional_immediate` para `digest_weekly`.
+
+**Decisao 3a - fazer a Fase D, e para quais tipos?**
+- Cenario A: mover os 4 tipos para digest agora.
+- Cenario B: adiar D; re-medir apos A/B/C e so mover um tipo se ainda estourar o headroom.
+- **Recomendacao: B, com veto a mover certificado e welcome.** A/B/C atacam a raiz (o fan-out de
+  `volunteer_agreement_signed` a 7,3/pessoa e do digest de lider a 4,8/pessoa cai para 1/pessoa so com
+  a Fase A). Certificado ficar pronto e um **momento** que o membro quer saber na hora (baixa/compartilha,
+  loop de reconhecimento/gamificacao); welcome atrasado uma semana e um sinal ruim de onboarding.
+  Mover esses troca UX (tempestividade) por volume que A/B/C ja resolvem. Recomendo amarrar a decisao
+  de D a **medicao pos-deploy de sabado 25/07** (item 1 da fila): se o cap nao morder, D e desnecessaria.
+
+---
+
+## 4. #1358 - "Stakeholder de capitulo" distinto de "ponto focal do nucleo"
+
+**Quem decide:** Voce (detem a lista nominal com PII, fora do repo publico). **Meu papel:** implementar
+a derivacao de categoria (so rotulo/categoria, SEM mudanca de autoridade; respeitando o procedimento do
+`V4_AUTHORITY_MODEL.md` para nao mexer em `engagement_kind_permissions` indevidamente).
+
+**Contexto:** 5 de 7 membros tagueados como ponto focal/liaison sao na verdade VP/diretor/PMO de
+capitulo parceiro (stakeholders): acessam dados do portfolio por conta do papel no capitulo, mas nao
+tem papel operacional no nucleo. So ~2-3 sao pontos focais reais. Descoberto ao montar os grupos de
+WhatsApp por funcao do C4 (grupo "Pontos Focais" inflado). O acesso a dado deles e legitimo; o errado
+e o **rotulo**.
+
+**Decisao 4a - adotar o split de categoria.**
+- Cenario A: criar categoria "stakeholder de capitulo" distinta de "ponto focal do nucleo"; aposentar
+  `chapter_liaison` como guarda-chuva.
+- Cenario B: manter a tag unica.
+- **Recomendacao: A.** Os criterios de aceite ja sao claros e a correcao e de modelagem, baixa
+  controversia. O unico julgamento humano e o **mapa nominal** (quais 5 sao stakeholders vs quais 2-3
+  sao focais reais), que exige o seu conhecimento. Preserva o acesso a dado (nao e mudanca de autoridade).
+- **O que preciso de voce:** a lista nominal de reclassificacao (fica na sessao dev / arquivo local,
+  fora do issue publico por PII).
+
+---
+
+## 5. #1014 - Mecanismo de convite de signup direcionado (aceitos sem conta)
+
+**Quem decide:** Voce (produto) + security-engineer no desenho do mecanismo escolhido. **Meu papel:**
+escrever a SPEC apos a escolha; implementar depois.
+
+**Contexto (aterrado no audit #1004):** na virada C3->C4, 4 de 36 aceitos tem `auth_id IS NULL` e nao
+conseguem logar no dia 9. Nao ha mecanismo direcionado e seguro para reenviar convite de cadastro a
+esses membros especificos. `request_account_claim` exige caller autenticado (fluxo errado);
+admin auth-invite nao existe; `send-global-onboarding` e broadcast de coorte (over-send). O gap recorre
+a cada virada de ciclo. Workaround imediato: nudge manual (nao bloqueia o dia 9).
+
+**Decisao 5a - qual mecanismo.**
+- Cenario A (nudge-to-signup): e-mail direcionado a `member_ids` especificos apontando para o cadastro
+  self-service com o e-mail da candidatura. Nao cria conta, so orienta. Reusa Resend/templates.
+- Cenario B (magic-link / auth-invite): a plataforma emite link de primeiro acesso
+  (`generateLink`/`inviteUserByEmail` ou token proprio) que cria/vincula a conta. Mais robusto.
+- **Recomendacao: comecar por A, escalar para B so se A nao bastar.** A resolve o gap recorrente do
+  dia-9 com o menor custo: reusa infra existente e **nao abre superficie de auth nova** (evita o custo
+  de seguranca + LGPD + escopo de token que B introduz). B e mais robusto mas so se justifica se os
+  membros nao se auto-cadastrarem via nudge. Requisitos comuns a qualquer opcao (gate de autoridade,
+  idempotencia/TTL, log de acesso PII Art. 37, alvo por lista explicita) entram na SPEC.
+
+---
+
+## 6. #485 - Recorrencia flexivel + timezone + Google Calendar sync
+
+**Quem decide:** Voce/PM. Prioridade **baixa** (deferred, nao urgente). **Meu papel:** implementar apos
+a decisao de modelo.
+
+**Contexto:** `create_recurring_weekly_events` e weekly-only, count-based. Pedidos: quinzenal, 2x/semana,
+mensal; selector de timezone; import/sync com Google Calendar (reusaria a infra de webhook do #472).
+
+**Decisao 6a - modelo de recorrencia (decidir ANTES de construir).**
+- Cenario A: estender o modelo atual de **rows materializadas** com parametros de frequencia/intervalo.
+- Cenario B: adotar um modelo de **regra de recorrencia (RRULE-style)**.
+- **Recomendacao: A para o curto prazo.** A plataforma ja materializa event rows discretas (attendance,
+  board links referenciam eventos concretos por `recurrence_group`); um modelo RRULE completo e um
+  refactor grande com payoff incerto na escala atual. Estender rows com frequencia/intervalo entrega o
+  valor pedido com risco menor.
+
+**Decisao 6b - escopo.**
+- **Recomendacao:** construir a **frequencia flexivel** primeiro (maior valor pedido pelos membros),
+  adiar tz selector (demanda menor) e GCal sync (reusa #472 depois). Coerente com a prioridade low.
+
+---
+
+## Nota de processo
+
+Nada aqui e executado sem a sua decisao. Depois que voce fechar cada ponto, a divisao e:
+- **Eu executo (codigo/SPEC/rascunho):** #1152 (apos ratificar o mapa), #1358 (com o mapa nominal),
+  #1014 (SPEC do mecanismo escolhido), #485, e os rascunhos do #1008.
+- **Voce roteia externamente:** #1008 (Presidencia PMI-GO + legal-counsel + c-level), #1152
+  (confirmacao Ivan/Lorena sobre a contraparte).
+- **Gate duro:** nenhum material do #1008 sai antes de PMI-GO ratificar o nome + legal revisar a linguagem.

--- a/docs/planning/2026-07-21_startup_prompt_next_session.md
+++ b/docs/planning/2026-07-21_startup_prompt_next_session.md
@@ -1,0 +1,28 @@
+# Prompt de arranque — próxima sessão (2026-07-21)
+
+> Ordem recomendada (dano ativo → risco → enhancement; DDL serializa):
+> **A) #1450 + #1445 (selection/VEP)** → **B) #1424 (Resend)** → **C) #1423 (Wave 1 DDL)** → **D) #1448 + #1449 (gamificação)** → **E) #485**.
+> Começar por A. Colar o bloco abaixo numa sessão limpa.
+
+---
+
+Sessão de trabalho no ai-pm-research-hub. Antes de agir: ler MEMORY.md, `git fetch`, e re-aterrar TODO número ao vivo (grounding obrigatório). Regras da casa: DDL só via apply_migration byte-igual ao arquivo + migration repair + NOTIFY + **deletar o phantom row HHMMSS** que o apply_migration MCP cria (mordeu o ADR-0097 em 20/07); NÃO aplicar 2ª DDL enquanto a 1ª PR não mergeou (entanglement de captura — serializar); merge só na sessão main; sem em-dash em entregáveis; Assisted-By nunca Co-Authored-By; 1 agente de conselho por subação.
+
+Prioridade e sequência (ratificadas 2026-07-21): #1450 → #1445 → #1424 → #1423 → #1448/#1449 → #485.
+
+## Sessão A (agora) — Selection/VEP
+
+### 1. #1450 — candidatos VEP importados convidados a agendar entrevista ANTES da objetiva
+Regressão confirmada ao vivo (20/07). Fluxo desenhado: entrevista só após objetiva; líder → `selection_cycles.interview_booking_url` (link Núcleo grupo); pesquisador → round-robin dos `interview_booking_url` do comitê (calendário Vitor+Fabricio). Gate: `schedule_interview` exige AI analysis + 2 peer evals + `objective_score`; convite sai por `notify_selection_cutoff_approved`.
+Estado anômalo: 2 pesquisadores em `interview_pending` **sem** objective_score (null), 1 peer eval, `cutoff_approved_email_sent_at=null` — Sarah Caroline Mazeu Branco + Jonas Thimoteo (ciclo `08c1e301` cycle4-2026). Transição SEM audit log.
+Leak: `src/pages/minha-candidatura.astro` mostra o CTA "agende" puramente por `status='interview_pending'`.
+Arranque: (a) re-aterrar o estado dos 2 + confirmar se TIVERAM objetiva antes do re-import de 20/07 23:15 (hipótese nº1: re-import limpou score e manteve status avançado — ver p472-vep-reimport-status-freeze / p693-vep-terminal-status-honor); (b) checar recompute/consistency crons (472_corr5, 705_eval_queue) que possam derivar interview_pending; (c) fix: gatear o convite/CTA pela objetiva concluída (mesma condição do schedule_interview), não só por status; garantir que re-import não avance status nem deixe interview_pending órfão de score. Guard test. Sarah/Jonas já foram aceitos pelo owner — NÃO mexer no estado deles sem decisão (evitar fricção); decidir seguir vs voltar à fila.
+
+### 2. #1445 — bucket de reconciliação "approved + oferta VEP retirada + member ativo"
+`get_vep_divergence_report()` não tem bucket para approved + `vep_status_raw IN (OfferNotExtended/Withdrawn/Declined)` + member ativo → invisível no /admin/vep-reconciliation (caso Hector, resolvido à mão). Fix: novo bucket + ação de offboard alcançável no card (reusar `admin_offboard_member inactive`, sem duplicar path). DDL (CREATE OR REPLACE da RPC) — serializa. Guard test.
+
+## Depois (sessões seguintes)
+- **B) #1424** Resend 100/dia estoura fim de semana (EF, sem DDL, paralelo). Aterrar volume real de sáb vs cota; escolher Plano A-E. Ver [[reference-resend-email-quota-lanes]].
+- **C) #1423** bridge órfão `manage_initiative_engagement` remove não re-deriva `members.initiative_id` (DDL/trigger). Fix análogo ao #1270 (limpar AMBAS colunas no mesmo UPDATE). Invariante AO. Precedente [[reference-dual-write-demotion-clear-both-columns]].
+- **D) #1448 + #1449** gamificação: certs vitalícias somem no Ciclo Atual (Henrique 270pts vitalício, certs 2024-25 pré-ciclo-4; verificar get_member_xp_pillars('cycle')) + tooltip de breakdown por categoria (auditar próprio + topo).
+- **E) #485** recorrência flexível + timezone + GCal sync + (comentário 21/07) exposição MCP `create_series` + edição em série 3-escopos (this/this_and_following/all). priority:low.

--- a/docs/planning/2026-07-21_startup_prompt_scoring_merit_audit.md
+++ b/docs/planning/2026-07-21_startup_prompt_scoring_merit_audit.md
@@ -1,0 +1,78 @@
+# Prompt de arranque — SESSÃO LIMPA: auditoria criteriosa de pontuação e mérito
+
+> Cole o bloco abaixo como PRIMEIRA mensagem de uma sessão nova/limpa.
+> **Modelo:** Opus 4.8 (não baixar/pinar; é o mais capaz — quality-first). `/fast` opcional se ficar interativo.
+> **Level of effort:** **`/effort xhigh`** (ou keyword `ultrathink`) — tema difícil e de alto risco.
+> Antes de agir: ler MEMORY.md, `git fetch`, re-aterrar TODO número ao vivo (grounding do CLAUDE.md).
+
+---
+
+Sessão de trabalho no ai-pm-research-hub. **Rodar em Opus 4.8 + effort xhigh.** Tema SÉRIO: pontuação
+e mérito envolvem **transparência e credibilidade** e vêm sendo levados de lado. Mandato: **auditoria
+criteriosa, adversarial, sem hand-waving** — nada de "parece certo"; traçar a matemática ponta a ponta,
+provar cada afirmação com query ao vivo, e reconciliar UI ↔ RPC ↔ DB. Regras da casa: DDL só via
+apply_migration byte-igual + repair + NOTIFY + deletar phantom rows (data real `202607*` ordena ANTES
+do sintético `202608*`; deletar por versão exata, checar SEM `LIMIT` curto — a armadilha do drift-lock);
+merge só na sessão main exceto autorização explícita do owner; sem em-dash em entregáveis; Assisted-By
+nunca Co-Authored-By.
+
+## Escopo (DOIS subsistemas, uma ótica: transparência + credibilidade do mérito)
+
+### A. Seleção — pontuação / ranking / corte (Ciclo 4 - 2026/2)
+Owner reportou (2026-07-21, print em `docs/planning/`): a tela de Processo Seletivo está errada.
+**Anomalias observadas (LEADS, não conclusões — provar/refutar ao vivo):**
+- Banner "**Rankings vazios: 14/14 aplicações sem rank (100%)**" MAS as linhas mostram ranks #47/#52/#12/#55
+  (contradição: 100% sem rank vs ranks exibidos).
+- "**Corte: 130.9 (98.2–130.9, n=45, dynamic)**" convivendo com rankings supostamente vazios (o corte foi
+  calculado sobre quê, se não há ranks?).
+- "**Corte Líder não calculado (cohort < 10 ou sem avaliações)**"; régua líder n=9<10 / n=8<10.
+- Botões "Recalcular Rankings" / "Iniciar Triagem"; blind review "not all evaluators have submitted yet".
+- **Pergunta explícita do owner:** o **corte do Ciclo 4 - 2026/2 está correto?**
+
+Entry points (portas de entrada, aterrar corpo VIVO via `pg_get_functiondef`, não grep de migration velha):
+- Ranking: `calculate_rankings`, `recalculate_cycle_rankings`, `get_selection_rankings`, `get_selection_dashboard`.
+- Corte: `compute_pert_cutoff`, `_compute_pert_cutoff_core`, `get_pert_cutoff_summary`,
+  `get_cutoff_dispatch_health`, `recompute_all_active_pert_cutoffs`, `_selection_cutoff_pending_cron`,
+  `notify_selection_cutoff_approved`.
+- Gate de entrevista por `objective_score_avg` (ver [[handoff_session_2026_07_21_selection_vep]]).
+- Schema/critério: `supabase/migrations/20260319100025_w124_phase2_blind_eval_scoring.sql`,
+  `20260401070000_s3_s11_criterion_notes_membership_flag.sql`, `20260401100000_interview_rubrics_observer_role.sql`.
+- UI: `src/pages/admin/selection.astro` + ilhas de avaliação.
+
+### B. Gamificação de membros — XP / pilares / leaderboard
+Owner: "ainda não está arrumado, ainda está errado". Sessão C (21/07) tocou #1448/#1449 (PR#1455, mig 472),
+mas segue errado. Entry points:
+- `get_gamification_leaderboard`, `get_public_leaderboard`, `get_member_gamification_stats`,
+  `get_my_gamification_stats`, `get_member_xp_pillars`, `get_gamification_rules_catalog`,
+  `get_gamification_category_activity`, `get_initiative_gamification`, `get_tribe_gamification`,
+  `get_cpmai_leaderboard`, `get_pre_onboarding_leaderboard`.
+- Regra fluxo (cycle) vs vitalício (estoque), surface-aware: [[reference-gamification-xp-flow-vs-lifetime-surface-aware]].
+- Issues vivos: **#1069** ([audit] sweep gamification/leaderboard RPCs por RETURNS TABLE OUT-var ORDER BY
+  conflict — CLASSE DE BUG que pode produzir ranking errado; começar por aqui), **#591** (drill-down pillar
+  breakdown), **#718** (split protagonismo no breakdown), **#1209** (fallback badge/10 Credly), **#1221**
+  (mérito imutável ao executor — guard MCP + auditoria), **#873** (jornada gamificada pré-onboarding).
+
+### C. Transparência por critério (pedido explícito do owner, atravessa A e B)
+"a forma de transparência de ver a **pontuação de todos alocada por critério**." Auditar: existe uma
+superfície (UI + RPC) que mostra, de forma auditável, o score de cada pessoa **decomposto por critério**
+(seleção: rubricas/critérios de avaliação; gamificação: pilares/categorias)? Está correto, completo, e
+visível para quem deve ver (respeitando blind review + LGPD)? Se não existe ou está errado, é o coração
+do problema de credibilidade.
+
+## Método de auditoria (criterioso)
+1. **Ponta a ponta:** avaliação bruta por critério → agregação → score final → ranking → corte. Provar cada
+   salto com query ao vivo. Onde a UI, o RPC e o DB divergem, isso É o achado.
+2. **Adversarial:** para cada "está certo", tentar refutar. Não pinar contagem como invariante (a invariante
+   é a regra, não o N — ver [[reference-guardian-must-not-recite-counts]]).
+3. **Corpo vivo vence comentário/log/migration velha** ([[reference-live-body-beats-failure-log-and-stale-comments]]).
+4. **Roteamento de conselho (justificado por ser tema estratégico de credibilidade):** `data-architect`
+   na matemática do score/ranking/corte + schema; `product-leader`/`ux-leader` na superfície de transparência
+   por critério; `security-engineer` no quem-vê-o-quê (blind review + LGPD). `/council-review` no fecho se
+   virar decisão de desenho. 1 agente por subação; declarar a justificativa antes de convocar múltiplos.
+5. **Entregável:** relatório de auditoria (achados provados, com antes/depois ao vivo) → issues/PRs por
+   achado. Corte do Ciclo 4: veredito explícito (correto? se não, por quê e qual o valor certo).
+
+## Não re-litigar / contexto travado
+- Wave 2 já fechada nesta rodada: #1170, #1008 (nome ACD aprovado pelo owner — [[project-wave2-human-decisions-ratified]]),
+  #1152 (committee_majority ativado). #1424-D adiado sáb 25/07.
+- Antes de doc/DDL de issue: GREP `docs/project-governance/` + `docs/council/decisions/` (lição do #1008).

--- a/docs/planning/2026-07-22_startup_prompt_next_session.md
+++ b/docs/planning/2026-07-22_startup_prompt_next_session.md
@@ -1,0 +1,101 @@
+# Prompt de arranque - proxima sessao (Wave 2, pos #1170 100% fechado, 2026-07-21)
+
+> Cole o bloco abaixo como primeira mensagem da proxima sessao. Antes de agir: ler MEMORY.md,
+> `git fetch`, e re-aterrar TODO numero ao vivo (grounding obrigatorio do CLAUDE.md). Os valores
+> aqui sao do fechamento de 21/07 e podem ter mudado.
+
+---
+
+Sessao de trabalho no ai-pm-research-hub. Regras da casa: DDL so via apply_migration byte-igual
+ao arquivo + migration repair + NOTIFY + deletar os phantom rows que o apply_migration MCP cria
+(1 phantom POR chamada apply; usam data REAL `20260721HHMMSS`, que ordena ANTES do sintetico
+`20260805NNNNNN` - checar por prefixo de data real, NUNCA por `>= head`, e deletar por versao
+exata `IN (...)`, nunca LIKE); NAO aplicar 2a DDL enquanto a 1a PR nao mergeou (serializar); merge
+so na sessao main (exceto autorizacao explicita do owner); sem em-dash em entregaveis; Assisted-By
+nunca Co-Authored-By; 1 agente de conselho por subacao.
+
+## Contexto (fechamento 2026-07-21)
+
+`main ≡ prod` (HEAD `171b721a`). Sessao anterior FECHOU o residuo do #1170: o "chamador rogue" do
+`arm9_inactivity_alert` era o PROPRIO contract test `detect-inactive-members-non-dry-run` (test #3,
+helper `threshold=0`), escrevendo na prod porque `Prefer: tx=rollback` NAO desfaz INSERT de funcao
+SECURITY DEFINER nesse Supabase (classe do #231). Prova: 4216 arm9, 100% titulados "0 dias" (so o
+helper produz), correlacao com runs do ci.yml, buraco noturno = expediente, 1o row anterior ao 1o
+cron. Fix (PR#1458, merged `171b721a`): o teste limpa o que cria (janela ancorada no tempo do
+servidor) + asserçao de residuo zero; 4214 arm9 historicos deletados (2367 nao-lidos nos 2 admins);
+prod em `arm9_total = 0`. Licao registrada na [LL] #588. Memoria:
+`reference-tx-rollback-not-honored-secdef-pollutes-prod`.
+
+Residuo opcional (DDL, deixado de fora): o helper `_test_detect_inactive_with_threshold` ainda faz
+um `DELETE arm9 < 6 dias` amplo antes de inserir (heranca do #1170) - agora redundante e landmine
+latente. Redesenho com subtransacao-abort (server-side, sem depender de tx=rollback nem deletar dado
+de prod) seria a limpeza definitiva. Sessao dedicada se quiser.
+
+Sessoes anteriores do dia (todas mergeadas, no MEMORY.md): A (#1450+#1445), B (#1424+#1423),
+C (gamificacao #1448/#1449), D (#1004 LGPD C3->C4), E (#1170 dedup), F (#1170 residuo, esta).
+
+## Fila desta sessao (prioridade)
+
+1. **[VERIFICACAO, barato - SO A PARTIR DE SABADO 25/07] Pos-deploy do #1424.**
+   O cap de e-mail so e exercitado no burst de sabado. Rodar (sab pos-12:00 UTC / domingo):
+   - `SELECT count(*) FROM email_webhook_events WHERE event_type='email.sent' AND created_at::date='2026-07-25';`
+     -> esperar <= ~90-95 (baseline anterior: 108-121).
+   - `SELECT count(*) FROM notifications WHERE delivery_mode='transactional_immediate' AND email_sent_at IS NULL;`
+     no domingo -> excedente adiado drenando, nao acumulando.
+   - Sanidade: ninguem recebeu duplicata; digests ricos vs simples separados corretos.
+   Se o cap estiver mordendo forte -> priorizar Fases C/D do #1424.
+
+2. **[Wave 2 - proximo: #1008 (high)]** Ratificacao PMI-GO do nome "AI Community Day" +
+   linguagem certificado/PDU. **E DECISAO HUMANA, nao codigo** (Presidencia PMI-GO + legal-counsel +
+   c-level-advisor). Eu so preparo rascunhos. Blocker de divulgacao (parte do EPIC #1002). O evento
+   16/07 ja passou, mas nome/PDU e recorrente p/ ACD futuros. **PERGUNTAR O RECORTE ANTES:** o que o
+   owner quer produzido nesta sessao? Opcoes provaveis:
+   - (a) Rascunho da consulta escrita a PMI-GO / PMI Latam (autorizacao do nome + referencia ao
+     Standard sem parecer emissor + limites de PDU).
+   - (b) Linguagem travada do certificado: "Certificado de participacao emitido pelo Nucleo IA & GP";
+     NUNCA "concede N PDUs"; se aplicavel "PDU autodeclaravel conforme categoria do PMI CCR".
+   - (c) Copy do convite/pagina enquadrando como "aftershow / extensao noturna" (slot 19-21h BRT),
+     nunca "evento paralelo/oficial".
+   Regras de comms: links via nucleoia.pmigo.org.br; sem em-dash; framing "iniciativa DOS capitulos
+   do PMI, sediada no PMI-GO"; kit de marca BAIXADO do Drive (nao improvisar).
+
+3. **[Wave 2 - proximo TECNICO se #1008 travar em decisao humana: #1152 (bug/governance)]**
+   Mapear funcao->gate explicitamente. `_can_sign_gate` funde no gate `president_go` do
+   `volunteer_term_template` duas funcoes distintas: Ivan (`legal_signer`, aprova a VERSAO do doc)
+   e Lorena (`voluntariado_director`, assina a CONTRAPARTE da entidade em cada Termo executado,
+   pos-aprovacao). O carve-out `voluntariado_director` dentro de `president_go` e a fusao indevida +
+   cheiro de segregacao de funcoes. Achado 2: `committee_majority` e STUB (retorna false) e travaria
+   o lock de `policy` no gate 1. Impacto do Achado 1: contornavel (threshold 1, Ivan assina a SEDE),
+   mas corrigir a semantica antes de virar precedente. Pedido: documentar o mapa funcao->gate em
+   `docs/reference/V4_AUTHORITY_MODEL.md` + refletir em `_can_sign_gate`. **ANTES de mexer em
+   `engagement_kind_permissions` ou gates: rodar o procedimento de 4 etapas do V4_AUTHORITY_MODEL.md**
+   (matriz capability->path) - auditoria mecanica de gates gera false positives (sediment p122e).
+   Ler `pg_get_functiondef('_can_sign_gate')` e `resolve_default_gates` ao vivo antes de propor DDL.
+   Refs: [[reference-volunteer-term-countersign-lorena]], [[reference-chapter-stakeholder-vs-focal]].
+
+4. **[Wave 2 - restante]** #1358 (distinguir "stakeholder de capitulo" de "ponto focal do nucleo";
+   `chapter_liaison` marcando diretores/VP como ponto focal) -> #1014 (convite signup direcionado p/
+   aceitos sem conta, precisa SPEC) -> #485 (low: recorrencia flexivel + tz + GCal sync; decidir
+   RRULE vs rows antes).
+
+## Higiene / follow-ups vivos
+- **#1170 residuo opcional (DDL):** redesenhar `_test_detect_inactive_with_threshold` com
+  subtransacao-abort para tirar o `DELETE arm9 < 6 dias` amplo (landmine latente). So se quiser.
+- **#1004 follow-up nao-LGPD:** 25 engagements terminados com `end_date` NULL (backfill opcional).
+- **Leticia** pendente: reconectar em `/mcp/semantic` (client_id nao-UUID cacheado, fix client-side).
+- **EPIC #1383** fecha a mao ~31/07 (wiki OK; falta so uso >= 2 semanas via `mcp_usage_log`).
+- #1440 (rate-limit `/oauth/register`), #1403 (watch spec MCP 2026-07-28).
+- Trap: `gh secret set` pelo shell `!` grava VAZIO - usar web UI. Branches: NUNCA deletar
+  `legacy/original-main` / `work`.
+
+## Lembretes de processo (CLAUDE.md)
+- **Grounding**: todo numero em prompt de decisao / PR / commit / memoria vem de tool na MESMA volta.
+- **Lane prepara, nao mergeia** - EXCETO autorizacao explicita do owner na sessao.
+- **DDL**: `apply_migration` (nao `execute_sql`); `execute_sql` so p/ DML/read-only.
+- **Phantom rows**: apos CADA apply_migration, checar `schema_migrations` por prefixo de data real
+  (nao por `>= head` sintetico) e deletar por versao exata. N applies = N phantoms.
+- **Testes DB-aware escrevem na PROD** (CI e `npm test` local usam a service_role do `.env`):
+  qualquer teste que muta via RPC SECDEF DEVE limpar explicito (tx=rollback nao desfaz). Audit:
+  `grep -rl "tx=rollback" tests/`. Ver [[reference-tx-rollback-not-honored-secdef-pollutes-prod]].
+- **EF que manda e-mail = outward-facing**: nao deployar sem aval; deploy pelo Bash do Claude.
+- Sem travessao longo em entregaveis.

--- a/docs/planning/2026-07-22_startup_wave1_apply_selection_scoring.md
+++ b/docs/planning/2026-07-22_startup_wave1_apply_selection_scoring.md
@@ -1,0 +1,47 @@
+# Prompt de arranque — SESSÃO LIMPA: Onda 1 (aplicar A1+A2 seleção) + merge
+
+> Cole o bloco abaixo como PRIMEIRA mensagem de uma sessão nova/limpa.
+> **Modelo:** Opus 4.8 (não pinar). **Effort:** `/effort xhigh`. Esta é sessão de EXECUÇÃO (aplica + mergeia à main).
+> Antes de agir: ler MEMORY.md + [[project-scoring-merit-audit-2026-07-21]], `git fetch`, e RE-ATERRAR todo número ao vivo.
+
+---
+
+Sessão de execução no ai-pm-research-hub — **Onda 1** do roadmap de correção de pontuação/mérito
+(relatório: `docs/audit/2026-07-21_scoring_merit_audit.md`). **Rodar em Opus 4.8 + xhigh.**
+
+## Contexto travado (NÃO re-litigar; provado na auditoria de 2026-07-21)
+- Ciclo 4 = `cycle4-2026` (`08c1e301-9f7b-4d01-a13c-43ac7775c0f7`), open/evaluating.
+- PR draft **#1466** (branch `fix/selection-scoring-rank-audit`) carrega as migrations, NÃO aplicadas:
+  - `20260805000475` (A2, #1461): `compute_application_scores` deriva research_score de
+    `objective_score_avg + interview_score` (PERT já min-gated). Nula 17 apps de 1-avaliador.
+  - `20260805000476` (A1, #1462): `get_selection_rankings` + `get_my_selection_result` rank em tempo de leitura.
+- Onda 2 (corte active-only, PR #1467) e B0 (gamificação, #1464) são DEPOIS. Não tocar aqui.
+
+## Mandato desta sessão (Onda 1)
+1. **Re-aterrar ANTES (grounding obrigatório):** re-rodar ao vivo e capturar o "antes":
+   - `count(*) FILTER (research_score NOT NULL AND objective_score_avg NULL)` no ciclo (esperado ~17).
+   - rank vivo vs armazenado do researcher (esperado: Francisco J. armazenado #39 / vivo #7; 13 NULL-stored).
+2. **Aplicar as 2 migrations** (regras da casa, `.claude/rules/database.md`):
+   - `apply_migration` (byte-igual ao arquivo) para 475 e depois 476.
+   - Cada apply via MCP cria PHANTOM tracking-row com versão de DATA REAL (`202607*`), que ordena ANTES do
+     sintético `202608*` — deletar por versão EXATA (`version IN (...)`, sem LIKE curto). Ver
+     [[feedback-apply-migration-creates-tracking-row]].
+   - `migration repair --status applied 20260805000475` e `...476`.
+   - `NOTIFY pgrst, 'reload schema'` (mudou assinatura/surface de RPC).
+3. **Backfill de dado (o que muda ranks):**
+   `SELECT public.compute_application_scores(id) FROM public.selection_applications WHERE cycle_id='08c1e301-9f7b-4d01-a13c-43ac7775c0f7';`
+   Isso nula os 17 e recomputa research/leader/final com a nova regra.
+4. **Re-aterrar DEPOIS (antes→depois ao vivo):**
+   - os 17 viraram research_score NULL (e saíram do ranking).
+   - `get_selection_rankings` agora inclui os 13+3 antes ocultos e Francisco J. aparece ~#7.
+   - conferir que nenhuma app de 2+ avaliadores mudou de score (divergência deve ser 0).
+5. **`npx astro build` + `npm test`** (com SUPABASE_URL + SERVICE_ROLE_KEY → roda os DB-aware). 0 fail.
+   - Não pinar baseline; a fonte é rodar o comando.
+6. **Merge do PR #1466 à main** (é sessão main; pode mergear). Fecha #1461 + #1462.
+7. Atualizar [[project-scoring-merit-audit-2026-07-21]] com o antes→depois vivo e o estado (Onda 1 fechada).
+
+## Regras da casa (não esquecer)
+- Números em prompt/PR/commit/memória = de tool result DESTA sessão; nunca recitar de memória.
+- Sem em-dash em entregáveis. Trailer `Assisted-By: Claude (Anthropic)`, nunca `Co-Authored-By`.
+- DDL só via `apply_migration` (não `execute_sql`). Deletar phantom por versão exata.
+- Onda 2 (#1467 corte retroativo) só DEPOIS desta mergeada (serial por drift-gate) e é decisão sensível (7 aprovados).

--- a/docs/planning/2026-07-22_startup_wave3_gamification_occurred_at.md
+++ b/docs/planning/2026-07-22_startup_wave3_gamification_occurred_at.md
@@ -1,0 +1,83 @@
+# Prompt de arranque - SESSÃO LIMPA: Onda 3 (B0 gamificação - occurred_at + rejanela por data-do-fato)
+
+> Cole o bloco abaixo como PRIMEIRA mensagem de uma sessão nova/limpa.
+> **Modelo:** Opus 4.8 (não pinar). **Effort:** `/effort xhigh`. Sessão de EXECUÇÃO (aplica + mergeia à main).
+> Antes de agir: ler MEMORY.md + [[project-scoring-merit-audit-2026-07-21]] + [[reference-gamification-cycle-windowed-by-createdat-trap]] + [[reference-gamification-xp-flow-vs-lifetime-surface-aware]], `git fetch`, e RE-ATERRAR todo número ao vivo.
+
+---
+
+Sessão de execução no ai-pm-research-hub - **Onda 3** do roadmap de pontuação/mérito
+(relatório: `docs/audit/2026-07-21_scoring_merit_audit.md`, seção B0 + "Plano B0"). **Rodar em Opus 4.8 + xhigh.**
+Ondas 1 (A1/A2 + invariante M, main `387f20d3`) e 2 (corte active-only retroativo + cross-role, main `5758eaa3`, #1463 CLOSED) já MERGEADAS. Onda 3 = **B0 gamificação (issue #1464)**.
+
+## Contexto travado (NÃO re-litigar; achado provado ao vivo na auditoria)
+- **B0 (ALTA):** o ranking do "ciclo atual" está contaminado por backfill histórico. O placar é janelado por
+  `gamification_points.created_at` (data do LANÇAMENTO do ponto), **não** pela data real do evento. Não existe
+  coluna de data-do-fato, então um backfill de presença histórica cai inteiro no ciclo corrente.
+- **A MATEMÁTICA de agregação está CORRETA** (leaderboard/pilares auditados: 0 categorias órfãs, 0 negativos, #1069 sem
+  colisão em 11 RPCs). O erro é **atribuição de ciclo**, não soma. NÃO re-auditar a soma.
+- `gamification_points` **NÃO tem `occurred_at`** (confirmado ao vivo 2026-07-22: colunas = id, member_id, points,
+  reason, category, ref_id, created_at, organization_id, granted_by).
+- **Windowing atual:** `get_member_gamification_stats` janela o ciclo por `gp.created_at >= cycles.cycle_start` (fonte =
+  tabela `public.cycles` onde `is_current=true`). Confirmado ao vivo: `cycle_start` atual = **2026-07-09**.
+- **PRESERVAR o surface-aware de certificações** (#1448/mig 472, [[reference-gamification-xp-flow-vs-lifetime-surface-aware]]):
+  certificações contam VITALÍCIO na visão de pilar de ciclo. A rejanela por `occurred_at` é para pontos de **FLUXO**
+  (presença etc.); NÃO pode quebrar o "certificações sempre contam" no perfil.
+
+## Números re-aterrados 2026-07-22 (RE-ATERRAR DE NOVO antes de aplicar)
+- Backfill de **2026-07-11** (batch, `granted_by IS NULL`): **560 linhas / 58 membros / 5620 pontos**.
+- Destes, **525 linhas / 5250 pontos / 48 membros** resolvem para eventos com data **< 2026-07-09** (cycle_start), datas
+  reais de **2025-10-08 a 2026-07-09** -> mal-atribuídos ao ciclo corrente. 2 linhas sem evento resolvível via `ref_id`.
+- Resolução: `gamification_points.ref_id` -> `attendance.id` -> `attendance.event_id` -> `events.date`.
+
+## Mandato desta sessão (Onda 3 - Plano B0 do relatório)
+1. **Re-aterrar ANTES (obrigatório):** re-rodar ao vivo `cycle_start` (esperado 2026-07-09), o batch de 11/07 (esperado
+   ~560/58/5620), os 525/5250/48 pré-ciclo, e um antes/depois NOMINAL de quem muda de posição no ranking do ciclo
+   (o relatório cita Ana C. 280->50, Jefferson P. 280->30, Marcos A. 260->20, Fabricio C. 230->10 - RE-ATERRAR).
+2. **Adicionar `gamification_points.occurred_at timestamptz`** = data REAL do fato (não do lançamento). DDL via
+   `apply_migration`; nullable; index se necessário.
+3. **Backfill `occurred_at`:** presença via `attendance.event_id -> events.date`; demais categorias via a fonte
+   (`ref_id`) quando resolvível, senão fallback `created_at`. As 2 linhas de presença sem evento resolvível -> fallback
+   `created_at` (documentar).
+4. **Rejanelar a atribuição de ciclo por `occurred_at`** (não `created_at`) em: `get_member_gamification_stats`
+   (CTEs `member_cycles` [streaks + active_cycles] E `cycle_pts` [points_this_cycle]), `get_member_xp_pillars` (ramo
+   `cycle`), e a lógica de ciclo do leaderboard (`get_public_leaderboard` / `get_gamification_leaderboard` - checar o
+   hybrid-scope p170). `created_at` continua sendo auditoria de "quando foi lançado". **Basear no corpo VIVO** (`pg_get_functiondef`);
+   byte-fiel + md5 normalizado live==arquivo ([[reference-apply-large-function-mcp-inline-md5-verify]]).
+5. **Normalizar o backfill de 2026-07-11** (525 linhas de eventos < cycle_start): `occurred_at` = data do evento,
+   tirando-as do ciclo corrente. É a mudança que corrige o ranking exibido.
+6. **Corrigir `get_member_xp_pillars`:** o `ORDER BY CASE pillar` não tem o caso `protagonismo` (fica sem posição de
+   ordenação). Adicionar.
+7. **UI (perfil):** rotular claramente chips de **ciclo** vs **vitalício** (fim da mistura sem legenda). i18n em pt/en/es.
+8. **HUMAN CHECKPOINT (a parte sensível):** a correção **muda rankings VISÍVEIS do ciclo** para membros (ex.: quem liderava
+   com presença de ciclos anteriores cai). Decidir com o owner **como comunicar/exibir**: silencioso (só corrige o número)?
+   nota explicativa? Pontos VITALÍCIOS não mudam (nada é revogado) - só a atribuição de ciclo. Levar antes/depois nominal.
+9. **Contract test:** pontos de ciclo janelam por `occurred_at`; um backfill (created_at no ciclo, occurred_at fora) NÃO
+   pode alterar o ranking do ciclo corrente. Registrar em AMBAS as whitelists do `package.json` (test + test:contracts).
+10. **`npx astro build` + `npm test`** (com SUPABASE_URL + SERVICE_ROLE_KEY -> DB-aware). 0 fail.
+11. **Grounding adversarial** (workflow 3-lentes) antes do backfill de dado retroativo: null-safety dos leitores /
+    side-effects (triggers de XP em `gamification_points`?) / completeness (surface-aware de certificações preservado?).
+    Valeu nas Ondas 1 e 2 (pegou bugs pré-apply).
+12. **Aplicar + registrar:** `apply_migration`; deletar phantom por versão EXATA ([[feedback-apply-migration-creates-tracking-row]]);
+    `migration repair --status applied <versão>`; `NOTIFY pgrst` se afeta superfície PostgREST.
+13. **Merge do PR à main** (sessão main; pode mergear). Fecha #1464.
+14. Atualizar [[project-scoring-merit-audit-2026-07-21]] + MEMORY.md com o antes->depois vivo (Onda 3 fechada) + LL em #588.
+
+## Regras da casa (não esquecer)
+- Números em prompt/PR/commit/memória = de tool result DESTA sessão; nunca recitar de memória.
+- Sem em-dash (—) em entregáveis. Trailer `Assisted-By: Claude (Anthropic)`, nunca `Co-Authored-By`.
+- DDL só via `apply_migration` (não `execute_sql`). Deletar phantom por versão exata.
+- Head de migrations atual: **20260805000479** (Onda 2). Próxima versão livre = re-consultar
+  `SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 1`.
+- Backfill retroativo de dado é irreversível-ish: grounding adversarial ANTES; byte-fidelidade provada.
+
+## Entry points (verificar ao vivo)
+- Tabela `gamification_points` (add `occurred_at`); `cycles` (`is_current`, `cycle_start/cycle_end`).
+- RPCs: `get_member_gamification_stats`, `get_member_xp_pillars`, `get_public_leaderboard`, `get_gamification_leaderboard`.
+- Triggers de XP em `gamification_points` (auto-XP phase3, mig p161) - checar se algum grava/lê data.
+- Frontend: perfil (chips ciclo vs vitalício) - grep `points_this_cycle` / pilares / leaderboard.
+
+## Ondas seguintes (depois da 3)
+4=backend de transparência (criterion_notes no consolidado + blind-review unificado - findings C-sel/C-blind);
+5=CAPSTONE UX #1465 (feature de transparência que os membros pedem - só DEPOIS das correções). Follow-up aberto **#1468**
+(recompute_application_status mediana cross-role, materialidade baixa).

--- a/docs/planning/2026-07-22_startup_wave4_transparency_backend.md
+++ b/docs/planning/2026-07-22_startup_wave4_transparency_backend.md
@@ -1,0 +1,62 @@
+# Prompt de arranque - SESSÃO LIMPA: Onda 4 (backend de transparência por critério)
+
+> Cole o bloco abaixo como PRIMEIRA mensagem de uma sessão nova/limpa.
+> **Modelo:** Opus 4.8 (não pinar). **Effort:** `/effort xhigh`. Sessão de EXECUÇÃO (aplica + mergeia à main).
+> Antes de agir: ler MEMORY.md + [[project-scoring-merit-audit-2026-07-21]], `git fetch`, e RE-ATERRAR todo número ao vivo.
+
+---
+
+Sessão de execução no ai-pm-research-hub - **Onda 4** do roadmap de pontuação/mérito
+(relatório: `docs/audit/2026-07-21_scoring_merit_audit.md`, seções C-sel + C-blind). **Rodar em Opus 4.8 + xhigh.**
+Ondas 1 (main `387f20d3`), 2 (`5758eaa3`) e 3 (`b5c7eaa2`, #1464 gamificação occurred_at) já MERGEADAS. Onda 4 = **backend de transparência por critério** (materialidade BAIXA; dois fixes de RPC + render).
+
+## Contexto travado (achados provados ao vivo; re-aterrar antes de aplicar)
+- **C-sel (BAIXA):** existe decomposição critério×avaliador (`get_evaluation_results`, renderizado em `selection.astro:4078`:
+  matriz + subtotal ponderado + alertas de calibração). MAS as `criterion_notes` (racional qualitativo por critério) **não
+  aparecem** no consolidado admin. Ao vivo 2026-07-22: **78 avaliações com criterion_notes preenchidas no Ciclo 4** (de 194
+  evals / 71 apps). Coluna = `selection_evaluations.criterion_notes` (jsonb). Só aparecem (a) no form travado do próprio
+  avaliador, (b) via MCP `get_application_score_breakdown` (`returns_criterion_notes=true`) que NENHUM `.astro` chama.
+  Um curador reconciliando score divergente não lê a justificativa no app web.
+- **C-blind (BAIXA, latente):** as duas superfícies DISCORDAM sobre quando desanonimizar. Confirmado ao vivo:
+  `get_evaluation_results` desanonimiza co-avaliador ao atingir `min_evaluators` (checks_min_evaluators=true); 54/74 apps já
+  em 2+ no C4. `get_application_score_breakdown` cega não-superadmins por FASE (evaluating/interviews). A promessa de revisão
+  cega fica inconsistente. Latente hoje (nenhum usuário alcança as duas superfícies no estado cego), mas é dívida.
+
+## Mandato desta sessão (Onda 4)
+1. **Re-aterrar ANTES:** re-rodar a contagem de criterion_notes do ciclo corrente, os corpos VIVOS de `get_evaluation_results`
+   e `get_application_score_breakdown` (`pg_get_functiondef`), e as duas lógicas de cegamento (min_evaluators vs phase).
+2. **C-sel fix:** incluir `criterion_notes` no retorno de `get_evaluation_results` (por critério×avaliador, respeitando o
+   cegamento vigente da própria função) E renderizar no consolidado (`selection.astro` ~4078). i18n pt/en/es se houver rótulo novo.
+   Base = corpo VIVO; byte-fiel md5 live==arquivo. DDL via `apply_migration`; deletar phantom por versão exata; migration repair.
+3. **C-blind fix (DECISÃO DO OWNER JÁ RATIFICADA — ver seção abaixo; NÃO re-perguntar):** unificar a regra de
+   desanonimização nas DUAS funções conforme a regra do owner — **candidato NUNCA vê; comitê vê; revelar co-avaliador
+   ao comitê APÓS o peer review (cego DURANTE, enquanto os avaliadores ainda submetem; revela quando o peer review
+   termina = min_evaluators atingido para a app). Aplicar a MESMA regra em ambas.** Preservar autoridade existente
+   (superadmin/manage_platform enxerga tudo). NENHUMA superfície de candidato é criada nesta onda.
+4. **Grounding adversarial** (workflow 3-lentes) antes de aplicar: (a) o cegamento não vaza PII de co-avaliador na fase cega;
+   (b) o render de criterion_notes não expõe nota fora do escopo de quem pode ver; (c) completude — as duas funções ficam
+   consistentes e nenhuma outra superfície (MCP, outras .astro) diverge.
+5. **`npx astro build` + `npm test`** (com SUPABASE_URL + SERVICE_ROLE_KEY → DB-aware). 0 fail. Registrar teste novo nas 2 whitelists.
+6. **Aplicar + merge à main** (sessão main; pode mergear). Fecha as issues de transparência (C-sel/C-blind — criar se não existirem).
+7. **Deploy do frontend** (`npx astro build && npx wrangler deploy`) — o consolidado admin é server-rendered; a nota só aparece pós-deploy.
+8. Atualizar [[project-scoring-merit-audit-2026-07-21]] + MEMORY.md (Onda 4 fechada) + **PRÓXIMA = Onda 5 (CAPSTONE UX #1465)**.
+
+## DECISÃO DO OWNER — RATIFICADA 2026-07-22 (LOCKED; não re-perguntar, não re-litigar)
+Regra de cegamento unificada (palavras do owner: "o candidato não pode ter acesso, o comitê tem que ter acesso, após o peer review"):
+- **Candidato: NUNCA tem acesso** a criterion_notes, notas ou nomes de avaliadores. (Já é verdade hoje — ambas as RPCs são
+  gated por autoridade de comitê/admin; NÃO criar nenhuma superfície de candidato nesta onda.)
+- **Comitê: TEM acesso.** Vê a matriz, as justificativas (C-sel) e, após o peer review, os nomes/scores dos co-avaliadores.
+- **Revelar co-avaliador ao comitê APÓS o peer review:** cego enquanto o peer review acontece (avaliadores ainda submetendo);
+  revela quando o peer review termina. Mapear "peer review terminou" = **`min_evaluators` atingido** para a application
+  (é o sinal natural de "os pares já avaliaram"). Aplicar essa MESMA regra nas duas funções (`get_evaluation_results` já
+  faz ~isso por min_evaluators; alinhar `get_application_score_breakdown`, que hoje cega por fase, ao mesmo gatilho).
+  Se ao re-aterrar houver ambiguidade real entre "min_evaluators" e "fase de avaliação fechada", confirmar com o owner
+  qual sinal — mas o candidato NUNCA vê em nenhum caso.
+
+## Regras da casa (não esquecer)
+- Números em prompt/PR/commit/memória = de tool result DESTA sessão; nunca recitar de memória.
+- Sem em-dash (—) em entregáveis. Trailer `Assisted-By: Claude (Anthropic)`, nunca `Co-Authored-By`.
+- DDL só via `apply_migration`; db-push BLOQUEADO neste repo (tracking divergente) → aplicar por função inline + md5-verify.
+- Head de migrations após Onda 3: **20260805000480**. Próxima livre = re-consultar ao vivo.
+- Adicionar coluna/retorno pode quebrar `gen-types-drift` → `npm run db:types` + commit `src/lib/database.gen.ts` (CLI pin 2.109.0).
+- Testes que fixam corpo canônico de função por md5 (p625/p599 e similares) → re-apontar para a migration nova se reescrever a função.

--- a/docs/planning/2026-07-23_startup_wave2_apply_cutoff_active_only.md
+++ b/docs/planning/2026-07-23_startup_wave2_apply_cutoff_active_only.md
@@ -1,0 +1,45 @@
+# Prompt de arranque - SESSÃO LIMPA: Onda 2 (corte active-only retroativo A3) + merge
+
+> Cole o bloco abaixo como PRIMEIRA mensagem de uma sessão nova/limpa.
+> **Modelo:** Opus 4.8 (não pinar). **Effort:** `/effort xhigh`. Sessão de EXECUÇÃO (aplica + mergeia à main).
+> Antes de agir: ler MEMORY.md + [[project-scoring-merit-audit-2026-07-21]], `git fetch`, e RE-ATERRAR todo número ao vivo.
+
+---
+
+Sessão de execução no ai-pm-research-hub - **Onda 2** do roadmap de pontuação/mérito
+(relatório: `docs/audit/2026-07-21_scoring_merit_audit.md`). **Rodar em Opus 4.8 + xhigh.**
+Onda 1 (A1/A2 + invariante M) já está MERGEADA (main `387f20d3`, #1461+#1462). Onda 2 estava serial-depois; agora desbloqueada.
+
+## Contexto travado (NÃO re-litigar; decisão do owner na auditoria de 2026-07-21)
+- Ciclo 4 = `cycle4-2026` (`08c1e301-9f7b-4d01-a13c-43ac7775c0f7`), open/evaluating.
+- **A3:** `_compute_pert_cutoff_core` aceita `p_filter_active_only` e NUNCA o usa (só loga `filter_active_only_legacy_arg`). O cohort do corte objetivo inclui já-rejeitados.
+- **Decisão do owner: corte active-only RETROATIVO.** Sobe a régua de todos. Ciente de que há aprovados entre a régua antiga e a nova; **NÃO revogar aprovação** de ninguém, **tratar o DISPLAY** dos que ficam abaixo da banda elevada.
+- PR draft **#1467** (branch `fix/selection-cutoff-active-only`) carrega a migration `20260805000477_audit_A3_cutoff_active_only_filter.sql`, NÃO aplicada.
+
+## Números re-aterrados 2026-07-22 (pós-Onda 1; RE-ATERRAR DE NOVO antes de aplicar)
+- Corte objetivo armazenado: **130.89** (`dynamic`, cohort n=**45** researchers com `objective_score_avg` não-nulo).
+- Active-only (excluindo rejeitados/terminais): **142.69** (n=**38**; exclui 7).
+- Onda 1 NÃO mexeu nesses números (o backfill de Onda 1 escreveu régua `final_score_pert`, não o corte objetivo `pert_target_score`).
+
+## Mandato desta sessão (Onda 2)
+1. **Re-aterrar ANTES (obrigatório):** re-rodar ao vivo corte armazenado (esperado 130.89), active-only (esperado 142.69), cohort n=45→38, e a lista NOMINAL dos aprovados com `objective_score_avg` entre 130.89 e 142.69 (os que "caem" com a régua nova). Capturar o "antes".
+2. **Renumerar a migration (recomendado):** 477 < 478 da Onda 1 (fica out-of-order no histórico). A 477 NÃO está aplicada; renomear o arquivo para a próxima versão livre (`SELECT version FROM supabase_migrations.schema_migrations ORDER BY version DESC LIMIT 1` → next). OU manter 477 (funciona, só não é monotônico). Decidir e ajustar referências internas do arquivo.
+3. **Basear no corpo VIVO:** a 477 é CREATE OR REPLACE de `_compute_pert_cutoff_core`. Antes de aplicar, `pg_get_functiondef` do corpo VIVO (Onda 1 NÃO alterou essa função, mas confirme) e garanta que a 477 só muda o ramo do `p_filter_active_only` (ver [[reference-create-or-replace-base-on-live-body]]). Aplicar byte-fiel + provar por md5 normalizado live==arquivo (ver [[reference-apply-large-function-mcp-inline-md5-verify]]).
+4. **Aplicar + registrar:** `apply_migration` via MCP; deletar phantom por versão EXATA; `migration repair --status applied <versão>`; `NOTIFY pgrst`.
+5. **Recompute do corte (o que muda a régua):** recomputar SÓ o corte objetivo active-only: `SELECT public._compute_pert_cutoff_core('08c1e301-...','researcher', TRUE, 'objective_score_avg', <actor>);`. **NÃO rodar `compute_application_scores` em massa** - isso re-dispararia a cascata da régua `final_score_pert` histórica que a Onda 1 limpou (ver [[reference-full-cycle-backfill-final-score-regua-side-effect]]).
+6. **Tratar cross-role (A3 parte 2):** o UPDATE do corte grava `pert_target_score` em TODAS as linhas do ciclo (inclusive líderes), e `get_cutoff_dispatch_health` compara sem filtro de role. Verificar se a 477 já corrige; senão, tratar (corte objetivo é researcher-only).
+7. **DISPLAY dos aprovados abaixo da banda elevada:** decidir com o owner como exibir os aprovados que ficam abaixo de 142.69 (badge/nota "aprovado antes da revisão de régua", NÃO revogar). É a parte sensível - **checkpoint humano**.
+8. **Re-aterrar DEPOIS:** corte armazenado 130.89→142.69, banda nova, quem mudou de posição na banda.
+9. **`npx astro build` + `npm test`** (com SUPABASE_URL + SERVICE_ROLE_KEY → DB-aware). 0 fail. Atenção: `p273-365e-current-cycle-pert-cohort` e `p274-365f-pert-band-thresholds` provavelmente checam a régua - podem exigir ajuste de baseline pós-corte.
+10. **Merge do PR #1467 à main** (sessão main; pode mergear). Fecha #1463.
+11. Atualizar [[project-scoring-merit-audit-2026-07-21]] + MEMORY.md com o antes→depois vivo (Onda 2 fechada) e o LL em #588.
+
+## Regras da casa (não esquecer)
+- Números em prompt/PR/commit/memória = de tool result DESTA sessão; nunca recitar de memória.
+- Sem em-dash em entregáveis. Trailer `Assisted-By: Claude (Anthropic)`, nunca `Co-Authored-By`.
+- DDL só via `apply_migration` (não `execute_sql`). Deletar phantom por versão exata.
+- Grounding adversarial antes de mutação irreversível em prod (workflow 3-lentes valeu na Onda 1).
+- Higiene: branch local morto `fix/scoring-merit-audit` pode ser deletado (`git branch -D`; não-pushado, redundante).
+
+## Ondas seguintes (depois da 2)
+3=B0 gamificação (`occurred_at`, rejanelar ciclo por data-do-fato) → [[reference-gamification-cycle-windowed-by-createdat-trap]]; 4=backend transparência (criterion_notes + blind-review unificado); 5=CAPSTONE UX #1465.

--- a/docs/planning/2026-07-23_startup_wave5_capstone_ux_transparency.md
+++ b/docs/planning/2026-07-23_startup_wave5_capstone_ux_transparency.md
@@ -1,0 +1,107 @@
+# Handoff + Prompt de arranque - Onda 5 (CAPSTONE UX: transparência de pontuação auditável)
+
+> **Diferença das ondas 1-4:** estas eram fixes de backend com mandato claro/LOCKED. **Onda 5 é uma FEATURE UX/UI
+> nova, membro + candidato, materialidade MÉDIA, outward-facing** (candidato = aplicante externo). Portanto o prompt
+> NÃO é LOCKED: a sessão ABRE com uma rodada de decisões do owner (escopo/UX) via `AskUserQuestion`, e só então
+> desenha + constrói. Modelo: Opus 4.8 (não pinar). Effort: `/effort xhigh`.
+
+---
+
+## HANDOFF - estado ao fechar a Onda 4 (2026-07-22)
+
+**Arco de auditoria pontuação/mérito: Ondas 1-4 FECHADAS + MERGEADAS.** Detalhe vivo → memória
+`project-scoring-merit-audit-2026-07-21`. main = `d2fb21ec`.
+
+- **Onda 1** (`387f20d3`, #1466): seleção A2 min_evaluators + A1 rank read-time + invariante M (mig 475/476/478).
+- **Onda 2** (`5758eaa3`, #1467, #1463): corte objetivo C4 130.9→142.69 active-only retroativo + cross-role (mig 479). Follow-up #1468.
+- **Onda 3** (`b5c7eaa2`, #1469, #1464): gamificação por `occurred_at` (data do fato); C4 7510→2250 pts; 10 leitores rejanelados (mig 480). Follow-up #1470.
+- **Onda 4** (`d2fb21ec`, #1472, #1471, mig **481**): backend de transparência. Predicado SSOT `selection_peer_review_complete(uuid)` unifica o cegamento nas 2 RPCs do comitê (fase→min_evaluators); `get_evaluation_results` ganhou `criterion_notes` + render no consolidado admin (`selection.astro`, bloco "Justificativas por critério"); descrições MCP realinhadas; deploy frontend (`baa5cee7`) + EF `nucleo-mcp` v2.80.0. Política de cegamento IMPLEMENTADA → `reference-selection-transparency-blind-review-policy`.
+
+**Dependências da Onda 5 (todas SATISFEITAS):** B0 `occurred_at` (Onda 3, permite ledger por data-do-fato) · A1 rank read-time + A3 corte (Ondas 1-2, número certo por trás) · `criterion_notes` no backend + render do comitê (Onda 4).
+
+**Migration head:** `20260805000481` → próxima livre re-consultar ao vivo (provável `20260805000482`).
+
+---
+
+## O QUE A ONDA 5 ENTREGA (proposto no relatório `docs/audit/2026-07-21_scoring_merit_audit.md`, seção "Onda 5")
+
+Princípio: **corrigir primeiro (feito), expor depois**. A superfície de transparência só sobe agora que os números
+por trás estão corrigidos e estáveis. Duas partes (audiências e superfícies DISTINTAS):
+
+### Parte A - Gamificação "Minha Pontuação, auditável" (membro; admin vendo qualquer membro)
+- Painel com **CICLO vs VITALÍCIO** claramente separados e rotulados (o header de chips hoje mistura escopos sem rótulo).
+- Breakdown por pilar **expansível até a linha de CADA fato** (evento/atividade) com **data real** (`occurred_at`), o
+  **ciclo** a que pertence e os **pontos**. Responde direto ao "de onde vêm estes pontos e em qual ciclo" (o caso Jefferson).
+- Rótulo explícito "certificações contam vitalício" (pilar certificações sempre conta no perfil, #1448).
+- Export.
+- **Fato de infra:** não existe RPC de ledger fato-a-fato hoje. Existem `get_member_xp_pillars(member, cycle_code, scope)`
+  (agregado por pilar, scope ciclo/vitalício), `get_member_cycle_xp(member)`, `get_member_gamification_stats(ids[])`.
+  A parte A provavelmente precisa de **1 RPC novo** que devolva as linhas de `gamification_points` (com `occurred_at`,
+  evento resolvido, ciclo, pontos) - o `occurred_at` da Onda 3 torna isso possível e correto.
+
+### Parte B - Seleção decomposta (candidato; o comitê já foi entregue na Onda 4)
+- O **comitê** já tem a matriz critério×avaliador COM `criterion_notes` (Onda 4). Falta a **visão do próprio candidato**:
+  seu breakdown por critério **pós-decisão**.
+- **RESTRIÇÃO LOCKED (Onda 4, não re-litigar):** candidato NUNCA vê `criterion_notes`, notas ou nomes de avaliadores.
+  Logo a visão do candidato = **seus próprios scores agregados por critério** (PERT objetivo/entrevista/líder) + posição
+  vs banda de corte + rank - NUNCA a identidade/racional de quem avaliou.
+- RPCs candidato que já existem: `get_my_selection_result()`, `get_my_application_status()`, `get_my_evaluation_feedback()`.
+  Página candidato: `src/pages/minha-candidatura.astro`. Verificar o que `get_my_selection_result` já devolve antes de criar RPC nova.
+
+---
+
+## DECISÕES DO OWNER - RATIFICADAS 2026-07-22 (não re-litigar)
+
+1. **Split: SIM.** Duas ondas independentes: **5a** = gamificação (interna, membro+admin), **5b** = candidato (outward-facing).
+   Cada uma tem seu PR + merge serial. Sub-issues criadas sob o umbrella #1465 (ver comentário em #1465).
+2. **Candidato pós-decisão (5b):** **REJEITADO vê SÓ "não selecionado"** (sem breakdown numérico). **APROVADO vê seu breakdown
+   por critério** (scores agregados próprios + posição vs banda de corte). Candidato NUNCA vê criterion_notes/notas/nomes de
+   avaliadores (LOCKED Onda 4). Nota: `get_my_evaluation_feedback()` já existe - VERIFICAR o que ele já mostra ao candidato
+   hoje e não regredir; a decisão "só não selecionado" é sobre o breakdown NUMÉRICO novo, não sobre feedback qualitativo pré-existente.
+3. **Timing (5b): RECOMENDAÇÃO = buildar AGORA, gated por fase** (só renderiza pós-decisão), com **QA contra apps DECIDIDAS do
+   Ciclo 3 (fechado)** via impersonação. Racional: desacopla eng do calendário operacional; feature pronta+testada antes do
+   momento de decisão do C4 (quando há pressão real); o gate de fase impede exposição prematura. *Confirmar no início da 5b
+   antes de construir; se o owner preferir aguardar o C4 fechar, adiar só a 5b (a 5a segue independente).*
+4. **Gamificação (5a): PÁGINA DEDICADA** (não estender `profile.astro` como container principal). PORÉM `profile.astro` já tem
+   breakdown de pontos (#1449) e **DEVE ser revisado/impactado** por estas mudanças (Ondas 1-4 já mexeram no ciclo/pilares; o
+   header de chips mistura escopos sem rótulo) - alinhar o profile à nova página (ou linkar) e não deixar duas fontes divergentes.
+   Export: definir formato no design (CSV default). Admin vê qualquer membro (relatório confirma).
+5. **i18n real:** superfícies membro/candidato são i18n pt/en/es de verdade - toda chave nova nas 3 dicts (pt-BR/en-US/es-LATAM)
+   + páginas /en/ e /es/ se criar rota nova (≠ do admin `selection.astro`, que é PT-hardcoded no client-side).
+
+---
+
+## MANDATO DA SESSÃO (após as decisões acima)
+
+1. **Re-aterrar ANTES:** ciclo 4 (fase/status), o que `get_my_selection_result`/`get_member_xp_pillars` já devolvem
+   (`pg_get_functiondef` vivo), migration head, e as páginas/RPCs de gamificação existentes. Nenhum número recitado de memória.
+2. **Design primeiro:** convocar **`ux-leader`** (1 agente - materialidade média UX; NÃO o conselho inteiro) para journey
+   do painel auditável + a visão do candidato. Se a decisão 2 envolver o que um rejeitado vê, convocar **`legal-counsel`** (1 agente).
+3. **Construir conforme a decisão.** Se RPC nova (ledger de gamificação): DDL via `apply_migration` byte-fiel + md5-verify;
+   REVOKE/GRANT corretos; **checar phantom tracking-row por NOME/statement, não por range** (ver gotcha abaixo); `migration
+   repair`; `NOTIFY pgrst`; `npm run db:types` + commit `database.gen.ts` se assinatura nova.
+4. **Grounding adversarial (workflow multi-lente)** antes de shippar superfície candidato: (a) candidato NUNCA vê
+   criterion_notes/nomes/notas de terceiros; (b) membro só vê o próprio (admin gate correto p/ ver outros); (c) export não
+   vaza PII fora de escopo; (d) números do painel batem com os RPCs corrigidos (Ondas 1-4).
+5. **`npx astro build` + `npm test`** (com SUPABASE_URL + SERVICE_ROLE_KEY → DB-aware). 0 fail. Teste novo nas **2 whitelists**
+   (`test` + `test:contracts` no package.json).
+6. **Aplicar + merge à main** (sessão main pode mergear). Fecha a sub-issue da vez (**5a = #1473**, **5b = #1474**);
+   o umbrella **#1465 fica ABERTO (Refs)** e é fechado À MÃO quando #1473 + #1474 mergearem.
+   **Ordem sugerida:** rodar **5a (#1473) primeiro** (interna, sem dependência de timing) e **5b (#1474) depois**
+   (confirmar o timing "buildar agora gated por fase vs aguardar C4" no início da 5b). Uma sub-onda por sessão limpa.
+7. **Deploy do frontend** (`npx astro build && npx wrangler deploy`) - superfícies são server-rendered/client; só aparecem pós-deploy.
+8. Atualizar `project-scoring-merit-audit-2026-07-21` + `MEMORY.md` (Onda 5 fechada; ARCO de auditoria COMPLETO 1-5).
+
+---
+
+## REGRAS DA CASA (não esquecer)
+- Números em prompt/PR/commit/memória = de tool result DESTA sessão; nunca recitar de memória.
+- Sem em-dash em entregáveis. Trailer `Assisted-By: Claude (Anthropic)`, nunca `Co-Authored-By`.
+- DDL só via `apply_migration`; db-push BLOQUEADO (tracking divergente) → aplicar por função inline + md5-verify.
+- **GOTCHA da Onda 4 (novo):** `apply_migration` MCP cria phantom tracking-row com **timestamp REAL** (ex.
+  `20260722184340`), NÃO da série sintética `20260805…`. Um check de limpeza filtrando `version >= <head>` é CEGO a ele.
+  Procurar phantom por **nome/statement** do migration (ou `version NOT LIKE '20260805%'`), não por range; o gate CI
+  **ADR-0097 missing-file drift** é a rede. Deletar por versão EXATA.
+- Adicionar coluna/assinatura quebra `gen-types-drift` → `npm run db:types` + commit `database.gen.ts` (CLI pin 2.109.0).
+- Superfícies membro/candidato: i18n pt/en/es real (3 dicts) + páginas /en/ e /es/ se criar rota nova.
+- Testes que fixam corpo de função por md5 → re-apontar p/ migration nova se reescrever a função.

--- a/docs/planning/2026-07-24_startup_backlog_retriage.md
+++ b/docs/planning/2026-07-24_startup_backlog_retriage.md
@@ -1,0 +1,53 @@
+# Brief de arranque — Re-triagem do backlog (próxima frente pós-arco de auditoria)
+
+> **Contexto:** o arco de auditoria pontuação/mérito (Ondas 1-5, umbrella #1465) fechou e deployou em 2026-07-23.
+> Não há mais frente aberta com prioridade urgente conhecida. Esta sessão NÃO executa uma feature específica: ela
+> **re-prioriza o backlog ao vivo** e apresenta ao owner a próxima frente. Modelo Opus 4.8; `/effort` normal para a
+> triagem, `xhigh` só se cair numa decisão dura. **Trazer opções + recomendação + porquê; auditar ao vivo antes de recomendar.**
+
+---
+
+## ESTADO AO FECHAR O ARCO (2026-07-23) — NÃO recitar, re-aterrar
+
+- **Arco 1-5 COMPLETO + MERGEADO + DEPLOYADO.** Detalhe vivo → memória `project-scoring-merit-audit-2026-07-21`.
+  main na 5b `2046820a`; migration head `20260805000483`; worker `f8745f1b`; EF nucleo-mcp v2.80.0.
+- **NÃO há item `high`/`P1` "pegando fogo"** conhecido: os 2 highs históricos já resolvidos (#1004 fechado; #1008
+  postura conservadora ratificada). Abertas ~137 (re-contar ao vivo). **Por isso a 1ª ação é triagem, não código.**
+
+### Resíduo do arco (3 follow-ups, BAIXA materialidade — NÃO justificam sessão própria)
+- **#1478** (o único "real"): `get_member_cycle_xp.cycle_points` sem upper-bound/org vs total do ledger auditável.
+  Risco: um membro ver `cycle_points` no ranking ≠ total do ledger. **Recomendação: dobrar numa futura sessão de
+  gamificação** (mesma superfície da Onda 3/5a), ~30min de checagem ao vivo antes. Não standalone.
+- **#1470** (baixa): digests de janela-móvel (`xp_delta`) ainda por `created_at` — decisão de produto, não bug.
+- **#1468** (baixa): `recompute_application_status` corte próprio cross-role — não-cron, `in_cutoff=0` hoje.
+> Deixar #1470/#1468 como backlog frio; reabrir só se a métrica mudar.
+
+---
+
+## MANDATO DA SESSÃO
+
+1. **Re-aterrar ao vivo (ANTES de recomendar qualquer coisa):**
+   - `gh issue list --state open --limit 300 --json number,title,labels,createdAt` — contagem real + varrer títulos.
+   - Checar labels de prioridade REAIS (nesta sessão `--label high` veio vazio; confirmar se o label existe:
+     `gh label list | grep -iE 'high|prio|urgent|p1'`). Não assumir esquema de labels.
+   - Confirmar os 3 follow-ups ainda abertos (#1478/#1470/#1468).
+   - **Se existir** `docs/planning/2026-07-20_backlog_triage_waves.md` (a memória o cita, mas ele NÃO estava presente
+     em 07-23 — provável scratch de outra sessão), usar como ponto de partida; **senão, re-triar do zero**.
+2. **Agrupar as abertas em ondas/temas** (ex.: gamificação, seleção/VEP, MCP/infra, comms, LGPD, higiene). Marcar
+   materialidade (alta/média/baixa) e dependências. Output = tabela curta de candidatos a próxima frente.
+3. **Convocação de conselho só se a próxima frente for decisão estratégica** (1 agente do domínio; NUNCA o conselho
+   inteiro por default — routing discipline do CLAUDE.md). Triagem em si não precisa de agente.
+4. **Apresentar ao owner** (`AskUserQuestion`) 2-4 frentes candidatas com recomendação + porquê. Números nas opções
+   DEVEM vir de query desta sessão (grounding MANDATÓRIO do CLAUDE.md). NÃO iniciar código antes da escolha.
+5. **Só depois da escolha:** abrir a frente escolhida (pode virar seu próprio brief/ondas, apply→merge serial).
+
+---
+
+## REGRAS DA CASA (herdadas)
+- Números em prompt/PR/commit/memória = de tool result DESTA sessão; nunca recitar de memória/handoff.
+- Merge à main = sessão main. Sem em-dash em entregáveis. Trailer `Assisted-By: Claude (Anthropic)`, nunca `Co-Authored-By`.
+- DDL só via `apply_migration` (byte-fiel; phantom por nome/statement; `migration repair`; `NOTIFY pgrst`).
+- Teste novo nas 2 whitelists do `package.json`. `npx astro build` + `npm test` (com `SUPABASE_URL`+`SERVICE_ROLE_KEY`).
+- Flake conhecido: `p599-600-initiative-roster-parity` fica vermelho na suíte cheia com `roster=null` universal
+  (transitório da prod compartilhada) mas **verde isolado** — re-rodar isolado antes de tratar como regressão. Idem
+  classe de rounding Postgres-vs-JS em taxas (%). NÃO bypassar por causa deles.

--- a/docs/planning/2026-07-24_startup_wave5b_candidate_transparency.md
+++ b/docs/planning/2026-07-24_startup_wave5b_candidate_transparency.md
@@ -1,0 +1,118 @@
+# Brief de arranque — Onda 5b (candidato pós-decisão: breakdown do aprovado, "não selecionado" do rejeitado)
+
+> **Sub-onda 5b do arco de auditoria pontuação/mérito (umbrella #1465).** A **5a fechou + mergeou** (#1473,
+> main `5172e964`). Esta é a segunda e ÚLTIMA sub-onda. **Materialidade MAIOR que a 5a: outward-facing** (candidato =
+> aplicante externo), envolve o que um **rejeitado** vê → superfície sensível. Modelo Opus 4.8 (não pinar), `/effort xhigh`.
+> **NÃO é LOCKED nos detalhes de UX:** abre com uma rodada curta de decisões do owner + `legal-counsel` ANTES de construir.
+
+---
+
+## HANDOFF — estado ao fechar a 5a (2026-07-22)
+
+**Arco 1–4 + 5a FECHADOS + MERGEADOS.** Detalhe vivo → memória `project-scoring-merit-audit-2026-07-21`.
+
+- **5a** (#1473 `5172e964`, PR#1475, mig **482**): painel "Minha Pontuação, auditável" (`/minha-pontuacao`). Helper interno
+  `_points_statement_json` + `get_my_points_statement` (self) + `get_member_points_ledger` (admin `?member=`). Deploy worker
+  `b0fb51bb`. Follow-up **#1478** (unificar janela/org de `get_member_cycle_xp.cycle_points` vs ledger) — independente, não bloqueia.
+- **Migration head (ao vivo 2026-07-22): `20260805000482`** → próxima livre provável `20260805000483` (re-consultar ao vivo).
+- **Umbrella #1465 ABERTO** (`Refs`, não `Closes`) — fechar À MÃO quando a 5b mergear (5a já mergeada).
+
+---
+
+## O QUE A 5b ENTREGA (Parte B do relatório `docs/audit/2026-07-21_scoring_merit_audit.md`)
+
+O **comitê** já tem a matriz critério×avaliador com `criterion_notes` (Onda 4). Falta a **visão do próprio candidato** pós-decisão:
+
+- **Candidato APROVADO** vê **seu próprio breakdown por critério** (scores agregados próprios — PERT objetivo / entrevista / líder)
+  + posição vs banda de corte + rank. NUNCA `criterion_notes`, notas ou nomes de avaliadores (LOCKED Onda 4).
+- **Candidato REJEITADO** vê **SÓ "não selecionado"** — sem breakdown NUMÉRICO novo.
+
+---
+
+## GROUNDING VIVO (2026-07-22, re-aterrar no início da sessão — NÃO recitar destes números)
+
+**Ciclos de seleção** (tabela `selection_cycles`, com `phase` própria — distinta dos `cycles` de gamificação):
+- `cycle3-2026` = **fase `announcement` (DECIDIDO/fechado)** → coorte de QA: **34 approved + 2 converted + 35 rejected**. Ideal
+  para QA por impersonação (tem os DOIS lados decididos). `cycle3-2026-b2`: 1 approved + 8 rejected + 1 withdrawn.
+- `cycle4-2026` = **fase `evaluating` (ABERTO)** → o gate de fase da 5b **NÃO** deve renderizar breakdown aqui até virar `announcement`.
+
+**RPCs de candidato que JÁ existem (todos self-only via `auth.uid()`, sem args):**
+- `get_my_selection_result()` — ⚠️ **JÁ retorna `objective_score`/`interview_score`/`research_score`/`leader_score` + `rank`
+  (RANK() ao vivo) para TODOS os status finais, INCLUINDO `rejected`** (`is_final` = approved/converted/rejected/objective_cutoff/
+  withdrawn/cancelled). **Este é o ponto #1 da sessão** (ver abaixo).
+- `get_my_evaluation_feedback()` — revela scores + `feedback` qualitativo gateado por **FASE** (`evaluations_closed`, `interviews`,
+  `interviews_closed`, `ranking`, `announcement`, `onboarding`). Pré-existente — a decisão "só não selecionado" é sobre o breakdown
+  NUMÉRICO NOVO, **não** sobre este feedback qualitativo pré-existente. **Não regredir.**
+- `get_my_application_status()` — status/phase/`submitted_eval` count durante `evaluating` (sem identidades).
+- Página do candidato: `src/pages/minha-candidatura.astro`.
+
+---
+
+## ⚠️ PONTO #1 DA SESSÃO — auditar ANTES de desenhar (potencial conflito com a decisão LOCKED)
+
+`get_my_selection_result()` **já devolve scores numéricos + rank para candidatos `rejected`**. A decisão LOCKED é "rejeitado vê só
+'não selecionado'". Logo, a PRIMEIRA tarefa é **auditar o que `minha-candidatura.astro` RENDERIZA hoje** para um rejeitado (via
+impersonação de um `rejected` do `cycle3-2026`):
+- Se o front **já esconde** scores/rank do rejeitado (só o RPC devolve, mas a UI não mostra) → a 5b só precisa garantir que o
+  breakdown por-critério NOVO também respeite isso.
+- Se o front **mostra** scores/rank ao rejeitado hoje → há uma exposição pré-existente que a 5b deve reconciliar com a decisão do
+  owner (é regressão de política ou estado atual aceito? decidir com o owner + `legal-counsel`; não assumir).
+
+Não construir nada antes de responder isso com evidência ao vivo.
+
+---
+
+## DECISÕES DO OWNER — já ratificadas (não re-litigar), CONFIRMAR só o timing
+
+1. **Split SIM** (feito): 5a interna (mergeada), 5b outward-facing (esta). PR + merge serial próprios.
+2. **Aprovado vê breakdown por critério próprio; REJEITADO vê só "não selecionado".** Candidato NUNCA vê criterion_notes/notas/
+   nomes de avaliadores (LOCKED Onda 4). A restrição "só não selecionado" é sobre o breakdown NUMÉRICO NOVO.
+3. **Timing (CONFIRMAR no início):** recomendação ratificada = **buildar AGORA, gated por fase** (só renderiza pós-decisão =
+   `announcement`), com **QA contra apps decididas do `cycle3-2026` (fechado)** via impersonação. Racional: desacopla eng do
+   calendário; feature pronta+testada antes da pressão do C4. Se o owner preferir aguardar o C4 fechar, adiar só a 5b. **Bater com
+   o owner antes de construir.**
+4. **i18n real** pt/en/es se criar rota nova (≠ do admin `selection.astro`, PT-hardcoded). Toda chave nova nas 3 dicts.
+
+---
+
+## MANDATO DA SESSÃO
+
+1. **Re-aterrar ao vivo ANTES:** migration head; corpos VIVOS (`pg_get_functiondef`) de `get_my_selection_result` /
+   `get_my_evaluation_feedback` / `get_my_application_status`; fase de cada `selection_cycles`; **e o PONTO #1** (auditar
+   `minha-candidatura.astro` + impersonar um `rejected` do cycle3-2026). Nenhum número recitado.
+2. **Rodada de decisões do owner** (`AskUserQuestion`) + convocar **`legal-counsel`** (1 agente — o que o rejeitado vê é decisão
+   de política/LGPD) e **`ux-leader`** (1 agente — journey candidato pós-decisão). NÃO o conselho inteiro.
+3. **Construir conforme a decisão:** a visão do aprovado = seus próprios scores agregados por critério (PERT objetivo/entrevista/
+   líder) + posição vs banda de corte + rank. Se precisar de RPC/coluna nova: **DDL só via `apply_migration`**, corpo **byte-fiel
+   ao arquivo** (ou alinhar o arquivo ao vivo depois — ver gotcha), REVOKE/GRANT corretos, phantom tracking-row por NOME/statement
+   (não por range), `migration repair`, `NOTIFY pgrst`, `npm run db:types` se assinatura nova.
+4. **Grounding adversarial (multi-lente)** antes de shippar: (a) candidato NUNCA vê criterion_notes/nomes/notas de terceiros;
+   (b) rejeitado NÃO vê breakdown numérico novo (nem via RPC nem via UI); (c) gate de fase impede render antes de `announcement`;
+   (d) números do candidato batem com os RPCs corrigidos (Ondas 1–2). QA por impersonação contra `cycle3-2026` (34 apr/35 rej).
+5. **`npx astro build` + `npm test`** (com `SUPABASE_URL`+`SERVICE_ROLE_KEY` → DB-aware). 0 fail. Teste novo nas **2 whitelists**
+   (`test` + `test:contracts` no package.json).
+6. **Aplicar + merge à main** (sessão main pode mergear). Fecha **#1474**; o umbrella **#1465 fecha À MÃO** (5a já mergeada → ao
+   mergear a 5b, fechar #1465 manualmente). Deploy frontend (`npx astro build && npx wrangler deploy`).
+7. Atualizar `project-scoring-merit-audit-2026-07-21` + `MEMORY.md` (**ARCO DE AUDITORIA COMPLETO 1–5**).
+
+---
+
+## REGRAS DA CASA + GOTCHAS (herdados da 5a)
+
+- Números em prompt/PR/commit/memória = de tool result DESTA sessão; nunca recitar.
+- Sem em-dash (—/–) em entregáveis (inclui strings i18n user-facing e fallbacks no script). Trailer `Assisted-By: Claude
+  (Anthropic)`, nunca `Co-Authored-By`.
+- **GOTCHA Phase C (novo na 5a):** ao aplicar DDL, se você RE-DIGITAR o SQL no `apply_migration` (em vez de colar byte-fiel do
+  arquivo) e enxugar comentários inline, o corpo vivo `prosrc` diverge do arquivo → `rpc-migration-coverage` Phase C fica VERMELHO.
+  Corpo vivo é o SSOT: ou cole byte-fiel, ou alinhe o ARQUIVO ao vivo (`pg_get_functiondef`) depois. → memórias
+  `reference-apply-large-function-mcp-inline-md5-verify`, `reference-create-or-replace-base-on-live-body`.
+- **GOTCHA phantom (Onda 4/5a):** `apply_migration` MCP cria tracking-row com **timestamp REAL de hoje** (ex. `20260723004115`),
+  não da série sintética `20260805…`. Procurar por NOME/statement (ou `version NOT LIKE '20260805%'`), deletar por versão EXATA;
+  registrar a sintética com `migration repair`.
+- Testes DB-aware rodam SERIAL (`--test-concurrency=1`) contra a prod compartilhada; `tx=rollback` NÃO desfaz INSERT de SECDEF
+  (limpar explícito). Novo teste nas 2 whitelists senão nem roda no CI.
+- **Flake conhecido já corrigido na 5a:** `tests/contracts/p277-419-m3-pr3a-tribe-stats-engagement.test.mjs` (tribo14 rounding
+  Postgres numeric ROUND vs JS Math.round) agora tem tolerância de 1 unidade de arredondamento. Se reaparecer em outro teste de
+  taxa (%), é a mesma classe (exact-equality de float entre banco e JS), não regressão.
+- `get_member_points_ledger`/`get_my_points_statement` (5a) são o padrão de referência para RPC self vs admin-gated com helper
+  interno compartilhado — reusar o padrão se a 5b precisar de leitura admin.


### PR DESCRIPTION
Move os briefs de arranque de sessão de scratch local (untracked) para o repo.

Cobre os startups das Ondas 1-5b do arco de auditoria pontuação/mérito (umbrella #1465, fechado) e o brief de re-triagem do backlog para a próxima frente (`2026-07-24_startup_backlog_retriage.md`).

Docs-only, sem mudança de código.

Refs #1465