### PR TITLE
docs(webinar-t6): pos-evento do 1o webinar da Tribo 6 — gravacao publicada, plataforma fechada e 5 issues

### DIFF
--- a/docs/_deliverables/2026-08-04_webinar_t6/CAPITULOS_YOUTUBE.txt
+++ b/docs/_deliverables/2026-08-04_webinar_t6/CAPITULOS_YOUTUBE.txt
@@ -1,0 +1,26 @@
+0:00 Abertura
+1:01 A Tribo 6 e o que ela produz
+4:47 O roteiro da noite
+6:51 Fernando Carvalho: o gargalo não é o prompt
+10:04 O gargalo operacional: leads e portfólio de cursos
+13:31 Academinho, o agente de atendimento
+17:41 MIA: usar também a conversa de quem não comprou
+18:45 O curso que parou de lotar
+21:04 Cinco agentes com papéis separados
+22:55 Contexto, premissas, memória e agent.md
+27:36 O resultado: reposicionamento e turmas cheias
+29:26 Limitações e contornos
+32:19 O kit de análise de cenário e portfólio
+33:06 Perguntas ao Fernando
+38:26 Clendson Gonçalves: Shadow AI, o estagiário invisível
+39:19 O caso Samsung: o dado não foi roubado, foi entregue
+44:18 Shadow IT governa ferramentas, Shadow AI governa decisões
+48:45 O paradoxo da produtividade
+50:48 Human in the loop quando vira teatro de supervisão
+52:21 AI Act artigo 14 e LGPD artigo 20
+53:17 Segregação de funções e o agente que faz os três papéis
+57:21 O kit prático: o semáforo dos dados e as 5 ações do GP
+60:58 O que muda no papel do gestor de projetos
+63:14 Para refletir
+65:01 Perguntas e o contraponto sobre governança
+69:36 Encerramento

--- a/docs/_deliverables/2026-08-04_webinar_t6/RELATORIO_POS_EVENTO.md
+++ b/docs/_deliverables/2026-08-04_webinar_t6/RELATORIO_POS_EVENTO.md
@@ -1,9 +1,10 @@
-# Relatório pós-evento — 1º Webinar da Tribo 6 (ROI & Portfólio)
+# Relatório pós-evento do 1º Webinar da Tribo 6 (ROI & Portfólio)
 
 **Evento:** Aplicações Práticas de IA (IA na priorização, na análise de cenário e na segurança da informação)
 **Quando:** terça, 04/08/2026, 19h00 às 20h18 (Brasília). Conteúdo de 19h05 a 20h18, 73 min.
 **Onde:** Airmeet · aberto ao público · gravado
 **Registro na plataforma:** webinar `4ff3a888-8959-4262-82e6-a6f54ffc3964` · evento `17497fca-c035-4d9a-8c37-9b721447c9fe`
+**Gravação:** https://youtu.be/__cXwlfgtwM (pública, playlist Webinars, 72min30s, com capítulos)
 
 > Fonte de todos os números: exports do Airmeet baixados em 05/08 às 00h04 (master, qna, chat, resource,
 > in_session_cta, survey) e consultas à plataforma feitas em 05/08. Os CSVs com PII ficam fora do
@@ -72,6 +73,21 @@ edições.
 nota. Se a avaliação importa para o relatório de portfólio, ela precisa ser configurada no Airmeet
 antes do evento, não depois.
 
+🟡 **O material do Fernando existe e está no ar, mas só como QR na tela.** Ele oferece um kit com os
+cinco agentes e os prompts que usa (planejador, crítico técnico, crítico de negócio, advogado do
+diabo e consolidador, cada um em um modelo diferente). O endereço aparece no slide de encerramento
+dele, aos 32min42s do vídeo publicado: **https://m2br.academy/materiais/pmi**, "Kit de Análise de
+cenário e gestão de portfólio com IA". Conferido em 05/08: responde **HTTP 200**, título "Kit PMI —
+Análise de cenário com IA | M2BR Academy".
+
+O que faltou foi registro em texto. O export de recursos do Airmeet veio **vazio** (nenhum recurso
+publicado, nenhum download) e o chat tem só os três links de LinkedIn dos palestrantes. Quem assiste
+ao replay precisa pausar e ler o slide, ou apontar a câmera para a tela. **A descrição do YouTube
+resolve isso**, e é onde o link foi colocado.
+
+Para os próximos: todo link mostrado por QR deveria ir também para a aba de recursos do Airmeet e
+para o chat, que são os dois lugares que viram registro.
+
 ## 4. Quem esteve lá, do ponto de vista da plataforma
 
 Cruzamento dos 61 presentes contra `members` + `member_emails`, por hash de e-mail:
