### PR TITLE
fix(backup): o dump nao restaurava o log de auditoria, e o vermelho de 3 semanas era cosmetico

### DIFF
--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -115,8 +115,14 @@ jobs:
             -e POSTGRES_DB=postgres \
             supabase/postgres:17.6.1.084
 
+          # `pg_isready` no socket unix NAO serve de sinal de prontidao nesta imagem: durante o
+          # init ela sobe um servidor TEMPORARIO que escuta so no socket, roda os scripts e o
+          # DESLIGA antes de subir o definitivo. Medido em 08/08: t=3s o socket ja aceita e o TCP
+          # nao; t=4s o TCP aceita. Conectar no temporario faz o restore morrer no meio com
+          # `FATAL: the database system is shutting down` e devolver um banco vazio.
+          # O TCP e o discriminador porque o servidor de init tem listen_addresses vazio.
           for i in $(seq 1 60); do
-            docker exec restore-probe pg_isready -U postgres >/dev/null 2>&1 && break
+            docker exec restore-probe pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1 && break
             sleep 2
           done
 
@@ -197,15 +203,22 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const artifacts = await github.rest.actions.listArtifactsForRepo({
+            // 2026-08-08 — este passo era VERDE E VAZIO. Pedia `per_page: 100` sem paginar, e o
+            // repositorio tem 387 artefatos: so 8 `db-backup-*` cabiam na primeira pagina, entao
+            // `slice(8)` sempre dava lista vazia. O log dizia "Kept 8 backups, deleted 0" com 12
+            // backups vivos, e "deleted 0" lia-se como "nada a fazer" em vez de "nao enxerguei".
+            // Paginar e o conserto; imprimir o TOTAL e o que impede o proximo mal-entendido.
+            const all = await github.paginate(github.rest.actions.listArtifactsForRepo, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               per_page: 100,
             });
 
-            const backups = artifacts.data.artifacts
-              .filter(a => a.name.startsWith('db-backup-'))
+            const backups = all
+              .filter(a => a.name.startsWith('db-backup-') && !a.expired)
               .sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+
+            console.log(`${all.length} artefatos no repo, ${backups.length} deles sao db-backup-*`);
 
             const toDelete = backups.slice(8); // Keep 8 most recent
 
@@ -218,4 +231,9 @@ jobs:
               });
             }
 
+            // Freio: nunca apagar tudo. Se o filtro quebrar e `backups` vier com o repo inteiro,
+            // e melhor o passo falhar do que drenar a retencao em silencio.
+            if (backups.length > 0 && toDelete.length >= backups.length) {
+              core.setFailed(`recusando apagar ${toDelete.length} de ${backups.length} backups`);
+            }
             console.log(`Kept ${Math.min(backups.length, 8)} backups, deleted ${toDelete.length}`);

--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -6,10 +6,23 @@ on:
     - cron: '0 23 * * 0'
   workflow_dispatch: # Allow manual trigger
 
+# Medido 2026-08-08: as execucoes de 19/07, 27/07 e 02/08 concluiram `failure` — e o pg_dump,
+# a verificacao de integridade, o upload e a copia para o R2 tinham TODOS passado. O vermelho
+# vinha do ultimo passo, `Cleanup old artifacts`, com 403 "Resource not accessible by
+# integration" no DELETE: sem bloco `permissions:` o GITHUB_TOKEN herda o default do repo, que
+# nao inclui `actions: write`.
+#
+# O custo nao era a limpeza: era o ALARME. Tres semanas de vermelho cosmetico tornam
+# indistinguivel a falha real do pg_dump, que produziria exatamente a mesma cor.
+permissions:
+  contents: read
+  actions: write # o passo de limpeza faz DELETE de artefato
+
 jobs:
   backup:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    # +20: o passo de verificacao restaura o dump num container e leva alguns minutos.
+    timeout-minutes: 30
 
     steps:
       - name: Install PostgreSQL client
@@ -35,6 +48,15 @@ jobs:
           FILENAME="backup_${TIMESTAMP}.sql.gz"
 
           echo "Starting backup at $(date -u)"
