### PR TITLE
feat(nav): a fila do avaliador entra no menu — o sinal que faltava agora existe (#1591)

### DIFF
--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -118,6 +118,9 @@ const jsI18n = JSON.stringify({
   // nav.cpmai, nav.docsMcp, nav.adminVepReconciliation). Nav resolves labels
   // via i18n[toCamelKey(item.key)] so each item.key needs a camelCase mapping.
   myPending: t('nav.myPending', lang),
+  // #1591: o Nav resolve rótulo por `i18n[toCamelKey(item.key)]`, então a chave 'my-evaluations'
+  // precisa desta entrada camelCase — sem ela o item renderiza o rótulo cru (defeito do p195).
+  myEvaluations: t('nav.myEvaluations', lang),
   cpmai: t('nav.cpmai', lang),
   docsMcp: t('nav.docsMcp', lang),
   adminVepReconciliation: t('nav.adminVepReconciliation', lang),

--- a/src/i18n/en-US.ts
+++ b/src/i18n/en-US.ts
@@ -5489,6 +5489,7 @@ const enUS: Record<string, string> = {
   'nav.certificates': 'My Certificates',
   'nav.myPending': '✍️ My pending signatures',
   'nav.myPoints': '📊 My Score',
+  'nav.myEvaluations': '🗳️ My Evaluations',
   'myPoints.title': 'My Score, auditable',
   'myPoints.heading': 'My Score, auditable',
   'myPoints.subtitle': 'Every point, with the date it happened and the cycle it belongs to.',

--- a/src/i18n/es-LATAM.ts
+++ b/src/i18n/es-LATAM.ts
@@ -5490,6 +5490,7 @@ const esLATAM: Record<string, string> = {
   'nav.certificates': 'Mis Certificados',
   'nav.myPending': '✍️ Mis firmas pendientes',
   'nav.myPoints': '📊 Mi Puntuación',
+  'nav.myEvaluations': '🗳️ Mis Evaluaciones',
   'myPoints.title': 'Mi Puntuación, auditable',
   'myPoints.heading': 'Mi Puntuación, auditable',
   'myPoints.subtitle': 'Cada punto, con la fecha del hecho y el ciclo al que pertenece.',

--- a/src/i18n/pt-BR.ts
+++ b/src/i18n/pt-BR.ts
@@ -5495,6 +5495,7 @@ const ptBR: Record<string, string> = {
   'nav.certificates': 'Meus Certificados',
   'nav.myPending': '✍️ Minhas pendências',
   'nav.myPoints': '📊 Minha Pontuação',
+  'nav.myEvaluations': '🗳️ Minhas Avaliações',
   'myPoints.title': 'Minha Pontuação, auditável',
   'myPoints.heading': 'Minha Pontuação, auditável',
   'myPoints.subtitle': 'Cada ponto, com a data do fato e o ciclo a que pertence.',

--- a/src/lib/navigation.config.ts
+++ b/src/lib/navigation.config.ts
@@ -107,15 +107,24 @@ export const NAV_ITEMS: NavItem[] = [
   // ─── Profile drawer only ───
   { key: 'profile', labelKey: 'nav.profile', href: '/profile', minTier: 'visitor', requiresAuth: true, section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' }, // #867 pre-term journey — guest-reachable (profile.astro self-gates via isRegisteredMember; own-row SECDEF)
   { key: 'my-points', labelKey: 'nav.myPoints', href: '/minha-pontuacao', minTier: 'member', requiresAuth: true, section: 'drawer', group: 'profile', drawerSection: 'meu-espaco' }, // #1473 Onda 5a — ledger de pontuação auditável (self via get_my_points_statement; admin ?member= via get_member_points_ledger)
-  // NOTA (auditoria 2026-08-03, Achado G): /minhas-avaliacoes existe e é gateada de forma
-  // AUTORITATIVA pelas próprias RPCs committee-scoped (get_my_pending_evaluations /
-  // get_evaluation_form / submit_evaluation), mas NÃO tem entrada de nav de propósito.
-  // Uma primeira versão aproximava "está no comitê" via allowedOperationalRoles:['tribe_leader',...]
-  // e foi barrada por `route-acl.test.mjs`: nenhuma rota lgpdSensitive pode ser alcançada por
-  // tribe_leader sem designation — política correta, já que a tela expõe PII de candidato.
-  // O sinal certo é participação em `selection_committee`, que hoje NÃO existe no payload de
-  // `get_member_by_auth` que alimenta o nav. Adicioná-lo é item de spec (muda RPC + db:types no
-  // mesmo PR). Até lá o acesso é por URL direta, entregue a quem está no comitê.
+  // #1591 — a fila do próprio avaliador, finalmente no menu.
+  //
+  // A nota anterior (auditoria 2026-08-03, Achado G) registrava por que esta entrada NÃO existia:
+  // aproximar "está no comitê" por `allowedOperationalRoles:['tribe_leader']` era barrado pelo
+  // `route-acl.test.mjs`, e com razão — a tela expõe PII de candidato, e há muito mais líder de
+  // tribo do que membro de comitê. A nota concluía que o sinal certo era participação em
+  // `selection_committee`, ausente do payload de `get_member_by_auth`, e que adicioná-lo seria
+  // item de spec.
+  //
+  // Foi o que o PR #1677 fez: `selection_committee_active` passou a vir no payload, DERIVADO do
+  // domínio, e `allowedSelectionCommittee` virou o quarto eixo, modelado também no guard de ACL.
+  // Com isso a aproximação perigosa deixa de ser necessária: quem entra aqui é quem está no
+  // comitê de um ciclo vivo, e mais ninguém.
+  //
+  // `lgpdSensitive` porque a fila lista nome de candidato. As RPCs continuam sendo a autoridade
+  // real (`get_my_pending_evaluations` / `get_evaluation_form` / `submit_evaluation`, todas
+  // committee-scoped); esta entrada é UX, não fronteira.
+  { key: 'my-evaluations', labelKey: 'nav.myEvaluations', href: '/minhas-avaliacoes', minTier: 'admin', requiresAuth: true, section: 'drawer', group: 'profile', drawerSection: 'meu-espaco', allowedSelectionCommittee: true, lgpdSensitive: true },
 
   // ─── Admin area ───
   { key: 'admin',           labelKey: 'nav.admin',          href: '/admin',           minTier: 'observer', requiresAuth: true, section: 'both',   group: 'admin', badge: 'purple', drawerSection: 'admin', navSlot: 'primary' },

--- a/tests/contracts/1591-comite-de-selecao-alcanca-o-admin.test.mjs
+++ b/tests/contracts/1591-comite-de-selecao-alcanca-o-admin.test.mjs
@@ -56,6 +56,31 @@ describe('#1591 A — o eixo existe e é declarado na rota certa', () => {
     assert.match(bloco, /allowedDesignations:\s*\['sponsor'\]/);
   });
 
+  it('a fila do avaliador (/minhas-avaliacoes) tem entrada de menu pelo eixo', () => {
+    // Era a issue original: a página existia e não tinha entrada de propósito, porque o único
+    // jeito de exprimir "é do comitê" seria abrir para todo tribe_leader. Com o eixo, deixa de ser.
+    const bloco = navSrc.match(/\{\s*key:\s*'my-evaluations'[\s\S]*?\}/)?.[0] ?? '';
+    assert.ok(bloco, 'entrada my-evaluations não encontrada');
+    assert.match(bloco, /href:\s*'\/minhas-avaliacoes'/);
+    assert.match(bloco, /allowedSelectionCommittee:\s*true/);
+    assert.match(bloco, /lgpdSensitive:\s*true/, 'a fila lista nome de candidato');
+    // E NÃO pode voltar a aproximar por papel operacional — foi o que o route-acl barrou.
+    assert.doesNotMatch(bloco, /allowedOperationalRoles/,
+      'aproximar "é do comitê" por tribe_leader abre a rota para muito mais gente do que o comitê');
+  });
+
+  it('o rótulo tem chave nos 3 dicionários E no mapa do Nav', () => {
+    // O Nav resolve por `i18n[toCamelKey(item.key)]`: sem a entrada camelCase o item renderiza
+    // a chave crua, que foi o defeito do p195.
+    for (const [lang, path] of Object.entries({
+      'pt-BR': 'src/i18n/pt-BR.ts', 'en-US': 'src/i18n/en-US.ts', 'es-LATAM': 'src/i18n/es-LATAM.ts',
+    })) {
+      assert.match(read(path), /'nav\.myEvaluations':/, `${lang}: rótulo ausente`);
+    }
+    assert.match(clientSrc, /myEvaluations:\s*t\('nav\.myEvaluations'/,
+      'sem o mapeamento camelCase o menu mostra a chave crua');
+  });
+
   it('AS DUAS implementações do menu conhecem o eixo', () => {
     // O defeito clássico é consertar a gêmea morta. Aqui as duas estão vivas: uma decide no
     // servidor, a outra no cliente, sobre o MESMO item de nav.


### PR DESCRIPTION
Fecha a issue **original** do #1591. O PR #1677 construiu o sinal e o usou para `/admin/selection`;
o que a issue pedia era a entrada de menu para **`/minhas-avaliacoes`**, a fila do próprio avaliador.

## O código já explicava por que a entrada não existia

No lugar exato desta entrada havia um bloco de NOTA (auditoria 2026-08-03, Achado G) dizendo:

> Uma primeira versão aproximava "está no comitê" via `allowedOperationalRoles:['tribe_leader',...]`
> e foi barrada por `route-acl.test.mjs` (…) O sinal certo é participação em `selection_committee`,
> que hoje **NÃO existe** no payload de `get_member_by_auth` (…) Adicioná-lo é item de spec.

E a nota estava certa: a tela lista nome de candidato, e há muito mais líder de tribo do que membro
de comitê. **O #1677 fez exatamente o item de spec** — `selection_committee_active` passou a vir no
payload, derivado do domínio, e `allowedSelectionCommittee` virou o quarto eixo, modelado também no
guard de ACL. Com a máquina pronta, esta entrada custa uma linha, e a aproximação perigosa deixa de
ser necessária.

Troquei a nota obsoleta pela entrada, mantendo no comentário o registro de por que a saída fácil
continua proibida.

## O que o teste afirma

- a entrada existe, aponta para `/minhas-avaliacoes`, usa o eixo do comitê e mantém `lgpdSensitive`
- **e NÃO volta a usar `allowedOperationalRoles`** — é o que separa o eixo novo de um vazamento
- o rótulo tem as **três** peças, não uma: chave nos 3 dicionários **e** o mapeamento camelCase no
  `jsI18n` do `Nav`, que resolve por `i18n[toCamelKey(item.key)]` e sem ele renderiza a chave crua
  (foi o defeito do p195)

`lgpdSensitive` fica. As RPCs continuam sendo a autoridade real (`get_my_pending_evaluations` /
`get_evaluation_form` / `submit_evaluation`, todas committee-scoped); a entrada é UX, não fronteira.

## Verificação

- `npm test`: **6540 testes, 6539 passam, 0 falhas, 1 skip**
- `route-acl.test.mjs` verde (13/13), incluindo a asserção de que o eixo abre **só** o que o declara
- `npx astro build` limpo

## Como confirmar na prática

Um membro do comitê logado deve passar a ver **Minhas Avaliações** no drawer. Medido em produção:
para um avaliador do ciclo aberto a fila tem **20 pendentes**; para quem já submeteu as 20, ela
aparece vazia com o progresso em `20/20 (100%)` — que é comportamento correto, não bug.

Closes #1591
Refs #1590, #1677