### PR TITLE
fix(digest): #1424 Fase C item 2 - digest de líder sai do sábado para segunda

### DIFF
--- a/supabase/migrations/20260805000491_1424_fasec_item2_stagger_leader_digest_monday.sql
+++ b/supabase/migrations/20260805000491_1424_fasec_item2_stagger_leader_digest_monday.sql
@@ -1,0 +1,49 @@
+-- #1424 Fase C (item 2) — tirar o digest de lider da colisao de sabado
+--
+-- Os dois digests semanais disparavam no mesmo dia, a 30 min um do outro:
+--   jobid 26 send-weekly-member-digest  sab 12:00 UTC
+--   jobid 27 send-weekly-leader-digest  sab 12:30 UTC
+--
+-- Medido em 2026-07-25 (consultas ao vivo):
+--   - media de envios por dia da semana (28d): Seg 15,5 · Ter 47,8 · Qua 16,3 ·
+--     Qui 28,3 · Sex 50,0 · SAB 124,8 · Dom 32,0.
+--   - o pico de sabado E o proprio digest: em 18/07 os 108 envios do dia foram
+--     71 member digest + 37 leader digest, sem trafego concorrente.
+--   - projecao do sabado ja com as Fases A+B e a agregacao (mig 490):
+--     71 + 20 = ~91 contra DAILY_SEND_CAP=90. Margem ~zero.
+--
+-- Por que mover o digest de LIDER (o menor) e nao o de membro (o maior):
+--   sabado nao tem trafego alem dos digests, entao o member digest (71) fica la
+--   com folga de ~19. Mover os 71 para um dia util seria PIOR: numa segunda cheia
+--   (30 envios) daria ~101 e o cap diferiria o excedente. Mover os 20 do lider
+--   para segunda (dia mais vazio, 15,5) deixa os dois dias folgados:
+--     sabado ~71 (folga 19) · segunda ~35 (folga 55)
+--
+-- Bonus de produto: o digest de lider e o acionavel (atas pendentes, presencas
+-- nao registradas, champions nao conferidos). Chegar na segunda de manha
+-- (12:00 UTC = 09:00 America/Sao_Paulo) poe as pendencias na frente do lider no
+-- inicio da semana de trabalho, e nao no sabado.
+--
+-- Transicao (uma vez so): o ultimo disparo no modelo antigo foi sabado 25/07 e o
+-- primeiro no novo sera segunda 27/07, 2 dias depois. Como get_weekly_initiative_digest
+-- reporta o ESTADO ATUAL de pendencias numa janela rolante de 7 dias (#1470), esse
+-- primeiro envio repete boa parte do anterior. E redundancia pontual, nao erro: o
+-- conteudo continua correto, e a cadencia volta a ser semanal a partir dai.
+--
+-- Altera apenas o schedule; o command do job fica intacto.
+
+DO $$
+DECLARE
+  v_jobid bigint;
+BEGIN
+  SELECT jobid INTO v_jobid
+  FROM cron.job
+  WHERE jobname = 'send-weekly-leader-digest';
+
+  IF v_jobid IS NULL THEN
+    RAISE EXCEPTION 'cron job send-weekly-leader-digest nao encontrado — verifique o nome antes de aplicar';
+  END IF;
+
+  -- '0 12 * * 1' = toda segunda-feira as 12:00 UTC (09:00 America/Sao_Paulo)
+  PERFORM cron.alter_job(job_id := v_jobid, schedule := '0 12 * * 1');
+END $$;

--- a/tests/contracts/1424-leader-digest-aggregate-per-leader.test.mjs
+++ b/tests/contracts/1424-leader-digest-aggregate-per-leader.test.mjs
@@ -103,6 +103,28 @@ test('#1424 Fase C: renderer handles aggregated payload and keeps the legacy pat
     'Renderer must keep the legacy single-initiative path for rows queued pre-Fase C.');
 });
 
+test('#1424 Fase C item 2: leader digest is staggered off the Saturday collision', () => {
+  // The two weekly digests used to fire 30 min apart on the same day, which put
+  // ~91 emails against DAILY_SEND_CAP=90. Measured 2026-07-25: Saturday carries
+  // no traffic other than the digests themselves (18/07 = 71 member + 37 leader,
+  // nothing else), so the SMALLER one moves and the member digest keeps Saturday.
+  const staggerSQL = readFileSync(
+    resolve(MIGRATIONS_DIR, '20260805000491_1424_fasec_item2_stagger_leader_digest_monday.sql'), 'utf8');
+
+  // '0 12 * * 1' = Monday 12:00 UTC (09:00 America/Sao_Paulo).
+  assert.match(staggerSQL, /schedule\s*:=\s*'0 12 \* \* 1'/,
+    'Leader digest must be rescheduled to Monday 12:00 UTC.');
+  // Resolved by NAME, never by a hardcoded jobid: job ids are not stable across
+  // environments, and altering the wrong job would silently retime something else.
+  assert.match(staggerSQL, /WHERE\s+jobname\s*=\s*'send-weekly-leader-digest'/,
+    'Job must be resolved by jobname, not a hardcoded jobid.');
+  assert.match(staggerSQL, /RAISE\s+EXCEPTION/,
+    'Migration must fail loudly if the job name does not resolve.');
+  // Saturday must not reappear for this job in the same migration.
+  assert.doesNotMatch(staggerSQL, /schedule\s*:=\s*'[^']*\* \* 6'/,
+    'Leader digest must not stay on Saturday (day-of-week 6).');
+});
+
 test('#1424 Fase C: leader digest stays a rich/individual type in the email lane', () => {
   // The email lane must NOT fold the leader digest into the generic coalesced
   // list — it has its own full-page renderer. Fase A put it in both sets; the


### PR DESCRIPTION
> **Empilhada sobre #1489** (base = `fix/1424-fasec-leader-digest-aggregate`). DDL em DB compartilhado serializa: aplicar a mig 490 e mergear #1489 primeiro, depois a mig 491 e esta.

## O problema

Os dois digests semanais disparavam no mesmo dia, a 30 min um do outro:

| jobid | job | schedule atual |
|---|---|---|
| 26 | `send-weekly-member-digest` | sáb 12:00 UTC |
| 27 | `send-weekly-leader-digest` | sáb 12:30 UTC |

Com as Fases A+B vivas e a agregação de #1489, a projeção do sábado é **71 + 20 = ~91** contra `DAILY_SEND_CAP=90`. Margem zero: qualquer transacional no sábado passa a ser diferido.

## Grounding (2026-07-25, consultas ao vivo)

Média de envios por dia da semana (28d):

| Seg | Ter | Qua | Qui | Sex | Sáb | Dom |
|---|---|---|---|---|---|---|
| 15,5 | 47,8 | 16,3 | 28,3 | 50,0 | **124,8** | 32,0 |

O pico de sábado **é** o próprio digest: em 18/07 os 108 envios do dia foram 71 member + 37 leader, sem tráfego concorrente.

## Por que move o digest de LÍDER e não o de membro

Contra-intuitivo, mas os dados mandam: como sábado não tem nada além dos digests, os 71 do member digest ficam lá com folga de ~19. Mover os **71** para um dia útil seria **pior** — numa segunda cheia (30 envios) daria ~101, e o cap diferiria o excedente para terça.

Movendo os **20** do líder para segunda (o dia mais vazio, 15,5), os dois dias ficam folgados:

- sábado ~71 (folga 19)
- segunda ~35 (folga 55)

**Bônus de produto:** o digest de líder é o acionável (atas pendentes, presenças não registradas, champions não conferidos). Chegar segunda 12:00 UTC = 09:00 America/Sao_Paulo põe as pendências na frente do líder no início da semana de trabalho, não no sábado.

## Transição (uma vez só)

Último disparo no modelo antigo: sáb 25/07. Primeiro no novo: seg 27/07, 2 dias depois. Como `get_weekly_initiative_digest` reporta o **estado atual** de pendências numa janela rolante de 7 dias (#1470), esse primeiro envio repete boa parte do anterior. É redundância pontual, não erro: o conteúdo continua correto e a cadência volta a ser semanal em seguida.

## Implementação

`cron.alter_job` mudando **apenas** o schedule; o command do job fica intacto. O job é resolvido por **nome**, com `RAISE EXCEPTION` se não resolver: jobid não é estável entre ambientes, e alterar o job errado retemporizaria outra coisa em silêncio.

Contract test estendido (6 asserts no total, arquivo já nas 2 whitelists do #1109): schedule de segunda, resolução por nome, falha alta se o nome não resolver, e sábado não pode reaparecer.

Refs #1424