+          # 2026-08-08 — `cron` e `net` entram nas exclusoes, e a razao NAO e tamanho.
+          # Ensaio de restauracao do backup de 03/08 num Postgres 17.6 local: o dump carregava
+          # `COPY cron.job`, o restore respondia `permission denied for table job` (tabela de
+          # EXTENSAO, nao do usuario), e a partir dali o psql passou a interpretar cada linha de
+          # dado como comando — 26.724 "syntax error" em cascata. A vitima medida foi
+          # `admin_audit_log`: 67.494 linhas na origem, ZERO no restaurado. O log de auditoria
+          # sumia inteiro num restore real, e nada no workflow acusava.
+          # Excluir os dois schemas remove a origem da dessincronizacao. `cron.job_run_details`
+          # tinha 146.271 linhas e e telemetria do agendador, nao dado de dominio.
           # #618 (2nd leg): /usr/bin/pg_dump is Ubuntu's pg_wrapper, which resolves to the
           # LOCAL cluster's version — the runner image ships a PostgreSQL 16 service, so the
           # wrapper kept picking pg_dump 16 even with client-17 installed. Call the versioned
@@ -55,6 +77,8 @@ jobs:
             --exclude-schema=pgsodium \
             --exclude-schema=vault \
             --exclude-schema=supabase_migrations \
+            --exclude-schema=cron \
+            --exclude-schema=net \
             | gzip > "$FILENAME"
 
           SIZE=$(du -h "$FILENAME" | cut -f1)
@@ -75,6 +99,68 @@ jobs:
             exit 1
           fi
           echo "✅ Backup size OK: $SIZE bytes"
+
+      # 2026-08-08 — o passo que faltava. Ate aqui o workflow provava que o arquivo EXISTE, que
+      # o gzip abre e que tem mais de 1 KB. Nada disso prova que ele RESTAURA: o backup de 03/08
+      # passava nos tres e mesmo assim perdia `admin_audit_log` inteiro.
+      #
+      # Restaura de verdade, num Postgres da mesma versao da plataforma, e afirma o que o ensaio
+      # manual mediu. As asseercoes sao pisos, nao igualdades: a base cresce entre um domingo e
+      # outro, e um teste que exige numero exato vira ruido em duas semanas.
+      - name: Verify backup RESTORES (not just that it exists)
+        run: |
+          set -o pipefail
+          docker run -d --name restore-probe \
+            -e POSTGRES_PASSWORD=probe_ephemeral \
+            -e POSTGRES_DB=postgres \
+            supabase/postgres:17.6.1.084
+
+          for i in $(seq 1 60); do
+            docker exec restore-probe pg_isready -U postgres >/dev/null 2>&1 && break
+            sleep 2
+          done
+
+          gunzip -c "$BACKUP_FILE" \
+            | docker exec -i restore-probe psql -U postgres -d postgres -q \
+            > restore.out 2> restore.err || true
+
+          q() { docker exec restore-probe psql -U postgres -tAc "$1"; }
+
+          # (a) A cascata do COPY. Um unico "syntax error" significa que o psql saiu de um bloco
+          # COPY e passou a ler dado como comando — foi assim que o admin_audit_log se perdeu.
+          SYNTAX=$(grep -c "syntax error" restore.err || true)
+          echo "syntax errors no restore: $SYNTAX"
+          if [ "$SYNTAX" -ne 0 ]; then
+            echo "::error::$SYNTAX erros de sintaxe no restore — o psql dessincronizou e ha perda silenciosa de dado"
+            grep -oE "ERROR:  [a-z ]+" restore.err | sort | uniq -c | sort -rn | head -10
+            exit 1
+          fi
+
+          # (b) Tabelas que nao podem voltar vazias. admin_audit_log esta aqui porque foi a que
+          # se perdeu; as outras cobrem dominio, pessoas e o funil de selecao.
+          for T in admin_audit_log members board_items events selection_applications notifications; do
+            N=$(q "select count(*) from public.$T;")
+            echo "  $T = $N"
+            if [ "$N" -eq 0 ]; then
+              echo "::error::$T restaurou VAZIA — backup nao e restauravel"
+              exit 1
+            fi
+          done
+
+          # (c) Pisos estruturais. Medidos em 08/08: 213 tabelas e 518 FKs no restaurado
+          # (prod tinha 216 e 523; a diferenca sao objetos criados depois do dump e as FKs
+          # que apontam para auth.users, excluido por desenho — ver o README de recuperacao).
+          TABLES=$(q "select count(*) from pg_tables where schemaname='public';")
+          FKS=$(q "select count(*) from pg_constraint c join pg_class t on t.oid=c.conrelid join pg_namespace n on n.oid=t.relnamespace where n.nspname='public' and c.contype='f';")
+          echo "tabelas=$TABLES fks=$FKS"
+          [ "$TABLES" -ge 200 ] || { echo "::error::so $TABLES tabelas restauradas (piso 200)"; exit 1; }
+          [ "$FKS" -ge 500 ]   || { echo "::error::so $FKS chaves estrangeiras (piso 500)"; exit 1; }
+
+          echo "✅ Restore verificado: $TABLES tabelas, $FKS FKs, 0 erro de sintaxe"
+
+      - name: Tear down restore probe
+        if: always()
+        run: docker rm -f restore-probe >/dev/null 2>&1 || true
 
       - name: Upload backup artifact
         uses: actions/upload-artifact@v4

