### PR TITLE
chore(mcp): a defesa que o bump podia ter apagado foi MEDIDA, não relida (#1620)

### DIFF
--- a/.claude/rules/mcp.md
+++ b/.claude/rules/mcp.md
@@ -131,10 +131,10 @@ curl https://ldrfrvwhxsmgaabwmaik.supabase.co/functions/v1/nucleo-mcp/health
 The per-session tool-count change-history is archived at `docs/audit/MCP_RULES_TOOLCOUNT_HISTORY_ARCHIVED_2026-05-30.md`.
 
 Worker proxy paths (`nucleoia.vitormr.dev`): `/mcp` → EF `/nucleo-mcp/mcp`; `/mcp/semantic` → EF `/nucleo-mcp/semantic`.
-Both shave the SDK 1.29.0 `execution.taskSupport` field via post-process strip (Perplexity-spec compat). See
+Both shave the SDK `execution.taskSupport` field via post-process strip (Perplexity-spec compat). See
 `docs/MCP_SETUP_GUIDE.md` for client routing.
 
-- Transport: `@modelcontextprotocol/sdk@1.29.0` `WebStandardStreamableHTTPServerTransport` (native).
+- Transport: `@modelcontextprotocol/sdk@1.30.0` `WebStandardStreamableHTTPServerTransport` (native).
 - Tool params: Zod schemas (`z.string()`, `z.number()`, …) — NOT plain JSON Schema objects.
 - Auth: OAuth 2.1 via Workers (nucleoia.vitormr.dev) → Supabase JWT. All tools log to `mcp_usage_log`.
 - Health observability tools: `get_invitation_health`, `get_lgpd_cron_health`, `get_digest_health`, `get_ots_pipeline_health`.
@@ -202,9 +202,16 @@ Expected: `[runtime] clean (N runtime ≡ N static)`. If drift is reported (`dri
 Re-running the matrix is also useful after migrations that change RPC signatures — diff `mcp-tool-matrix.json` to see which tools call the changed RPC.
 
 ## SDK Compatibility
-- **SDK 1.29.0**: stable on Deno with native `WebStandardStreamableHTTPServerTransport`. Tool params MUST use Zod schemas. (Latest 1.x confirmed via npm `dist-tags.latest` — re-query, don't trust this line; 2.0 is a breaking alpha, do not adopt.)
-- **Zod import**: `import { z } from "npm:zod@4.3.6";` — pinned exact (MCP is critical infra; minor zod bumps could change validation behavior silently). SDK 1.29.0 supports `zod ^3.25 || ^4.0`. Update consciously when reading release notes.
-- **History**: SDK 1.27.1 worked but required manual SSE wrapping (85 lines). 1.29.0 native transport works after converting tools to Zod + upgrading deps.
+- **SDK 1.30.0**: stable on Deno with native `WebStandardStreamableHTTPServerTransport`. Tool params MUST use Zod schemas. (Latest 1.x confirmed via npm `dist-tags.latest` — re-query, don't trust this line; 2.0 is a breaking alpha, do not adopt.)
+- **Zod import**: `import { z } from "npm:zod@4.3.6";` — pinned exact (MCP is critical infra; minor zod bumps could change validation behavior silently). SDK 1.30.0 supports `zod ^3.25 || ^4.0`. Update consciously when reading release notes.
+- **`LATEST_PROTOCOL_VERSION` is `2025-11-25` in 1.29.0 AND in 1.30.0** — 1.30.0 shipped 2026-07-27, one day
+  BEFORE the 2026-07-28 spec, so it does NOT advance the spec migration (#1620). Bumping the pin is hygiene;
+  do not read a version bump as spec progress without grepping `LATEST_PROTOCOL_VERSION` in the tarball.
+- **A bump must re-measure the `execution.taskSupport` strip, not just re-read it.** The proxies strip a
+  literal JSON substring; if a future SDK changes the field's shape the regex silently becomes a no-op while
+  the code still looks like a defense. The tripwire in `tests/contracts/mcp-tools-list-execution-strip.test.mjs`
+  (`STRIP_VERIFIED_AGAINST`) fails the build until the live upstream→proxy delta is re-measured.
+- **History**: SDK 1.27.1 worked but required manual SSE wrapping (85 lines). 1.29.0 native transport works after converting tools to Zod + upgrading deps. 1.30.0 (#1620) is a no-behavior-change bump for our surface: `server/mcp.js` is byte-identical, and the deltas are SSE keep-alive frames + `X-Accel-Buffering: no` on stream responses, `_closed` race guards, resumable-stream fixes, a parsed `Content-Type` check (`isJsonContentType`), and zod-compat error-message formatting.
 
 ## Tool Pattern
 ```typescript

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ supabase functions deploy <name> --no-verify-jwt  # Deploy EF
 ## Key Architecture Decisions (do NOT re-litigate)
 1. `checkOrigin: false` + manual CSRF in middleware (Astro's check blocks OAuth/MCP POSTs)
 2. Custom domain `nucleoia.vitormr.dev` (`.workers.dev` has Bot Fight Mode blocking datacenter IPs)
-3. `@modelcontextprotocol/sdk@1.29.0` + WebStandardStreamableHTTPServerTransport + Zod 4 schemas for MCP
+3. `@modelcontextprotocol/sdk@1.30.0` + WebStandardStreamableHTTPServerTransport + Zod 4 schemas for MCP
 4. Webinars table is source of truth (not events filtered by type)
 5. Board items read-all for Tier 1+ members (curators need cross-board access). **Carve-out (ADR-0105, #785):** confidential initiatives (`initiatives.visibility='confidential'`) are EXCLUDED from this read-all — their board/events/artifacts/docs are visible only to engaged members + GP (`manage_platform`). Gate = `rls_can_see_initiative()`; curation excludes confidential by default. Any new SECDEF read RPC over initiative-linked tables MUST apply the gate (see `docs/reference/V4_AUTHORITY_MODEL.md`).
 6. LGPD: anon/ghost gets nothing from PII tables; public data via SECURITY DEFINER RPCs only

--- a/src/pages/mcp.ts
+++ b/src/pages/mcp.ts
@@ -106,7 +106,8 @@ export const ALL: APIRoute = async ({ request }) => {
   }
 
   // p220: detect tools/list so we can post-process the response to strip
-  // the non-MCP-spec `execution.taskSupport` field added by @modelcontextprotocol/sdk@1.29.0.
+  // the non-MCP-spec `execution.taskSupport` field added by @modelcontextprotocol/sdk@1.29.0
+  // and still emitted unchanged by 1.30.0 (re-measured #1620: 342 occurrences upstream → 0 here).
   // Stricter MCP clients (Perplexity) silently drop the entire tools array when
   // unknown top-level fields appear on each tool — symptom: "No tools to display"
   // despite tools/list returning 200 with all 299 tools. The field is Anthropic-

--- a/src/pages/mcp/actions.ts
+++ b/src/pages/mcp/actions.ts
@@ -107,7 +107,8 @@ export const ALL: APIRoute = async ({ request }) => {
   }
 
   // p220 — tools/list spec-cleanup (mirrors mcp.ts): strip non-MCP-spec
-  // `execution.taskSupport` field emitted per-tool by @modelcontextprotocol/sdk@1.29.0.
+  // `execution.taskSupport` field emitted per-tool by @modelcontextprotocol/sdk@1.29.0,
+  // unchanged in 1.30.0 (re-measured #1620: 88 occurrences upstream → 0 here).
   // Stricter MCP clients (Perplexity) silently drop tools array on unknown top-level fields.
   const isToolsList = typeof reqBody === 'string' && /"method"\s*:\s*"tools\/list"/.test(reqBody);
 

--- a/src/pages/mcp/semantic.ts
+++ b/src/pages/mcp/semantic.ts
@@ -103,7 +103,8 @@ export const ALL: APIRoute = async ({ request }) => {
   }
 
   // p220 — tools/list spec-cleanup (mirrors mcp.ts): strip non-MCP-spec
-  // `execution.taskSupport` field emitted per-tool by @modelcontextprotocol/sdk@1.29.0.
+  // `execution.taskSupport` field emitted per-tool by @modelcontextprotocol/sdk@1.29.0,
+  // unchanged in 1.30.0 (re-measured #1620: 53 occurrences upstream → 0 here).
   // Stricter MCP clients (Perplexity) silently drop tools array on unknown top-level fields.
   // Apply universally even for 3-tool semantic surface — same SDK, same field.
   const isToolsList = typeof reqBody === 'string' && /"method"\s*:\s*"tools\/list"/.test(reqBody);

--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -180,12 +180,12 @@
 //   manage_initiative_engagement (action='remove' only), offboard_member, delete_card, archive_card.
 //   Default returns preview; confirm=true executes. Breaking behavior change.
 // V4 Cutover: canWrite/canWriteBoard → canV4 (ADR-0007, engagement-derived authority)
-// Transport: SDK 1.29.0 WebStandardStreamableHTTPServerTransport (native Streamable HTTP)
+// Transport: SDK 1.30.0 WebStandardStreamableHTTPServerTransport (native Streamable HTTP)
 // GC-132/133: Phase 1+2 | GC-161: P1 | GC-164: P2
 
 import { Hono } from "jsr:@hono/hono@4.12.9";
-import { McpServer } from "npm:@modelcontextprotocol/sdk@1.29.0/server/mcp.js";
-import { WebStandardStreamableHTTPServerTransport } from "npm:@modelcontextprotocol/sdk@1.29.0/server/webStandardStreamableHttp.js";
+import { McpServer } from "npm:@modelcontextprotocol/sdk@1.30.0/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "npm:@modelcontextprotocol/sdk@1.30.0/server/webStandardStreamableHttp.js";
 import { createClient, type SupabaseClient } from "jsr:@supabase/supabase-js@2";
 import { z } from "npm:zod@4.3.6";
 import {
@@ -12353,7 +12353,7 @@ function statelessGetNotAllowed(req: Request): Response | null {
 }
 
 // MCP endpoint — Native Streamable HTTP via WebStandardStreamableHTTPServerTransport
-// SDK 1.29.0 handles all protocol details: initialize, session, tools/list, tool/call, SSE
+// SDK 1.30.0 handles all protocol details: initialize, session, tools/list, tool/call, SSE
 app.all("/mcp", async (c) => {
   const getBlocked = statelessGetNotAllowed(c.req.raw); // #1497
   if (getBlocked) return getBlocked;
@@ -12447,14 +12447,14 @@ app.get("/health", (c) => c.json({
   // #1598 — bumpado de propósito: no arco anterior o ef_version ficou igual no vivo e no fonte, e
   // o /health não serviu de testemunha do deploy (a prova teve de ser grep de sentinela no corpo
   // baixado). Bumpar aqui torna o deploy verificável por UMA chamada.
-  ef_version: "2.93.0",
+  ef_version: "2.94.0",
   surfaces: {
     "/mcp": { server: "nucleo-ia-hub", version: "2.80.0", tools: MCP_TOOL_COUNT },
     "/semantic": { server: "nucleo-ia-semantic", version: SEMANTIC_SURFACE_VERSION, tools: SEMANTIC_TOOL_COUNT },
     "/actions": { server: "nucleo-ia-actions", version: "0.2.0", tools: ACTIONS_ALLOWLIST.size },
   },
   transport: "native-streamable-http",
-  sdk: "1.29.0",
+  sdk: "1.30.0",
 }));
 
 Deno.serve(app.fetch);

--- a/tests/contracts/mcp-lgpd-retroactive-operator-tools.test.mjs
+++ b/tests/contracts/mcp-lgpd-retroactive-operator-tools.test.mjs
@@ -210,8 +210,8 @@ test('#1418: nucleo-ia-hub MCP server bumped to 2.80.0 (was 2.79.0 pre-#1418 raw
   );
 });
 
-test('ef_version is 2.93.0 (#1619 marca de proveniencia na fronteira; 2.92.0 no #1613)', () => {
-  assert.match(EF, /ef_version:\s*"2\.93\.0"/, '/health must report ef_version 2.93.0');
+test('ef_version is 2.94.0 (#1620 bump do SDK 1.30.0; 2.93.0 no #1619)', () => {
+  assert.match(EF, /ef_version:\s*"2\.94\.0"/, '/health must report ef_version 2.94.0');
 });
 
 test('#1392: /health /mcp surface derives its tool count + keeps version 2.80.0', () => {

--- a/tests/contracts/mcp-tools-list-execution-strip.test.mjs
+++ b/tests/contracts/mcp-tools-list-execution-strip.test.mjs
@@ -36,6 +36,25 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 const SRC = readFileSync(resolve(process.cwd(), 'src/pages/mcp.ts'), 'utf8');
+const EF = readFileSync(resolve(process.cwd(), 'supabase/functions/nucleo-mcp/index.ts'), 'utf8');
+
+/**
+ * The SDK version whose tools/list output the strip was last MEASURED against
+ * (not merely read). #1620, 2026-08-06 — live upstream→proxy delta per surface:
+ * /mcp 342→0, /semantic 53→0, /actions 88→0, tool counts preserved on both sides.
+ *
+ * Every assertion above this line is a source grep: it proves the regex EXISTS.
+ * None of them can prove it still MATCHES. The strip targets a literal JSON
+ * substring (`"execution":{"taskSupport":"forbidden"}`), so an SDK that renames
+ * the field, adds a sibling key inside `execution`, or changes the emitted value
+ * turns the defense into a silent no-op while the code keeps looking correct.
+ * That is the failure class this constant exists to catch.
+ *
+ * When bumping the SDK pin: re-run the measurement against the DEPLOYED EF
+ * (POST tools/list to the EF surface and to the proxy, compare the count of
+ * `"execution":{"taskSupport":"forbidden"}` occurrences), then update this value.
+ */
+const STRIP_VERIFIED_AGAINST = '1.30.0';
 
 test('mcp proxy: detects tools/list method via request body regex', () => {
   assert.match(SRC, /const\s+isToolsList\s*=\s*[\s\S]*?"method"\s*[\\]*?[\s\S]*?"tools\\?\/list"/,
@@ -95,4 +114,23 @@ test('mcp proxy: strip applies universally (not gated on User-Agent)', () => {
   const block = SRC.slice(conditionMatch.index, conditionMatch.index + 2000);
   assert.doesNotMatch(block, /user-agent|userAgent/i,
     'Strip block must NOT branch on User-Agent — universal application');
+});
+
+test('#1620 tripwire: EF SDK pin still matches the version the strip was MEASURED against', () => {
+  // Iterate every import (a single assert.match would pass on any ONE matching
+  // pin and miss a second import left behind on the old version).
+  const pins = [...EF.matchAll(/npm:@modelcontextprotocol\/sdk@([0-9]+\.[0-9]+\.[0-9]+)\//g)]
+    .map((m) => m[1]);
+  assert.ok(pins.length >= 2,
+    `expected the EF to import the SDK on a pinned version, found ${pins.length} import(s)`);
+
+  const distinct = [...new Set(pins)];
+  assert.equal(distinct.length, 1,
+    `all SDK imports must pin the SAME version — found: ${distinct.join(', ')}`);
+
+  assert.equal(distinct[0], STRIP_VERIFIED_AGAINST,
+    `The EF now pins SDK ${distinct[0]}, but the execution.taskSupport strip was last measured ` +
+    `against ${STRIP_VERIFIED_AGAINST}. The strip matches a LITERAL JSON substring, so a shape ` +
+    `change turns it into a silent no-op that no source grep can detect. Re-measure the live ` +
+    `upstream→proxy delta on all three surfaces, then update STRIP_VERIFIED_AGAINST.`);
 });


### PR DESCRIPTION
Fecha os dois passos baratos da #1620. O item 3 do aceite fica aberto de propósito.

## O que este PR promete, e o que não promete

**Não promete avanço de spec.** A 1.30.0 **não** implementa a spec 2026-07-28: `LATEST_PROTOCOL_VERSION` é `2025-11-25` em 1.29.0 **e** em 1.30.0, e a versão saiu em 2026-07-27, um dia *antes* da spec. O bump é higiene. A premissa do passo 1 da issue ("subir o SDK informa o resto") se inverteu na medição, e a informação foi que o SDK não avança a migração.

## Deploy verificado por superfície, não no total

`/health` vivo: `ef_version` **2.94.0**, `sdk` **1.30.0**.

`tools/list` nas três superfícies, contra a EF deployada:

| superfície | /health | tools/list | erro |
|---|---|---|---|
| `/mcp` | 342 | **342** | nenhum |
| `/semantic` | 53 | **53** | nenhum |
| `/actions` | 88 | **88** | nenhum |

Smoke de `initialize` não entra como prova: ele passa mesmo quando a serialização quebra. O tell da quebra é `-32603` com `Cannot read properties of undefined (reading '_zod')`, e não apareceu em nenhuma superfície.

## O risco de verdade era o strip, e nenhum teste do repo o cobria

Os três proxies removem `execution.taskSupport` por regex sobre um **trecho literal de JSON**. Se a 1.30.0 tivesse mudado a forma do campo, o strip viraria no-op e o código continuaria com cara de defesa - a classe "defesa que continua existindo e parou de proteger".

Medido nas duas pontas, com a EF já em 1.30.0:

| superfície | ocorrências na EF | depois do proxy | tools preservadas |
|---|---|---|---|
| `/mcp` | 342 | **0** | 342 → 342 |
| `/semantic` | 53 | **0** | 53 → 53 |
| `/actions` | 88 | **0** | 88 → 88 |

No fonte, `server/mcp.js` é **byte-idêntico** entre 1.29.0 e 1.30.0, então a emissão do campo não mudou. Vale notar que a medição do proxy usou o **worker vivo** contra a EF nova. Isso é exatamente o par que a produção terá depois do merge: este PR não altera uma linha executável dos três proxies (o diff neles é 100% comentário), então a lógica de strip medida é byte-a-byte a que está sendo mergeada.

## Tripwire: converter "medi desta vez" em "não dá para pular"

Os oito testes do strip são todos grep de fonte. Provam que o regex **existe**; nenhum prova que ele ainda **casa**. Entra `STRIP_VERIFIED_AGAINST` em `tests/contracts/mcp-tools-list-execution-strip.test.mjs`, comparando o pino do SDK na EF com a versão contra a qual o strip foi medido de verdade. No próximo bump o build fica vermelho até alguém re-medir.

Verificado por mutação: com o pino divergente do constante, o teste falha (`pass 8 / fail 1`). Não é decorativo. O arquivo já estava registrado nas duas whitelists do `package.json`, então roda em CI.

## O que a 1.30.0 muda de fato na nossa superfície

Keep-alive de SSE (frames `: keepalive`, 15s), `X-Accel-Buffering: no` e `Cache-Control: no-transform` nas respostas de stream, guardas de corrida em `_closed`, correções de stream resumível, checagem de `Content-Type` parseada (`isJsonContentType`, em vez de `includes`) e formatação de mensagem de erro no `zod-compat`. Nada disso toca `tools/list`.

## Passo 2 do aceite: `iss` (RFC 9207)

Re-medido agora:

| fonte | `issuer` declarado | `authorization_response_iss_parameter_supported` |
|---|---|---|
| nossa metadata (worker) | `https://nucleoia.vitormr.dev` | ausente |
| GoTrue, o AS de verdade | `https://ldrfrvwhxsmgaabwmaik.supabase.co/auth/v1` | ausente |

**O AS não suporta RFC 9207 hoje**, então não há validação de `iss` para ligar do nosso lado. O achado que importa é outro: nossa metadata é híbrida - declara `issuer` do nosso domínio e aponta os endpoints para o Supabase. Quando o `iss` entrar, um cliente que siga a spec compara os dois e a comparação falha. O efeito não é aviso, é **login quebrado**. É item de vendor, para acompanhar; não há código nosso a escrever agora.

## Aceite da #1620

- [x] SDK avaliado na 1.30.0 e decisão registrada - higiene, não migração; deployado e verificado
- [x] validação de `iss` conferida no fluxo OAuth (medida, não presumida) - não suportada pelo AS; o risco real é a divergência de `issuer`
- [ ] plano de transporte com data - **fica aberto**: 12 meses de offramp e o SDK ainda não oferece destino

## Rollback

Trocar o pino de volta para `1.29.0` e re-deployar. Não há migração de dado envolvida, então é limpo.

## Testes

`npx astro build` passa. `npm test` com `.env` exportado: **6396 testes, 6395 pass, 0 fail, 1 skip**. Manifesto não regenerado de propósito - a contagem não mudou (395), e rodar o gerador só mexeria no `generated_at`.
