### PR TITLE
fix(gamification): #1537 fase 2b — 'orphan' é o veredito humano, e o ratchet vira zero

### DIFF
--- a/supabase/migrations/20260805000497_1537_ref_kind_orphan_verdict_phase2b.sql
+++ b/supabase/migrations/20260805000497_1537_ref_kind_orphan_verdict_phase2b.sql
@@ -1,0 +1,67 @@
+-- #1537 fase 2b — 'orphan': o veredito humano sobre as 42 que não resolvem em lugar nenhum.
+--
+-- Decisão do PM em 30/07/2026, depois da investigação da fase 2a: **manter as 42 e documentar**. Elas podem
+-- ser mérito legítimo cujo alvo foi apagado no refactor Domain Model V4 (concluído 13/04/2026), e mérito de
+-- trabalho concluído é imutável. Apagar sob incerteza tira de quem fez; manter sob incerteza deixa 440 pts a
+-- mais numa base da ordem de 8,6 mil. O erro barato é manter.
+--
+-- O PROBLEMA QUE ESSA DECISÃO CRIA, e a razão desta migration existir:
+--
+-- Enquanto as 42 seguirem com `ref_kind IS NULL`, o balde NULL passa a guardar DUAS coisas outra vez:
+--   (a) "investigada, alvo confirmadamente inexistente, mérito preservado por decisão"  <- as 42
+--   (b) "não classificada, ninguém olhou ainda"                                          <- órfã nova
+-- Que é exatamente o vício do `ref_id` polimórfico se reinstalando um nível acima — e o arco inteiro do
+-- #1537 existe para matar esse vício, não para movê-lo de lugar. Pior: com o ratchet em 42, uma órfã NOVA
+-- se esconde atrás do teto até que o total passe de 42, e ninguém acende.
+--
+-- Com 'orphan' separado:
+--   NULL     volta a significar UMA coisa (não classificada) e o ratchet vira ZERO ESTRITO
+--   'orphan' significa revisada + alvo inexistente + mérito mantido
+-- Uma órfã nova nasce NULL e acende o guard NO MESMO DIA, em vez de envelhecer em silêncio.
+--
+-- ⚠️ O trigger derivador NÃO atribui 'orphan' sozinho, de propósito: 'orphan' é veredito humano, não
+-- resultado de lookup falho. Se o trigger pudesse concedê-lo, "revisada" viraria sinônimo de "não achei", e
+-- a distinção que esta migration compra se perderia na primeira linha nova.
+--
+-- ⚠️ As 42 são marcadas pelos IDs EXATOS, nunca por predicado (`ref_kind IS NULL AND ref_id IS NOT NULL`).
+-- Um predicado absorveria em silêncio qualquer órfã que chegue entre a medição e o apply — exatamente a
+-- linha que o guard deveria acender. Contagem medida em produção em 30/07/2026: 42 linhas, 440 pontos,
+-- 26 membros distintos (40 de `attendance` = #1534, mais 2 de `curation_doc_authored`).
+
+ALTER TABLE public.gamification_points DROP CONSTRAINT IF EXISTS gamification_points_ref_kind_check;
+ALTER TABLE public.gamification_points ADD CONSTRAINT gamification_points_ref_kind_check
+  CHECK (ref_kind IS NULL OR ref_kind IN (
+    'none','attendance','event','document_version','board_item','event_showcase',
+    'meeting_artifact','meeting_action_item','event_agenda_block','champion_award',
+    'approval_signoff','document_comment','initiative','orphan'));
+
+COMMENT ON COLUMN public.gamification_points.ref_kind IS
+  'Discriminador do ref_id polimórfico (#1537). ''none'' = categoria sem referência por natureza; '
+  'nome da tabela = referência resolvida; ''orphan'' = revisada por humano, alvo inexistente, mérito '
+  'preservado por decisão (#1534); NULL = NÃO CLASSIFICADO, e o guard exige que seja zero. '
+  'Preenchido pelo trigger trg_gamification_points_ref_kind, que NUNCA atribui ''orphan'' sozinho.';
+
+UPDATE public.gamification_points SET ref_kind = 'orphan'
+WHERE id IN (
+  '01742962-2281-4bed-8272-79e5891a61a0','06a06155-f269-4070-bbde-10cd8246690c',
+  '0cd30b6d-550e-4bd4-8fc8-811f586e789d','0f3b0705-a291-4f72-ad5f-87beeb680a6e',
+  '0f5639ce-b431-42eb-b233-32c88f2b1777','14f1d061-16ad-4567-9964-bc955b6f6d56',
+  '1e21495c-4230-4627-b6dc-c7edf2fea48e','2d771c1c-d545-44d4-bafa-3312ad0ea775',
+  '322e806b-ca1e-4128-820e-d9dcc8e7701b','3290fb4a-f73c-4c80-9b6c-e07aebb9d8f0',
+  '3849bc64-6268-4665-8e3a-c30c7e362914','3866d269-7f05-49b2-a49a-e720897e5858',
+  '3cae18f8-d80d-4dcf-beef-97e9e6c34ac8','3fa8481a-c756-4544-a0f9-92bae545f3ac',
+  '4ae1d08c-cc93-49dc-a3d2-18798338e33f','4d18dd5d-2ad7-46b7-9c95-3ce3fb4c7f53',
+  '56315425-2f8c-4d4d-9677-5e28f9cfaa2c','570fc011-a58a-4622-be2f-9eca3cdb5664',
+  '5bdeafac-cef4-420e-a1f1-666761c00adf','7569ecd7-4178-4492-95d8-6d3fb5bdefdb',
+  '75de9c5a-4943-41be-a32c-b88acff223fb','7add6d23-78b8-427d-b97e-5bff4493a227',
+  '7b054876-6eac-4103-aa40-f3a579a25bd4','81643625-4872-429a-9195-575af6a85bc7',
+  '8805dedb-5872-426b-8a04-3eeacd50e5d4','8c86d5c4-a207-42ce-9377-6b019c8240ed',
+  '92cf8e3a-426e-4202-8fe4-64f5f7e0fa01','9910d3d6-cec1-4bc4-9339-2d146ce3b90a',
+  'afabae34-f689-4863-9799-d231517cb316','b1ebc12e-a706-456b-ae88-353af160a532',
+  'bb5820f8-c51a-4f4a-b787-12e1cb8341f5','bc982bae-a184-42ed-b214-c03951dde209',
+  'c9d2316f-26b4-438e-b76f-0eb8015bf4c7','ca0a1209-7afd-4873-adf0-ff24a3a2d869',
+  'ca3e36b0-7a9a-4bef-ac4a-22d3768f82e7','dde0dfe2-0ccd-44f9-9442-cf6995e4f538',
+  'e25b845d-4c37-4b3e-a72d-d96a6f9e67f3','e6db1fed-9115-479b-9ca8-c54c337612be',
+  'e7b765f8-6586-4c30-a427-45895d4bd7eb','f0c26acb-8cc1-4ca8-aa5e-cc6f72e06337',
+  'f3882965-b50e-4084-aa68-6d6b37a34767','f4461b25-88d7-421e-93a5-cc0d869c6f66'
+) AND ref_kind IS NULL;

--- a/tests/contracts/1537-gamification-ref-kind-discriminator.test.mjs
+++ b/tests/contracts/1537-gamification-ref-kind-discriminator.test.mjs
@@ -46,10 +46,22 @@ const VOCABULARIO = {
   initiative: 'initiatives',
 };
 
-// Teto medido em 2026-07-30 DEPOIS da fase 2a (era 176 na fase 1; 134 daquelas eram vocabulário faltando,
-// não dívida). Só pode CAIR: cada linha resolvida abaixa este número. Se subir, uma linha nova nasceu
-// apontando para alvo inexistente — ou uma tabela nova entrou como alvo sem entrar no vocabulário.
-const UNCLASSIFIED_BASELINE = 42;
+/**
+ * ZERO ESTRITO desde a fase 2b. A escada foi 176 (fase 1) → 42 (fase 2a, quando 134 se revelaram vocabulário
+ * faltando e não dívida) → 0 (fase 2b, quando as 42 órfãs REAIS ganharam `ref_kind = 'orphan'`).
+ *
+ * O ratchet só volta a admitir número maior que zero se alguém decidir que órfã nova é aceitável — e essa é
+ * a decisão que este teto existe para forçar a acontecer explicitamente, em vez de a linha se esconder atrás
+ * de um teto herdado.
+ */
+const UNCLASSIFIED_BASELINE = 0;
+
+/**
+ * As 42 revisadas em 2026-07-30 (#1534): alvo confirmadamente inexistente em TODO o schema, mérito
+ * preservado por decisão do PM. Contagem congelada de propósito — se aparecer uma 43ª com 'orphan', alguém
+ * concedeu o veredito humano sem revisão, que é o único jeito de este balde crescer.
+ */
+const ORPHAN_REVIEWED = 42;
 
 test('#1537 a coluna ref_kind existe e o backfill classificou o histórico resolvível', { skip: !sb }, async () => {
   const { data, error } = await sb.from('gamification_points').select('ref_kind');
@@ -65,11 +77,46 @@ test('#1537 a coluna ref_kind existe e o backfill classificou o histórico resol
 });
 
 test('#1537 nenhum valor fora do vocabulário do CHECK', { skip: !sb }, async () => {
-  const PERMITIDOS = new Set(['none', ...Object.keys(VOCABULARIO)]);
+  // 'none' e 'orphan' não estão em VOCABULARIO porque não discriminam tabela nenhuma: 'none' é ausência de
+  // referência por natureza, 'orphan' é veredito humano sobre alvo inexistente.
+  const PERMITIDOS = new Set(['none', 'orphan', ...Object.keys(VOCABULARIO)]);
   const { data, error } = await sb.from('gamification_points').select('ref_kind');
   assert.equal(error, null, `leitura falhou: ${error?.message}`);
   const invalidos = [...new Set(data.map((r) => r.ref_kind))].filter((k) => k !== null && !PERMITIDOS.has(k));
   assert.deepEqual(invalidos, [], `ref_kind fora do vocabulário: ${invalidos.join(', ')}`);
+});
+
+test("#1537 as 'orphan' continuam sem alvo, e são exatamente as revisadas", { skip: !sb }, async () => {
+  // 'orphan' é um veredito sobre o mundo ("este alvo não existe"), e veredito sobre o mundo tem de ser
+  // reconferido, não arquivado. Se uma document_version apagada for restaurada, a linha deixa de ser órfã e
+  // precisa voltar a ser classificada — este teste é quem avisa.
+  const { data, error } = await sb
+    .from('gamification_points')
+    .select('id, category, ref_id')
+    .eq('ref_kind', 'orphan');
+  assert.equal(error, null, `leitura falhou: ${error?.message}`);
+
+  assert.equal(
+    data.length,
+    ORPHAN_REVIEWED,
+    `'orphan' tem ${data.length} linhas, revisadas foram ${ORPHAN_REVIEWED}. Crescer aqui significa que ` +
+      "alguém concedeu o veredito humano sem revisão — 'orphan' nunca é atribuído pelo trigger.",
+  );
+
+  const refs = [...new Set(data.map((r) => r.ref_id).filter(Boolean))];
+  const ressuscitados = [];
+  for (const [kind, tabela] of Object.entries(VOCABULARIO)) {
+    const { data: achados, error: errTab } = await sb.from(tabela).select('id').in('id', refs);
+    assert.equal(errTab, null, `leitura de ${tabela} falhou: ${errTab?.message}`);
+    for (const linha of achados ?? []) ressuscitados.push(`${linha.id} voltou a existir em ${tabela} (=> ${kind})`);
+  }
+
+  assert.deepEqual(
+    ressuscitados,
+    [],
+    "linha marcada 'orphan' tem alvo que EXISTE agora — o veredito caducou, reclassificar:\n" +
+      ressuscitados.join('\n'),
+  );
 });
 
 test('#1537 nenhuma não-classificada resolve em tabela do vocabulário', { skip: !sb }, async () => {
@@ -117,17 +164,14 @@ test('#1537 a dívida de não-classificadas não cresce (ratchet)', { skip: !sb 
     'linha com ref_id NULL deveria ter ref_kind = none, não NULL — o trigger não classificou',
   );
 
-  assert.ok(
-    data.length <= UNCLASSIFIED_BASELINE,
-    `não-classificadas subiram de ${UNCLASSIFIED_BASELINE} para ${data.length}: uma linha nova nasceu ` +
-      'apontando para um alvo inexistente (classe do #1534). Investigar antes de mexer no baseline.',
+  assert.deepEqual(
+    data.map((r) => `${r.id} (${r.category}, ref_id=${r.ref_id})`),
+    [],
+    `não-classificadas deveriam ser ${UNCLASSIFIED_BASELINE} e são ${data.length}: uma linha nova nasceu ` +
+      'apontando para alvo inexistente (classe do #1534). Duas saídas, nenhuma é mexer no teto: (a) o alvo ' +
+      'existe e falta vocabulário — corrigir o trigger; (b) o alvo não existe — revisar e, se o mérito for ' +
+      "para manter, marcar 'orphan' pelo id exato numa migration, como a fase 2b fez com as 42.",
   );
-
-  if (data.length < UNCLASSIFIED_BASELINE) {
-    console.warn(
-      `[#1537] dívida caiu para ${data.length} (baseline ${UNCLASSIFIED_BASELINE}) — abaixe a constante.`,
-    );
-  }
 });
 
 test('#1537 o trigger deriva ref_kind sem que o chamador precise passar', { skip: !sb }, async () => {


### PR DESCRIPTION
## O que é

Fase 2b do `ref_kind`, e o registro executável da decisão do PM sobre as 42 órfãs do #1534:
**manter e documentar**.

## A decisão, e por quê

A investigação da fase 2a (PR #1541) fechou o balde "reconectável": **nenhum dos 42 alvos existe em nenhuma
tabela do schema**. E a reconciliação por `reason` + data que o #1534 sugeria não fecha — o `reason` das 9
linhas de 06/03 descreve "Reunião Geral — Núcleo IA & GP", e o único evento vivo em 05/03–07/03 é o kickoff
de **05/03**, com título e data diferentes. Forçar o vínculo inventaria presença.

Restou escolher entre "o encontro existiu, o registro sumiu" e "sem lastro nenhum", e a evidência não
distingue os dois. Sob essa incerteza, apagar tira mérito de quem possivelmente compareceu (invariante do
projeto), e manter deixa 440 pts numa base da ordem de 8,6 mil. O erro barato é manter. É o oposto do
#1528, onde o ponto era **comprovadamente** segunda contagem e apagar não tirava mérito de ninguém.

## O problema que a decisão cria, e que esta migration existe para fechar

Enquanto as 42 seguirem `ref_kind IS NULL`, o balde volta a guardar **duas** coisas:

- "investigada, alvo confirmadamente inexistente, mérito preservado por decisão" — as 42
- "não classificada, ninguém olhou ainda" — uma órfã nova

Que é o vício do `ref_id` polimórfico se reinstalando um nível acima. O arco do #1537 existe para matar esse
vício, não para mudá-lo de lugar. Pior: com o ratchet em 42, uma órfã **nova** se esconde atrás do teto até
o total passar de 42.

## Antes → depois (produção, medido)

| `ref_kind` | antes | depois |
|---|---:|---:|
| não classificadas (`NULL`) | 42 | **0** (o valor sumiu do agrupamento) |
| `orphan` | 0 | **42** (440 pts, 26 membros distintos) |
| todos os demais | — | **inalterados** |

Total segue **2898**. A escada completa do arco: 176 (fase 1) → 42 (fase 2a) → **0**.

## Duas escolhas de desenho, que são o conteúdo da migration

1. **O trigger nunca atribui `'orphan'` sozinho.** Se pudesse, "revisada" viraria sinônimo de "não achei" e
   a distinção se perderia na primeira linha nova. `'orphan'` é veredito humano, não resultado de lookup
   falho.
2. **As 42 são marcadas pelos ids exatos, nunca por predicado.** Um predicado
   (`ref_kind IS NULL AND ref_id IS NOT NULL`) absorveria em silêncio qualquer órfã que chegasse entre a
   medição e o apply — justamente a linha que o guard deveria acender.

## Guards

- **Novo:** `as 'orphan' continuam sem alvo, e são exatamente as revisadas`. Veredito sobre o mundo tem de
  ser reconferido, não arquivado: se uma `document_version` apagada for restaurada, a linha deixa de ser
  órfã e precisa voltar a ser classificada.
- **Ratchet endurecido:** deixa de ser `<=` e passa a **listar as linhas ofensoras**, com as duas saídas
  escritas na mensagem (corrigir o vocabulário do trigger, OU revisar e marcar `'orphan'` por id numa
  migration) — porque mexer no teto não é uma delas.

## Mutation-test

| mutação | resultado |
|---|---|
| ratchet lendo as 42 linhas de `'orphan'` | ratchet **falha** — o zero não passa por vacuidade |
| `ORPHAN_REVIEWED = 41` | o teste das órfãs **falha** |

## Verificação

- `npm test` com `.env` exportado (`set -a; . ./.env; set +a`): **fail 0, skipped 1**, 6213 testes,
  389 suites. O par é o que prova que a lane DB-aware rodou (#1533).
- `npx astro build`: passa. `npm run db:types`: sem drift.
- Migration aplicada e registrada via `supabase migration repair`; a phantom row do `apply_migration` via
  MCP (`20260731012425`) apagada por versão exata, com `rpc-migration-coverage` verde depois.

Refs #1537
Closes #1534
