### PR TITLE
sec(ef): #1513 onda 3 — send-weekly-member-digest e verify-credly

### DIFF
--- a/supabase/functions/send-weekly-member-digest/index.ts
+++ b/supabase/functions/send-weekly-member-digest/index.ts
@@ -1,5 +1,9 @@
 /// <reference types="https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts" />
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+import { isServiceRoleToken, bearerFrom } from '../_shared/service-auth.ts'
+
+// #1513 onda 3: read once at module scope so the caller gate and the handler share it.
+const SUPABASE_URL_FOR_AUTH = Deno.env.get('SUPABASE_URL') ?? ''
 
 /**
  * Edge Function: send-weekly-member-digest
@@ -33,6 +37,21 @@ Deno.serve(async (req) => {
     new Response(JSON.stringify(d), { status: s, headers: { ...cors, 'Content-Type': 'application/json' } })
 
   if (req.method === 'OPTIONS') return new Response('ok', { headers: cors })
+
+  // #1513 onda 3: service-role only.
+  //
+  // Esta EF não estava na lista do issue — o grep original a perdeu. Medida
+  // 2026-07-28: verify_jwt=false e NENHUMA verificação de chamador, exatamente o
+  // mesmo perfil da irmã send-notification-email (#1514). Um POST anônimo
+  // disparava o envio do digest semanal para todos os membros optados,
+  // queimando a mesma cota Resend compartilhada que já foi incidente (#1424).
+  //
+  // Chamador legítimo único: pg_cron jobid 26 (sáb 12:00 UTC), que manda a
+  // service_role_key do Vault — aceita pelo probe PostgREST (#738). Fail-closed
+  // antes de qualquer RPC ou envio.
+  if (!(await isServiceRoleToken(SUPABASE_URL_FOR_AUTH, bearerFrom(req)))) {
+    return json({ error: 'unauthorized', detail: 'service-role only' }, 401)
+  }
 
   try {
     const url = Deno.env.get('SUPABASE_URL') ?? ''

--- a/supabase/functions/verify-credly/index.ts
+++ b/supabase/functions/verify-credly/index.ts
@@ -1,5 +1,9 @@
 import { createClient, type SupabaseClient } from 'https://esm.sh/@supabase/supabase-js@2'
 import { classifyBadge, PMI_TRAIL_KEYWORDS, selectCanonicalCpmai } from '../_shared/classify-badge.ts'
+import { isServiceRoleToken, bearerFrom } from '../_shared/service-auth.ts'
+
+// #1513 onda 3: read once at module scope so the caller gate and the handler share it.
+const SUPABASE_URL = Deno.env.get('SUPABASE_URL')!
 
 // Retry with exponential backoff for external API calls
 async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 3): Promise<Response> {
@@ -217,6 +221,56 @@ Deno.serve(async (req) => {
   try {
     const { member_id, credly_url } = await req.json()
     const sb = createClient<any, "public", any>(Deno.env.get('SUPABASE_URL')!, Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!)
+
+    // ─── #1513 onda 3 — caller auth ────────────────────────────────────────────
+    //
+    // Medido 2026-07-28: esta EF deployava com verify_jwt=false e NÃO verificava
+    // o chamador. Ela não é só de leitura — com `member_id` vindo do corpo ela
+    // INSERE em gamification_points, INSERE em course_progress e faz UPDATE em
+    // members. Um chamador anônimo podia portanto creditar XP e badges a
+    // QUALQUER membro a partir de um perfil Credly que ele mesmo controla, o que
+    // quebra a invariante de que mérito pertence a quem fez o trabalho.
+    //
+    // A EF é user-facing (profile.astro chama do browser), então um gate de
+    // service-role puro quebraria a tela. Dois caminhos, espelhando pmi-ai-triage:
+    //   • service-role  → confiado, pode passar qualquer member_id (sync-credly-all)
+    //   • JWT de usuário → getUser() valida a assinatura, o membro é resolvido por
+    //     auth_id, e só o PRÓPRIO member_id é aceito. Verificar Credly é
+    //     self-service; ninguém verifica em nome de outro.
+    const authHeader = req.headers.get('Authorization') ?? ''
+    const isServiceRole = await isServiceRoleToken(SUPABASE_URL, bearerFrom(req))
+    if (!isServiceRole) {
+      const anonKey = Deno.env.get('SUPABASE_ANON_KEY') ?? ''
+      if (!anonKey) {
+        return new Response(JSON.stringify({ success: false, error: 'anon_key_missing' }), {
+          status: 503, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        })
+      }
+      const userClient = createClient<any, "public", any>(SUPABASE_URL, anonKey, {
+        global: { headers: { Authorization: authHeader } },
+      })
+      const { data: userData } = await userClient.auth.getUser()
+      if (!userData?.user) {
+        return new Response(JSON.stringify({ success: false, error: 'unauthorized' }), {
+          status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        })
+      }
+      const { data: callerMember } = await sb
+        .from('members').select('id').eq('auth_id', userData.user.id).maybeSingle()
+      if (!callerMember?.id) {
+        return new Response(JSON.stringify({ success: false, error: 'member_not_found' }), {
+          status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        })
+      }
+      // Rejeitar explicitamente em vez de sobrescrever calado: a UI já manda o
+      // próprio id, então divergência aqui é abuso, não uso legítimo.
+      if (member_id && member_id !== callerMember.id) {
+        return new Response(JSON.stringify({ success: false, error: 'forbidden', detail: 'member_id must be your own' }), {
+          status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        })
+      }
+    }
+    // ───────────────────────────────────────────────────────────────────────────
 
     // Resolve username
     let username: string | null = credly_url ? extractUsername(credly_url) : null

--- a/tests/contracts/1513-ef-caller-auth-sweep.test.mjs
+++ b/tests/contracts/1513-ef-caller-auth-sweep.test.mjs
@@ -113,6 +113,75 @@ for (const { slug, marker } of SECRET_GATED) {
   });
 }
 
+// ── Onda 3: EFs abertas que NÃO estavam na lista do issue.
+//
+// A lista de 13 do #1513 veio de um grep; a varredura completa das 46 EFs por
+// verificação de chamador de ENTRADA achou mais 3 abertas. A lição vale mais que
+// o achado: "menciona Authorization" não é "verifica o chamador" — as três
+// mencionam (em CORS ou em chamada de saída) e nenhuma verificava.
+
+test("#1513 onda 3: send-weekly-member-digest gateia em service-role", () => {
+  // Perfil idêntico ao da irmã send-notification-email: cron jobid 26 com a
+  // service_role_key do Vault, e um POST anônimo disparava envio em massa.
+  const src = read("send-weekly-member-digest");
+  assert.match(src, /import \{ isServiceRoleToken, bearerFrom \} from ['"]\.\.\/_shared\/service-auth\.ts['"]/);
+  assert.match(src, /if \(!\(await isServiceRoleToken\(SUPABASE_URL_FOR_AUTH, bearerFrom\(req\)\)\)\)/);
+  assert.match(src, /status:\s*401|,\s*401\)/);
+  // fail-closed: o gate precede a RPC que gera e enfileira os digests.
+  // Procurar a CHAMADA (`rpc('...')`), não o nome solto — ele também aparece no
+  // cabeçalho de documentação do arquivo, antes de qualquer código.
+  const gate = src.indexOf("isServiceRoleToken(SUPABASE_URL_FOR_AUTH");
+  const rpc = src.indexOf("rpc('generate_weekly_member_digest_cron')");
+  assert.ok(gate !== -1 && rpc !== -1 && gate < rpc, "gate deve preceder a RPC de geração");
+});
+
+test("#1513 onda 3: verify-credly aceita service-role OU o dono do member_id, nunca anônimo", () => {
+  // Esta EF ESCREVE (gamification_points, course_progress, members) com member_id
+  // vindo do corpo. Sem gate, um anônimo creditava XP a qualquer membro.
+  const src = read("verify-credly");
+  assert.match(src, /import \{ isServiceRoleToken, bearerFrom \} from ['"]\.\.\/_shared\/service-auth\.ts['"]/);
+  assert.match(src, /const isServiceRole = await isServiceRoleToken\(SUPABASE_URL, bearerFrom\(req\)\)/);
+  // caminho de usuário: assinatura verificada por getUser(), membro resolvido por auth_id
+  assert.match(src, /userClient\.auth\.getUser\(\)/);
+  assert.match(src, /\.eq\('auth_id', userData\.user\.id\)/);
+  // e a posse é exigida, não sobrescrita em silêncio
+  assert.match(src, /member_id !== callerMember\.id/);
+  assert.match(src, /status:\s*403/);
+});
+
+test("#1513 onda 3: em verify-credly o gate precede TODA escrita", () => {
+  // ⚠️ Ordenação por texto tem uma armadilha própria: o comentário DO GATE cita
+  // as tabelas que ele protege, então um indexOf ingênuo acha o comentário e
+  // conclui que a escrita vem antes. Mesma classe de
+  // reference-apply-migration-comment-word-flips-text-audit. Por isso: remover
+  // comentários primeiro e procurar a CHAMADA, não o nome da tabela.
+  const raw = read("verify-credly");
+  const src = raw.replace(/\/\/[^\n]*/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+  const gate = src.indexOf("const isServiceRole = await isServiceRoleToken");
+  assert.ok(gate !== -1, "gate presente");
+  const serve = src.indexOf("Deno.serve");
+  for (const call of ["from('gamification_points')", "from('course_progress')", "from('members').update("]) {
+    const idx = src.indexOf(call, serve);
+    if (idx !== -1) assert.ok(gate < idx, `gate deve preceder a escrita em ${call}`);
+  }
+  // e as escritas em helpers só são alcançáveis pelo handler, que passa pelo gate
+  assert.ok(src.indexOf("upsertCredlyPoints(sb, member_id", serve) > gate);
+});
+
+test("#1513 onda 3: as EFs user-facing por token de corpo seguem validando o token", () => {
+  // pmi-video-init-upload / finalize NÃO levam gate de service-role por desenho
+  // (portal do candidato, auth por token no corpo). O guard existe para que
+  // ninguém remova esse token achando que a EF "não tem auth".
+  for (const slug of ["pmi-video-init-upload", "pmi-video-finalize-upload"]) {
+    const src = read(slug);
+    assert.match(src, /token/, `${slug} deve continuar exigindo o token do corpo`);
+  }
+  // sync-wiki: HMAC do GitHub, fail-closed sem assinatura
+  const wiki = read("sync-wiki");
+  assert.match(wiki, /verifyGitHubSignature/);
+  assert.match(wiki, /if \(!signature\) return false/);
+});
+
 test("#1513: tokenMatches das EFs OTS compara em tempo constante e rejeita segredo vazio", () => {
   const src = read("ots-stamp");
   assert.match(src, /if \(secret\.length === 0 \|\| token\.length !== secret\.length\) return false/);

--- a/tests/edge-functions/ef-smoke.test.mjs
+++ b/tests/edge-functions/ef-smoke.test.mjs
@@ -37,10 +37,14 @@ test('smoke: sync-credly-all rejects anon token', { skip: !canRun && skipMsg }, 
   assert.ok([401, 403].includes(status), `Expected 401/403, got ${status}`);
 });
 
-test('smoke: verify-credly rejects invalid member_id', { skip: !canRun && skipMsg }, async () => {
+test('smoke: verify-credly rejects the anon key (#1513 onda 3)', { skip: !canRun && skipMsg }, async () => {
+  // Antes do #1513 esta EF não verificava chamador nenhum, e este teste media o
+  // comportamento DEPOIS do gate inexistente: a anon key entrava e o erro vinha
+  // da validação de member_id (400/500). Agora a anon key não é usuário nem
+  // service-role, então para no gate. Ela escreve em gamification_points,
+  // course_progress e members — deixar a anon key passar era o buraco.
   const { status, json } = await efPost('verify-credly', { member_id: '00000000-0000-0000-0000-000000000000' });
-  // Should return 400 (no Credly URL) or 500 (member not found)
-  assert.ok([400, 500].includes(status), `Expected 400/500, got ${status}`);
+  assert.ok(status === 401, `Expected 401, got ${status}`);
   assert.ok(json !== null, 'Response should be valid JSON');
 });
 
@@ -56,8 +60,18 @@ test('smoke: send-campaign rejects anon token', { skip: !canRun && skipMsg }, as
   assert.ok([401, 403].includes(status), `Expected 401/403, got ${status}`);
 });
 
-test('smoke: get-comms-metrics responds', { skip: !canRun && skipMsg }, async () => {
-  const { status, json } = await efPost('get-comms-metrics', {});
-  // JWT-verified: anon key should work for read-only
-  assert.ok([200, 405].includes(status), `Expected 200/405, got ${status}`);
+test('smoke: get-comms-metrics rejects the anon key (#1513 fase 2)', { skip: !canRun && skipMsg }, async () => {
+  // Este teste afirmava "JWT-verified: anon key should work for read-only", que
+  // era precisamente a premissa errada do #1513: verify_jwt=true aceita QUALQUER
+  // JWT do projeto, e a anon key é pública. Ela devolvia 200 com métricas da
+  // organização lidas em service role. Agora tem gate de service-role.
+  const { status } = await efPost('get-comms-metrics', {});
+  assert.ok(status === 401, `Expected 401, got ${status}`);
 });
+
+// ⚠️ NOTA DE MANUTENÇÃO (#1513, 2026-07-28). Este arquivo bate em PRODUÇÃO, então
+// o resultado depende do que está DEPLOYADO, não do que está na branch. O gate do
+// get-comms-metrics passou verde no CI do PR que o introduziu — porque o deploy
+// ainda não tinha acontecido — e só ficou vermelho depois. Ao mudar auth de EF,
+// espere estes smokes virarem no momento do deploy, não no do merge.
+// (Classe "invariante de CI sobre dado vivo", #1487 classe B.)


### PR DESCRIPTION
Onda 3 do #1513. A lista de 13 do issue **estava incompleta**.

## Como as 3 escaparam

O grep original procurava sinais de auth. Mas **"menciona `Authorization`" ≠ "verifica o chamador"** —
a string aparece também em header de *saída* e em CORS. Varrendo as 46 EFs por verificação de
chamador de **entrada**, sobraram 7 sem nenhuma; 4 são por desenho (`nucleo-mcp` OAuth 2.1, os dois
`pmi-video-*` com token no corpo, `sync-wiki` com HMAC do GitHub) e **3 eram buracos reais**.

## `send-weekly-member-digest`

Perfil **idêntico** ao da irmã `send-notification-email` (#1514): `verify_jwt: false`, nenhuma
verificação. Um POST anônimo disparava o digest semanal para todos os membros optados, queimando a
mesma cota Resend compartilhada que já foi incidente (#1424).

Chamador legítimo único: **pg_cron jobid 26** (sáb 12:00 UTC) com a `service_role_key` do Vault.
Gate = service-role, fail-closed antes da RPC de geração.

## `verify-credly` — a pior das três, e não é só leitura

Com `member_id` vindo do corpo e **sem auth nenhuma**, ela:

- `INSERT` em `gamification_points`
- `INSERT` em `course_progress`
- `UPDATE` em `members`

Ou seja: um anônimo podia **creditar XP e badges a qualquer membro** a partir de um perfil Credly que
ele mesmo controla. Isso quebra a invariante de que mérito pertence a quem fez o trabalho.

Ela é user-facing (`profile.astro` chama do browser **com o JWT do usuário**), então um gate de
service-role puro quebraria a tela. Dois caminhos, espelhando `pmi-ai-triage`:

| caminho | tratamento |
|---|---|
| service-role | confiado, pode passar qualquer `member_id` |
| JWT de usuário | `getUser()` valida a assinatura → membro resolvido por `auth_id` → **só o próprio `member_id`** |

Divergência de id é **rejeitada com 403**, não sobrescrita em silêncio: a UI já manda o próprio id,
então divergência ali é abuso, não uso legítimo.

## Dois smokes de produção corrigidos — eles afirmavam o buraco

```js
// antes
// JWT-verified: anon key should work for read-only
assert.ok([200, 405].includes(status))
```

Isso era **literalmente a premissa que a fase 2 derrubou**. Ambos agora esperam 401.

⚠️ Deixei uma nota de manutenção no arquivo: `ef-smoke` bate em **produção**, então o resultado
depende do que está **deployado**, não do que está na branch. O gate do `get-comms-metrics` passou
verde no CI do PR que o introduziu — porque o deploy ainda não tinha acontecido — e só ficou vermelho
depois. Classe #1487 B.

**Achado adjacente (não corrigido aqui, é decisão do PM):** o step `Run Unit Tests` do CI exporta
`SUPABASE_URL` e `SUPABASE_SERVICE_ROLE_KEY`, mas **não** `SUPABASE_ANON_KEY` — embora o secret
exista. Logo esses smokes **pulam no CI**. São os únicos testes que verificam auth de EF *deployada*,
exatamente a lacuna que declarei como limite nos PRs anteriores. Ligá-los tem um custo: o CI ficaria
vermelho entre merge e deploy em toda mudança de auth de EF.

## Mutation-test — 5 mutações, 5 vermelhas

| mutação | resultado |
|---|---|
| remove o `await` do gate do digest | 🔴 |
| gate depois da RPC de geração | 🔴 |
| remove a checagem de posse do `member_id` | 🔴 |
| aceita sem validar o JWT (`getUser()` fake) | 🔴 |
| remove o gate inteiro do `verify-credly` | 🔴 |

## Verificação

- `npx astro build` ✅
- `npm test`: **6158 testes**, 1 falha esperada e transitória — o smoke de `verify-credly` espera 401
  e a EF ainda não foi deployada. Fecha no deploy pós-merge, e vou reconferir localmente.
- Pós-merge: deploy das 2 + probe sem credencial e com a anon key, esperando **401** em ambas.

Refs #1513