### PR TITLE
test(selection): a régua era afirmada por INSTANTÂNEO, e o instantâneo venceu (#1634)

### DIFF
--- a/tests/contracts/p246-229b-final-score-pert-by-track.test.mjs
+++ b/tests/contracts/p246-229b-final-score-pert-by-track.test.mjs
@@ -169,41 +169,64 @@ describe('p246 #229b Foundation — final-score PERT régua by track', () => {
         assert.ok(probe.data !== null, 'should return data array (possibly empty) without column error');
       });
 
-      it('cycle4 researcher-track apps have final_score_pert_target populated (after recompute)', async () => {
-        // Scope to cycle4 via inner-join on selection_cycles to avoid hitting historical
-        // cycles where recompute never ran (those would have NULL régua).
+      // ⚠️ Estes dois testes afirmavam um INSTANTÂNEO do dado, não a regra: "researcher é
+      // dynamic" e "leader é disabled". Eram verdades de um dia. Em 06/08/2026 o coorte
+      // histórico de líder chegou a EXATAMENTE 10 e a régua da trilha virou `dynamic`
+      // (12 candidaturas, alvo 249.52, recalculado 17:30 UTC) — o sistema obedeceu a
+      // própria regra e o teste ficou vermelho. Registrado como achado de produto em #1634.
+      //
+      // A regra vive em `_compute_pert_cutoff_core` e tem TRÊS saídas, não duas:
+      //   v_n >= 10                        -> 'dynamic'
+      //   v_n <  10 e há alvo de outro ciclo -> 'historical_fallback'
+      //   v_n <  10 e não há               -> 'disabled'
+      //
+      // Afirmar a regra pega os dois defeitos que importam (régua não calculada; método
+      // incoerente com o coorte) e para de quebrar quando uma candidatura entra ou sai.
+      const CUTOFF_MIN_COHORT = 10;
+
+      it('a régua de final_score foi calculada no cycle4 (recompute rodou)', async () => {
         const { data, error } = await sb
           .from('selection_applications')
-          .select('final_score_pert_target, final_score_pert_cohort_n, final_score_pert_cutoff_method, role_applied, selection_cycles!inner(cycle_code)')
-          .eq('role_applied', 'researcher')
+          .select('final_score_pert_cutoff_method, selection_cycles!inner(cycle_code)')
           .eq('selection_cycles.cycle_code', 'cycle4-2026')
           .not('final_score', 'is', null)
-          .limit(5);
+          .not('final_score_pert_cutoff_method', 'is', null);
         if (error) {
           assert.fail(`probe error: ${error.message}`);
         }
-        assert.ok(data && data.length > 0, 'expect at least 1 cycle4 researcher with final_score populated');
-        const hasDynamic = data.some(r => r.final_score_pert_cutoff_method === 'dynamic');
-        assert.ok(hasDynamic, 'expect at least one cycle4 researcher with dynamic final_score régua post-recompute');
+        assert.ok(
+          data && data.length > 0,
+          'nenhuma candidatura do cycle4 tem método de régua — o recompute não rodou, e um NULL em toda a base passaria calado numa asserção por amostra'
+        );
       });
 
-      it('cycle4 leader-track apps have method=disabled (cohort_n<10 historical leaders)', async () => {
+      it('o método da régua obedece o coorte em TODA linha, nas duas trilhas', async () => {
         const { data, error } = await sb
           .from('selection_applications')
-          .select('final_score_pert_cutoff_method, final_score_pert_cohort_n, role_applied, selection_cycles!inner(cycle_code)')
-          .eq('role_applied', 'leader')
+          .select('id, role_applied, final_score_pert_cutoff_method, final_score_pert_cohort_n, selection_cycles!inner(cycle_code)')
           .eq('selection_cycles.cycle_code', 'cycle4-2026')
           .not('final_score', 'is', null)
-          .limit(5);
+          .not('final_score_pert_cutoff_method', 'is', null);
         if (error) {
           assert.fail(`probe error: ${error.message}`);
         }
-        if (data && data.length > 0) {
-          const allDisabled = data.every(r => r.final_score_pert_cutoff_method === 'disabled');
-          assert.ok(
-            allDisabled,
-            `cycle4 leader-track final régua should be disabled (cohort_n<10); got: ${JSON.stringify(data.map(r => r.final_score_pert_cutoff_method))}`
-          );
+        assert.ok(data && data.length > 0, 'nada para verificar — ver o teste anterior');
+
+        // Invariante universal: iterar. Um `.some()` aqui passaria com uma linha certa e
+        // dez erradas.
+        for (const r of data) {
+          const n = r.final_score_pert_cohort_n;
+          const m = r.final_score_pert_cutoff_method;
+          const onde = `${r.role_applied} app=${r.id} cohort_n=${n} method=${m}`;
+          assert.ok(Number.isInteger(n), `coorte ausente: ${onde}`);
+          if (n >= CUTOFF_MIN_COHORT) {
+            assert.equal(m, 'dynamic', `coorte >= ${CUTOFF_MIN_COHORT} exige método dynamic: ${onde}`);
+          } else {
+            assert.ok(
+              m === 'disabled' || m === 'historical_fallback',
+              `coorte < ${CUTOFF_MIN_COHORT} não pode produzir régua dynamic: ${onde}`
+            );
+          }
         }
       });
     });


### PR DESCRIPTION
## O vermelho não era do código, era do calendário

A CI da `main` em `1db46b79` estava **verde às 08:49 UTC** de 06/08. Às 17:30 UTC o recompute
da régua PERT rodou, e desde então `p246-229b-final-score-pert-by-track` falha — **sem nenhum
commit no meio**.

Causa medida: o coorte histórico da trilha de líder chegou a **exatamente 10**, o mínimo que
`_compute_pert_cutoff_core` aceita, e a régua virou `dynamic` sobre 12 candidaturas (alvo
249.52). O sistema obedeceu a própria regra. O teste é que afirmava um **instante**:

```js
// antes
const allDisabled = data.every(r => r.final_score_pert_cutoff_method === 'disabled');
```

## O que muda

A regra tem **três** saídas, e o teste antigo conhecia duas:

```
v_n >= 10                          -> 'dynamic'
v_n <  10 e há alvo de outro ciclo -> 'historical_fallback'
v_n <  10 e não há                 -> 'disabled'
```

Os dois testes DB-gated passam a afirmar a regra:

1. **a régua foi calculada** — existe ao menos uma linha do `cycle4` com método não-nulo.
   (O teste antigo, por amostra de 5, deixava passar um NULL em toda a base.)
2. **o método obedece o coorte em TODA linha, nas duas trilhas** — iterando, não com
   `.some()`: um acerto esconderia dez erros.

Some-se: caiu o `.limit(5)`. Verificar invariante por amostra de 5 é sorte, não guard.

## Fica mais forte, não mais fraco

| defeito | teste antigo | teste novo |
|---|---|---|
| régua não calculada (NULL em toda a base) | ❌ passava (amostra) | ✅ pega |
| método incoerente com o coorte | ❌ só na trilha de líder | ✅ nas duas, toda linha |
| coorte entra/sai de uma candidatura | 💥 quebra | ✅ indiferente |

**Verificado por mutação:** mover `CUTOFF_MIN_COHORT` de 10 para 50 — simulando regra em
código divergindo do dado — derruba a suíte (17 pass / 1 fail). Sem mutação: **18/18**.

## O sinal não foi apagado

O caminho fácil era relaxar a asserção e fechar a CI. Isso teria descartado um fato de
produto: **uma régua dinâmica ligou no meio de um ciclo em andamento, calculada sobre o
coorte mínimo, alcançando 12 candidaturas de líder que antes não tinham banda de corte.**

Está registrado em **#1634** para decisão do PM, com as duas leituras possíveis (o limiar
é ratificado e deve valer / n=10 é piso e o critério não deveria mudar debaixo de quem já
foi avaliado).

Refs #1634. Destrava a CI do #1633 (Wave 0 de segurança), que herdava este vermelho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHkKNRTbNBTvtLCjZwJs12
