### PR TITLE
fix(offboarding): captura local da DDL + regen de types — os 3 sintomas do mesmo apply_migration

### DIFF
--- a/src/lib/database.gen.ts
+++ b/src/lib/database.gen.ts
@@ -28861,6 +28861,7 @@ export type Database = {
       }
       admin_offboard_member: {
         Args: {
+          p_effective_date?: string
           p_member_id: string
           p_new_status: string
           p_reason_category: string

--- a/supabase/migrations/20260803233204_offboard_member_honor_effective_date.sql
+++ b/supabase/migrations/20260803233204_offboard_member_honor_effective_date.sql
@@ -1,0 +1,296 @@
+-- FIX: p_effective_date era aceito por offboard_member() e descartado silenciosamente.
+-- admin_offboard_member() carimbava now()/CURRENT_DATE em todos os pontos de data,
+-- inclusive no TEXTO do certificado alumni (documento entregue ao voluntario).
+-- Esta migration faz a data efetiva ser honrada de ponta a ponta.
+-- Semantica adotada: offboarded_at / end_date / texto do certificado = data EFETIVA (quando valeu);
+-- status_changed_at / updated_at / revoked_at / issued_at = now() (quando foi registrado).
+
+DROP FUNCTION IF EXISTS public.admin_offboard_member(uuid, text, text, text, uuid);
+
+CREATE OR REPLACE FUNCTION public.admin_offboard_member(
+  p_member_id uuid,
+  p_new_status text,
+  p_reason_category text,
+  p_reason_detail text DEFAULT NULL::text,
+  p_reassign_to uuid DEFAULT NULL::uuid,
+  p_effective_date date DEFAULT NULL::date
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller             record;
+  v_member             record;
+  v_audit_id           uuid;
+  v_new_role           text;
+  v_items_reassigned   integer := 0;
+  v_engagements_closed integer := 0;
+  v_vol_terms_skipped  integer := 0;
+  v_prev_status        text;
+  v_reason_record      record;
+  v_reason_code        text;
+  v_certificate_id     uuid;
+  v_certificate_code   text;
+  v_emit_error         text;
+  v_current_cycle_int  integer;
+  v_effective_date     date;
+  v_effective_ts       timestamptz;
+  v_is_backdated       boolean;
+BEGIN
+  SELECT * INTO v_caller FROM public.members WHERE auth_id = auth.uid();
+  IF NOT FOUND THEN RETURN jsonb_build_object('error','Not authenticated'); END IF;
+  IF NOT public.can_by_member(v_caller.id, 'manage_member') THEN
+    RETURN jsonb_build_object('error','Unauthorized: requires manage_member permission');
+  END IF;
+
+  -- data efetiva: nunca futura; NULL = comportamento legado (agora)
+  IF p_effective_date IS NOT NULL AND p_effective_date > CURRENT_DATE THEN
+    RETURN jsonb_build_object('error','Invalid p_effective_date: cannot be in the future');
+  END IF;
+  v_effective_date := COALESCE(p_effective_date, CURRENT_DATE);
+  v_effective_ts   := COALESCE(p_effective_date::timestamptz, now());
+  v_is_backdated   := (p_effective_date IS NOT NULL AND p_effective_date < CURRENT_DATE);
+
+  IF p_new_status NOT IN ('alumni','inactive') THEN
+    RETURN jsonb_build_object('error','Invalid status: ' || p_new_status);
+  END IF;
+
+  SELECT * INTO v_member FROM public.members WHERE id = p_member_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('error','Member not found'); END IF;
+
+  v_prev_status := COALESCE(v_member.member_status,'active');
+
+  IF v_prev_status = p_new_status THEN
+    RETURN jsonb_build_object('error','Member is already ' || p_new_status);
+  END IF;
+
+  BEGIN
+    PERFORM public.validate_status_transition(v_prev_status, p_new_status);
+  EXCEPTION WHEN sqlstate '22023' THEN
+    INSERT INTO public.admin_audit_log (actor_id, action, target_type, target_id, changes, metadata)
+    VALUES (
+      v_caller.id, 'member.status_transition_blocked', 'member', p_member_id,
+      jsonb_build_object('attempted_from', v_prev_status, 'attempted_to', p_new_status),
+      jsonb_build_object('error', SQLERRM, 'arm9_gate', 'validate_status_transition')
+    );
+    RETURN jsonb_build_object('error', SQLERRM, 'arm9_gate', 'validate_status_transition');
+  END;
+
+  v_new_role := CASE p_new_status
+    WHEN 'alumni'   THEN 'alumni'
+    WHEN 'inactive' THEN 'none'
+  END;
+
+  INSERT INTO public.admin_audit_log (actor_id, action, target_type, target_id, changes, metadata)
+  VALUES (
+    v_caller.id, 'member.status_transition', 'member', p_member_id,
+    jsonb_strip_nulls(jsonb_build_object(
+      'previous_status', v_prev_status, 'new_status', p_new_status,
+      'previous_tribe_id', v_member.tribe_id
+    )),
+    jsonb_strip_nulls(jsonb_build_object(
+      'reason_category', p_reason_category, 'reason_detail', p_reason_detail,
+      'items_reassigned_to', p_reassign_to,
+      'effective_date', v_effective_date,
+      'recorded_at', now(),
+      'backdated', v_is_backdated
+    ))
+  )
+  RETURNING id INTO v_audit_id;
+
+  IF v_member.operational_role IS DISTINCT FROM v_new_role THEN
+    INSERT INTO public.admin_audit_log (actor_id, action, target_type, target_id, changes, metadata)
+    VALUES (
+      v_caller.id, 'member.role_change', 'member', p_member_id,
+      jsonb_build_object(
+        'field', 'operational_role',
+        'old_value', to_jsonb(v_member.operational_role),
+        'new_value', to_jsonb(v_new_role),
+        'effective_date', v_effective_date
+      ),
+      jsonb_strip_nulls(jsonb_build_object(
+        'change_type', 'role_changed',
+        'reason', p_reason_detail,
+        'authorized_by', v_caller.id
+      ))
+    );
+  END IF;
+
+  SELECT code INTO v_reason_code FROM public.offboard_reason_categories WHERE code = p_reason_category;
+  v_reason_code := COALESCE(v_reason_code, 'other');
+
+  INSERT INTO public.member_offboarding_records (
+    member_id, offboarded_at, offboarded_by,
+    reason_category_code, reason_detail,
+    tribe_id_at_offboard, chapter_at_offboard, cycle_code_at_offboard
+  ) VALUES (
+    p_member_id, v_effective_ts, v_caller.id,
+    v_reason_code, NULLIF(TRIM(COALESCE(p_reason_detail, '')), ''),
+    v_member.tribe_id, v_member.chapter,
+    (SELECT cycle_code FROM public.cycles WHERE is_current = true ORDER BY cycle_start DESC LIMIT 1)
+  )
+  ON CONFLICT (member_id) DO NOTHING;
+
+  UPDATE public.members SET
+    member_status        = p_new_status,
+    operational_role     = v_new_role,
+    is_active            = false,
+    designations         = '{}'::text[],
+    offboarded_at        = v_effective_ts,
+    offboarded_by        = v_caller.id,
+    status_changed_at    = now(),
+    status_change_reason = COALESCE(p_reason_detail, p_reason_category),
+    updated_at           = now()
+  WHERE id = p_member_id;
+
+  IF v_member.person_id IS NOT NULL THEN
+    UPDATE public.engagements SET
+      status = 'offboarded', end_date = v_effective_date,
+      revoked_at = now(), revoked_by = v_caller.person_id,
+      revoke_reason = COALESCE(p_reason_detail, p_reason_category),
+      updated_at = now()
+    WHERE person_id = v_member.person_id AND status = 'active';
+    GET DIAGNOSTICS v_engagements_closed = ROW_COUNT;
+  END IF;
+
+  IF p_reassign_to IS NOT NULL THEN
+    UPDATE public.board_items SET assignee_id = p_reassign_to
+    WHERE assignee_id = p_member_id AND status != 'archived';
+    GET DIAGNOSTICS v_items_reassigned = ROW_COUNT;
+  END IF;
+
+  UPDATE public.onboarding_progress
+  SET
+    status = 'skipped',
+    completed_at = now(),
+    updated_at = now(),
+    metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object(
+      'completed_via', 'p234_322_offboarding_extension',
+      'reason', 'offboarded_pre_signing',
+      'offboarded_to_status', p_new_status,
+      'offboarded_at', v_effective_ts,
+      'migration', '20260805000019'
+    )
+  WHERE member_id = p_member_id
+    AND step_key = 'volunteer_term'
+    AND status = 'pending';
+  GET DIAGNOSTICS v_vol_terms_skipped = ROW_COUNT;
+
+  IF v_vol_terms_skipped > 0 THEN
+    INSERT INTO public.admin_audit_log (actor_id, action, target_type, target_id, changes)
+    VALUES (
+      v_caller.id,
+      'onboarding.volunteer_term_skipped_on_offboard',
+      'member',
+      p_member_id,
+      jsonb_build_object(
+        'rows_affected', v_vol_terms_skipped,
+        'offboarded_to_status', p_new_status,
+        'reason', 'offboarded_pre_signing',
+        'migration', '20260805000019'
+      )
+    );
+  END IF;
+
+  -- ARM-9 G3: auto-emit alumni_recognition certificate
+  IF p_new_status = 'alumni' AND p_reason_category IS NOT NULL THEN
+    SELECT * INTO v_reason_record FROM public.offboard_reason_categories
+    WHERE code = p_reason_category;
+
+    IF FOUND AND v_reason_record.preserves_return_eligibility = true THEN
+      BEGIN
+        SELECT COALESCE(NULLIF(regexp_replace(cycle_code, '[^0-9]', '', 'g'), '')::int, 3)
+        INTO v_current_cycle_int
+        FROM public.cycles WHERE is_current = true LIMIT 1;
+        v_current_cycle_int := COALESCE(v_current_cycle_int, 3);
+
+        v_certificate_code := 'CERT-' || extract(year FROM v_effective_ts)::text || '-' || upper(substr(md5(random()::text), 1, 6));
+
+        INSERT INTO public.certificates (
+          member_id, type, title, description, cycle, function_role,
+          language, issued_by, verification_code, issued_at, source
+        ) VALUES (
+          p_member_id,
+          'alumni_recognition',
+          'Reconhecimento Alumni — Núcleo IA & GP',
+          'Em reconhecimento à contribuição como voluntário(a) ao programa Núcleo IA & GP. Saída amigável em ' || to_char(v_effective_ts, 'DD/MM/YYYY') || ' (' || v_reason_record.label_pt || '). Elegível para retorno via re-engagement pipeline.',
+          v_current_cycle_int,
+          v_member.operational_role,
+          'pt-BR',
+          v_caller.id,
+          v_certificate_code,
+          now(),
+          'arm9_g3_auto_emit'
+        )
+        RETURNING id INTO v_certificate_id;
+
+        PERFORM public.create_notification(
+          p_member_id,
+          'certificate_issued',
+          'Certificado Alumni emitido',
+          'Você recebeu o certificado Reconhecimento Alumni — válido para perfil profissional e LinkedIn.',
+          '/gamification',
+          'certificate',
+          v_certificate_id
+        );
+      EXCEPTION WHEN OTHERS THEN
+        v_emit_error := SQLERRM;
+        v_certificate_id := NULL;
+        INSERT INTO public.admin_audit_log (actor_id, action, target_type, target_id, changes, metadata)
+        VALUES (
+          v_caller.id, 'arm9.alumni_badge_emit_failed', 'member', p_member_id,
+          jsonb_build_object('reason_category', p_reason_category),
+          jsonb_build_object('error', v_emit_error)
+        );
+      END;
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true,
+    'audit_id', v_audit_id,
+    'transition_id', v_audit_id,
+    'member_name', v_member.name,
+    'previous_status', v_prev_status,
+    'new_status', p_new_status,
+    'new_role', v_new_role,
+    'effective_date', v_effective_date,
+    'recorded_at', now(),
+    'backdated', v_is_backdated,
+    'items_reassigned', v_items_reassigned,
+    'engagements_closed', v_engagements_closed,
+    'vol_terms_skipped', v_vol_terms_skipped,
+    'designations_cleared', COALESCE(array_length(v_member.designations,1),0),
+    'alumni_certificate_id', v_certificate_id,
+    'alumni_certificate_emit_error', v_emit_error
+  );
+END;
+$function$;
+
+GRANT EXECUTE ON FUNCTION public.admin_offboard_member(uuid, text, text, text, uuid, date) TO PUBLIC, anon, authenticated, service_role;
+
+-- wrapper legado: agora REPASSA a data efetiva (antes descartava)
+CREATE OR REPLACE FUNCTION public.offboard_member(
+  p_member_id uuid,
+  p_new_status text,
+  p_reason text,
+  p_effective_date date DEFAULT NULL::date
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  RETURN public.admin_offboard_member(
+    p_member_id       => p_member_id,
+    p_new_status      => p_new_status,
+    p_reason_category => 'other',
+    p_reason_detail   => p_reason,
+    p_reassign_to     => NULL,
+    p_effective_date  => p_effective_date
+  );
+END;
+$function$;

--- a/supabase/migrations/20260805000507_recapture_offboard_member_live_body.sql
+++ b/supabase/migrations/20260805000507_recapture_offboard_member_live_body.sql
@@ -1,0 +1,33 @@
+-- Recaptura do corpo VIVO de offboard_member() — sem mudanca de comportamento.
+--
+-- Por que este arquivo existe: a DDL real rodou em 20260803233204 (arquivo
+-- irmao, escrito no mesmo PR). O gate Phase C elege a captura vencedora pela
+-- ORDEM ALFABETICA do nome do arquivo, e 20260803233204 ordena ANTES de
+-- 20260805000078, que carrega a assinatura antiga do wrapper (a que aceitava
+-- p_effective_date e descartava). Sem esta recaptura, a captura canonica de
+-- offboard_member continuaria sendo a versao morta.
+--
+-- CREATE OR REPLACE idempotente: o corpo abaixo ja e o corpo vivo em producao.
+
+CREATE OR REPLACE FUNCTION public.offboard_member(
+  p_member_id uuid,
+  p_new_status text,
+  p_reason text,
+  p_effective_date date DEFAULT NULL::date
+)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  RETURN public.admin_offboard_member(
+    p_member_id       => p_member_id,
+    p_new_status      => p_new_status,
+    p_reason_category => 'other',
+    p_reason_detail   => p_reason,
+    p_reassign_to     => NULL,
+    p_effective_date  => p_effective_date
+  );
+END;
+$function$;


### PR DESCRIPTION
## O que

Fecha os **tres sintomas** do mesmo evento: a DDL de offboarding que entrou pelo `apply_migration` do MCP, que aplica no banco remoto mas nao escreve arquivo local nem registra versao.

Absorve o **#1585** (que fica superseded): sozinho ele nao conseguia ficar verde, porque lhe faltavam os arquivos de migration daqui — e este PR, sem o regen de types dele, nao passava no `gen-types-drift`. Cada um carregava metade do conserto do mesmo evento, entao nenhuma ordem de merge destravava os dois. Juntos, fecham.

## Os tres sintomas

**1. `gen-types-drift`** (commit do #1585) — `src/lib/database.gen.ts` ganha `p_effective_date?: string` em `admin_offboard_member`.

**2. `ADR-0097: no NEW missing-file drift`** — `20260803233204_offboard_member_honor_effective_date.sql`, verbatim de `supabase_migrations.schema_migrations`: a DDL que de fato rodou. De quebra, da captura a assinatura de 6 args de `admin_offboard_member`, orfa por sobrecarga.

**3. `Phase C: no NEW body-hash drift`** — `20260805000507_recapture_offboard_member_live_body.sql`.

A terceira existe por um detalhe de ordenacao que vale registrar: o Phase C elege a captura canonica pela **ordem alfabetica do nome do arquivo** (`loadLatestCaptures`, "last file in sort order wins"). O `apply_migration` usa timestamp real (`20260803233204`), o repo usa uma sequencia sintetica (`20260805000xxx`). Entao o arquivo historico ordena **antes** de `20260805000078`, que carrega o wrapper morto — o que aceitava `p_effective_date` e descartava. Sem a recaptura, a captura vencedora seguiria sendo a versao morta.

## Sem mudanca de comportamento

Os dois corpos ja sao os de producao. `CREATE OR REPLACE` idempotente.

Corpos conferidos byte-a-byte contra o vivo pelo parser do proprio repo (`tests/helpers/rpc-body-drift-parser.mjs`):

| funcao | md5 | len |
|---|---|---|
| `admin_offboard_member` | `75feae19402eed74e9e6fd139e7e59a4` | 9568 |
| `offboard_member` | `2662185a2aa8d64f789a121580893f5a` | 275 |

## Validacao

- `tests/contracts/rpc-migration-coverage.test.mjs` — **22/22** (era 20/22)
- `npm test` — **6267/6270 pass, 1 skip** (era 6265/6270)
- `npx astro build` — OK

As 2 falhas restantes **nao vem deste diff**: `#1468` e `p240/#251`, transitorias, os 2 flips pendentes que o cron 49 (`selection-status-recompute-daily`, 13:00 UTC) resolve. Nao foram forcadas na mao de proposito — mexer em dado de producao para pintar CI de verde seria o inverso do certo.

## Achado lateral, para decidir depois (nao mexido aqui)

O `GRANT` da migration original expoe as duas funcoes a `PUBLIC` e `anon`:

```
{=X/postgres,postgres=X/postgres,anon=X/postgres,authenticated=X/postgres,service_role=X/postgres}
```

Nao e explorável — o gate `manage_member` vive no corpo e anon recebe `Not authenticated`. Mas e superficie desnecessaria numa SECDEF de ciclo de vida de membro, e contraria o padrao de `REVOKE ... FROM PUBLIC`. Mantive verbatim porque este PR e captura fiel do que rodou; o aperto do ACL merece issue propria.