--- a/docs/reference/RECUPERACAO_DE_DESASTRE.md
+++ b/docs/reference/RECUPERACAO_DE_DESASTRE.md
@@ -1,0 +1,122 @@
+# Recuperação de desastre: onde estão os backups e o que eles realmente restauram
+
+> Tudo abaixo foi **medido em 08/08/2026** restaurando o backup real de 03/08. Nada aqui é
+> suposição de projeto. Ao reler, re-meça: `scripts/pull-backup-local.sh --restore` refaz o ensaio
+> inteiro em poucos minutos.
+
+## As três cópias
+
+| onde | o que é | cadência | retenção |
+|---|---|---|---|
+| Supabase (plataforma) | backup **físico** WAL-G do projeto | diário, ~04:20 UTC | janela da plataforma |
+| GitHub Actions artifact | dump **lógico** `pg_dump` gzipado | semanal, domingo 23:00 UTC | 60 dias, 8 cópias |
+| Cloudflare R2 (`nucleoia-db-backups`) | o **mesmo** dump lógico, offsite | semanal, junto com o de cima | bucket |
+| máquina local (opcional) | o mesmo dump, via `scripts/pull-backup-local.sh` | semanal, timer `systemd --user` | 8 cópias, `chmod 600` |
+
+A separação existe por desenho (#618): código e backup não podem morar na mesma cesta de
+fornecedor. A cópia local é a terceira perna e é a única que sobrevive à perda de acesso às duas
+contas de nuvem.
+
+⚠️ **`pitr_enabled` era `false` em 08/08.** Sem point-in-time, o RPO é a granularidade do diário,
+e uma falha do diário empurra isso para 48 h ou mais.
+
+## O que o dump lógico NÃO contém
+
+O `pg_dump` do `backup-database.yml` exclui doze schemas. Dois grupos, por motivos diferentes:
+
+**Excluídos porque são da plataforma, não do domínio:** `storage`, `supabase_functions`,
+`extensions`, `graphql`, `graphql_public`, `realtime`, `pgsodium`, `vault`, `supabase_migrations`,
+e (desde 08/08) `cron` e `net`.
+
+**Excluído com consequência de recuperação: `auth`.**
+
+Medido no ensaio de 08/08, restaurando o backup de 03/08:
+
+| | |
+|---|---|
+| `auth.users` no restaurado | **0** |
+| membros com `auth_id` órfão | **100** de 131 |
+| chaves estrangeiras | 523 na origem, **518** no restaurado |
+
+As 4 FKs ausentes são `members_auth_id_fkey`, `user_profiles_id_fkey`, `events_created_by_fkey` e
+`webinars_created_by_fkey`, todas contra `auth.users`.
+
+**Em português:** restaurar só este dump devolve todo o dado e **nenhuma identidade**. Ninguém
+consegue entrar. A recuperação completa exige, além do dump, reprovisionar as identidades (backup
+físico do Supabase, ou recriação via OAuth com re-vínculo de `members.auth_id`).
+
+Incluir o schema `auth` no dump resolveria e levaria hashes de senha e refresh tokens para o
+artefato do GitHub. É decisão de PM, e enquanto não for tomada, este documento é o registro dela.
+
+## Fidelidade medida do dump lógico
+
+Ensaio de 08/08 sobre o backup de 03/08, restaurado num `supabase/postgres:17.6.1.084`:
+
+- **213 de 216** tabelas do schema `public`. As 3 ausentes (`alert_deliveries`,
+  `cron_vitality_watch`, `selection_booking_attempts`) foram **criadas em 05/08**, depois do dump.
+  A ausência estava correta.
+- **153 de 213** com contagem idêntica à produção no dia do teste.
+- O restante é crescimento de 5 dias, confirmado contra um oráculo recortado na data do dump
+  (`count(*) filter (where created_at < '<data>')`). Exemplos que fecharam exatos: `events` 625,
+  `selection_evaluations` 420, `gate_attempts` 30.
+
+## Como ler o resultado de um ensaio sem se enganar
+
+Três armadilhas, todas custaram uma volta em 08/08:
+
+1. **Compare contra a data do BACKUP, não contra produção agora.** Dezenas de tabelas parecem
+   divergentes e são só crescimento. O controle mais barato: uma tabela que só ganhou linhas depois
+   do dump deve voltar **vazia**. Se ela vier cheia, você está lendo produção por engano.
+2. **Tabela ausente pode ter nascido depois.** Datar pela migration resolve:
+   `git log -1 --format=%ad -- supabase/migrations/<arquivo>.sql`.
+3. **Qualquer `syntax error` no log do restore é perda silenciosa de dado**, não ruído. Ele
+   significa que o `psql` saiu de um bloco `COPY` e passou a interpretar linhas de dado como
+   comando. O tell é o token do erro ser um valor (`localhost`, `3`) e não um identificador SQL.
+
+Foi exatamente assim que `admin_audit_log` se perdeu inteiro (67.494 linhas na origem, zero no
+restaurado) antes da correção do #1684: o dump carregava `COPY cron.job`, tabela de extensão, o
+restore respondia `permission denied for table job`, e a cascata levou junto tabelas sem relação
+nenhuma com `cron`.
+
+## Procedimento de restauração local
+
+```bash
+# baixa o mais novo, verifica o gzip, mantém 8 cópias e ENSAIA a restauração
+scripts/pull-backup-local.sh --restore
+
+# instala o timer semanal (segunda 09:00, depois do dump de domingo 23:00 UTC)
+scripts/pull-backup-local.sh --install-timer
+```
+
+O script recusa um destino dentro de um repositório git: o dump contém PII de membros e
+candidatos, e o destino nasce `0700` com os arquivos `0600`.
+
+## O ambiente restaurado também é o laboratório de perfis
+
+Gates que resolvem por `auth.uid()` não são mensuráveis em produção: `execute_sql` entra como
+`service_role` e o conector MCP entra como o dono da conta. Numa cópia restaurada:
+
+```sql
+begin;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '<auth_id do perfil alvo>', true);
+select public.a_rpc_que_voce_quer_testar();
+rollback;
+```
+
+⚠️ A imagem `supabase/postgres` define `auth.uid()` lendo `request.jwt.claim.sub` (singular).
+Produção aceita também `request.jwt.claims`. Confira com `pg_get_functiondef` antes de concluir que
+um gate está quebrado.
+
+⚠️ **A cópia é da data do backup.** Para testar código de hoje, aplique por cima as migrations
+posteriores ao dump. Rodar cru mede o comportamento **antigo**, o que é útil como controle
+histórico e enganoso como validação.
+
+Usos reais em 08/08:
+
+- **#1591:** avaliador não-GP resolveu `selection_committee_role = 'evaluator'` e atravessou
+  `submit_evaluation`; observador resolveu `'observer'` e levou
+  `Unauthorized: observer role does not evaluate`. As **duas classes de recusa diferentes** são o
+  que prova o gate: se ambos falhassem igual, o teste não provaria nada.
+- **#1682:** o defeito do ledger foi reproduzido, corrigido e validado com controle negativo, e o
+  alcance (**34** pessoas) bateu com a medição feita em produção por consulta independente.

--- a/scripts/pull-backup-local.sh
+++ b/scripts/pull-backup-local.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# pull-backup-local.sh — traz o backup semanal do banco para a maquina local e, opcionalmente,
+# ENSAIA a restauracao.
+#
+# Por que existe (medido em 08/08/2026):
+#
+#   1. TERCEIRA COPIA. O dump semanal vivia em dois lugares, GitHub artifacts e Cloudflare R2,
+#      ambos na nuvem e ambos alcancados pelas mesmas credenciais. Uma copia local e a unica que
+#      sobrevive a perda de acesso as duas contas.
+#
+#   2. BACKUP SO E BACKUP DEPOIS DE RESTAURADO. O workflow verificava que o arquivo existe, que o
+#      gzip abre e que tem mais de 1 KB. O backup de 03/08 passava nos tres e perdia
+#      `admin_audit_log` inteiro: 67.494 linhas na origem, ZERO no restaurado (#1684).
+#
+#   3. AMBIENTE DE TESTE DE PERSONA. Gates que resolvem por `auth.uid()` nao sao mensuraveis nem
+#      por SQL em producao (entra como service_role) nem pelo conector MCP (entra como o dono).
+#      Numa copia restaurada, `set role authenticated` + `set_config('request.jwt.claim.sub', ...)`
+#      testa qualquer perfil. Foi assim que #1591 e #1682 sairam do achismo.
+#
+# ⚠️ O ARQUIVO BAIXADO CONTEM PII. O diretorio de destino nasce 0700, os dumps 0600, e o script
+#    RECUSA um destino que esteja dentro de um repositorio git.
+#
+# Uso:
+#   scripts/pull-backup-local.sh                  # baixa o mais novo e poda
+#   scripts/pull-backup-local.sh --restore        # baixa e ensaia a restauracao
+#   scripts/pull-backup-local.sh --keep 4         # muda a retencao
+#   scripts/pull-backup-local.sh --install-timer  # instala o timer semanal do systemd --user
+#
+# Requer: gh (autenticado), jq, unzip. Para --restore, docker.
+
+set -euo pipefail
+
+REPO="${NUCLEO_BACKUP_REPO:-VitorMRodovalho/ai-pm-research-hub}"
+DEST="${NUCLEO_BACKUP_HOME:-$HOME/.local/share/nucleo-backups}"
+KEEP="${NUCLEO_BACKUP_KEEP:-8}"
+PG_IMAGE="${NUCLEO_BACKUP_PG_IMAGE:-supabase/postgres:17.6.1.084}"
+DO_RESTORE=0
+INSTALL_TIMER=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dest)          DEST="$2"; shift 2 ;;
+    --keep)          KEEP="$2"; shift 2 ;;
+    --repo)          REPO="$2"; shift 2 ;;
+    --image)         PG_IMAGE="$2"; shift 2 ;;
+    --restore)       DO_RESTORE=1; shift ;;
+    --install-timer) INSTALL_TIMER=1; shift ;;
+    -h|--help)       sed -n '2,30p' "$0"; exit 0 ;;
+    *) echo "flag desconhecida: $1" >&2; exit 2 ;;
+  esac
+done
+
+log() { printf '%s %s\n' "$(date -u +%H:%M:%S)" "$*"; }
+die() { printf '\033[0;31mERRO:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ── install-timer ────────────────────────────────────────────────────────────
+if [ "$INSTALL_TIMER" = "1" ]; then
+  UNITS="$HOME/.config/systemd/user"
+  SELF="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+  mkdir -p "$UNITS"
+  cat > "$UNITS/nucleo-backup-pull.service" <<EOF
+[Unit]
+Description=Traz o backup semanal do Nucleo IA para a maquina local e ensaia a restauracao
+Documentation=https://github.com/$REPO/blob/main/scripts/pull-backup-local.sh
+
+[Service]
+Type=oneshot
+ExecStart=$SELF --restore
+# O dump tem PII: nada de log verboso no journal do usuario.
+StandardOutput=journal
+EOF
+  cat > "$UNITS/nucleo-backup-pull.timer" <<'EOF'
+[Unit]
+Description=Backup local semanal do Nucleo IA (segunda de manha, depois do dump de domingo 23:00 UTC)
+
+[Timer]
+OnCalendar=Mon *-*-* 09:00:00
+Persistent=true
+RandomizedDelaySec=30m
+
+[Install]
+WantedBy=timers.target
+EOF
+  systemctl --user daemon-reload
+  systemctl --user enable --now nucleo-backup-pull.timer
+  log "timer instalado. Proxima execucao:"
+  systemctl --user list-timers nucleo-backup-pull.timer --no-pager | sed -n '1,2p'
+  exit 0
+fi
+
+# ── pre-condicoes ────────────────────────────────────────────────────────────
+command -v gh   >/dev/null || die "gh nao encontrado"
+command -v jq   >/dev/null || die "jq nao encontrado"
+command -v unzip >/dev/null || die "unzip nao encontrado"
+gh auth status >/dev/null 2>&1 || die "gh nao autenticado (rode: gh auth login)"
+
+# O destino NAO pode estar dentro de um repositorio: o dump tem PII e um `git add -A` distraido
+# alcancaria 121 membros e 81 candidatos. Isto e barreira, nao conselho.
+mkdir -p "$DEST"
+if git -C "$DEST" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  die "destino '$DEST' esta dentro de um repositorio git. Escolha um caminho fora (o dump tem PII)."
+fi
+chmod 700 "$DEST"
+
+# ── qual e o artefato mais novo ──────────────────────────────────────────────
+log "procurando o backup mais recente em $REPO..."
+# Duas armadilhas do `gh api`, ambas pegas ao testar o script em 08/08:
+#   1. `--paginate` emite UM documento JSON POR PAGINA. Sem juntar, o filtro roda por pagina e
+#      devolve um objeto por pagina — o script montava uma URL com dois ids concatenados.
+#   2. `--slurp` junta as paginas num array, mas e INCOMPATIVEL com `--jq`. Dai o pipe externo.
+NEWEST=$(gh api "repos/$REPO/actions/artifacts" --paginate --slurp \
+  | jq -c '[.[].artifacts[] | select((.name|startswith("db-backup-")) and (.expired|not))]
+           | sort_by(.created_at) | last // empty')
+[ -n "$NEWEST" ] || die "nenhum artefato db-backup-* disponivel (todos expirados?)"
+
+ART_ID=$(jq -r '.id'         <<<"$NEWEST")
+ART_NAME=$(jq -r '.name'     <<<"$NEWEST")
+ART_WHEN=$(jq -r '.created_at' <<<"$NEWEST")
+ART_SIZE=$(jq -r '.size_in_bytes' <<<"$NEWEST")
+log "mais recente: $ART_NAME ($ART_WHEN, $((ART_SIZE/1024/1024)) MB)"
+
+STAMP="${ART_NAME#db-backup-}"
+TARGET="$DEST/backup_${STAMP}.sql.gz"
+
+if [ -f "$TARGET" ]; then
+  log "ja existe localmente, nada a baixar: $(basename "$TARGET")"
+else
+  # Idade do backup: se o cron de domingo falhou, o mais novo pode ter semanas. Avisar e o
+  # ponto — um backup velho e silencioso e pior que um erro barulhento.
+  TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+  log "baixando..."
+  gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > "$TMP/a.zip"
+  unzip -o -q "$TMP/a.zip" -d "$TMP"
+  SRC=$(find "$TMP" -name '*.sql.gz' -print -quit)
+  [ -n "$SRC" ] || die "o artefato nao contem .sql.gz"
+  gzip -t "$SRC" || die "gzip corrompido — NAO substituindo a copia local anterior"
+  mv "$SRC" "$TARGET"
+  chmod 600 "$TARGET"
+  log "gravado: $(basename "$TARGET") ($(du -h "$TARGET" | cut -f1))"
+fi
+
+AGE_DAYS=$(( ( $(date -u +%s) - $(date -u -d "$ART_WHEN" +%s) ) / 86400 ))
+if [ "$AGE_DAYS" -gt 9 ]; then
+  printf '\033[1;33mATENCAO:\033[0m o backup mais novo tem %s dias. O cron de domingo pode estar falhando.\n' "$AGE_DAYS"
+fi
+
+# ── poda ─────────────────────────────────────────────────────────────────────
+mapfile -t ALL < <(ls -1 "$DEST"/backup_*.sql.gz 2>/dev/null | sort -r)
+if [ "${#ALL[@]}" -gt "$KEEP" ]; then
+  for old in "${ALL[@]:$KEEP}"; do
+    log "podando (retencao $KEEP): $(basename "$old")"
+    rm -f "$old"
+  done
+fi
+log "copias locais: $(ls -1 "$DEST"/backup_*.sql.gz 2>/dev/null | wc -l) (retencao $KEEP)"
+
+[ "$DO_RESTORE" = "1" ] || exit 0
+
+# ── ensaio de restauracao ────────────────────────────────────────────────────
+command -v docker >/dev/null || die "--restore precisa de docker"
+CTR="nucleo-restore-probe-$$"
+# O log de erro do restore fica APENAS quando o ensaio falha: ele e o unico jeito de diagnosticar,
+# e pode conter linhas de dado (foi assim que a cascata do COPY apareceu). Em caso de sucesso e
+# apagado; em caso de falha fica 0600 e o caminho e impresso.
+cleanup() { docker rm -f "$CTR" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+# O volume do container vive na raiz do docker, nao no destino. Avisar se a raiz estiver apertada:
+# uma base restaurada ocupa perto de 1 GB e um disco cheio aborta o restore pela metade, que e a
+# forma mais confusa de falhar.
+FREE_MB=$(df -Pm /var/lib/docker 2>/dev/null | awk 'NR==2{print $4}' || df -Pm / | awk 'NR==2{print $4}')
+[ "${FREE_MB:-0}" -gt 3000 ] || printf '\033[1;33mATENCAO:\033[0m so %s MB livres onde o docker guarda dados.\n' "${FREE_MB:-?}"
+
+log "subindo $PG_IMAGE..."
+docker run -d --name "$CTR" -e POSTGRES_PASSWORD=probe_ephemeral -e POSTGRES_DB=postgres "$PG_IMAGE" >/dev/null
+
+# ⚠️ `pg_isready` no socket unix NAO e sinal de prontidao nesta imagem. O init sobe um servidor
+# TEMPORARIO que escuta so no socket, roda os scripts e o DESLIGA antes de subir o definitivo.
+# Medido em 08/08: t=3s o socket aceita e o TCP nao; t=4s o TCP aceita. Conectar no temporario
+# faz o restore morrer no meio (`FATAL: the database system is shutting down`) e devolver um banco
+# VAZIO — que e exatamente como um backup ruim se parece. O TCP discrimina porque o servidor de
+# init roda com listen_addresses vazio.
+READY=0
+for _ in $(seq 1 60); do
+  if docker exec "$CTR" pg_isready -h 127.0.0.1 -U postgres >/dev/null 2>&1; then READY=1; break; fi
+  sleep 2
+done
+[ "$READY" = "1" ] || die "o Postgres do container nao ficou pronto em 120s"
+
+log "restaurando $(basename "$TARGET")..."
+gunzip -c "$TARGET" | docker exec -i "$CTR" psql -U postgres -d postgres -q \
+  >/dev/null 2> "$DEST/restore.err" || true
+
+q() { docker exec "$CTR" psql -U postgres -tAc "$1"; }
+FAIL=0
+
+# (a) A cascata do COPY. Um unico "syntax error" significa que o psql saiu de um bloco COPY e
+# passou a ler dado como comando — foi assim que o admin_audit_log se perdeu inteiro.
+SYNTAX=$(grep -c "syntax error" "$DEST/restore.err" || true)
+if [ "$SYNTAX" -ne 0 ]; then
+  printf '\033[0;31mFALHOU:\033[0m %s erros de sintaxe no restore (perda silenciosa de dado)\n' "$SYNTAX"
+  grep -oE "ERROR:  [a-z ]+" "$DEST/restore.err" | sort | uniq -c | sort -rn | head -5
+  FAIL=1
+else
+  log "ok: 0 erro de sintaxe"
+fi
+
+# (b) Tabelas que nao podem voltar vazias.
+for T in admin_audit_log members board_items events selection_applications notifications; do
+  N=$(q "select count(*) from public.$T;" 2>/dev/null || echo 0)
+  if [ "${N:-0}" -eq 0 ]; then
+    printf '\033[0;31mFALHOU:\033[0m %s restaurou VAZIA\n' "$T"; FAIL=1
+  else
+    log "ok: $T = $N"
+  fi
+done
+
+# (c) Pisos estruturais (medidos em 08/08: 213 tabelas, 518 FKs).
+TABLES=$(q "select count(*) from pg_tables where schemaname='public';")
+FKS=$(q "select count(*) from pg_constraint c join pg_class t on t.oid=c.conrelid join pg_namespace n on n.oid=t.relnamespace where n.nspname='public' and c.contype='f';")
+[ "$TABLES" -ge 200 ] || { printf '\033[0;31mFALHOU:\033[0m so %s tabelas (piso 200)\n' "$TABLES"; FAIL=1; }
+[ "$FKS"    -ge 500 ] || { printf '\033[0;31mFALHOU:\033[0m so %s FKs (piso 500)\n' "$FKS"; FAIL=1; }
+log "estrutura: $TABLES tabelas, $FKS chaves estrangeiras"
+
+# (d) O que este backup NAO restaura, por desenho — informativo, nao falha.
+ORFAOS=$(q "select count(*) from public.members m where m.auth_id is not null and not exists (select 1 from auth.users u where u.id=m.auth_id);")
+printf '\033[1;33mnota:\033[0m --exclude-schema=auth deixa %s membros com auth_id orfao. O banco volta, o login nao.\n' "$ORFAOS"
+
+if [ "$FAIL" = "0" ]; then
+  rm -f "$DEST/restore.err"
+  printf '\033[0;32m✅ Ensaio OK\033[0m — %s restaura: %s tabelas, %s FKs, 0 erro de sintaxe.\n' "$(basename "$TARGET")" "$TABLES" "$FKS"
+else
+  chmod 600 "$DEST/restore.err" 2>/dev/null || true
+  printf 'log do restore preservado em %s (0600, pode conter dado — apague depois de diagnosticar)\n' "$DEST/restore.err"
+  die "ensaio de restauracao FALHOU — o backup nao e confiavel"
+fi


### PR DESCRIPTION
## Como isto apareceu

Ensaio de recuperacao em 08/08/2026, feito sobre o backup **real** de 03/08 (o mesmo artefato que sobe para o R2), restaurado num `supabase/postgres:17.6.1.084` local. Sem credencial nenhuma: o artefato do proprio workflow basta.

**213 de 216 tabelas** voltaram, **153 com contagem identica** a producao. As 3 ausentes foram criadas em 05/08 (#1621, #1609), entao a ausencia estava correta. Deltas como `events` (-44) e `selection_evaluations` (-37) batem exatamente com um oraculo de prod recortado em 03/08, ou seja, sao crescimento de 5 dias e nao perda.

Tres coisas, porem, nao estavam certas.

## 1. `admin_audit_log` restaurou VAZIO

| | |
|---|---|
| linhas na origem em 03/08 | **67.494** |
| linhas no restaurado | **0** |

O log de quem fez o que sumia inteiro num restore real, e nenhum passo do workflow acusava.

## 2. A causa raiz e o schema `cron`, e cabe numa linha

O `pg_dump` excluia 10 schemas e **nao excluia `cron` nem `net`**. O dump entao carregava `COPY cron.job`, que e tabela de **extensao**. No restore:

```
ERROR:  permission denied for table job
ERROR:  syntax error at or near "localhost"
ERROR:  syntax error at or near "3"
...
```

O `COPY` falha, o psql sai do bloco e passa a interpretar **cada linha de dado como comando**: **26.724** erros de sintaxe em cascata, com o `admin_audit_log` entre as vitimas. `cron.job_run_details` sozinha tinha **146.271** linhas de telemetria do agendador, que nunca deveriam estar num backup de dominio.

## 3. O alarme estava saturado ha 3 semanas

As execucoes de **19/07, 27/07 e 02/08** concluiram `failure`. E o `pg_dump`, a verificacao de integridade, o upload do artefato e a copia offsite para o R2 tinham **todos passado** — a prova e que `db-backup-20260803_000010` existe, 17,4 MB, nao expirado, produzido pela execucao "que falhou".

O 403 vinha do ultimo passo, `Cleanup old artifacts`: sem bloco `permissions:`, o `GITHUB_TOKEN` herda o default do repo, que nao inclui `actions: write`.

O custo nao foi a limpeza. Foi o **significado do vermelho**: uma falha verdadeira do `pg_dump` produziria exatamente a mesma cor, e ninguem olharia.

## O que este PR muda

| mudanca | efeito |
|---|---|
| `--exclude-schema=cron --exclude-schema=net` | remove a origem da dessincronizacao |
| bloco `permissions:` com `actions: write` | o vermelho volta a significar alguma coisa |
| passo `Verify backup RESTORES` | restaura de verdade e afirma o resultado |
| `timeout-minutes` 10 -> 30 | cabe o restore |

O passo novo existe porque **os tres passos anteriores provavam que o arquivo existe, que o gzip abre e que tem mais de 1 KB** — e o backup de 03/08 passava nos tres enquanto perdia o log de auditoria. Ele sobe o container, restaura, e afirma:

- **zero** ocorrencia de `syntax error` (o tell da cascata)
- seis tabelas criticas nao-vazias, `admin_audit_log` entre elas
- pisos de **200** tabelas e **500** FKs

As asseercoes sao pisos e nao igualdades, de proposito: a base cresce entre um domingo e outro, e um teste ancorado em numero exato vira ruido em duas semanas.

## Registrado e NAO corrigido aqui: o backup nao restaura identidade

`--exclude-schema=auth` e desenho, mas tem consequencia medida:

| | |
|---|---|
| `auth.users` no restaurado | **0** |
| membros com `auth_id` apontando para nada | **100** de 131 |
| FKs perdidas | 523 na origem -> **518** no restaurado |

As 4 FKs perdidas sao `members_auth_id_fkey`, `user_profiles_id_fkey`, `events_created_by_fkey` e `webinars_created_by_fkey` — todas contra `auth.users`. Num desastre, o banco volta e **ninguem entra**.

Incluir o schema `auth` resolveria, e levaria hashes de senha e refresh tokens para o artefato do GitHub. E decisao de PM, nao de patch, entao fica declarada.

## Fora do escopo, para a mesma conversa

O lado do fornecedor tambem foi medido em 08/08: `pitr_enabled: false`, e a janela de diarios tem **02/08 e 07/08 ausentes**, com o mais novo em 06/08 — 46 h. Nao vai em issue publica pelo motivo obvio.

Refs #618