### PR TITLE
fix(sec): #1440 rate-limit /oauth/register (DCR) per IP

### DIFF
--- a/src/pages/oauth/register.ts
+++ b/src/pages/oauth/register.ts
@@ -22,6 +22,17 @@
 
 import type { APIRoute } from "astro";
 import { env as cfEnv } from "cloudflare:workers";
+import { checkIpRateLimit, clientIpFrom } from "../../lib/ip-rate-limit";
+
+// #1440 — DCR is an open, unauthenticated endpoint (RFC 7591): every valid POST
+// mints a GoTrue OAuth client via the admin API. Historically it had NO rate
+// limiting (only a 5-redirect_uri cap per request), so an automated caller could
+// flood /auth/v1/admin/oauth/clients, pollute the oauth_clients table, and burn
+// Supabase's admin API budget. We add a per-IP throttle (defense-in-depth; the
+// consent + login gate remains the real authority boundary). A legitimate client
+// registers ~once, so a low cap is generous. Fail-open on KV/IP hiccups so a
+// throttle-store outage never blocks a real registration.
+const DCR_RATE_LIMIT_PER_MIN = 10;
 
 // Backward-compat fallback: the pre-existing shared client. Used only when the admin
 // API is unreachable (e.g. local dev without a service role key). Its fixed allow-list
@@ -69,6 +80,31 @@ function sanitizeRedirectUris(input: unknown): string[] {
 }
 
 export const POST: APIRoute = async ({ request }) => {
+  // #1440: per-IP flood dampening BEFORE any work (parse/admin call). Keyed by
+  // cf-connecting-ip + action, fail-open when KV/IP is absent (checkIpRateLimit
+  // handles that). The consent + login flow, not this throttle, is the authority
+  // gate — this only bounds oauth_clients pollution and admin-API budget burn.
+  const rlKv = (cfEnv as any)?.SESSION;
+  const rl = await checkIpRateLimit(rlKv, clientIpFrom(request), "oauth-register", DCR_RATE_LIMIT_PER_MIN);
+  if (!rl.allowed) {
+    return new Response(
+      JSON.stringify({
+        error: "rate_limited",
+        error_description: "Too many registration requests. Retry after a minute.",
+      }),
+      {
+        status: 429,
+        headers: {
+          "Content-Type": "application/json",
+          "Retry-After": String(rl.retryAfter ?? 60),
+          "X-RateLimit-Limit": String(DCR_RATE_LIMIT_PER_MIN),
+          "X-RateLimit-Remaining": "0",
+          ...CORS,
+        },
+      }
+    );
+  }
+
   let body: any = {};
   try { body = JSON.parse((await request.text()) || "{}"); } catch { /* keep {} */ }
 

--- a/tests/contracts/oauth-dcr-hardening.test.mjs
+++ b/tests/contracts/oauth-dcr-hardening.test.mjs
@@ -14,6 +14,10 @@
  *          and /mcp/actions advertise their own resource (not a hardcoded /mcp), and
  *          each proxy's WWW-Authenticate must point at its path-scoped metadata.
  *
+ *  #1440 — /oauth/register (open, unauthenticated DCR endpoint) must apply a
+ *          per-IP rate limit before minting a GoTrue OAuth client, so a flood
+ *          can't pollute oauth_clients or burn the admin API budget.
+ *
  * Static source assertions (same offline-safe style as 1210-mcp-native-oauth.test.mjs)
  * so the gate runs in CI without secrets or network.
  *
@@ -56,6 +60,28 @@ test('FM-01: register 400s when a non-empty redirect_uris request sanitizes to n
     /body\.redirect_uris\.length\s*>\s*0\s*&&\s*redirectUris\.length\s*===\s*0/,
     'the 400 must be gated strictly on "non-empty request sanitized to empty" (not on the no-service-role path)'
   );
+});
+
+// ── #1440: DCR endpoint must be rate-limited per IP ──────────────────────────
+test('#1440: register.ts applies a per-IP rate limit before the admin OAuth-client call', () => {
+  assert.match(REGISTER, /from\s+["']\.\.\/\.\.\/lib\/ip-rate-limit["']/,
+    'must import the per-IP rate-limit helper (checkIpRateLimit/clientIpFrom)');
+  assert.match(REGISTER, /checkIpRateLimit\(/,
+    'the POST handler must call checkIpRateLimit');
+  assert.match(REGISTER, /clientIpFrom\(\s*request\s*\)/,
+    'the rate limit must key on the client IP from the request');
+  assert.match(REGISTER, /status:\s*429/,
+    'a throttled request must return HTTP 429');
+});
+
+test('#1440: the rate-limit gate runs BEFORE the admin oauth/clients POST', () => {
+  // Anchor on the CALL site ('checkIpRateLimit(' — the import has no paren) and the
+  // actual fetch (lastIndexOf — the admin path also appears in the header comment).
+  const rlIdx = REGISTER.indexOf('checkIpRateLimit(');
+  const adminIdx = REGISTER.lastIndexOf('/auth/v1/admin/oauth/clients');
+  assert.ok(rlIdx > -1 && adminIdx > -1, 'both the rate-limit call and the admin call must exist');
+  assert.ok(rlIdx < adminIdx,
+    'checkIpRateLimit must be positioned before the admin oauth/clients call so a flood is rejected before any client is minted');
 });
 
 // ── PPX-3 / FM-04: path-aware protected-resource metadata ────────────────────


### PR DESCRIPTION
Rate limiting por-IP no /oauth/register (DCR aberto, RFC 7591). Liga src/lib/ip-rate-limit.ts (#1050, nunca consumido) ao POST antes de parsear/chamar admin. cf-connecting-ip + oauth-register, 10/min, fail-open. 429 c/ Retry-After. Runtime-verified + 2 asserts no oauth-dcr-hardening.test.mjs (CI-wired, 8/8 verde). astro build verde. Closes #1440