### PR TITLE
fix(types): regenera database.gen.ts apos admin_offboard_member ganhar p_effective_date

### DIFF
--- a/src/lib/database.gen.ts
+++ b/src/lib/database.gen.ts
@@ -28861,6 +28861,7 @@ export type Database = {
       }
       admin_offboard_member: {
         Args: {
+          p_effective_date?: string
           p_member_id: string
           p_new_status: string
           p_reason_category: string


### PR DESCRIPTION
Desbloqueia o `gen-types-drift`, que estava vermelho em **todo** PR, inclusive nos que só tocam documentação.

## Causa

O último run verde da main foi `3d77e815` às 23:08 UTC de 03/08. A DDL que adicionou `p_effective_date` a `admin_offboard_member` entrou no banco **depois** disso, e `src/lib/database.gen.ts` não foi regenerado no mesmo PR. É a classe registrada em `reference-rpc-signature-change-requires-gen-types-in-same-pr`.

## O que muda

Uma linha, idêntica ao diff que o CI reportou:

```
       admin_offboard_member: {
         Args: {
 +          p_effective_date?: string
             p_member_id: string
```

Gerado com o CLI **2.109.0**, o mesmo pin de `.github/workflows/gen-types-drift.yml`, então a saída é byte-idêntica à do CI.

## Ordem de merge

Este PR **antes** do #1583, que está bloqueado por este mesmo vermelho.

Refs #1570 (a correção de `p_effective_date` no offboarding), onde a pendência de regenerar os tipos estava implícita.