### PR TITLE
docs(planning): versiona o handoff do arco de consentimento e os arranques da virada

### DIFF
--- a/docs/planning/2026-08-07_CONTROLE_SESSAO.md
+++ b/docs/planning/2026-08-07_CONTROLE_SESSAO.md
@@ -1,0 +1,233 @@
+# Painel de controle — sessão de 07/08/2026
+
+> Documento vivo. Existe para que o plano original (Blocos A→D do prompt de arranque) não se perca
+> conforme entram assuntos novos. **Atualizar a cada bloco fechado.**
+> Legenda: ✅ feito · 🟡 parcial · ⛔ não iniciado · ⏸️ suspenso por decisão · 🔴 espera decisão do Vitor
+
+---
+
+## 1. O plano original (ordem acordada, não reordenar)
+
+| Bloco | Escopo | Estado |
+|---|---|---|
+| **A** | Action items e governança da reunião de 06/08 | ✅ **medido E lançado** (07/08 16:21) |
+| **B** | Auditoria de cobertura do MCP ao longo da jornada | ✅ **fechado** (07/08 16:55) — detalhe logo abaixo, em "Bloco B, detalhado" |
+| **C** | Vídeo: editar → YouTube (não listado **E** na playlist) → publicar → lançar action items | ✅ **FECHADO** (07/08 20:50) — e ampliado: a #8 de 23/07, que estava sem ata e sem gravação há 15 dias, foi fechada junto. Ver seções 2.2, 2.3 e 2.4 |
+| **D** | Documentação em dia ao longo de tudo | ✅ em dia — lições da sessão registradas na **[LL] #588** |
+
+### Bloco A, detalhado
+
+| # | Item | Estado | Onde está |
+|---|---|---|---|
+| A1 | Extrair action items por líder | ✅ **23 itens**, com carimbo de tempo | `docs/planning/2026-08-07_ata_lideranca_06ago_action_items_governanca.md` |
+| A2 | Lançar os action items nas superfícies | ✅ **ata publicada + 23 ações rastreáveis** no evento `Reunião de Liderança #9` (22 abertas, 1 resolvida, 19 com dono, 4 com prazo) | evento `2db03506` |
+| A3 | Governança: confrontar o dito com o banco | ✅ medido, 7 pessoas | ata, seção 2 |
+| A4 | Tarefa pendente do bloco anterior: flag de entregável + cards sem data por tribo | ✅ medido, 12 tribos | ata + #1661 |
+
+### Bloco B, detalhado (fechado 07/08 16:55)
+
+Auditado **exercitando as portas** pelo conector semântico `nucleo-ia` (53 tools), contra a jornada concreta. Mapa completo no comentário da **#1588**.
+
+| etapa da jornada | veredito |
+|---|---|
+| ata · decisões · action items · governança | ✅ coberto |
+| reunião (evento) · cards · presença · ciclo seletivo | 🟡 parcial |
+| transcrição/gravação · agenda/recorrência · portfólio/publicação | 🔴 sem porta ou quebrado |
+
+**Aberto:** #1669 (ciclo fantasma no `housekeeping` + `tribe_deliverables` sem escrita) · #1670 (6 ponteiros mortos em `next_actions`) · #1671 (`is_portfolio_item` legível só card a card).
+
+**Comentado com medição:** #1661 (duas falhas empilhadas; a que dispara é `id` ambíguo, não `pb.cycle_code`) · #1658 (MCP: 7 RPCs de recorrência, 1 exposta; tribos 1, 6 e 14 confrontadas contra a regra viva) · #1601 (`update_event` tem 15 params e 0 referências no MCP; 204 de 214 eventos sem gravação) · #1586 (Rogério passa em todos os guards).
+
+**Correções ao que estava escrito:** `interview_manage action='stage_override'` **está vivo** (o manifesto do conector estava em cache). E o Rogério **é** destravável por `execute_sql` — o handoff do Bloco A dizia que não era. Ver seção 3.1.
+
+---
+
+## 2. Entregue nesta sessão
+
+### 2.2 Bloco C — vídeo (07/08 20:20)
+
+**Vídeo publicado:** https://youtu.be/8GJaTby6eRo · não listado · playlist `Ciclo 4 (2026/2) - Reunião de Liderança` (`PLfWCBF5VAWZM`, criada nesta sessão, não listada) · 33 capítulos.
+
+Edição, com tudo medido antes e depois:
+
+| sinal | cru | publicado |
+|---|---|---|
+| duração | 4530,54 s (75min30s) | **4341,92 s (72min21s)** |
+| Integrated | -15,5 LUFS | **-14,2 LUFS** (alvo -14) |
+| True peak | **+0,9 dBFS** (estourando) | **-1,1 dBFS** |
+| LRA | 7,1 LU | 5,8 LU |
+| vídeo | h264 1280x720 | idêntico, `-c:v copy` (sem perda de geração) |
+
+Corte em **188,625 s**, num keyframe dentro do silêncio, tirando 3min08s de conversa política de pré-reunião (Venezuela, comércio global) que antecedia a abertura. Decisão sua.
+
+⚠️ **A armadilha registrada não valia aqui.** [[reference-webinar-recording-publish-traps]] dizia "áudio ~10 dB abaixo no vídeo inteiro" e mandava usar `afftdn`. Medido nesta gravação: o nível estava a **1,5 LU** do alvo e o ruído de fundo em -88 dB nos silêncios. O defeito real era **o pico passando de 0 dBFS**. Denoise **não** foi aplicado, porque não havia ruído a tirar.
+
+**Re-carimbo:** os 23 action items traziam o carimbo cru dentro da própria descrição. Deslocados em -188,6 s por um único UPDATE (`meeting_action_items` só tem trigger de XP em `resolved_at`, então não gerou linha de auditoria). A ata foi reancorada junto, preservando os dois números que **não** são posição: `3min36s` (diferença entre duas criações de evento) e `75min30s` (duração da gravação crua).
+
+**Vínculo:** feito por SQL, por decisão sua ("se não tem rota via MCP é um puta gap, faça por SQL e abra o issue"). A rota não existe mesmo, remedida contra o **servidor deployado**: `update_event` tem 0 referências, `p_youtube_url`/`p_recording_url`/`p_is_recorded` 0, e `youtube_url`/`recording_url` só aparecem em **leitura**, inclusive num filtro `has_recording`. A issue já existia e está aberta: **#1601**, escalada com a medição.
+
+Custo pago, medido no log do próprio evento: a ata publicada às 16:18 **pelo MCP** gravou `actor_id: 880f736c`, `source: user`; o link às 20:30 **por SQL** gravou `actor_id: null`, `source: system`. Mesmo evento, mesmo dia, mesmo autor humano. O que decide se o log guarda o nome é só a existência da rota.
+
+### 2.3 Reunião de Liderança #8 (23/07) — fechada retroativamente
+
+Descoberta ao varrer os 109 uploads do canal: **nenhuma liderança do ciclo 4 tinha sido publicada**, e a #8 estava com `is_recorded=true`, sem link, **sem ata** e com **zero** action items, havia 15 dias.
+
+| entrega | resultado |
+|---|---|
+| gravação | achada no Drive (739 MB) → **https://youtu.be/5LD9xsXXKjo**, não listada, na playlist, 38 capítulos |
+| edição | **sem corte** (a reunião começa em `00:00:03` e a transcrição fecha em `01:32:12`, batendo com os 5532,96 s). Áudio de **-15,9 → -14,2 LUFS**, pico de **+0,5 → -1,1 dBFS** |
+| ata | publicada pelo MCP, com ator nominal |
+| action items | **18**, com carimbo; 2 já fechados com prova, 16 abertos, 15 com dono |
+| mapeamento board/card | na ata, seção 1.1 |
+
+🟢 **Brinde:** a transcrição oficial do Meet (aba do doc `Notes by Gemini`) tem **falantes identificados** — melhor que rodar WhisperX, que não separa quem fala. Não foi preciso transcrever nada.
+
+🔴 **Dois achados do mapeamento:** o webinar de patente e PI **existe** em `webinars` parado em **28/05** com status `planned`, uma data que passou há 71 dias, e **não há nenhum webinar em setembro**. E o card do framework do Marcos está com `forecast_date` **08/09**, três semanas depois do ~18/08 que ele se comprometeu na reunião.
+
+⚠️ **Presença da #8 não sustenta leitura:** 14 pessoas falaram, existem 8 linhas, e **7 falaram sem registro** (Vitor, Fabrício, Roberto, Adailson, Hayala, Sarah, Jefferson).
+
+### 2.4 Fechamento da série de gravações e higiene de títulos (07/08 21:00-22:40)
+
+| entrega | resultado |
+|---|---|
+| playlist `Ciclo 4 (2026/2) - Reuniões Gerais` | **`PLanpm8h-DzgQ`**, pública, com Kick-off + Geral de 30/07 |
+| títulos com prefixo `yyyy-mm-dd - ` | **31 → 40**; 9 renomeados, nenhum com data chutada |
+| série de gravações | **39 de 40** vídeos datados referenciados |
+| eventos com link de gravação | **33 → 39** |
+| `recording_type` nulo | **22 → 0** |
+| webinars de 2025 criados | `5f7048a5` (11/09) e `fdc8a319` (20/11), em `webinars` |
+| PR | **#1673** aberto |
+
+**Decisões suas registradas:** vídeos de intro de tribo e institucionais ficam **fora** da regra do prefixo; o `Macedo_Antonio` é o não listado do LIM LATAM e fica como está; os três "Bem-vindo ao Ciclo 04" em duas playlists **não são erro** (a tribo veio do ciclo anterior com o mesmo tema).
+
+⚠️ **PR #1673 está vermelho por herança, não por defeito próprio.** Prod está à frente do `main` pela migração do #1666, cujo arquivo só existe no **PR #1674**. Os dois gates de drift acusam em qualquer PR aberto hoje. Destrava com o merge do #1674, depois um rebase. Medição completa no comentário do #1673.
+
+⚠️ **O working tree foi levado para a branch da outra sessão** (`fix/1666-consentimento-auditavel`) no meio do trabalho. O commit já estava empurrado, nada se perdeu, e não fiz checkout de volta para não arrancar o diretório de quem está usando.
+
+### Issues abertas (7)
+
+| # | Título curto | Origem |
+|---|---|---|
+| **#1675** | Bloco de pauta reservado é **apagado** junto com o evento por `ON DELETE CASCADE`, sem aviso ao dono e sem ator no log. Prova: o único `delete` da tabela de auditoria é "Calculadora de Token" do Marcos, 20/07 | ata da #8 |
+| **#1676** | Duplo clique no criador de recorrência gera a série duas vezes: **65 eventos apagados à mão em 3 dias**, em 3 séries | ata da #8 |
+| **#1672** | Briefing da reunião conta 22 ações pendentes e entrega **0**: o #1548 corrigiu 1 das 4 subqueries escopadas de `get_meeting_preparation`. 84 eventos org-wide, 24 briefings, 431 aparições suprimidas | Bloco C, item 4 |
+| **#1660** | Falta simples não tem como ser gravada: `mark_member_present(false)` APAGA a linha desde 19/05 | Ana, 23min05s |
+| **#1661** | Portfólio Executivo não responde "quais são os webinars": `get_portfolio_items` quebra em 100% (42703) | Vitor, 67min05s e 69min18s |
+| **#1662** | Filiação é conversão, não porteiro: painel de ROI alimentado por `Promise.resolve(null)` | regra de produto do Vitor, 07/08 |
+| **#1664** | Fila "Reservas de entrevista sem candidatura": 11 das 31 acionáveis são do operador e o rótulo é falso | print do Vitor, 07/08 |
+
+Comentário cruzado no **#1657** ligando a face de escrita (#1660) à de leitura.
+
+### Documentos
+
+| arquivo | o que é |
+|---|---|
+| `docs/planning/2026-08-07_ata_lideranca_06ago_action_items_governanca.md` | ata + 23 action items + tabela de governança |
+| `docs/specs/SPEC_TROCA_DE_TRIBO_JANELA_E_ALERTA.md` | por que o offboard do Marcelo foi suspenso + correção em 4 waves |
+| `docs/planning/2026-08-07_CONTROLE_SESSAO.md` | este arquivo |
+| memória `feedback-only-term-signing-is-gated-by-pmi-affiliation` | a regra de filiação/conversão |
+
+---
+
+## 3. Decisões — despachadas em 07/08 16:15-16:21
+
+| # | Decisão | Desfecho |
+|---|---|---|
+| 1 | Fabrícia Maciel | ✅ **offboard concluído** → `alumni`, 1 engajamento encerrado, 1 card reatribuído ao Fernando, certificado de alumni emitido |
+| 2 | Vinicyus Saraiva | ✅ **offboard concluído** → `alumni`, 1 engajamento encerrado, sem cards abertos |
+| 3 | Marcelo Pereira | ✅ **movido para a tribo 5** via `engagement_write` (add na 5 → remove da 13). `tribe_id=5` e engajamento `5:active` casam, sem órfão |
+| 4 | 23 action items | ✅ **ata publicada + 23 ações rastreáveis** no evento `Reunião de Liderança #9` |
+| 5 | Rogério Severo | ✅ **RESOLVIDO** 07/08 17:00 — convite reemitido com token governado (expira 21/08). Ver seção 3.1 |
+
+### 3.1 ✅ Rogério Severo — RESOLVIDO em 07/08 17:00 UTC
+
+Por decisão sua no fechamento do Bloco B, executado por `execute_sql` (opção 2 das três). `selection_rescue_unbooked_invite` passou em todos os guards, `gate_mode: full`, `email_sent: true`.
+
+| sinal | antes 17:00:06 | depois 17:00:20 |
+|---|---|---|
+| token `interview_booking` | **0** | **1**, expira 21/08 |
+| `interview_auto_rescue_count` | 0 | 1 (cap consumido) |
+| `cutoff_approved_email_sent_at` | 31/07 | 07/08 17:00:11 |
+
+**Custo pago, e anotado na #1586:** duas linhas de `admin_audit_log` com `actor_id: null` e `dispatch_source: 'cron'`. 4ª ocorrência do defeito.
+
+**Achado de brinde:** a linha de auditoria de 31/07 não tem `link_kind` nem `token_prefix`, enquanto a de hoje tem `governed_token` / `XwiUjRYp`. Está provado no próprio log que o e-mail de 31/07 saiu sem token. ⚠️ O avaliador resolvido mudou (Fabrício → Fernando), então os dois e-mails levam a calendários diferentes.
+
+<details><summary>Diagnóstico original (histórico)</summary>
+
+Único dos 11 `interview_pending` sem token. Nota **191,50**, a 2ª maior. Despacho de 31/07 saiu **sem token emitido** (o `GATE_NO_AI` recusou a emissão e o e-mail foi assim mesmo) — é isso que o Fabrício leu como "abriu duas vezes e não marcou".
+
+Às **04:01 de 07/08 você reemitiu manualmente** para 4 (Jonas, Marina, Rafael, Patrícia); o Ramon pegou o dele às 03:23 por tráfego de teste. **O Rogério ficou fora da leva.**
+
+Não consigo fazer por dois motivos, ambos medidos:
+- `issue_interview_booking_token` **não está exposta no MCP** (só `get_application_gate_attempts`, que a menciona na descrição)
+- ela é gateada por `auth.uid()`, então service_role não passa
+- `interview_manage action='rescue'` **não cobre**: só aceita `interview_scheduled`, e ele está em `interview_pending`
+
+**Ação:** mesma tela e mesmo botão que você usou às 04:01, para o Rogério. `application_id` `4303cd58-bd5c-49e7-ba04-a3ded1ec236c`.
+
+</details>
+
+> ⚠️ **Corrigido no Bloco B (07/08 16:53), e depois EXECUTADO às 17:00.** O parágrafo acima está incompleto: existe `selection_rescue_unbooked_invite`, que atende exatamente `interview_pending`, e o Rogério passa em **todos** os guards dela — ciclo `cycle4-2026` aberto, status `interview_pending`, `interview_auto_rescue_count = 0`. O `GATE_NO_AI` que o recusou em 31/07 saiu de produção com o #1640. Ela **não** tem superfície no MCP (é a #1586), então por `execute_sql` a auditoria grava `actor_id = NULL` e `dispatch_source: 'cron'` — um ato seu registrado como automação, a 4ª ocorrência. **São três opções, não duas:** (1) UI, auditoria limpa; (2) `execute_sql` agora, com o registro falso anotado na #1586; (3) consertar a #1586 primeiro e usar a porta certa, que pelo conector sai com ator nominal. Não executei nada. Medição completa no comentário da #1586.
+
+### 3.2 Ainda sem resposta
+
+| item | situação |
+|---|---|
+| Issue da defasagem de `vep_opportunities` | metadados de vaga de 01/04 exibidos no admin como vivos (42 vagas × 67 pessoas). Perguntado, sem resposta |
+| Responder a Maria Driele | resolvido sozinho: candidatura de 16/07, entrevista concluída 04/08, `final_eval` com 157 (corte 154,7). Opcional |
+| Confirmação Adailson × Jefferson | o action item ficou **aberto de propósito**: o Marcelo já foi movido por decisão sua, mas os dois líderes ainda não conversaram |
+
+---
+
+## 4. Assuntos que entraram fora do plano (e o que fizeram com ele)
+
+| assunto | o que gerou | custou o quê ao plano |
+|---|---|---|
+| Offboard do Marcelo Pereira | SPEC + ⏸️ suspensão | ~30 min |
+| 5 PDFs de e-mail | 5 casos medidos, 2 viraram decisão | ~20 min |
+| Regra de filiação/conversão | auditoria + memória + #1662 | ~30 min |
+| JSON do VEP + tabela de reservas | Maria Driele localizada + #1664 | ~30 min |
+
+**Nenhum deles avançou os Blocos B ou C.** É por isso que este arquivo existe.
+
+---
+
+## 5. O que sobra, e de quem é
+
+Os quatro blocos do plano estão fechados. O que resta não é continuação deles.
+
+**Esperando merge alheio:** o **PR #1673** precisa do **#1674** (#1666) entrar primeiro; depois, rebase. Não é desta lane mergear.
+
+**Dos líderes:** **38 action items abertos** (16 da #8, 22 da #9), todos com carimbo e a maioria com dono.
+
+**Do Vitor, nominalmente:**
+
+| item | estado medido |
+|---|---|
+| Webinar de patente e PI | 🔴 linha em `webinars` parada em **28/05** com status `planned`, data vencida há 71 dias. **Zero** webinares agendados em setembro |
+| Transparência das aplicações a eventos | 🔴 sem card; existe só no quadro de alinhamento com o Ivan |
+| Varrer cards marcando entregável + metadata | aberto desde 06/08 |
+| Adicionar líderes como gestores do canal | aberto desde 06/08 |
+| Recorrência do Paulo (quinzenal → semanal) | aberto desde 06/08 |
+
+**Decisões que ficaram com você:**
+
+- Card do framework do Marcos com `forecast_date` **08/09**, três semanas depois do ~18/08 que ele se comprometeu em 23/07. Confirmar com ele ou ajustar.
+- **7 pessoas falaram na #8 e não têm registro de presença** (Vitor, Fabrício, Roberto, Adailson, Hayala, Sarah, Jefferson). Dá para inserir, mas é dado de presença e não deve ser fabricado sem palavra sua.
+
+---
+
+## 6. Estado do repositório
+
+- `origin/main` em **`6221e990`** (o #1642 e o #1649 entraram às 20:38)
+- **PR #1673** (playlists do ciclo 4 no SSOT) aberto, 1 arquivo, `validate` vermelho **por herança** — ver seção 2.4
+- **PR #1674** (#1666, consentimento auditável) aberto pela outra sessão; é ele que destrava o #1673
+- **PR #1647** (Paulo, #1644 + #1645) segue **aberto**, vermelho por falhas provadas pré-existentes. É da main lane decidir
+- **#1637** Dependabot astro 6→7: **não mergear** (política #611)
+- ⚠️ O working tree está na branch **da outra sessão**. Conferir `git log -1` antes de qualquer `checkout -b`
+- Os `docs/planning/*` desta sessão seguem **não commitados**, e as **atas continuam fora do git de propósito**: o repositório é público e elas nomeiam voluntários com juízo de desempenho, motivo de desligamento e estado de saúde
+
+---
+
+_Atualizado em 07/08/2026, 22:45._

--- a/docs/planning/2026-08-07_PROMPT_ARRANQUE_MAIN_LANE_1673.md
+++ b/docs/planning/2026-08-07_PROMPT_ARRANQUE_MAIN_LANE_1673.md
@@ -1,0 +1,181 @@
+# Prompt de arranque - MAIN LANE - QA e merge do PR #1673
+
+> Escrito pela lane do Bloco C em 07/08/2026, com tudo re-medido no momento da escrita.
+> Números datados; **re-medir antes de agir** (regra de grounding do `CLAUDE.md`).
+
+---
+
+## O pedido
+
+Fazer QA e mergear o **PR #1673**, que está pronto e desbloqueado, tomando o cuidado
+descrito na seção "O risco" abaixo. Depois, decidir sobre os residuais da seção final.
+
+---
+
+## 1. O que o PR #1673 faz
+
+**Um arquivo, `src/data/youtube-playlists.ts`.** Acrescenta duas playlists ao bloco
+`GENERATED` e uma nota no cabeçalho.
+
+Corrige um defeito **vivo em produção**: os três dicionários de i18n já diziam
+"Reuniões Gerais - Ciclo 4", mas `getPlaylistUrl('generalMeetings')` resolvia para a
+playlist do **Ciclo 3**, porque a do Ciclo 4 não existia no canal. Ela foi criada nesta
+sessão (`PLanpm8h-DzgQ`, pública), junto com a de Liderança (`PLfWCBF5VAWZM`, não
+listada). O resolver `latestByPattern` passa a cair no ciclo certo sozinho.
+
+A nota do cabeçalho registra que **id curto não é id truncado**: playlists criadas de
+07/2026 em diante recebem id de 13 caracteres, as antigas têm 34. Confirmado criando uma
+pela API e lendo de volta. Estava listado como suspeita no arranque anterior; foi
+resolvido, e a nota existe para ninguém "consertar" isso depois.
+
+---
+
+## 2. O risco (leia antes de tocar no branch)
+
+O branch `fix/youtube-playlists-ciclo4-gerais-e-lideranca` tem **duas pontas diferentes**:
+
+```
+remoto (origin/...)  ->  55bb9265   1 commit, 1 arquivo. É o que o PR #1673 mostra. LIMPO.
+local  (.git local)  ->  08a17f2f   commit EXTRA por cima, de outra sessão, nunca empurrado.
+                         55bb9265
+```
+
+O `08a17f2f` é trabalho do **#1666** (5 arquivos, 539 acréscimos) que outra sessão deixou
+no branch errado. **Se alguém empurrar o branch local, esses 539 acréscimos entram no PR
+#1673.**
+
+### Ele é seguro de descartar, e foi medido
+
+O #1666 **já está na main** pelo commit `49a8586f`. Comparando arquivo a arquivo:
+
+| arquivo | veredito |
+|---|---|
+| `20260807000600_1666_...sql` | **idêntico** ao da main |
+| `tests/contracts/1666-...test.mjs` | **idêntico** ao da main |
+| `database.gen.ts` | as 3 linhas (`evidence`) já estão na main |
+| `PMIOnboardingPortal.tsx` | todo o bloco já está na main, **exceto a versão** |
+| `package.json` | o teste já está ligado na main (2 ocorrências, regra do `npm test`) |
+
+🔴 **A única divergência é uma regressão.** O órfão tem `AI_CONSENT_VERSION = 'v2'`; a
+main tem **`'v3'`**. O órfão é a versão **mais velha**. Reaplicá-lo rebaixaria a versão
+do consentimento de IA, que é exatamente o dano que o comentário do próprio arquivo
+descreve (LGPD art. 8º, §2º: o ônus da prova do consentimento é do controlador).
+
+**Conclusão:** o `08a17f2f` está integralmente superado. Descartá-lo não perde nada.
+A lane do Bloco C não o apagou porque apagar trabalho de outra sessão não é decisão dela.
+
+### O caminho seguro
+
+Trabalhe a partir do **remoto**, nunca do branch local:
+
+```bash
+git fetch origin
+git log --oneline origin/main..origin/fix/youtube-playlists-ciclo4-gerais-e-lideranca
+# deve imprimir EXATAMENTE uma linha: 55bb9265. Se imprimir duas, pare.
+```
+
+Para atualizar o PR, **merge, não rebase**: force-push está bloqueado pelo harness desta
+máquina, e um rebase exigiria force-push.
+
+Se e quando quiser limpar o branch local (decisão sua, não da lane do Bloco C):
+
+```bash
+git branch -f fix/youtube-playlists-ciclo4-gerais-e-lideranca origin/fix/youtube-playlists-ciclo4-gerais-e-lideranca
+```
+
+---
+
+## 3. Por que o CI está vermelho, e por que já não deveria estar
+
+O `validate` do #1673 falhou em **2 de 6.483** testes:
+
+- `Phase C: body-hash drift`
+- `ADR-0097: missing-file drift`
+
+**A causa não é do PR.** Provado na hora: a main em `6221e990` passou verde às 20:38, e
+prod tinha a migration `20260807000600_1666_...` cujo arquivo só existia num branch não
+empurrado de outra sessão. Os dois gates comparam prod contra os arquivos do repositório,
+então acusavam a ausência do arquivo, não o conteúdo do #1673.
+
+**Isso acabou.** O arquivo chegou à main pelo `49a8586f`. Confirmado:
+
+```bash
+git cat-file -e origin/main:supabase/migrations/20260807000600_1666_consentimento_de_ia_vira_registro_auditavel.sql
+```
+
+Basta o CI rodar de novo sobre a base atual. Um merge de `origin/main` no branch remoto
+dispara isso.
+
+⚠️ O PR **#1674** foi **fechado sem merge**, mas o conteúdo entrou por outro caminho. Não
+conclua pelo estado do #1674 que o #1666 não subiu.
+
+---
+
+## 4. QA sugerido
+
+O commit é de um arquivo só e de dado, não de lógica. O que vale conferir:
+
+```bash
+npx astro build                                   # tem que passar
+npm test                                          # exportar o .env antes, senão 548 testes PULAM calado
+node --test tests/contracts/youtube-playlists-ssot.test.mjs   # 4/4 na lane
+```
+
+⚠️ `npm test` sem `.env` exportado pula centenas de testes **sem falhar**. Conferir o
+número de skips, não só o "0 failures"
+(memória `reference-npm-test-needs-env-exported-or-548-skip`).
+
+Verificação funcional, se quiser ir além do gate: o rodapé e a `TribesSection` resolvem
+por `getPlaylistUrl(key)`, então o link de "Reuniões Gerais" deve passar a apontar para
+`PLanpm8h-DzgQ`. Em produção, **furar o cache de borda** para ver o efeito.
+
+Estado no momento da escrita: `origin/main` em `6481534c`; #1673 `OPEN`, `mergeable
+UNKNOWN`, `validate FAILURE` (execução antiga). Havia 12 PRs abertos.
+
+---
+
+## 5. Residuais que sobraram desta sessão
+
+Nenhum bloqueia o merge.
+
+| item | situação |
+|---|---|
+| `08a17f2f` órfão no branch local | medido acima, superado, decisão de quem tocou o #1666 |
+| Painel `2026-08-07_CONTROLE_SESSAO.md` não cita a **#1681** | uma linha na tabela de issues |
+| Worktree `wt-1673` | **já removida** pela lane do Bloco C |
+| PR **#1647** (Paulo) segue aberto | as 5 falhas do `validate` foram provadas pré-existentes; é decisão da main lane |
+| **#1637** Dependabot astro 6 -> 7 | **NÃO mergear**, política #611 |
+
+### Fora do repositório, e de dono humano
+
+- **38 action items abertos** entre as Lideranças #8 (23/07) e #9 (06/08).
+- **Webinar de patente e PI parado em 28/05/2026** com status `planned`, e **zero**
+  webinares agendados em setembro.
+- **Card do framework do Marcos** com `forecast_date` 08/09, três semanas depois do
+  ~18/08 que ele se comprometeu em 23/07.
+- **7 pessoas falaram na #8 sem registro de presença** (Vitor, Fabrício, Roberto,
+  Adailson, Hayala, Sarah, Jefferson).
+- Playlist `Ciclo 4 (2026/2) - Reuniões Gerais` existe, mas o backfill das Gerais
+  **mais antigas** não foi varrido.
+
+### Issues abertas nesta sessão, todas com medição fresca
+
+**#1672** (briefing conta 22 pendências e entrega 0) · **#1675** · **#1676** ·
+**#1681** (loop de retroalimentação do MCP, com captura do papel de quem faz o request).
+**#1601** foi escalada por decisão do Vitor: não há rota de MCP para vincular gravação a
+evento, e o custo está provado no log (ata pelo MCP com `actor_id` nominal, link por SQL
+com `actor_id: null`).
+
+---
+
+## Contexto que a main lane talvez não tenha
+
+O Bloco C fechou e se ampliou: as Lideranças **#9 e #8** foram publicadas, vinculadas e
+com ata mais 41 action items. A **#8, de 23/07, estava abandonada havia 15 dias**, sem
+ata, sem link e com zero ações. Detalhe completo na memória
+`handoff_2026_08_07_bloco_c_fechado_lideranca_8_e_9` e no painel
+`docs/planning/2026-08-07_CONTROLE_SESSAO.md`.
+
+⚠️ **Repositório é PÚBLICO.** Gravações, transcrições e mp4 editados ficam em
+`~/Downloads/`. A ata retroativa da #8 nomeia voluntários com juízo de desempenho e não
+foi commitada de propósito.

--- a/docs/planning/2026-08-07_handoff_arco_consentimento_e_acesso.md
+++ b/docs/planning/2026-08-07_handoff_arco_consentimento_e_acesso.md
@@ -1,90 +1,143 @@
-# Handoff — o arco de consentimento fechado, o acesso por componente aberto (07/08/2026)
+# Handoff — arco de consentimento fechado, acesso por componente aberto (07/08/2026)
 
-> `main` em `6221e990` (o #1642 + #1649 já mergeados). PR aberto desta sessão: **#1677**.
-> PR **#1674 fechado como superado** (não abandonado — o commit dele está inteiro no #1677).
+> `main` em **`6481534c`**. Tudo desta sessão está MERGEADO. Migrations `20260807000400` a
+> `20260807001000` aplicadas, registradas e com arquivo no checkout (conferido).
 
 ## Regra zero
 
-Nada aqui pode ser recitado. Toda contagem foi medida em 07/08 e a base é viva.
+Nada aqui pode ser recitado. Toda contagem foi medida em 07/08 e a base é viva. O padrão que mais
+custou nesta sessão foi **número certo, significado errado** — três vezes.
 
 ---
 
-## Mergeado: #1642 + #1649 (PR #1667, `6221e990`)
+## Fechado hoje
 
-- **#1642** — a comunicação negava a consequência. Três superfícies nos 3 idiomas, mais a correção
-  de subprocessador: a tela nomeava só a Anthropic e as **47 de 47** análises do ciclo eram
-  `gemini-2.5-flash`. Cada texto nomeava um provedor e omitia o outro.
-- **#1649** — a varredura lia 147.794 linhas para devolver zero. Pré-filtro por faixa de `runid`
-  (5212 ms → 78 ms; O(tabela) → O(constante)) com guarda O(1) que cai para a varredura completa se
-  a faixa deixar de cobrir 48h. O `set_config` do #1663 era **inerte** e saiu.
-
----
-
-## No PR #1677 (verde local: 6535 testes, 6534 passam, 0 falhas, 1 skip)
-
-### #1666 — o consentimento de IA virou registro auditável
-`consent_records` **já existia e estava vazia** (0 linhas, todos os tipos), com `policy_type`
-prevendo `'ai_analysis'`, FK da candidatura e ponte de volta. Faltava coluna de prova e a escrita.
-Backfill dos 56 como `v1-pre-1642` com `evidence` NULL — **sem inventar hash**.
-⚠️ A exigência de evidência (`RAISE`, como no ramo de voz) é o **passo seguinte**, depois de
-confirmado o front no ar. Hoje ela é registrada, não exigida.
-
-### #1591 — o comitê alcança `/admin/selection`
-Quarto eixo `is_selection_committee_member(membro, ciclo)`, **escopado por ciclo** (sem isso, o
-comitê de hoje leria o PII de todos os ciclos passados). As **duas** implementações do menu
-mudaram, e o `route-acl.test.mjs` foi ensinado sobre o eixo.
-⏭️ **Falta o Fernando confirmar na prática**: abrir `/admin/selection` e `/minhas-avaliacoes`
-logado. Não dá para medir por SQL (a RPC resolve por `auth.uid()`; o conector passa como o Vitor).
-
-### #1665 — transferência internacional
-Google, Anthropic e OpenAI entram em `privacy.s5int`. Bases separadas: infra no art. 33, IX; IA no
-art. 33, **VIII**. ⚠️ O VIII exige informação prévia sobre o caráter internacional, então o texto
-de consentimento ganhou "sediados nos Estados Unidos" e a versão foi para `v3`.
-⚠️ **A escolha do inciso é jurídica** e vai ao comitê.
-
-### #1423 — a transferência de tribo partia a ponte
-A issue culpava o `remove`; medido, aquele caminho já estava coberto (`UPDATE status='expired'`,
-não DELETE). A causa é **assimetria**: `tribe_id` escrito incondicionalmente, `initiative_id` só
-`WHERE IS NULL`. Verificado por sonda em transação abortada; zero órfãos na base.
+| issue | o que era |
+|---|---|
+| **#1640** | o gate de IA negava o convite de entrevista |
+| **#1642** | a comunicação NEGAVA a consequência (3 superfícies, 3 idiomas) + subprocessador errado |
+| **#1649** | a varredura lia 147.794 linhas para devolver zero; o teto do #1663 era inerte |
+| **#1666** | o consentimento gravava carimbo, não COM O QUE a pessoa concordou |
+| **#1665** | transferência internacional listava 6 e omitia os 3 de IA |
+| **#1423** | a transferência de tribo partia a ponte `initiative_id` |
+| **#1591** | o comitê não alcançava a tela que opera + observador recebia a fila de avaliação |
+| **#1641** | fechada por decisão: **não reemitir** (ver abaixo) |
 
 ---
 
-## ⚠️ O erro desta sessão, para não repetir
+## Estado final da seleção, medido
 
-Apliquei DDL em produção com o #1674 aberto e **serializei os PRs**. Os três gates de drift caíram
-por causa que não era do diff dele.
+| papel no comitê | pessoas | vê a FILA de avaliação | vê o PAINEL do processo |
+|---|---|---|---|
+| `evaluator` | 3 | 3 | 3 |
+| `observer` | 4 | **0** | 4 |
 
-A memória `reference-prod-ahead-ddl-serializes-every-open-pr` foi **corrigida hoje** e o recorte
-certo é: **não é "isso é DDL?", é "vou registrar uma versão?"**. Qualquer `migration repair` deixa
-todo branch sem aquele `.sql` vermelho, mesmo que o conteúdo tenha sido um `UPDATE` de dado.
+⏭️ **Falta confirmação humana:** um avaliador logado deve ver *Minhas Avaliações* (20 pendentes) e
+*Processo Seletivo*; observador deve ver só o segundo. **Não dá para medir por SQL** — as RPCs
+resolvem por `auth.uid()` e o conector MCP passa como o Vitor.
 
 ---
 
-## Pendências de decisão (não são de código)
+## Aberto, e o que cada um espera
 
-1. **#1641 — recomendação REVISTA para NÃO reemitir.** Dois fatos medidos:
-   - **nenhuma** das 34 está em `submitted`, e `dispatch_consent_nudge` filtra por esse status: a
-     ferramenta da issue alcança **zero**;
-   - os "3 em processo sem token" são **2 `final_eval` + 1 `interview_done`**, todos já avaliados e
-     já com entrevista. A análise de IA não tem finalidade restante para eles.
-   Os 6 em `interview_pending` já têm token vivo e podem consentir sozinhos.
+### #1679 — curadoria (investigação pura, NÃO precisa de decisão)
+37 submissões, 7 publicações, **zero** linhas em toda a maquinaria de blind review, **zero**
+portadores da designation `curator` (que gateia 9 entradas de nav).
+⚠️ **NÃO tem relação com o comitê de seleção.** São corpos e domínios distintos; a confusão já
+aconteceu uma vez nesta apuração. O aviso está no topo da issue.
 
-2. **Coerência round-robin × fila compartilhada.** O e-mail `peer_review_request` diz "você foi
-   escolhido (round-robin) para avaliar a candidatura de X"; `get_my_pending_evaluations` mostra
-   **todos** os avaliáveis do ciclo para **todos** do comitê (20 hoje). Decidir qual é o modelo
-   antes de mexer em qualquer um dos dois. Inclui a afirmação incondicional "Pré-análise IA
-   concluída" para candidatura sem análise.
+### #1643 — varrer outros consentimentos "opcionais" com gate escondido
+Também investigação. O método ganhou uma **terceira classe** hoje: além de "gate de tratamento"
+(ok) e "gate de avanço" (defeito), existe **"afirmação incondicional sobre tratamento
+condicional"** — foi o caso do `peer_review_request`, corrigido.
 
-3. **Comitê**: redação do #1642 (já publicada), inciso do art. 33 (#1665), e a cláusula nova no
-   texto de consentimento.
+### #1632 — épica; só fecha quando #1643 e #1679 fecharem.
 
-4. **`curator` é vocabulário órfão**: zero portadores em toda a base, e gateia 10 entradas de nav
-   (webinars, publicações, analytics, portfólio, agenda viva, cross-tribes, sustentabilidade,
-   governança). A superfície de curadoria está fechada para todos, em silêncio. É atribuição de
-   designation, não código. **98 membros não têm designation nenhuma.**
+### Pendências de comitê (não de código)
+- a redação do consentimento, **já publicada**, incluindo a cláusula "sediados nos Estados Unidos"
+- o **inciso do art. 33** (VIII para as transferências de IA)
+
+---
+
+## Resíduos declarados (escolhidos, não esquecidos)
+
+1. **Observador por URL direta** ainda vê a fila em `/minhas-avaliacoes` com botão que vai recusar.
+   A fronteira está fechada em `submit_evaluation`; o que falta é UX. Mexer no retorno de
+   `get_my_pending_evaluations` muda contrato com a tela.
+2. **A evidência de consentimento ainda não é EXIGIDA.** `give_consent_via_token` registra quando
+   vem e grava `unversioned` quando não vem. O aperto (`RAISE`, como no ramo de voz) espera
+   confirmação de que o front novo está no ar.
+3. **Escapador parcial em 3 arquivos de teste pré-existentes**
+   (`admin-selection-import-error-rendering`, `consent-voice-biometric-ui`,
+   `p519-visible-excused-affordance`). O CodeQL não os acusa porque só reporta código alterado.
+
+---
+
+## ⚠️ Os erros desta sessão, para não repetir
+
+1. **Apliquei DDL com PR aberto e serializei tudo.** O recorte certo **não é "isso é DDL?", é "vou
+   registrar uma versão?"** — qualquer `migration repair` deixa vermelho todo branch sem aquele
+   `.sql`. A memória foi corrigida.
+2. **Aceitei um "todos verdes" onde o gate que importa nem estava na lista.** `validate` estava na
+   fila do grupo de concorrência e ainda não tinha registrado check-run; minha condição de parada
+   era vacuamente verdadeira. **Monitorar por RUN, não por `gh pr checks`.**
+3. **Repeti um escapador parcial 3 linhas depois de corrigi-lo.** Duas cópias de um escapador é uma
+   cópia a mais.
+4. **Confundi o comitê de SELEÇÃO com o de CURADORIA.** Foi o PM quem corrigiu — e a correção
+   revelou que observadores receberiam a fila de avaliação.
+5. **`Closes #a, #b, #c` fecha só a primeira.** Cada número precisa da palavra-chave.
+
+---
+
+## ⚠️ OUTRA LANE VIVA: PR #1673 (worktree separada) — LER ANTES DE TOCAR NAQUELE BRANCH
+
+Prompt próprio: **`docs/planning/2026-08-07_PROMPT_ARRANQUE_MAIN_LANE_1673.md`** (ler antes de
+qualquer coisa naquela frente). Objetivo: **QA e merge do PR #1673**
+(`fix(comms)`: o rodapé dizia "Ciclo 4" e levava à playlist do ciclo 3, porque a do 4 não existia).
+
+### O commit órfão é MEU, e a árvore de trabalho é a causa
+
+Medido em 07/08 à noite:
+
+```
+origin/fix/youtube-playlists-ciclo4-gerais-e-lideranca → 55bb9265   ← o head REAL do PR
+local /fix/youtube-playlists-ciclo4-gerais-e-lideranca → 08a17f2f   ← órfão POR CIMA
+                                                          55bb9265
+```
+
+`08a17f2f` é `fix(lgpd): o consentimento de IA gravava o carimbo…` (#1666) — **desta sessão**. Ele
+caiu ali porque este diretório estava com o branch do #1673 em check-out no momento do commit, e é
+literalmente a armadilha de `reference-two-sessions-one-working-tree-contaminate-the-branch`:
+**`git log -1` ANTES de `checkout -b`.**
+
+✅ **Nada se perdeu:** o conteúdo do `08a17f2f` já está na `main` pelo squash `49a8586f`. O órfão é
+**resíduo local**, não trabalho pendente.
+
+### Regras para aquela lane
+
+1. **Trabalhe SEMPRE a partir de `origin/`**, nunca do branch local — o local tem o órfão por cima.
+2. **Atualize o PR por MERGE, nunca rebase.** Force-push está bloqueado nesta máquina (o harness
+   recusa; só o Vitor consegue).
+3. **NÃO empurre o `08a17f2f`** para aquele branch: ele já está na `main` e reapareceria como
+   diff duplicado no PR.
+
+### Estado do PR, medido em 07/08 à noite
+
+| | |
+|---|---|
+| head do PR | `55bb9265` · `mergeable = MERGEABLE` |
+| `validate` | **fail** — classificar antes de qualquer coisa |
+| demais gates | CodeQL, analyze, browser_guards, check-invariants, deno, gen-types-drift, issue_reference_gate, visual_dark_mode: **pass** |
+
+⚠️ O `validate` vermelho **precisa ser classificado, não presumido**. Nesta sessão houve três
+classes de vermelho que não eram do PR: a #1649 (fechada), a **esm.sh fora do ar** no `deno`, e o
+**timeout do passo `Smoke Test Routes`** (teto de 2 min do passo, com o dev server levando 13 s
+para subir). Comparar com um commit vizinho que passou é o instrumento mais barato.
+
+---
 
 ## Regras da casa
 
 - Commit: `Assisted-By:`, nunca `Co-Authored-By`.
 - Repo **PÚBLICO**: nenhum candidato ou membro nomeado, só contagens.
-- Não rodar `npm test` local com CI em voo (os dois escrevem no mesmo banco de produção).
+- Não rodar `npm test` local com CI em voo — **gatear**, não só imprimir o número.

--- a/docs/planning/2026-08-08_PROMPT_ARRANQUE.md
+++ b/docs/planning/2026-08-08_PROMPT_ARRANQUE.md
@@ -1,0 +1,113 @@
+# Prompt de arranque — depois do arco de consentimento (08/08/2026)
+
+> Colar depois do `/clear`. **Effort: `xhigh`.**
+> Handoff completo: `docs/planning/2026-08-07_handoff_arco_consentimento_e_acesso.md`.
+> `main` em **`6481534c`**.
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Re-medir com tool call na mesma volta antes de qualquer
+decisão. O padrão que custou três leituras erradas na sessão anterior: **número certo, significado
+errado**. O instrumento é barato — rode o grupo de controle, ou pergunte *de quem é este valor* e
+*em que ponto do processo essa população está*, em vez de *quantos são*.
+
+Dois exemplos da sessão passada, ambos inverteram a decisão:
+- "3 candidatos impedidos de consentir" era verdade — e os 3 já tinham sido avaliados E
+  entrevistados, então a análise de IA não tinha finalidade restante. A recomendação virou **não**
+  reemitir.
+- "4 observadores nunca avaliaram" era verdade — e era por **hábito**, não por trava: nenhuma RPC
+  olhava o papel. O menu novo ia transformar isso em convite.
+
+---
+
+## Não re-litigar (fechado e em produção)
+
+- **#1640, #1642, #1649, #1666, #1665, #1423, #1591** fechadas. `#1641` fechada por decisão do PM
+  (não reemitir), com a medição registrada na issue.
+- O consentimento de IA agora tem **ledger auditável** (`consent_records` + `evidence`), o comitê
+  **alcança** `/admin/selection` e `/minhas-avaliacoes`, e **observador não avalia**.
+- Migrations `20260807000400`–`001000` aplicadas, registradas e com arquivo no checkout.
+
+---
+
+## ⚠️ ANTES DE TUDO, SE FOR MEXER NO PR #1673
+
+Lane separada (worktree), com prompt próprio:
+**`docs/planning/2026-08-07_PROMPT_ARRANQUE_MAIN_LANE_1673.md`** — ler antes de qualquer coisa ali.
+Objetivo: QA e merge do #1673.
+
+O branch **local** tem um commit órfão por cima do head real do PR:
+
+```
+origin/fix/youtube-playlists-ciclo4-gerais-e-lideranca → 55bb9265   ← head REAL
+local /fix/youtube-playlists-ciclo4-gerais-e-lideranca → 08a17f2f   ← órfão
+                                                          55bb9265
+```
+
+`08a17f2f` é o commit do #1666 da sessão de 07/08: caiu ali porque a árvore de trabalho estava com
+aquele branch em check-out. **O conteúdo já está na `main`** (squash `49a8586f`), então é resíduo,
+não trabalho pendente.
+
+1. Trabalhe **sempre a partir de `origin/`**, nunca do branch local.
+2. Atualize o PR por **MERGE, nunca rebase** — force-push está bloqueado nesta máquina.
+3. **NÃO empurre o `08a17f2f`**: apareceria como diff duplicado.
+
+Estado medido em 07/08 à noite: head `55bb9265`, `mergeable`, **`validate` fail**, outros 8 gates
+verdes. ⚠️ **Classificar o vermelho, não presumir** — na sessão anterior houve três classes de
+vermelho alheias ao PR (#1649, esm.sh fora do ar no `deno`, e timeout do passo `Smoke Test Routes`).
+Comparar com um commit vizinho que passou é o instrumento mais barato.
+
+---
+
+## Ordem sugerida (lane LGPD/seleção)
+
+### 1. Confirmar com gente (não dá para medir por SQL)
+As RPCs resolvem por `auth.uid()` e o conector MCP passa como o Vitor. Pedir a um **avaliador** que
+abra a plataforma logado: deve ver *Minhas Avaliações* (20 pendentes) e *Processo Seletivo*. Um
+**observador** deve ver só o segundo. Se vier diferente, é bug medido — e aí sim investigar.
+
+### 2. #1679 — curadoria (investigação, não precisa de decisão)
+37 submissões, 7 publicações, **zero** revisões registradas, **zero** portadores de `curator`.
+⚠️ **NÃO confundir com o comitê de SELEÇÃO.** São corpos e domínios distintos. A confusão já
+aconteceu; o aviso está no topo da issue.
+Declarar qual das leituras é: curadoria fora da plataforma, ou algo impedindo o uso.
+
+### 3. #1643 — outros consentimentos "opcionais" com gate escondido
+Método na issue, com uma **terceira classe** acrescentada: além de "gate de tratamento" (ok) e
+"gate de avanço" (defeito), procurar **"afirmação incondicional sobre tratamento condicional"** —
+foi o caso do `peer_review_request`, que dizia "Pré-análise IA concluída" para candidatura sem
+análise.
+
+### 4. Resíduos, se o PM quiser fechá-los
+- exigir evidência no consentimento de IA (`RAISE`), depois de confirmado o front no ar
+- observador por URL direta ainda vê a fila com botão que recusa
+- escapador parcial em 3 arquivos de teste pré-existentes
+
+---
+
+## Armadilhas medidas (07/08)
+
+- **Serialização não é sobre DDL, é sobre REGISTRAR VERSÃO.** Qualquer `migration repair` deixa
+  vermelho todo branch sem aquele `.sql`, mesmo que o conteúdo tenha sido `UPDATE` de dado.
+  **Antes de aplicar, olhe os PRs abertos.**
+- **`gh pr checks` mente por omissão.** Um gate na fila do grupo de concorrência ainda não registrou
+  check-run, então "todos os reportados passaram" é vacuamente verdadeiro. **Monitorar por RUN.**
+- **Função de 19 KB: NÃO transcrever.** Aplicar por `replace` ancorado sobre `pg_get_functiondef`
+  com `RAISE` se a âncora não casar, e extrair o corpo vivo para o arquivo **por script** (o script
+  precisa rodar de dentro do projeto para achar `node_modules`).
+- **`apply_migration` cria phantom row** — deletar (1 por chamada) e `migration repair` no
+  timestamp sintético.
+- **`Closes #a, #b`** fecha só a primeira; cada número precisa da palavra-chave.
+- **Não rodar `npm test` com CI em voo** — **gatear**, não só imprimir o número.
+- **Guard ancorado num ARQUIVO não observa o mundo**: fica verde com o mecanismo inerte e depois de
+  removido. Camada B no corpo vivo.
+- **Mutação é obrigatória**, e ela pega asserção frouxa própria: `INSERT INTO public.consent_records`
+  casava `consent_records_XX` como substring.
+
+## Regras da casa
+
+- Merge à `main` é da sessão main; lane leva o PR até verde e para.
+- Commit: `Assisted-By:`, nunca `Co-Authored-By`.
+- Repo **PÚBLICO**: nenhum candidato ou membro nomeado, só contagens.


### PR DESCRIPTION
Higiene de historico, sem mudanca de codigo.

O handoff de 07/08 (`docs/planning/2026-08-07_handoff_arco_consentimento_e_acesso.md`) e arquivo **rastreado** e estava como modificacao nao commitada na `main` (115 insercoes, 62 remocoes). Diferente dos outros planning docs da pasta, que sao untracked, ele aparecia como sujeira no working tree de toda sessao seguinte sem nunca entrar no historico.

Entram 4 arquivos, todos da mesma virada de 07 para 08/08:

| arquivo | estado anterior |
|---|---|
| `2026-08-07_handoff_arco_consentimento_e_acesso.md` | rastreado, **modificado** |
| `2026-08-08_PROMPT_ARRANQUE.md` | novo |
| `2026-08-07_PROMPT_ARRANQUE_MAIN_LANE_1673.md` | novo |
| `2026-08-07_CONTROLE_SESSAO.md` | novo |

Os outros **50** planning docs da pasta seguem nao rastreados de proposito: versiona-los e decisao separada, nao residuo desta virada.

Refs #1632, #1679, #1682