### PR TITLE
fix(gamification): #1537 fase 2a — as três tabelas que faltavam no vocabulário do ref_kind

### DIFF
--- a/supabase/migrations/20260805000496_1537_ref_kind_vocabulary_three_missing_tables.sql
+++ b/supabase/migrations/20260805000496_1537_ref_kind_vocabulary_three_missing_tables.sql
@@ -1,0 +1,108 @@
+-- #1537 fase 2a — as três tabelas que faltavam no vocabulário do discriminador `ref_kind`.
+--
+-- A fase 1 (migration ...495) listou NOVE tabelas no trigger derivador e classificou 2722 de 2898
+-- linhas, deixando 176 com `ref_kind IS NULL`. A leitura de então foi que as 176 eram dívida de DADO
+-- (referência órfã, mesma família do #1534). Uma varredura de TODO o schema público — toda tabela com
+-- coluna `id` do tipo uuid, não um subconjunto adivinhado — mostrou que a maioria não é dívida de dado
+-- nenhuma: são referências perfeitamente resolvíveis para tabelas que simplesmente não estavam na
+-- lista. Medido em 30/07/2026, em produção:
+--
+--   approval_signoffs   98 linhas (curation_ratification)      — resolve 98/98
+--   document_comments   29 linhas (curation_comment_resolved)  — resolve 29/29
+--   initiatives          7 linhas (showcase_talk)              — resolve  7/7, em 2 iniciativas
+--   ── não resolve em NENHUMA tabela do schema ─────────────────────────────────────────────────────
+--   attendance          40 linhas — as órfãs do #1534
+--   curation_doc_authored 2 linhas — órfãs equivalentes, que o #1534 não cobre (document_versions
+--                                    apagadas). Registradas no #1534 para não se perderem.
+--
+-- Confirmado pelo CÓDIGO, não por inferência sobre o dado: `trg_approval_signoff_xp` chama
+-- `_grant_auto_xp('curation_ratification', NEW.signer_id, NEW.id, ...)` a partir de um trigger em
+-- `approval_signoffs`; `trg_doc_comment_resolved_xp` faz o mesmo a partir de `document_comments`; e os
+-- dois `ref_id` de `showcase_talk` são iniciativas reais (`kind = 'congress'`) cujos títulos batem com
+-- o `reason` da linha de ponto.
+--
+-- ⚠️ POR QUE ISSO É URGENTE, e não cosmético: o guard da fase 1 fixou o ratchet das não-classificadas
+-- em 176. Como `approval_signoffs` e `document_comments` seguem em uso, CADA ratificação assinada e
+-- CADA comentário resolvido nasce com `ref_kind` NULL (e com RAISE WARNING). O ratchet seria então
+-- rompido pela OPERAÇÃO NORMAL da plataforma, não por regressão — um guard que acusa o inocente. Esta
+-- migration fecha essa porta antes que isso aconteça.
+--
+-- A semântica da fase 1 permanece intacta e é o que torna a medição possível:
+--   'none'   = a categoria não referencia nada por natureza (ref_id IS NULL)
+--   <tabela> = referência resolvida
+--   NULL     = NÃO CLASSIFICADO (é a dívida, e continua mensurável — agora 42, não 176)
+
+ALTER TABLE public.gamification_points DROP CONSTRAINT IF EXISTS gamification_points_ref_kind_check;
+ALTER TABLE public.gamification_points ADD CONSTRAINT gamification_points_ref_kind_check
+  CHECK (ref_kind IS NULL OR ref_kind IN (
+    'none','attendance','event','document_version','board_item','event_showcase',
+    'meeting_artifact','meeting_action_item','event_agenda_block','champion_award',
+    'approval_signoff','document_comment','initiative'));
+
+-- Os três ramos novos entram no FIM da cascata, de propósito: assim nenhuma linha já classificada pela
+-- fase 1 pode mudar de valor por efeito colateral desta migration. A ordem só importaria se dois ids
+-- colidissem entre tabelas, o que uuid v4 não produz.
+CREATE OR REPLACE FUNCTION public.derive_gamification_ref_kind()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  -- Só (re)deriva quando falta valor ou quando o alvo mudou; um UPDATE de pontos não paga o custo.
+  IF TG_OP = 'UPDATE' AND NEW.ref_id IS NOT DISTINCT FROM OLD.ref_id AND NEW.ref_kind IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'INSERT' AND NEW.ref_kind IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF NEW.ref_id IS NULL THEN
+    NEW.ref_kind := 'none';
+  ELSIF EXISTS (SELECT 1 FROM public.attendance t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'attendance';
+  ELSIF EXISTS (SELECT 1 FROM public.events t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'event';
+  ELSIF EXISTS (SELECT 1 FROM public.document_versions t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'document_version';
+  ELSIF EXISTS (SELECT 1 FROM public.board_items t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'board_item';
+  ELSIF EXISTS (SELECT 1 FROM public.event_showcases t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'event_showcase';
+  ELSIF EXISTS (SELECT 1 FROM public.meeting_artifacts t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'meeting_artifact';
+  ELSIF EXISTS (SELECT 1 FROM public.meeting_action_items t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'meeting_action_item';
+  ELSIF EXISTS (SELECT 1 FROM public.event_agenda_blocks t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'event_agenda_block';
+  ELSIF EXISTS (SELECT 1 FROM public.champions_awarded t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'champion_award';
+  ELSIF EXISTS (SELECT 1 FROM public.approval_signoffs t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'approval_signoff';
+  ELSIF EXISTS (SELECT 1 FROM public.document_comments t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'document_comment';
+  ELSIF EXISTS (SELECT 1 FROM public.initiatives t WHERE t.id = NEW.ref_id) THEN
+    NEW.ref_kind := 'initiative';
+  ELSE
+    -- Não resolveu: um ponto novo nascendo órfão é exatamente a classe do #1534. NÃO levanta exceção
+    -- (isso derrubaria concessão de ponto em produção por um alvo que pode ser criado logo depois), mas
+    -- deixa NULL e avisa, para o guard de CI detectar em vez de o problema envelhecer em silêncio.
+    NEW.ref_kind := NULL;
+    RAISE WARNING 'gamification_points: ref_id % nao resolve em nenhuma tabela conhecida (category=%)',
+      NEW.ref_id, NEW.category;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+REVOKE ALL ON FUNCTION public.derive_gamification_ref_kind() FROM PUBLIC;
+
+-- Backfill restrito ao que a fase 1 deixou NULL. Nenhuma linha já classificada é tocada.
+UPDATE public.gamification_points gp SET ref_kind =
+  CASE
+    WHEN EXISTS (SELECT 1 FROM public.approval_signoffs t WHERE t.id = gp.ref_id) THEN 'approval_signoff'
+    WHEN EXISTS (SELECT 1 FROM public.document_comments t WHERE t.id = gp.ref_id) THEN 'document_comment'
+    WHEN EXISTS (SELECT 1 FROM public.initiatives t WHERE t.id = gp.ref_id) THEN 'initiative'
+    ELSE NULL
+  END
+WHERE gp.ref_kind IS NULL AND gp.ref_id IS NOT NULL;

--- a/tests/contracts/1537-gamification-ref-kind-discriminator.test.mjs
+++ b/tests/contracts/1537-gamification-ref-kind-discriminator.test.mjs
@@ -3,17 +3,24 @@ import assert from 'node:assert/strict';
 import { createClient } from '@supabase/supabase-js';
 
 /**
- * #1537 item 3, fase 1 — `gamification_points.ref_id` é POLIMÓRFICO: aponta para 9 tabelas diferentes
- * (attendance, events, document_versions, board_items, event_showcases, meeting_artifacts,
- * meeting_action_items, event_agenda_blocks, champions_awarded) sem nenhuma coluna dizendo qual.
+ * #1537 item 3 — `gamification_points.ref_id` é POLIMÓRFICO: aponta para DOZE tabelas diferentes sem
+ * nenhuma coluna dizendo qual (ver VOCABULARIO abaixo, que é a lista viva).
  *
  * Isso já custou caro duas vezes: no #1528 uma auditoria que juntava por um lado só devolveu ZERO e quase
  * virou "a issue está errada"; e no #1534 quarenta linhas órfãs sobreviveram meses porque a coluna
  * polimórfica impede FK.
  *
- * A fase 1 fecha a porta para linhas NOVAS (trigger que deriva) e classifica o histórico resolvível. As
+ * A fase 1 fechou a porta para linhas NOVAS (trigger que deriva) e classificou o histórico resolvível. As
  * não-resolvidas ficam com ref_kind NULL DE PROPÓSITO — é a dívida da fase 2, e este guard existe para que
  * ela só possa DIMINUIR.
+ *
+ * A fase 2a corrigiu o próprio vocabulário: a fase 1 listou NOVE tabelas e leu as 176 sobras como dívida de
+ * DADO, mas 134 delas resolviam em três tabelas que faltavam na lista (approval_signoffs, document_comments,
+ * initiatives). Duas lições viraram guard aqui:
+ *   1. lista incompleta faz referência boa parecer órfã — por isso o teste `nenhuma não-classificada resolve`
+ *      abaixo varre TODAS as tabelas do vocabulário antes de aceitar uma linha como dívida real;
+ *   2. um ratchet apoiado nesse engano quebra pela OPERAÇÃO NORMAL: como as três tabelas seguem em uso, cada
+ *      ratificação assinada nascia NULL e teria estourado o teto de 176 sem nenhuma regressão real.
  *
  * Semântica que os testes protegem: 'none' = categoria sem referência por natureza · <tabela> = resolvida ·
  * NULL = não classificado. Se NULL voltar a significar as duas coisas, o vício original está de volta.
@@ -23,9 +30,26 @@ const URL = process.env.SUPABASE_URL;
 const KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const sb = URL && KEY ? createClient(URL, KEY, { auth: { persistSession: false } }) : null;
 
-// Teto histórico medido em 2026-07-30, logo após o backfill. Só pode CAIR: cada linha resolvida na fase 2
-// abaixa este número. Se subir, uma linha nova nasceu órfã e o trigger avisou por RAISE WARNING.
-const UNCLASSIFIED_BASELINE = 176;
+/** ref_kind → tabela que ele discrimina. Espelha o CHECK e a cascata do trigger derivador. */
+const VOCABULARIO = {
+  attendance: 'attendance',
+  event: 'events',
+  document_version: 'document_versions',
+  board_item: 'board_items',
+  event_showcase: 'event_showcases',
+  meeting_artifact: 'meeting_artifacts',
+  meeting_action_item: 'meeting_action_items',
+  event_agenda_block: 'event_agenda_blocks',
+  champion_award: 'champions_awarded',
+  approval_signoff: 'approval_signoffs',
+  document_comment: 'document_comments',
+  initiative: 'initiatives',
+};
+
+// Teto medido em 2026-07-30 DEPOIS da fase 2a (era 176 na fase 1; 134 daquelas eram vocabulário faltando,
+// não dívida). Só pode CAIR: cada linha resolvida abaixa este número. Se subir, uma linha nova nasceu
+// apontando para alvo inexistente — ou uma tabela nova entrou como alvo sem entrar no vocabulário.
+const UNCLASSIFIED_BASELINE = 42;
 
 test('#1537 a coluna ref_kind existe e o backfill classificou o histórico resolvível', { skip: !sb }, async () => {
   const { data, error } = await sb.from('gamification_points').select('ref_kind');
@@ -35,17 +59,46 @@ test('#1537 a coluna ref_kind existe e o backfill classificou o histórico resol
   const kinds = new Set(data.map((r) => r.ref_kind));
   assert.ok(kinds.has('attendance'), "backfill deve ter classificado linhas como 'attendance'");
   assert.ok(kinds.has('none'), "backfill deve ter marcado 'none' nas categorias sem referência");
+  // Fase 2a: sem isto, reverter a migration do vocabulário devolveria as 98 ratificações ao balde NULL e
+  // o único sintoma seria o ratchet — que ninguém lê enquanto estiver "verde por estar abaixo do teto".
+  assert.ok(kinds.has('approval_signoff'), "fase 2a: ratificações devem estar em 'approval_signoff'");
 });
 
 test('#1537 nenhum valor fora do vocabulário do CHECK', { skip: !sb }, async () => {
-  const PERMITIDOS = new Set([
-    'none', 'attendance', 'event', 'document_version', 'board_item', 'event_showcase',
-    'meeting_artifact', 'meeting_action_item', 'event_agenda_block', 'champion_award',
-  ]);
+  const PERMITIDOS = new Set(['none', ...Object.keys(VOCABULARIO)]);
   const { data, error } = await sb.from('gamification_points').select('ref_kind');
   assert.equal(error, null, `leitura falhou: ${error?.message}`);
   const invalidos = [...new Set(data.map((r) => r.ref_kind))].filter((k) => k !== null && !PERMITIDOS.has(k));
   assert.deepEqual(invalidos, [], `ref_kind fora do vocabulário: ${invalidos.join(', ')}`);
+});
+
+test('#1537 nenhuma não-classificada resolve em tabela do vocabulário', { skip: !sb }, async () => {
+  // ESTE é o guard que a fase 1 não tinha, e a razão de 134 referências boas terem passado por órfãs. Uma
+  // linha só pode ser chamada de dívida depois de NÃO ser encontrada em NENHUMA das tabelas do vocabulário.
+  // Se alguma for encontrada, o defeito está no trigger/backfill (lista incompleta ou ordem), não no dado.
+  const { data, error } = await sb
+    .from('gamification_points')
+    .select('id, category, ref_id')
+    .is('ref_kind', null)
+    .not('ref_id', 'is', null);
+  assert.equal(error, null, `leitura falhou: ${error?.message}`);
+
+  const refs = [...new Set(data.map((r) => r.ref_id))];
+  if (refs.length === 0) return; // dívida zerada: nada a verificar, e o ratchet abaixo cobre o resto
+
+  const resolviveis = [];
+  for (const [kind, tabela] of Object.entries(VOCABULARIO)) {
+    const { data: achados, error: errTab } = await sb.from(tabela).select('id').in('id', refs);
+    assert.equal(errTab, null, `leitura de ${tabela} falhou: ${errTab?.message}`);
+    for (const linha of achados ?? []) resolviveis.push(`${linha.id} existe em ${tabela} (=> ${kind})`);
+  }
+
+  assert.deepEqual(
+    resolviveis,
+    [],
+    'linha marcada como não-classificada tem alvo EXISTENTE — o trigger deixou de classificá-la:\n' +
+      resolviveis.join('\n'),
+  );
 });
 
 test('#1537 a dívida de não-classificadas não cresce (ratchet)', { skip: !sb }, async () => {


### PR DESCRIPTION
## O que é

Fase 2a do `ref_kind` (#1537 item 3). A fase 1 (mergeada em #1539) listou **nove** tabelas no trigger
derivador e classificou 2722 de 2898 linhas, deixando 176 com `ref_kind IS NULL`. A leitura de então foi
que as 176 eram dívida de **dado** — referência órfã, mesma família do #1534.

Uma varredura de **todo** o schema público (toda tabela com coluna `id` do tipo uuid, via `query_to_xml`,
não um subconjunto adivinhado) mostrou que a maior parte não é dívida de dado nenhuma.

## Medição em produção (30/07/2026)

| alvo real do `ref_id` | categoria | linhas | refs distintos | membros | pontos |
|---|---|---:|---:|---:|---:|
| `approval_signoffs` | `curation_ratification` | 98 | 98 | 17 | 2450 |
| `document_comments` | `curation_comment_resolved` | 29 | 29 | 3 | 145 |
| `initiatives` | `showcase_talk` | 7 | 2 | 6 | 175 |
| **não resolve em nenhuma tabela** | `attendance` | **40** | 32 | 26 | 400 |
| **não resolve em nenhuma tabela** | `curation_doc_authored` | **2** | 2 | 1 | 40 |

**134 das 176 resolvem perfeitamente**, em três tabelas que faltavam no vocabulário.

Confirmado pelo **código**, não por inferência sobre o dado:

- `trg_approval_signoff_xp` (trigger em `approval_signoffs`) chama
  `_grant_auto_xp('curation_ratification', NEW.signer_id, NEW.id, ...)`
- `trg_doc_comment_resolved_xp` (trigger em `document_comments`) faz o mesmo com `NEW.id`
- os dois `ref_id` de `showcase_talk` são iniciativas reais (`kind='congress'`): "IA & Competências 2026 —
  Mesa Redonda Universidade de Vassouras" e "Webinar — Do hype ao padrão: o novo standard ANSI/PMI de IA",
  títulos que batem com o `reason` das linhas de ponto.

## Por que era urgente, e não cosmético

O guard da fase 1 fixou o ratchet das não-classificadas em **176**. Como `approval_signoffs` e
`document_comments` seguem em uso, **cada** ratificação assinada e **cada** comentário resolvido nascia com
`ref_kind` NULL. O ratchet seria rompido pela **operação normal da plataforma**, não por regressão — um
guard que acusa o inocente, que é pior do que guard nenhum, porque ensina a relaxar o baseline.

## Antes → depois (produção, medido)

| `ref_kind` | antes | depois |
|---|---:|---:|
| não classificadas (NULL) | 176 | **42** |
| `approval_signoff` | 0 | 98 |
| `document_comment` | 0 | 29 |
| `initiative` | 0 | 7 |
| todos os demais | — | **inalterados** |

Os três ramos novos entram no **fim** da cascata de propósito: nenhuma linha já classificada pela fase 1
pode mudar de valor por efeito colateral.

## O que este PR NÃO faz

Não toca nas 42 órfãs reais. Elas podem ser mérito legítimo cujo alvo foi apagado depois, e mérito de
trabalho concluído é imutável — o oposto do #1528, onde o ponto era comprovadamente segunda contagem.
Registrado no #1534 que **2** delas (`curation_doc_authored`, 23/05 e 11/06, 40 pts, 1 membro) são
`document_versions` apagadas e não estavam no escopo original daquela issue, que fala só de presença.

## Guard novo

`#1537 nenhuma não-classificada resolve em tabela do vocabulário` varre as 12 tabelas antes de aceitar uma
linha como dívida. É exatamente o teste que faltava: com ele, o engano da fase 1 teria ficado vermelho no
mesmo dia em vez de virar baseline. O ratchet cai de 176 para 42, e a asserção de que
`approval_signoff` existe impede que reverter a migration passe despercebido.

## Verificação

- `npm test` com `.env` exportado (`set -a; . ./.env; set +a`): **fail 0, skipped 1**, 6209 testes,
  389 suites. O par (fail, skipped) é o que prova que a suíte DB-aware rodou — a baseline offline pula
  ~548 calada (#1533).
- `npx astro build`: passa.
- `npm run db:types`: sem drift (um CHECK de texto não altera os tipos gerados).
- Migration aplicada em produção e registrada via `supabase migration repair`; a phantom row do
  `apply_migration` via MCP (`20260730232111`) foi apagada por versão exata, com o `rpc-migration-coverage`
  confirmando antes e depois.

Refs #1537
Refs #1534