@@ -83,23 +99,54 @@ Cruzamento dos 61 presentes contra `members` + `member_emails`, por hash de e-ma
 | membros com presença já registrada antes desta apuração | 5 |
 | membros com presença registrada nesta apuração | 23 |
 
-Os 28 membros vêm de 10 capítulos (GO, CE, RS, MG, DF, RJ, PE, PR, AM, MA).
+Os 28 membros vêm de **9 capítulos**: CE (7), GO (6), RS (4), MG (3), PE (2), RJ (2), DF (2), PR (1)
+e AM (1). Um webinar de tribo puxando presença de nove capítulos é o argumento multi-capítulo do KPI
+acontecendo na prática.
 
 **Os 33 externos não têm registro em lugar nenhum da plataforma.** Não são membros, não entraram como
 `visitor_leads` (a captura de lead é do formulário do site, não do Airmeet) e não há rota para gravar
 presença de não-membro. Ou seja: a plataforma enxerga 28 de 61. Aberto em **#1602**.
 
-## 5. Efeito nos indicadores
+## 5. O que foi gravado na plataforma
 
-- **Presença do evento:** de 5 para 28 (`attendance_record action='register'`, via MCP).
-- **Duração real:** o evento estava com `duration_actual = 60`; passou para **73**. Horas de impacto do
-  webinar: 28 × 73 min ≈ **34 h** (era ≈ 28 h com o valor errado).
-- **Meta "6+ Webinares ou Talks":** continua em **0 de 6** e **não sobe** com este webinar. A janela de
-  medição de `get_annual_kpis` está congelada em 30/06/2026 e os três webinares realizados são de
-  julho e agosto. O mesmo defeito segura "Eventos realizados" em 147 quando o número até hoje é 220.
-  Aberto em **#1603**.
+| o quê | antes | depois |
+| --- | --- | --- |
+| presença no evento | 5 | **28** |
+| `duration_actual` | 60 | **73** |
+| `events.initiative_id` | `null` | Tribo 6 |
+| `events.is_recorded` | `false` | `true` (+ `recording_url`, `recording_type='youtube'`) |
+| `webinars.status` | `confirmed` | **`completed`** |
+| `webinars.youtube_url` | `null` | https://youtu.be/__cXwlfgtwM |
+| ata do evento | inexistente | publicada, com 4 ações e 2 decisões estruturadas |
+| card no board | `in_progress` | `done` |
+| pipeline de comms | "preparar follow-up pós-evento" | **"divulgar replay e materiais"** |
 
