### PR TITLE
fix(selection): observador OBSERVA, e o e-mail prometia um round-robin que nao existe (#1591)

### DIFF
--- a/src/components/nav/Nav.astro
+++ b/src/components/nav/Nav.astro
@@ -377,8 +377,16 @@ const NAV_PUBLIC_SUPABASE_ANON_KEY = (import.meta.env.PUBLIC_SUPABASE_ANON_KEY |
     // #1591 — ESTA função é a gêmea de `getItemAccessibility` em `src/lib/navigation.config.ts`.
     // As duas decidem a mesma coisa em runtimes diferentes (servidor e cliente), então um eixo
     // novo em só uma delas produz menu que aparece de um lado e some do outro. Mexer nas duas.
-    const hasCommittee = item.allowedSelectionCommittee === true
-      && _member?.selection_committee_active === true;
+    //
+    // O eixo distingue PAPEL: observador acompanha o processo ('any') mas não recebe a fila de
+    // avaliação ('evaluator'). Tratar os dois como iguais convidava o observador a pontuar.
+    const _committeeRole = _member?.selection_committee_role ?? null;
+    const hasCommittee =
+      item.allowedSelectionCommittee === 'any'
+        ? Boolean(_committeeRole)
+        : item.allowedSelectionCommittee === 'evaluator'
+          ? _committeeRole === 'evaluator'
+          : false;
     const enabled = meetsMinTier || hasDesig || hasOpRole || hasCommittee;
     if (item.lgpdSensitive && !enabled) return { visible: false, enabled: false };
     return { visible: true, enabled };

--- a/src/lib/database.gen.ts
+++ b/src/lib/database.gen.ts
@@ -33273,6 +33273,10 @@ export type Database = {
         Args: { p_caller_id: string; p_cycle_id: string }
         Returns: boolean
       }
+      selection_committee_role_for: {
+        Args: { p_member_id: string }
+        Returns: string
+      }
       selection_consistency_report: {
         Args: { p_cycle_id?: string }
         Returns: Json

--- a/src/lib/navigation.config.ts
+++ b/src/lib/navigation.config.ts
@@ -29,10 +29,18 @@ export interface NavItem {
    * na tribo (tribe_leader) e usá-lo abriria a rota para TODO tribe_leader, que é exatamente o que
    * o `route-acl.test.mjs` barra numa rota `lgpdSensitive`.
    *
-   * O sinal vem de `get_member_by_auth().selection_committee_active`, que é verdade do domínio
+   * O sinal vem de `get_member_by_auth().selection_committee_role`, que é verdade do domínio
    * (`selection_committee` × ciclo aberto/avaliando), não um espelho mantido à mão.
+   *
+   * ⚠️ O eixo distingue PAPEL, e a primeira versão não distinguia — tratava `evaluator` e
+   * `observer` como a mesma coisa. Isso importa porque observador OBSERVA: dar a ele a fila de
+   * avaliação é convidá-lo a pontuar candidato, que não é a função dele.
+   *
+   *   'any'       — qualquer membro do comitê, inclusive observador (ex.: o painel do processo,
+   *                 que é literalmente o que o observador existe para acompanhar)
+   *   'evaluator' — só quem avalia (ex.: a fila de avaliação)
    */
-  allowedSelectionCommittee?: boolean;
+  allowedSelectionCommittee?: 'any' | 'evaluator';
   requiresAuth: boolean;
   section: 'main' | 'drawer' | 'both';
   group?: string;
@@ -124,7 +132,7 @@ export const NAV_ITEMS: NavItem[] = [
   // `lgpdSensitive` porque a fila lista nome de candidato. As RPCs continuam sendo a autoridade
   // real (`get_my_pending_evaluations` / `get_evaluation_form` / `submit_evaluation`, todas
   // committee-scoped); esta entrada é UX, não fronteira.
-  { key: 'my-evaluations', labelKey: 'nav.myEvaluations', href: '/minhas-avaliacoes', minTier: 'admin', requiresAuth: true, section: 'drawer', group: 'profile', drawerSection: 'meu-espaco', allowedSelectionCommittee: true, lgpdSensitive: true },
+  { key: 'my-evaluations', labelKey: 'nav.myEvaluations', href: '/minhas-avaliacoes', minTier: 'admin', requiresAuth: true, section: 'drawer', group: 'profile', drawerSection: 'meu-espaco', allowedSelectionCommittee: 'evaluator', lgpdSensitive: true },
 
   // ─── Admin area ───
   { key: 'admin',           labelKey: 'nav.admin',          href: '/admin',           minTier: 'observer', requiresAuth: true, section: 'both',   group: 'admin', badge: 'purple', drawerSection: 'admin', navSlot: 'primary' },
@@ -153,7 +161,7 @@ export const NAV_ITEMS: NavItem[] = [
   // até aqui não tinha porta nenhuma — o domínio sabia (`selection_committee.role`), o menu não.
   // As RPCs de dashboard passaram a aceitar o mesmo predicado na MESMA migration: abrir só o menu
   // faria a página carregar e negar os dados, que é o defeito do #1590 ao contrário.
-  { key: 'admin-selection', labelKey: 'nav.adminSelection', href: '/admin/selection', minTier: 'admin', requiresAuth: true, section: 'drawer', group: 'admin-sub', drawerSection: 'admin', allowedDesignations: ['sponsor'], allowedSelectionCommittee: true, lgpdSensitive: true }, // sponsor = host/chapter president full read (Wave 1 — Ivan/LIM; RPC data already gated view_chapter_dashboards which sponsor holds)
+  { key: 'admin-selection', labelKey: 'nav.adminSelection', href: '/admin/selection', minTier: 'admin', requiresAuth: true, section: 'drawer', group: 'admin-sub', drawerSection: 'admin', allowedDesignations: ['sponsor'], allowedSelectionCommittee: 'any', lgpdSensitive: true }, // sponsor = host/chapter president full read (Wave 1 — Ivan/LIM; RPC data already gated view_chapter_dashboards which sponsor holds)
   { key: 'admin-vep-reconciliation', labelKey: 'nav.adminVepReconciliation', href: '/admin/vep-reconciliation', minTier: 'admin', requiresAuth: true, section: 'drawer', group: 'admin-sub', drawerSection: 'admin', allowedDesignations: ['sponsor'] },
   { key: 'admin-campaigns', labelKey: 'nav.adminCampaigns', href: '/admin/campaigns', minTier: 'admin', requiresAuth: true, section: 'main', group: 'admin-sub', navSlot: 'none', allowedDesignations: ['comms_team'] },
   { key: 'admin-blog', labelKey: 'nav.adminBlog', href: '/admin/blog', minTier: 'admin', requiresAuth: true, section: 'main', group: 'admin-sub', navSlot: 'none', allowedDesignations: ['comms_team'] },
@@ -174,7 +182,7 @@ export function getItemAccessibility(
   designations: string[],
   isLoggedIn: boolean,
   operationalRole?: string,
-  onSelectionCommittee?: boolean
+  selectionCommitteeRole?: string | null
 ): ItemAccessibility {
   if (item.requiresAuth && !isLoggedIn) {
     return { visible: false, enabled: false, requiredTier: item.minTier };
@@ -188,7 +196,14 @@ export function getItemAccessibility(
     ? item.allowedOperationalRoles.includes(operationalRole || '')
     : false;
   // #1591: só conta quando a entrada declara o eixo — um `true` solto no perfil não abre nada.
-  const hasCommittee = item.allowedSelectionCommittee === true && onSelectionCommittee === true;
+  // #1591: só conta quando a ENTRADA declara o eixo — um papel solto no perfil não abre nada.
+  // E distingue papel: 'any' inclui observador, 'evaluator' não.
+  const hasCommittee =
+    item.allowedSelectionCommittee === 'any'
+      ? Boolean(selectionCommitteeRole)
+      : item.allowedSelectionCommittee === 'evaluator'
+        ? selectionCommitteeRole === 'evaluator'
+        : false;
   const enabled = meetsMinTier || hasDesig || hasOperationalRole || hasCommittee;
 
   if (item.lgpdSensitive && !enabled) {

--- a/supabase/migrations/20260807000900_1591_observador_observa_nao_avalia.sql
+++ b/supabase/migrations/20260807000900_1591_observador_observa_nao_avalia.sql
@@ -1,0 +1,367 @@
+-- #1591 (2ª parte) — OBSERVADOR OBSERVA. O eixo de autoridade passa a distinguir papel.
+--
+-- O QUE A 1ª PARTE ERROU
+-- A migration 20260807000700 criou o quarto eixo ("é do comitê de seleção") e o expôs ao menu como
+-- um BOOLEANO, `selection_committee_active`. Booleano não tem como dizer *qual* papel, então
+-- `evaluator` e `observer` viraram a mesma coisa em toda a superfície.
+--
+-- Isso passou despercebido porque o servidor já era assim: nem `submit_evaluation` nem
+-- `get_my_pending_evaluations` olhavam `sc.role` — bastava estar no `selection_committee`. Medido
+-- em 07/08/2026 no ciclo vivo:
+--
+--   papel        pessoas   avaliações submetidas
+--   evaluator       3              455
+--   observer        4                0
+--
+-- Ou seja: o comportamento estava certo por HÁBITO das pessoas, não por trava. Uma capacidade que
+-- apenas não é exercida por costume não é uma regra — e o #1591 ia piorar isso, porque acabou de
+-- pôr `/minhas-avaliacoes` no menu. Os 4 observadores passariam a ver a fila com botão "Avaliar".
+-- Latente virava convite.
+--
+-- Foi o PM quem apontou a distinção, ao corrigir uma confusão minha entre o comitê de SELEÇÃO
+-- (que tem observadores) e o comitê de CURADORIA de artigos, que é outro corpo e outro domínio.
+--
+-- A DECISÃO (PM, 07/08/2026)
+-- Peer review aberto a todo o comitê, EXCETO observadores, que só visualizam.
+--
+-- O QUE MUDA, EM DUAS CAMADAS
+--   1. `submit_evaluation` — a FRONTEIRA. Recusa `observer` com `insufficient_privilege`. O escape
+--      de `manage_platform` continua, porque a correção é sobre papel no comitê, não sobre quem
+--      administra a plataforma.
+--   2. `get_member_by_auth` — o SINAL. `selection_committee_active` (booleano) dá lugar a
+--      `selection_committee_role` ('evaluator' | 'observer' | NULL), derivado por
+--      `selection_committee_role_for()`. Uma representação só: booleano + papel seriam duas
+--      verdades sobre o mesmo fato, e é assim que uma envelhece.
+--
+-- No nav, o eixo deixa de ser `boolean` e passa a ser `'any' | 'evaluator'`:
+--   `/admin/selection`   → 'any'        (acompanhar o processo é a função do observador)
+--   `/minhas-avaliacoes` → 'evaluator'  (a fila é de quem pontua)
+--
+-- ⚠️ RESÍDUO DECLARADO: `get_my_pending_evaluations` continua listando a fila para observador que
+-- chegue por URL direta. Isso é coerente com "só visualizam" e a fronteira (submissão) está
+-- fechada, mas significa que um observador teimoso vê um botão que vai recusar. Não foi tratado
+-- aqui de propósito: mexer no retorno da RPC muda contrato com a tela, e a decisão foi sobre quem
+-- AVALIA, não sobre quem VÊ.
+--
+-- Como este arquivo foi produzido: alteração aplicada por substituição ancorada sobre
+-- `pg_get_functiondef` (com RAISE se a âncora não casasse) e corpos extraídos do banco por script.
+--
+-- Refs #1591, #1590
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- O papel, como predicado derivado do domínio.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.selection_committee_role_for(p_member_id uuid)
+RETURNS text
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path TO 'public', 'pg_temp'
+AS $function$
+  -- Papel da pessoa no comite de algum ciclo VIVO. `evaluator` vence `observer` quando ha os dois
+  -- (alguem pode observar um ciclo e avaliar outro; a capacidade maior e a que vale).
+  -- NULL = nao esta em comite nenhum vivo.
+  SELECT CASE
+           WHEN bool_or(sc.role = 'evaluator') THEN 'evaluator'
+           WHEN count(*) > 0 THEN 'observer'
+         END
+  FROM public.selection_committee sc
+  JOIN public.selection_cycles c ON c.id = sc.cycle_id
+  WHERE sc.member_id = p_member_id
+    AND (c.status = 'open' OR c.phase = 'evaluating');
+$function$;
+
+COMMENT ON FUNCTION public.selection_committee_role_for(uuid) IS
+  '#1591 — papel no comite de selecao de ciclo vivo: evaluator | observer | NULL. Substitui o '
+  'booleano `selection_committee_active`, que tratava observador e avaliador como a mesma coisa e '
+  'por isso convidava o observador a avaliar. Observador OBSERVA (decisao do PM, 07/08/2026).';
+
+-- `FROM PUBLIC` sozinho não fecha nada: anon e authenticated têm GRANT próprio.
+REVOKE ALL ON FUNCTION public.selection_committee_role_for(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.selection_committee_role_for(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.submit_evaluation(p_application_id uuid, p_evaluation_type text, p_scores jsonb, p_notes text DEFAULT NULL::text, p_criterion_notes jsonb DEFAULT NULL::jsonb, p_ai_suggestion_id uuid DEFAULT NULL::uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_caller record;
+  v_app record;
+  v_cycle record;
+  v_committee record;
+  v_criteria jsonb;
+  v_criterion jsonb;
+  v_key text;
+  v_score numeric;
+  v_weight numeric;
+  v_max numeric;
+  v_weighted_sum numeric := 0;
+  v_eval_id uuid;
+  v_total_evaluators int;
+  v_submitted_count int;
+  v_all_subtotals numeric[];
+  v_pert_score numeric;
+  v_min_sub numeric;
+  v_max_sub numeric;
+  v_avg_sub numeric;
+  v_cutoff numeric;
+  v_median numeric;
+  v_new_status text;
+BEGIN
+  SELECT * INTO v_caller FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller IS NULL THEN RAISE EXCEPTION 'Unauthorized: member not found'; END IF;
+
+  SELECT * INTO v_app FROM public.selection_applications WHERE id = p_application_id;
+  IF v_app IS NULL THEN RAISE EXCEPTION 'Application not found'; END IF;
+
+  SELECT * INTO v_cycle FROM public.selection_cycles WHERE id = v_app.cycle_id;
+
+  SELECT * INTO v_committee FROM public.selection_committee
+  WHERE cycle_id = v_app.cycle_id AND member_id = v_caller.id;
+  IF v_committee IS NULL AND NOT public.can_by_member(v_caller.id, 'manage_platform'::text) THEN
+    RAISE EXCEPTION 'Unauthorized: not a committee member';
+  END IF;
+
+  -- #1591 — OBSERVADOR OBSERVA, nao avalia.
+  -- Ate aqui estar no comite bastava: nem esta funcao nem `get_my_pending_evaluations` olhavam o
+  -- `role`. Na pratica os 4 observadores do ciclo vivo nunca submeteram (455 avaliacoes, TODAS de
+  -- `evaluator`), entao o comportamento estava certo por HABITO das pessoas, nao por trava. Uma
+  -- capacidade que so nao e exercida por costume nao e uma regra.
+  -- Decisao do PM (07/08/2026): peer review aberto a todo o comite, EXCETO observadores.
+  -- O escape de `manage_platform` continua, para nao mudar a autoridade de quem administra.
+  IF v_committee.role = 'observer'
+     AND NOT public.can_by_member(v_caller.id, 'manage_platform'::text) THEN
+    RAISE EXCEPTION 'Unauthorized: observer role does not evaluate'
+      USING ERRCODE = 'insufficient_privilege';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.selection_evaluations
+    WHERE application_id = p_application_id
+      AND evaluator_id = v_caller.id
+      AND evaluation_type = p_evaluation_type
+      AND submitted_at IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION 'Evaluation already submitted and locked';
+  END IF;
+
+  v_criteria := CASE p_evaluation_type
+    WHEN 'objective' THEN v_cycle.objective_criteria
+    WHEN 'interview' THEN v_cycle.interview_criteria
+    WHEN 'leader_extra' THEN v_cycle.leader_extra_criteria
+    ELSE '[]'::jsonb
+  END;
+
+  FOR v_criterion IN SELECT * FROM jsonb_array_elements(v_criteria)
+  LOOP
+    v_key := v_criterion ->> 'key';
+    v_weight := COALESCE((v_criterion ->> 'weight')::numeric, 1);
+    v_max := COALESCE((v_criterion ->> 'max')::numeric, 10);
+    IF NOT (p_scores ? v_key) THEN RAISE EXCEPTION 'Missing score for criterion: %', v_key; END IF;
+    v_score := (p_scores ->> v_key)::numeric;
+    IF v_score IS NULL THEN RAISE EXCEPTION 'Score for % must be numeric', v_key; END IF;
+    IF v_score < 0 OR v_score > v_max THEN
+      RAISE EXCEPTION 'Score % for criterion "%" must be between 0 and % (schema max)', v_score, v_key, v_max;
+    END IF;
+    v_weighted_sum := v_weighted_sum + (v_weight * v_score);
+  END LOOP;
+
+  INSERT INTO public.selection_evaluations (
+    application_id, evaluator_id, evaluation_type,
+    scores, weighted_subtotal, notes, criterion_notes, submitted_at
+  ) VALUES (
+    p_application_id, v_caller.id, p_evaluation_type,
+    p_scores, ROUND(v_weighted_sum, 2), p_notes,
+    COALESCE(p_criterion_notes, '{}'::jsonb), now()
+  )
+  ON CONFLICT (application_id, evaluator_id, evaluation_type)
+  DO UPDATE SET
+    scores = EXCLUDED.scores,
+    weighted_subtotal = EXCLUDED.weighted_subtotal,
+    notes = EXCLUDED.notes,
+    criterion_notes = EXCLUDED.criterion_notes,
+    submitted_at = now()
+  RETURNING id INTO v_eval_id;
+
+  SELECT COUNT(*) INTO v_total_evaluators FROM public.selection_committee
+  WHERE cycle_id = v_app.cycle_id AND role IN ('evaluator', 'lead');
+
+  SELECT COUNT(*) INTO v_submitted_count FROM public.selection_evaluations
+  WHERE application_id = p_application_id AND evaluation_type = p_evaluation_type AND submitted_at IS NOT NULL;
+
+  IF v_submitted_count >= v_cycle.min_evaluators THEN
+    SELECT ARRAY_AGG(weighted_subtotal ORDER BY weighted_subtotal) INTO v_all_subtotals
+    FROM public.selection_evaluations
+    WHERE application_id = p_application_id AND evaluation_type = p_evaluation_type AND submitted_at IS NOT NULL;
+
+    v_min_sub := v_all_subtotals[1];
+    v_max_sub := v_all_subtotals[array_upper(v_all_subtotals, 1)];
+    SELECT AVG(unnest) INTO v_avg_sub FROM unnest(v_all_subtotals);
+    v_pert_score := ROUND((2 * v_min_sub + 4 * v_avg_sub + 2 * v_max_sub) / 8, 2);
+
+    IF p_evaluation_type = 'objective' THEN
+      UPDATE public.selection_applications SET objective_score_avg = v_pert_score, updated_at = now() WHERE id = p_application_id;
+      SELECT PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY objective_score_avg) INTO v_median
+      FROM public.selection_applications WHERE cycle_id = v_app.cycle_id AND objective_score_avg IS NOT NULL;
+      v_cutoff := ROUND(COALESCE(v_median, 0) * 0.75, 2);
+      IF v_pert_score < v_cutoff AND v_cutoff > 0 THEN v_new_status := 'objective_cutoff'; ELSE v_new_status := 'interview_pending'; END IF;
+      UPDATE public.selection_applications SET status = v_new_status, updated_at = now()
+      WHERE id = p_application_id AND status IN ('submitted', 'screening', 'objective_eval');
+    ELSIF p_evaluation_type = 'interview' THEN
+      UPDATE public.selection_applications
+        SET interview_score = v_pert_score,
+            status = 'final_eval',
+            updated_at = now()
+      WHERE id = p_application_id;
+      PERFORM public.compute_application_scores(p_application_id);
+    ELSIF p_evaluation_type = 'leader_extra' THEN
+      UPDATE public.selection_applications
+        SET leader_extra_pert_score = v_pert_score,
+            updated_at = now()
+      WHERE id = p_application_id;
+      PERFORM public.compute_application_scores(p_application_id);
+    END IF;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'success', true, 'evaluation_id', v_eval_id, 'weighted_subtotal', ROUND(v_weighted_sum, 2),
+    'all_submitted', v_submitted_count >= v_cycle.min_evaluators,
+    'pert_score', v_pert_score, 'new_status', v_new_status
+  );
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.get_member_by_auth()
+ RETURNS json
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_uid uuid := auth.uid();
+  v_email text;
+  v_member_id uuid;
+  v_existing_auth_id uuid;
+  v_result json;
+BEGIN
+  IF v_uid IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Step 1: direct match on members.auth_id (the common case)
+  SELECT id INTO v_member_id FROM public.members WHERE auth_id = v_uid LIMIT 1;
+
+  -- Step 2: match on secondary_auth_ids (admin-pre-approved alternates -> safe to rotate)
+  IF v_member_id IS NULL THEN
+    SELECT id INTO v_member_id
+      FROM public.members
+     WHERE v_uid = ANY(COALESCE(secondary_auth_ids, '{}'))
+     LIMIT 1;
+
+    IF v_member_id IS NOT NULL THEN
+      SELECT auth_id INTO v_existing_auth_id FROM public.members WHERE id = v_member_id;
+
+      UPDATE public.members
+         SET auth_id            = v_uid,
+             secondary_auth_ids = array_append(
+                                    array_remove(COALESCE(secondary_auth_ids, '{}'::uuid[]), v_uid),
+                                    v_existing_auth_id
+                                  ),
+             updated_at         = now()
+       WHERE id = v_member_id;
+
+      -- p177 D=1 fix: sync persons.auth_id to the new primary (mirror try_auto_link_ghost).
+      UPDATE public.persons
+         SET auth_id = v_uid
+       WHERE legacy_member_id = v_member_id
+         AND (auth_id IS NULL OR auth_id <> v_uid);
+
+      INSERT INTO public.admin_audit_log(actor_id, action, target_type, target_id, changes, metadata)
+      VALUES (
+        v_member_id,
+        'members.auth_id.rotated_secondary_to_primary',
+        'member',
+        v_member_id,
+        jsonb_build_object(
+          'promoted_auth_id', v_uid,
+          'demoted_auth_id', v_existing_auth_id
+        ),
+        jsonb_build_object('via', 'get_member_by_auth.step2_secondary_auth_ids_match')
+      );
+    END IF;
+  END IF;
+
+  -- Step 3: PRIMARY email first-link (only when auth_id IS NULL -- genuine ghost first login).
+  -- P168 R3-a: dropped the (a) secondary_emails match branch and (b) replace-existing-auth_id
+  -- branch. Both were the mechanism behind Paulo Alves identity hijack.
+  IF v_member_id IS NULL THEN
+    SELECT lower(email) INTO v_email FROM auth.users WHERE id = v_uid;
+
+    IF v_email IS NOT NULL THEN
+      SELECT id INTO v_member_id
+        FROM public.members
+       WHERE lower(email) = v_email
+         AND auth_id IS NULL
+       LIMIT 1;
+
+      IF v_member_id IS NOT NULL THEN
+        UPDATE public.members
+           SET auth_id    = v_uid,
+               updated_at = now()
+         WHERE id = v_member_id;
+
+        -- p177 D=1 fix: sync persons.auth_id on first-link (mirror try_auto_link_ghost).
+        UPDATE public.persons
+           SET auth_id = v_uid
+         WHERE legacy_member_id = v_member_id
+           AND (auth_id IS NULL OR auth_id <> v_uid);
+
+        INSERT INTO public.admin_audit_log(actor_id, action, target_type, target_id, changes, metadata)
+        VALUES (
+          v_member_id,
+          'members.auth_id.first_link',
+          'member',
+          v_member_id,
+          jsonb_build_object(
+            'linked_auth_id', v_uid,
+            'matched_via',    'primary_email',
+            'matched_email',  v_email
+          ),
+          jsonb_build_object('via', 'get_member_by_auth.step3_primary_email_when_null')
+        );
+      END IF;
+    END IF;
+  END IF;
+
+  IF v_member_id IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  -- Return JSON shape -- adds allow_precise_location_in_public_map (Cycle4 PD-MAP unified opt-in); rest UNCHANGED.
+  SELECT row_to_json(q) INTO v_result FROM (
+    SELECT m.id, m.name, m.email, m.secondary_emails,
+      m.pmi_id, m.phone, m.operational_role, m.designations,
+      compute_legacy_role(m.operational_role, m.designations)  AS role,
+      compute_legacy_roles(m.operational_role, m.designations) AS roles,
+      m.chapter, m.tribe_id, m.current_cycle_active, m.is_superadmin, m.is_active,
+      m.member_status, m.state, m.country, m.share_whatsapp, m.signature_url,
+      m.address, m.city, m.birth_date,
+      m.share_address, m.share_birth_date, m.allow_state_in_public_map, m.allow_precise_location_in_public_map,
+      m.privacy_consent_accepted_at, m.privacy_consent_version, m.data_last_reviewed_at,
+      m.inactivated_at, m.inactivation_reason,
+      m.photo_url, m.linkedin_url, m.auth_id,
+      m.credly_url, m.credly_badges, m.cpmai_certified,
+      m.created_at, m.updated_at,
+      -- #1591: o quarto eixo de autoridade que o nav nao tinha. E DERIVADO do dominio
+      -- (selection_committee x ciclo vivo), nunca uma coluna espelho mantida a mao — espelho
+      -- envelhece e passa a conceder o que ja acabou.
+      public.selection_committee_role_for(m.id) AS selection_committee_role
+    FROM public.members m
+    WHERE m.id = v_member_id
+  ) q;
+
+  RETURN v_result;
+END;
+$function$;

--- a/supabase/migrations/20260807001000_coerencia_o_email_prometia_round_robin.sql
+++ b/supabase/migrations/20260807001000_coerencia_o_email_prometia_round_robin.sql
@@ -1,0 +1,93 @@
+-- Coerência do convite de avaliação: o e-mail prometia um modelo que a plataforma não tem.
+--
+-- O DESCOMPASSO, MEDIDO EM 07/08/2026
+-- `peer_review_request` dizia, nas 3 línguas: *"Você foi escolhido(a) (round-robin) para avaliar a
+-- candidatura de X"*. Isso descreve atribuição individual.
+--
+-- `get_my_pending_evaluations` implementa outra coisa: escolhe o ciclo em `phase='evaluating'`,
+-- confere participação no comitê e devolve **todos** os candidatos não-terminais que a pessoa
+-- ainda não submeteu. Não há tabela de atribuição, não há round-robin, não há dono. Hoje isso são
+-- 20 candidatos avaliáveis, e os mesmos 20 aparecem para todo o comitê.
+--
+-- Ou seja: o e-mail prometia dono e a tela entregava fila. Quem recebia podia concluir que só ele
+-- avaliaria aquele candidato — ou o contrário, ignorar por achar que "não era o dele".
+--
+-- A DECISÃO (PM, 07/08/2026): a FILA COMPARTILHADA é o modelo. É o que a plataforma faz, é o que
+-- produziu as 455 avaliações do ciclo, e é coerente com "mínimo de 2 avaliadores por candidato":
+-- quem pega, pega. O texto é que muda.
+--
+-- TRÊS AFIRMAÇÕES SAEM, e todas eram falsas de formas diferentes:
+--
+--   1. "escolhido (round-robin)" — descreve mecanismo inexistente.
+--
+--   2. "Pré-análise IA concluída" — INCONDICIONAL, e o template não tem variável de IA nenhuma
+--      (as 5 declaradas são first_name, applicant_name, chapter, role_applied, eval_url). A
+--      análise depende de consentimento opcional: das avaliações já registradas na base, a MAIORIA
+--      é sobre candidatura sem análise. O avaliador era informado de um artefato que muitas vezes
+--      não existe. Sai por completo: a tela mostra a sugestão quando ela existe, e é lá que essa
+--      informação pertence.
+--
+--   3. "outro avaliador será designado" — pressupõe atribuição de novo. Numa fila compartilhada,
+--      quem não pode avaliar simplesmente não pega; o candidato continua disponível para os demais.
+--
+-- Nada aqui muda autoridade: o convite é comunicação. Quem pode avaliar continua sendo decidido
+-- por `submit_evaluation`, que na migration 20260807000900 passou a recusar observador.
+--
+-- Não é DDL: é UPDATE numa linha de `campaign_templates`. O bloco verifica o efeito pela contagem
+-- de linhas atingidas, não por `FOUND`.
+--
+-- Refs #1591, #1643
+
+DO $$
+DECLARE
+  v_rows int;
+BEGIN
+  UPDATE public.campaign_templates SET
+    body_html = jsonb_build_object(
+      'pt', '<p>Olá {{peer_first_name}},</p>'
+         || '<p>A candidatura de <strong>{{applicant_name}}</strong> ({{chapter}}, vaga de {{role_applied}}) está na fila de avaliação do comitê.</p>'
+         || '<p>A fila é <strong>compartilhada</strong>: qualquer avaliador do comitê pode assumir esta candidatura. Esperamos 2 avaliações por candidato.</p>'
+         || '<p><a href="{{eval_url}}" style="background:#0066cc;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">Avaliar candidato</a></p>'
+         || '<p style="color:#666;font-size:13px;">Se você não puder avaliar (conflito de interesse, indisponibilidade), não precisa responder: a candidatura segue na fila para os demais avaliadores.</p>'
+         || '<p>Obrigado!<br/>Núcleo IA &amp; GP — Comitê de Seleção</p>',
+      'en', '<p>Hello {{peer_first_name}},</p>'
+         || '<p><strong>{{applicant_name}}</strong>''s application ({{chapter}}, role: {{role_applied}}) is in the committee''s review queue.</p>'
+         || '<p>The queue is <strong>shared</strong>: any committee evaluator can take this application. We expect 2 evaluations per candidate.</p>'
+         || '<p><a href="{{eval_url}}" style="background:#0066cc;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">Review candidate</a></p>'
+         || '<p style="color:#666;font-size:13px;">If you cannot review it (conflict of interest, unavailability), no reply is needed: the application stays in the queue for the other evaluators.</p>'
+         || '<p>Thank you!<br/>Núcleo IA &amp; GP — Selection Committee</p>',
+      'es', '<p>Hola {{peer_first_name}},</p>'
+         || '<p>La candidatura de <strong>{{applicant_name}}</strong> ({{chapter}}, rol de {{role_applied}}) está en la fila de evaluación del comité.</p>'
+         || '<p>La fila es <strong>compartida</strong>: cualquier evaluador del comité puede tomar esta candidatura. Esperamos 2 evaluaciones por candidato.</p>'
+         || '<p><a href="{{eval_url}}" style="background:#0066cc;color:#fff;padding:10px 20px;text-decoration:none;border-radius:4px;">Evaluar candidato</a></p>'
+         || '<p style="color:#666;font-size:13px;">Si no puede evaluarla (conflicto de interés, indisponibilidad), no hace falta responder: la candidatura sigue en la fila para los demás evaluadores.</p>'
+         || '<p>¡Gracias!<br/>Núcleo IA &amp; GP — Comité de Selección</p>'
+    ),
+    body_text = jsonb_build_object(
+      'pt', 'Olá {{peer_first_name}},' || E'\n\n'
+         || 'A candidatura de {{applicant_name}} ({{chapter}}, vaga de {{role_applied}}) está na fila de avaliação do comitê.' || E'\n\n'
+         || 'A fila é compartilhada: qualquer avaliador do comitê pode assumir. Esperamos 2 avaliações por candidato.' || E'\n\n'
+         || 'Avaliar: {{eval_url}}' || E'\n\n'
+         || 'Se você não puder avaliar, não precisa responder: a candidatura segue na fila para os demais.' || E'\n\n'
+         || 'Núcleo IA & GP — Comitê de Seleção',
+      'en', 'Hello {{peer_first_name}},' || E'\n\n'
+         || '{{applicant_name}}''s application ({{chapter}}, role: {{role_applied}}) is in the committee''s review queue.' || E'\n\n'
+         || 'The queue is shared: any committee evaluator can take it. We expect 2 evaluations per candidate.' || E'\n\n'
+         || 'Review: {{eval_url}}' || E'\n\n'
+         || 'If you cannot review it, no reply is needed: it stays in the queue for the others.' || E'\n\n'
+         || 'Núcleo IA & GP — Selection Committee',
+      'es', 'Hola {{peer_first_name}},' || E'\n\n'
+         || 'La candidatura de {{applicant_name}} ({{chapter}}, rol de {{role_applied}}) está en la fila de evaluación del comité.' || E'\n\n'
+         || 'La fila es compartida: cualquier evaluador del comité puede tomarla. Esperamos 2 evaluaciones por candidato.' || E'\n\n'
+         || 'Evaluar: {{eval_url}}' || E'\n\n'
+         || 'Si no puede evaluarla, no hace falta responder: sigue en la fila para los demás.' || E'\n\n'
+         || 'Núcleo IA & GP — Comité de Selección'
+    ),
+    updated_at = now()
+  WHERE slug = 'peer_review_request';
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  IF v_rows <> 1 THEN
+    RAISE EXCEPTION 'esperava atingir exatamente 1 linha de peer_review_request, atingiu %', v_rows;
+  END IF;
+END $$;

--- a/tests/contracts/1591-comite-de-selecao-alcanca-o-admin.test.mjs
+++ b/tests/contracts/1591-comite-de-selecao-alcanca-o-admin.test.mjs
@@ -45,12 +45,17 @@ const read = (p) => (existsSync(p) ? readFileSync(p, 'utf8') : '');
 const navSrc = read(NAV);
 const clientSrc = read(NAV_CLIENT);
 const migSrc = read(MIGRATION).replace(/^\s*--.*$/gm, '');
+// #1591 (2a parte): o eixo passou a distinguir PAPEL, e o gate real da avaliacao recusa
+// observador. Migration propria porque e mudanca de MODELO, nao ajuste da anterior.
+const MIGRATION_PAPEL = 'supabase/migrations/20260807000900_1591_observador_observa_nao_avalia.sql';
+const migPapel = read(MIGRATION_PAPEL).replace(/^\s*--.*$/gm, '');
 
 describe('#1591 A — o eixo existe e é declarado na rota certa', () => {
   it('a rota de seleção declara o eixo do comitê', () => {
     const bloco = navSrc.match(/\{\s*key:\s*'admin-selection'[\s\S]*?\}/)?.[0] ?? '';
     assert.ok(bloco, 'entrada admin-selection não encontrada');
-    assert.match(bloco, /allowedSelectionCommittee:\s*true/);
+    assert.match(bloco, /allowedSelectionCommittee:\s*'any'/,
+      'o painel do processo vale para o comite inteiro, inclusive observador');
     assert.match(bloco, /lgpdSensitive:\s*true/, 'a tela expõe PII de candidato');
     // sponsor não pode sair: o eixo novo SOMA, não substitui a leitura institucional.
     assert.match(bloco, /allowedDesignations:\s*\['sponsor'\]/);
@@ -62,7 +67,8 @@ describe('#1591 A — o eixo existe e é declarado na rota certa', () => {
     const bloco = navSrc.match(/\{\s*key:\s*'my-evaluations'[\s\S]*?\}/)?.[0] ?? '';
     assert.ok(bloco, 'entrada my-evaluations não encontrada');
     assert.match(bloco, /href:\s*'\/minhas-avaliacoes'/);
-    assert.match(bloco, /allowedSelectionCommittee:\s*true/);
+    assert.match(bloco, /allowedSelectionCommittee:\s*'evaluator'/,
+      'a fila é só de quem avalia: observador OBSERVA (decisão do PM, 07/08)');
     assert.match(bloco, /lgpdSensitive:\s*true/, 'a fila lista nome de candidato');
     // E NÃO pode voltar a aproximar por papel operacional — foi o que o route-acl barrou.
     assert.doesNotMatch(bloco, /allowedOperationalRoles/,
@@ -84,21 +90,21 @@ describe('#1591 A — o eixo existe e é declarado na rota certa', () => {
   it('AS DUAS implementações do menu conhecem o eixo', () => {
     // O defeito clássico é consertar a gêmea morta. Aqui as duas estão vivas: uma decide no
     // servidor, a outra no cliente, sobre o MESMO item de nav.
-    assert.match(navSrc, /item\.allowedSelectionCommittee === true && onSelectionCommittee === true/,
+    assert.match(navSrc, /item\.allowedSelectionCommittee === 'evaluator'/,
       'servidor: getItemAccessibility não considera o eixo');
-    assert.match(clientSrc, /item\.allowedSelectionCommittee === true[\s\S]{0,120}selection_committee_active === true/,
+    assert.match(clientSrc, /_committeeRole === 'evaluator'/,
       'cliente: getItemAccessClient não considera o eixo');
   });
 
-  it('o eixo só conta quando a ENTRADA o declara', () => {
-    // Sem esta condição, um perfil "sou do comitê" abriria qualquer rota — chave-mestra.
+  it('o eixo só conta quando a ENTRADA o declara, e distingue PAPEL', () => {
+    // Duas coisas de uma vez: (a) um perfil "sou do comitê" não pode abrir rota que não declarou
+    // o eixo — seria chave-mestra; (b) 'any' e 'evaluator' têm de ser tratados diferente, senão
+    // observador recebe a fila de avaliação.
     for (const [src, nome] of [[navSrc, 'servidor'], [clientSrc, 'cliente']]) {
-      // `\s*` porque a conjunção pode estar quebrada em duas linhas — foi o que aconteceu no
-      // cliente, e um padrão preso a uma linha só teria reprovado código correto.
-      assert.ok(
-        /allowedSelectionCommittee === true\s*&&/.test(src),
-        `${nome}: o eixo abriria rota que não o declarou`,
-      );
+      assert.match(src, /allowedSelectionCommittee === 'any'/, `${nome}: falta o ramo 'any'`);
+      assert.match(src, /allowedSelectionCommittee === 'evaluator'/, `${nome}: falta o ramo 'evaluator'`);
+      // O `: false` final é o que fecha a porta para entrada que não declarou o eixo.
+      assert.match(src, /:\s*false;/, `${nome}: sem o default negativo o eixo vira chave-mestra`);
     }
   });
 });
@@ -123,9 +129,23 @@ describe('#1591 A — a migration', () => {
     assert.match(migSrc, /selection_coi_recused/, 'ADR-0109 não pode sair junto');
   });
 
-  it('o payload do nav expõe a flag DERIVADA, não uma coluna espelho', () => {
-    assert.match(migSrc, /public\.is_selection_committee_member\(m\.id\) AS selection_committee_active/,
-      'um espelho mantido à mão envelhece e passa a conceder o que já acabou');
+  it('o payload do nav expõe o sinal DERIVADO, não uma coluna espelho', () => {
+    // A 000700 expunha um booleano (`selection_committee_active`); a 000900 o substituiu pelo
+    // PAPEL, porque o booleano tratava observador e avaliador como a mesma coisa. Em ambas o ponto
+    // que importa é o mesmo: derivado do domínio, nunca espelho mantido à mão — espelho envelhece
+    // e passa a conceder o que já acabou.
+    assert.match(migPapel, /public\.selection_committee_role_for\(m\.id\) AS selection_committee_role/);
+  });
+
+  it('o gate REAL da avaliação recusa observador', () => {
+    // A fronteira não é o menu: é `submit_evaluation`. Antes, estar no comitê bastava — nem esta
+    // função nem `get_my_pending_evaluations` olhavam o `role`. Os 4 observadores do ciclo vivo
+    // nunca submeteram (455 avaliações, todas de `evaluator`), então o comportamento estava certo
+    // por HÁBITO e não por trava. Uma capacidade que só não é exercida por costume não é regra.
+    assert.match(migPapel, /v_committee\.role = 'observer'/);
+    assert.match(migPapel, /observer role does not evaluate/);
+    // O escape de manage_platform continua: a correção é sobre papel no comitê, não sobre admin.
+    assert.match(migPapel, /AND NOT public\.can_by_member\(v_caller\.id, 'manage_platform'::text\)/);
   });
 });
 
@@ -217,7 +237,7 @@ describe('#1591 B — o predicado VIVO responde certo', () => {
 describe('#1591 B — os corpos VIVOS carregam a mudança', () => {
   for (const [fn, marca, oque] of [
     ['get_selection_dashboard', /v_via_committee/, 'a porta do dashboard'],
-    ['get_member_by_auth', /selection_committee_active/, 'a flag do nav'],
+    ['get_member_by_auth', /selection_committee_role/, 'o papel no payload do nav'],
   ]) {
     it(`${fn}: ${oque} está em produção`, { skip: dbGated ? false : skipMsg }, async () => {
       const { data, error } = await sb.rpc('_audit_function_source', { p_proname: fn });

--- a/tests/contracts/route-acl.test.mjs
+++ b/tests/contracts/route-acl.test.mjs
@@ -59,7 +59,7 @@ function parseNavItem(key) {
     // #1591 — quarto eixo. Precisa estar MODELADO aqui: um eixo de autoridade que o guard de ACL
     // não conhece é um caminho para rota `lgpdSensitive` que ninguém vigia, e as asserções abaixo
     // continuariam verdes enquanto a porta estivesse aberta.
-    allowedSelectionCommittee: readBooleanProp(block, 'allowedSelectionCommittee'),
+    allowedSelectionCommittee: readStringProp(block, 'allowedSelectionCommittee'),
   };
 }
 
@@ -70,7 +70,10 @@ function canAccess(item, profile) {
   const hasOpRole = item.allowedOperationalRoles.includes(profile.operationalRole || '');
   // Só conta quando a ENTRADA declara o eixo: um perfil "sou do comitê" não abre rota que não o
   // declarou. Espelha `getItemAccessibility` em src/lib/navigation.config.ts.
-  const hasCommittee = item.allowedSelectionCommittee === true && profile.onSelectionCommittee === true;
+  const hasCommittee =
+    item.allowedSelectionCommittee === 'any' ? Boolean(profile.selectionCommitteeRole)
+    : item.allowedSelectionCommittee === 'evaluator' ? profile.selectionCommitteeRole === 'evaluator'
+    : false;
   const enabled = meetsMinTier || hasDesig || hasOpRole || hasCommittee;
   if (item.lgpdSensitive && !enabled) return false;
   return enabled;
@@ -120,7 +123,7 @@ test('#1591: committee membership opens ONLY the routes that declare the axis', 
   // tudo o mais, um voluntário comum: não pode ganhar acesso a comms, finanças ou settings.
   const committeeMember = {
     tier: 'member', isLoggedIn: true, designations: [], operationalRole: 'tribe_leader',
-    onSelectionCommittee: true,
+    selectionCommitteeRole: 'evaluator',
   };
   const abertas = navItemKeys.map(parseNavItem)
     .filter(i => i.requiresAuth && canAccess(i, committeeMember))
@@ -128,22 +131,38 @@ test('#1591: committee membership opens ONLY the routes that declare the axis', 
 
   // O que sobra tem de ser explicável por tier/designation, nunca pelo comitê.
   for (const item of abertas) {
-    const semComite = canAccess(item, { ...committeeMember, onSelectionCommittee: false });
+    const semComite = canAccess(item, { ...committeeMember, selectionCommitteeRole: null });
     assert.equal(semComite, true,
       `${item.key} abriu POR CAUSA do comitê sem declarar allowedSelectionCommittee`);
   }
 });
 
-test('#1591: a rota de seleção abre para o comitê e fecha para quem não é', () => {
+test('#1591: a rota de seleção abre para o comitê INTEIRO e fecha para quem não é', () => {
   const item = parseNavItem('admin-selection');
   assert.equal(item.lgpdSensitive, true, 'a tela expõe PII de candidato — o flag não pode sumir');
-  assert.equal(item.allowedSelectionCommittee, true, 'o eixo do comitê saiu da rota de seleção');
+  assert.equal(item.allowedSelectionCommittee, 'any', 'o painel é o que o observador acompanha');
 
   const base = { tier: 'member', isLoggedIn: true, designations: [], operationalRole: 'tribe_leader' };
-  assert.equal(canAccess(item, { ...base, onSelectionCommittee: true }), true,
-    'quem está no comitê tem de alcançar a tela que ele opera');
-  assert.equal(canAccess(item, { ...base, onSelectionCommittee: false }), false,
+  assert.equal(canAccess(item, { ...base, selectionCommitteeRole: 'evaluator' }), true);
+  assert.equal(canAccess(item, { ...base, selectionCommitteeRole: 'observer' }), true,
+    'observar o processo é literalmente a função do observador');
+  assert.equal(canAccess(item, { ...base, selectionCommitteeRole: null }), false,
     'tribe_leader FORA do comitê continua barrado — é o que separa o eixo novo de um vazamento');
+});
+
+test('#1591: a FILA de avaliação é só de quem avalia — observador não', () => {
+  // Decisão do PM (07/08/2026): peer review aberto a todo o comitê, EXCETO observadores, que só
+  // visualizam. A primeira versão do eixo não distinguia papel e teria posto a fila (com botão
+  // "Avaliar") na frente dos 4 observadores do ciclo vivo.
+  const item = parseNavItem('my-evaluations');
+  assert.equal(item.allowedSelectionCommittee, 'evaluator');
+  assert.equal(item.lgpdSensitive, true, 'a fila lista nome de candidato');
+
+  const base = { tier: 'member', isLoggedIn: true, designations: [], operationalRole: 'tribe_leader' };
+  assert.equal(canAccess(item, { ...base, selectionCommitteeRole: 'evaluator' }), true);
+  assert.equal(canAccess(item, { ...base, selectionCommitteeRole: 'observer' }), false,
+    'observador OBSERVA: convidá-lo a pontuar candidato não é a função dele');
+  assert.equal(canAccess(item, { ...base, selectionCommitteeRole: null }), false);
 });
 
 test('LGPD-sensitive routes are accessible to admin tier', () => {


### PR DESCRIPTION
Duas correções que saíram da mesma conversa, depois de o PM apontar que eu havia **confundido o
comitê de SELEÇÃO** (que tem observadores) **com o comitê de CURADORIA de artigos** — corpos e
domínios distintos, que só se encontram no menu do admin.

`npm test`: **6542 testes, 6541 passam, 0 falhas, 1 skip.**

---

## 1. Observador não avalia

A 1ª parte do #1591 expôs o eixo do comitê ao menu como **booleano**, então `evaluator` e
`observer` viraram a mesma coisa. Isso passou despercebido porque **o servidor já era assim**: nem
`submit_evaluation` nem `get_my_pending_evaluations` olhavam `sc.role`. Medido no ciclo vivo:

| papel | pessoas | avaliações submetidas |
|---|---|---|
| `evaluator` | 3 | **455** |
| `observer` | 4 | **0** |

O comportamento estava certo **por hábito das pessoas, não por trava**. Uma capacidade que apenas
não é exercida por costume não é uma regra.

⚠️ **E o #1591 ia piorar isso.** Ele acabou de pôr `/minhas-avaliacoes` no menu: os 4 observadores
passariam a ver a fila com botão "Avaliar". Latente virava convite.

O que muda, em duas camadas:

- **`submit_evaluation` (a FRONTEIRA)** recusa `observer` com `insufficient_privilege`. O escape de
  `manage_platform` continua — a correção é sobre papel no comitê, não sobre quem administra.
- **`selection_committee_role_for()`** substitui o booleano por `'evaluator' | 'observer' | NULL`.
  Uma representação só: booleano + papel seriam duas verdades sobre o mesmo fato.
- **O eixo do nav** vira `'any' | 'evaluator'`:
  `/admin/selection` → `'any'` (acompanhar o processo é literalmente a função do observador);
  `/minhas-avaliacoes` → `'evaluator'`.
- **`route-acl.test.mjs`** modela o eixo COM papel e afirma que observador não alcança a fila.

⚠️ **RESÍDUO DECLARADO:** `get_my_pending_evaluations` continua listando a fila para observador que
chegue por **URL direta**. É coerente com "só visualizam" e a fronteira está fechada, mas ele veria
um botão que vai recusar. Não tratei de propósito: mexer no retorno muda contrato com a tela, e a
decisão foi sobre quem **avalia**, não sobre quem **vê**.

## 2. O e-mail prometia atribuição individual

`peer_review_request` dizia *"você foi escolhido(a) (round-robin) para avaliar X"*. **Não existe
round-robin:** `get_my_pending_evaluations` devolve todos os avaliáveis do ciclo para todo o comitê.

Decisão do PM: **a fila compartilhada é o modelo** (é o que produziu as 455 avaliações e é coerente
com "mínimo de 2 avaliadores por candidato"); o texto é que muda.

Três afirmações falsas saíram, cada uma de um jeito diferente:

1. **"escolhido (round-robin)"** — mecanismo inexistente.
2. **"Pré-análise IA concluída"** — INCONDICIONAL, e o template **não tem variável de IA nenhuma**
   (as 5 declaradas são `peer_first_name`, `applicant_name`, `chapter`, `role_applied`,
   `eval_url`). A análise depende de consentimento opcional, e a maioria das avaliações da base é
   sobre candidatura **sem** análise. O avaliador era informado de um artefato que muitas vezes não
   existe.
3. **"outro avaliador será designado"** — pressupõe atribuição de novo.

Verificado após aplicar: nenhuma das três sobrevive, e as 3 línguas dizem fila compartilhada.

Nada aqui muda autoridade: o convite é comunicação. Quem pode avaliar continua sendo decidido por
`submit_evaluation`.

---

## Como as migrations foram produzidas

Alteração aplicada por **substituição ancorada** sobre `pg_get_functiondef`, com `RAISE` se
qualquer âncora não casasse, e os corpos extraídos do banco para o arquivo **por script** — não
transcritos.

Refs #1591, #1590, #1643