### PR TITLE
fix(infra): "nao teve sucesso" nao e o mesmo conjunto que "falhou" — a varredura acusava a si mesma (#1621)

### DIFF
--- a/supabase/migrations/20260805000515_1621_entrega_de_alerta.sql
+++ b/supabase/migrations/20260805000515_1621_entrega_de_alerta.sql
@@ -217,7 +217,12 @@ BEGIN
            left(coalesce(max(d.return_message), ''), 200) AS msg
     FROM cron.job_run_details d
     JOIN cron.job j ON j.jobid = d.jobid
-    WHERE d.status <> 'succeeded'
+  -- ⚠️ O filtro é POSITIVO (`= 'failed'`), e isso não é estilo. `<> 'succeeded'` também casa o
+  -- estado EM VOO: enquanto a própria varredura roda, a linha dela em `cron.job_run_details` está
+  -- `running`, e o filtro negativo a lia como falha — a varredura acusava a si mesma, e mandou
+  -- e-mail sobre isso em 2026-08-06 02:07 UTC. "Não teve sucesso" e "falhou" são conjuntos
+  -- diferentes quando o em-progresso divide a mesma coluna.
+    WHERE d.status = 'failed'
       AND d.start_time > v_now - interval '48 hours'
     GROUP BY 1, 2
   LOOP

--- a/tests/contracts/1621-alert-delivery.test.mjs
+++ b/tests/contracts/1621-alert-delivery.test.mjs
@@ -126,6 +126,18 @@ test('1621 static: a janela de falha de cron é curta, e o agrupamento é por (j
     'as 71 falhas medidas foram 3 tempestades — alertar por execução daria 71 linhas para 3 fatos');
 });
 
+test('1621 static: o filtro de falha é POSITIVO — "não teve sucesso" ≠ "falhou"', () => {
+  const sweep = mig.match(/FUNCTION public\._alert_sweep_cron\([\s\S]*?\$function\$([\s\S]*?)\$function\$/)?.[1];
+  assert.match(sweep, /WHERE d\.status = 'failed'/,
+    'o desfecho é afirmado, não deduzido por exclusão');
+  // ⚠️ Regressão medida em produção: `<> 'succeeded'` também casa o estado EM VOO. Enquanto a
+  // própria varredura roda, a linha dela em cron.job_run_details está `running` — e ela abriu um
+  // alerta contra SI MESMA às 02:07 UTC de 2026-08-06, com e-mail e tudo. Um filtro negativo sobre
+  // uma coluna que mistura desfecho com progresso engole o em-progresso.
+  assert.ok(!/d\.status <> 'succeeded'/.test(sweep),
+    'REGRESSÃO: filtro negativo de volta — a varredura acusa todo cron em voo, inclusive ela mesma');
+});
+
 test('1621 static: a notificação usa o overload EXPLÍCITO de 7 argumentos', () => {
   const sweep = mig.match(/FUNCTION public\._alert_sweep_cron\([\s\S]*?\$function\$([\s\S]*?)\$function\$/)?.[1];
   // `create_notification` tem TRÊS overloads e a ambiguidade já derrubou uma RPC antes.


### PR DESCRIPTION
Correção do #1621, encontrada pela própria coisa que ele instalou: **o cron rodou sozinho pela primeira vez às 02:07 UTC e abriu um alerta contra si mesmo.**

## O defeito

O filtro da fonte A era `d.status <> 'succeeded'`. Isso também casa o estado **em voo**: enquanto a varredura executa, a linha dela em `cron.job_run_details` está `running`, e o filtro negativo a lia como falha.

O alerta gerado dizia, literalmente, `Cron platform-alert-sweep-hourly falhou 1 vez(es) em 2026-08-06`, com `ultima` igual ao `start_time` daquele mesmo run - que terminou `succeeded` um segundo depois.

**Custo: 2 e-mails falsos** para os dois GPs (somados aos 2 que a rodada do teste entregou antes de o freio `p_deliver_email` existir).

## Por que passou por tudo

Em 7 dias a tabela só carrega `succeeded` (16.843) e `failed` (13) - **depois** que o run termina. O estado intermediário existe apenas durante a execução, então nenhuma consulta feita de fora o enxerga: nem a medição que fiz para desenhar a issue, nem o teste de contrato, nem a sonda manual. Ele só aparece quando **o leitor é ele mesmo um dos jobs** - que é precisamente o caso quando a varredura vira cron.

## A correção

Filtro **positivo**: `d.status = 'failed'`. O desfecho passa a ser afirmado, não deduzido por exclusão.

A lição generaliza: **um filtro negativo sobre uma coluna que mistura desfecho com progresso engole o em-progresso.** É parente de "valor ausente tratado como valor medido", com o em-voo no lugar do ausente.

## O que entrou junto

- o alerta falso saiu do ledger - mantê-lo como "resolvido" deixaria no histórico que o GP vai consultar um fato que nunca existiu
- teste de contrato trava a regressão **nos dois sentidos**: exige `= 'failed'` e recusa o `<> 'succeeded'`
- varredura pós-correção: `new=0, open=0, emails=0`, ledger vazio

## Verificação

- `npx astro build` ok
- `npm test`: **6384 testes, 0 falhas, 1 skip**
- drift de corpo de RPC: limpo

Refs #1621