-## 6. Pendências abertas por este evento
+A presença entrou por `attendance_record action='register'` e a ata por `meeting_minutes`, ambos pelo
+MCP. Os campos de `webinars` e de gravação do evento foram por UPDATE direto, porque não há rota MCP
+(#1600, #1601) e porque a rota da tela apagaria o `board_item_id` (#1604).
+
+## 6. Efeito nos indicadores
+
+**O contador da meta não se mexeu, e isso não é erro de execução.** Medido depois de fechar tudo:
+
+| medida | valor |
+| --- | --- |
+| webinares com `status='completed'` no banco | 2 → **3** |
+| `get_webinars_count` na janela do KPI (até 30/06) | **0** |
+| `get_webinars_count` de 01/01 até hoje | **3** |
+| Horas de Impacto, janela default do painel | **842** |
+| Horas de Impacto, de 01/01 até hoje | **1387** |
+
+A meta "6+ Webinares ou Talks" continua exibindo **0 de 6** com três webinares realizados, porque a
+janela de medição parou em 30/06/2026 e os três são de julho e agosto. O mesmo defeito segura
+"Eventos realizados" em 147 quando o número até hoje é 220, e o painel do workspace em 842 horas de
+impacto quando são 1387. As 28 presenças registradas hoje caem inteiras fora de todas as janelas
+default, porque o evento é de agosto. Aberto em **#1603**.
+
+Duração real: `duration_actual` foi de 60 para **73**, o que muda a conta de horas de impacto deste
+webinar de ≈28 h para ≈34 h. Esse ganho só aparece em superfície com janela corrigida.
+
+## 7. Pendências abertas por este evento
 
 | # | item |
 | --- | --- |
@@ -107,8 +154,32 @@ presença de não-membro. Ou seja: a plataforma enxerga 28 de 61. Aberto em **#1
 | #1601 | `event_write` não alcança os campos de realização (gravação, `duration_actual`, `initiative_id`) |
 | #1602 | presença de público externo e resolução de e-mail em lote não têm rota |
 | #1603 | janela congelada em `get_annual_kpis` (meta de webinares e eventos realizados) |
+| #1604 | editar um webinar pelo modal do admin apaga o `board_item_id` |
 
-Fora do MCP, um achado de higiene: `comms_report scope='pending_webinars'` ainda lista **três webinares
-de abril** das tribos 2, 4 e 5 (`91759ba1`, `2ab12ccf`, `cd596843`) parados em `confirmed` com
-"preparar follow-up pós-evento". Ou aconteceram e nunca foram fechados, ou não aconteceram e deveriam
-estar cancelados.
+⚠️ **A #1604 saiu de uma tentativa de fazer a coisa certa.** Antes de fechar o webinar por SQL fui
+conferir se dava para fechar pelo admin, e dava: `upsert_webinar` aceita `p_status` e `p_youtube_url`,
+e o gate dela permite ao **próprio organizador** (o Denis, neste caso) fechar o webinar dele. Só que a
+função grava `board_item_id = p_board_item_id` sem `COALESCE` e o modal nunca envia esse parâmetro.
+Fechar este webinar pela tela teria apagado, em silêncio, o vínculo com o card
+`f5a77542-4007-4229-916b-ead5852b20e6`. Por isso o fechamento foi por UPDATE direto.
+
+Isso também corrigiu a #1600, que eu havia escrito afirmando que o líder de tribo dependia do owner
+para fechar um webinar. Não depende: a capacidade existe na web. O que não existe é a rota no MCP.
+
+## 8. Achados de higiene, sem issue aberta
+
+**Três webinares de abril presos no pipeline.** `comms_report scope='pending_webinars'` ainda lista
+`91759ba1`, `2ab12ccf` e `cd596843` (tribos 2, 4 e 5) em `confirmed` com "preparar follow-up
+pós-evento". Ou aconteceram e nunca foram fechados, ou não aconteceram e deveriam estar cancelados. É
+o mesmo sintoma que a #1600 descreve: sem rota de fechamento, webinar não fecha.
+
+**Cópia velha de liderança em `initiatives.metadata`.** O `metadata.leader_member_id` da Tribo 6
+aponta para o líder anterior. O SSOT (`engagements`, papel `leader` desde 23/06) e a coluna que a
+tela realmente lê (`tribes.leader_member_id`) trazem o líder atual, então **não há efeito visível
+hoje**. Fica registrado porque é uma terceira representação do mesmo fato, e a única das três que
+está errada. Detectado ouvindo o próprio webinar, onde a transição de liderança é anunciada.
+
+**Kickoff de comms nunca registrado.** `comms_kickoff_at` do webinar é `null` e
+`comms_kickoff_logged` é `false`, embora a divulgação tenha saído em 27/07 e 02/08. Marcar agora
+gravaria a data de hoje, que seria pior que o `null`: o campo aceita apenas "agora"
+(`mark_kickoff`), não uma data retroativa.

--- a/docs/_deliverables/2026-08-04_webinar_t6/RELATORIO_POS_EVENTO.md
+++ b/docs/_deliverables/2026-08-04_webinar_t6/RELATORIO_POS_EVENTO.md
@@ -1,0 +1,114 @@
+# Relatório pós-evento — 1º Webinar da Tribo 6 (ROI & Portfólio)
+
+**Evento:** Aplicações Práticas de IA (IA na priorização, na análise de cenário e na segurança da informação)
+**Quando:** terça, 04/08/2026, 19h00 às 20h18 (Brasília). Conteúdo de 19h05 a 20h18, 73 min.
+**Onde:** Airmeet · aberto ao público · gravado
+**Registro na plataforma:** webinar `4ff3a888-8959-4262-82e6-a6f54ffc3964` · evento `17497fca-c035-4d9a-8c37-9b721447c9fe`
+
+> Fonte de todos os números: exports do Airmeet baixados em 05/08 às 00h04 (master, qna, chat, resource,
+> in_session_cta, survey) e consultas à plataforma feitas em 05/08. Os CSVs com PII ficam fora do
+> repositório. Nenhum e-mail ou nome de participante externo aparece aqui.
+
+## 1. O funil
+
+| medida | valor |
+| --- | --- |
+| inscritos | 127 |
+| presentes | 61 |
+| **taxa de comparecimento** | **48,0%** |
+| entraram na sessão ao vivo | 60 |
+| assistiram só pelo replay do Airmeet | 2 |
+| entraram no lounge / networking | 0 |
+
+Quebra por histórico, que é o dado mais acionável do lote:
+
+| | inscritos | presentes | comparecimento |
+| --- | --- | --- | --- |
+| novos (1º evento do Núcleo) | 62 | 23 | **37,1%** |
+| recorrentes | 65 | 38 | **58,5%** |
+
+Quem já veio antes comparece a uma taxa 1,6× maior. A divulgação trouxe metade da base como gente nova,
+e essa metade é a que evapora entre a inscrição e a sala.
+
+## 2. Retenção
+
+Tempo assistido, entre os 61 presentes: mediana **53 min**, média 51,5 min, sobre uma sessão de 73 min.
+Mediana equivale a **73% da sessão**.
+
+| corte | presentes |
+| --- | --- |
+| ≥ 5 min | 57 |
+| ≥ 20 min | 45 |
+| ≥ 45 min | 34 |
+| ≥ 60 min | 26 |
+
+Não houve queda concentrada: a curva é suave. Três pessoas ficaram menos de 5 min.
+
+## 3. Interação
+
+| medida | valor |
+| --- | --- |
+| mensagens no feed | 39, de 23 pessoas |
+| linhas no Q&A | 12, de 7 pessoas |
+| **perguntas de conteúdo** | **4, de 2 pessoas** |
+| reações (emojis) | 90 |
+| mãos levantadas | 0 |
+| respostas ao survey | 0 |
+| recursos publicados / baixados | 0 |
+| CTAs em sessão | 0 |
+
+⚠️ **As 12 do Q&A não são 12 perguntas.** Oito são saudação, emoji, agradecimento ou recado de áudio.
+As quatro de conteúdo foram duas sobre a arquitetura de agentes apresentada (critério de alocação de
+cada agente a um LLM diferente, e técnicas de refinamento do aprendizado, com o paralelo ao Model
+Context Protocol) e duas sobre governança (o WhatsApp como canal corporativo de facto sem versão
+Business, e o argumento de que a IA amplifica um problema cuja causa-raiz é a governança da empresa).
+Qualquer leitura de "12 perguntas" superestima o engajamento por 3×.
+
+⚠️ **As próprias abas do Airmeet divergem entre si.** A aba de resumo do chat diz 23 pessoas no feed e
+a aba de atividade diz 25; o Q&A diz 7 e a atividade diz 8. Usar sempre a mesma aba ao comparar
+edições.
+
+⚠️ **Survey com zero respostas.** Não houve pesquisa de satisfação neste webinar, então não há NPS nem
+nota. Se a avaliação importa para o relatório de portfólio, ela precisa ser configurada no Airmeet
+antes do evento, não depois.
+
+## 4. Quem esteve lá, do ponto de vista da plataforma
+
+Cruzamento dos 61 presentes contra `members` + `member_emails`, por hash de e-mail:
+
+| | valor |
+| --- | --- |
+| presentes que são membros | **28** |
+| presentes que não são membros | **33** |
+| membros com presença já registrada antes desta apuração | 5 |
+| membros com presença registrada nesta apuração | 23 |
+
+Os 28 membros vêm de 10 capítulos (GO, CE, RS, MG, DF, RJ, PE, PR, AM, MA).
+
+**Os 33 externos não têm registro em lugar nenhum da plataforma.** Não são membros, não entraram como
+`visitor_leads` (a captura de lead é do formulário do site, não do Airmeet) e não há rota para gravar
+presença de não-membro. Ou seja: a plataforma enxerga 28 de 61. Aberto em **#1602**.
+
+## 5. Efeito nos indicadores
+
+- **Presença do evento:** de 5 para 28 (`attendance_record action='register'`, via MCP).
+- **Duração real:** o evento estava com `duration_actual = 60`; passou para **73**. Horas de impacto do
+  webinar: 28 × 73 min ≈ **34 h** (era ≈ 28 h com o valor errado).
+- **Meta "6+ Webinares ou Talks":** continua em **0 de 6** e **não sobe** com este webinar. A janela de
+  medição de `get_annual_kpis` está congelada em 30/06/2026 e os três webinares realizados são de
+  julho e agosto. O mesmo defeito segura "Eventos realizados" em 147 quando o número até hoje é 220.
+  Aberto em **#1603**.
+
+## 6. Pendências abertas por este evento
+
+| # | item |
+| --- | --- |
+| #1600 | `webinar_manage` não fecha o webinar (status e youtube_url fora da rota MCP) |
+| #1601 | `event_write` não alcança os campos de realização (gravação, `duration_actual`, `initiative_id`) |
+| #1602 | presença de público externo e resolução de e-mail em lote não têm rota |
+| #1603 | janela congelada em `get_annual_kpis` (meta de webinares e eventos realizados) |
+
+Fora do MCP, um achado de higiene: `comms_report scope='pending_webinars'` ainda lista **três webinares
+de abril** das tribos 2, 4 e 5 (`91759ba1`, `2ab12ccf`, `cd596843`) parados em `confirmed` com
+"preparar follow-up pós-evento". Ou aconteceram e nunca foram fechados, ou não aconteceram e deveriam
+estar cancelados.

--- a/scripts/design-kit/build_t6_thumb_youtube.py
+++ b/scripts/design-kit/build_t6_thumb_youtube.py
@@ -1,0 +1,60 @@
+"""Miniatura do YouTube (1280x720) da gravação do 1o Webinar da Tribo 6, 04/08/2026.
+
+Por que não reaproveitar o banner 1440x810 do Airmeet: o texto dele é convite
+("4 de agosto · 19h às 20h30"), tempo futuro, e a miniatura do replay é lida depois
+do evento. Aqui a pílula diz gravação e data, e os dois palestrantes aparecem, que é
+o que ajuda o reconhecimento numa miniatura vista pequena.
+
+As fotos vêm do kit do webinar no Drive:
+  NUCLEO_FOTOS="<kit>/fotos-palestrantes" python build_t6_thumb_youtube.py
+"""
+from brand import *
+
+FER = img_uri(FOTOS / "fernando-900.png")
+CLE = img_uri(FOTOS / "clendson-900.png")
+
+TITULO = "Aplicações Práticas de IA"
+SUB = "IA na priorização, na análise de cenário e na segurança da informação"
+QUANDO = "Gravação · 4 de agosto de 2026"
+ASSIN = 'Realização <b>Núcleo IA &amp; GP</b> · Tribo ROI &amp; Portfólio'
+
+TIME = [(FER, "Fernando Carvalho"), (CLE, "Clendson Gonçalves, MSc.")]
+
+
+def thumb():
+    W, H = 1280, 720
+    retratos = "".join(
+        f'<div class="qi">{retrato(f, 132)}<div class="qn">{n}</div></div>'
+        for f, n in TIME
+    )
+    html = f"""<!doctype html><meta charset="utf-8"><style>{css_base(W,H)}
+.wrap {{ padding:44px 72px 104px; display:flex; align-items:center; gap:36px; }}
+.col {{ display:flex; flex-direction:column; justify-content:center; flex:1; }}
+.eyebrow {{ font-size:18px; }}
+h1 {{ font-size:74px; margin-top:16px; max-width:720px; }}
+.sub {{ margin-top:18px; font-size:24px; line-height:1.35; color:{TEXT}; max-width:660px; }}
+.quando {{ display:inline-flex; margin-top:26px; padding:14px 28px; font-size:21px; }}
+.time {{ display:flex; gap:14px; }}
+.qi {{ text-align:center; width:230px; }}
+.qn {{ font-weight:800; font-size:18px; color:{WHITE}; margin-top:6px; line-height:1.25; }}
+.rodape {{ padding:20px 72px 30px; font-size:18px; }}
+.orb-a {{ width:1000px; height:1000px; right:-380px; top:120px; }}
+/* sem dot ciano: no 1280x720 ele cai exatamente atrás da pílula (medido) */
+</style>
+<div class="orb orb-a"></div>
+<img class="faixa" src="{FAIXA}">
+<div class="wrap">
+  <div class="col">
+    <div class="eyebrow">1º Webinar · Tribo ROI &amp; Portfólio</div>
+    <h1>{TITULO}</h1>
+    <div class="sub">{SUB}</div>
+    <div><span class="pill quando">{QUANDO}</span></div>
+  </div>
+  <div class="time">{retratos}</div>
+</div>
+<div class="rodape"><div>{ASSIN}</div><div>youtube.com/@nucleo_ia</div></div>"""
+    return render("t6-youtube-thumb-1280x720", html, W, H)
+
+
+if __name__ == "__main__":
+    print("ok", thumb())


### PR DESCRIPTION
## O que é

Operação pós-evento do 1º webinar da Tribo 6 (04/08/2026). Só docs: o relatório com os números
medidos e a lista de capítulos publicada no YouTube. As mudanças de dado foram aplicadas direto na
plataforma (presença, ata, status do webinar, gravação, card), e estão descritas no relatório com
antes e depois.

## Gravação

https://youtu.be/__cXwlfgtwM — pública, playlist Webinars, 72min30s, 26 capítulos, miniatura de
replay gerada pelo `build_t6_thumb_youtube.py` deste PR.

Corte e áudio: removidos 4min50s de espera inicial e o encerramento morto. O áudio original estava em
cerca de **-24 a -26 LUFS**, muito abaixo do alvo -14 do YouTube, no webinar inteiro e não só no
trecho em que o microfone falhou. Depois da normalização, os mesmos três trechos medem **-13,5**,
**-15,0** e **-16,6**.

## Números do evento

127 inscritos, 61 presentes (48,0%). Novo comparece a 37,1% e recorrente a 58,5%. Retenção mediana de
53 min sobre 73 de sessão. Dos 61 presentes, 28 são membros de 9 capítulos e 33 não são membros.

Das 12 linhas do Q&A do Airmeet, **4 são pergunta de conteúdo**; as outras 8 são saudação, emoji ou
recado de áudio. Survey, recursos e CTA vieram vazios.

## O que mudou na plataforma

| | antes | depois |
| --- | --- | --- |
| presença no evento | 5 | 28 |
| `duration_actual` | 60 | 73 |
| `events.initiative_id` | `null` | Tribo 6 |
| `webinars.status` | `confirmed` | `completed` |
| `webinars.youtube_url` | `null` | o link acima |
| ata | inexistente | publicada, 4 ações e 2 decisões estruturadas |
| card | `in_progress` | `done` |

## Cinco issues abertas por esta sessão

- **#1600** `webinar_manage` não fecha webinar pelo MCP. ⚠️ A issue foi **corrigida por comentário**:
  eu havia afirmado que o líder de tribo dependia do owner, e é falso, `upsert_webinar` permite ao
  próprio organizador fechar. O gap é só do MCP.
- **#1601** `event_write` não alcança os campos de realização.
- **#1602** presença de público externo e resolução de e-mail em lote não têm rota. 33 de 61
  presentes não existem na plataforma.
- **#1603** janela de medição congelada em 30/06 **em três lugares**. O painel do workspace mostra
  842 horas de impacto quando o número é 1387, e a meta de webinares mostra 0 de 6 com três
  realizados. Tem ainda uma quarta leitura, do alerta operacional, que diz "abaixo de 50%" para o
  mesmo KPI que o painel anual diz "achieved 163%".
- **#1604** editar um webinar pelo modal do admin apaga o `board_item_id`, em silêncio. Achado ao
  conferir se dava para fechar pelo admin em vez de por SQL; dava, e teria custado o vínculo do card.

## Achado que vale um follow-up

O kit do Fernando (cinco agentes com papéis separados, com os prompts) só foi oferecido por QR na
tela, e o export de recursos do Airmeet veio vazio. O endereço foi recuperado lendo o frame do vídeo,
conferido (HTTP 200) e colocado na descrição do YouTube: https://m2br.academy/materiais/pmi

O kit do Clendson não tem link: ele envia a quem o procurar no LinkedIn. Virou ação rastreável na ata.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>
