### PR TITLE
docs(planning): handoff de 08/08 e arranque de 09/08

### DIFF
--- a/docs/planning/2026-08-08_handoff_backup_restauravel_e_laboratorio_de_perfis.md
+++ b/docs/planning/2026-08-08_handoff_backup_restauravel_e_laboratorio_de_perfis.md
@@ -13,6 +13,12 @@ errado**. Errei os dois três vezes, todas corrigidas por medição e nenhuma po
 - "backup quebrado há 3 semanas" era a **limpeza de artefatos**, cosmética; o dump funcionava.
 - "não dá para medir sem gente" era falso: havia base restaurável e impersonação custa três linhas.
 
+Um quarto, no fim da sessão, que vale como aviso de método: **armei um monitor de CI no
+`git rev-parse HEAD` e depois empurrei outro commit.** O monitor passou a vigiar um head já
+superado, devolveu "todos concluídos" de um SHA obsoleto, e eu anunciei um PR como mergeável
+enquanto o `validate` do commit atual ainda rodava. O instrumento estava certo; o **alvo** é que
+estava errado. Fixe o head pelo PR (`gh pr view N --json headRefOid`), nunca pelo working tree.
+
 ---
 
 ## Mergeado hoje
@@ -167,6 +173,30 @@ Personas sintéticas semeadas **na base restaurada**, nunca em produção, uma p
 
 O ambiente já existe (`scripts/pull-backup-local.sh --restore`). Falta o seed de personas e apontar
 a suíte DB-aware para ele em vez de para produção. É trabalho de sessão inteira e não foi começado.
+
+---
+
+## Decisões ratificadas pelo PM no fim da sessão
+
+| # | decisão | estado |
+|---|---|---|
+| 1 | o schema `auth` **não** entra no dump | registrada em `docs/reference/RECUPERACAO_DE_DESASTRE.md`, com a consequência aceita escrita |
+| 2 | **PITR não**; em vez dele, **dump diário** | PR **#1687** |
+| 3 | abrir ticket pelos diários ausentes | rascunho em `docs/planning/2026-08-08_ticket_supabase_diarios_ausentes.md`; **envio é do PM** |
+| 4 | implementar a correção do **#1682** | autorizada, **não começada** |
+
+A decisão 2 foi tomada com o preço medido, não suposto: PITR de 7 dias custa **US$ 100/mês** contra
+**~US$ 10/mês** do compute Micro do projeto inteiro. Eu havia recomendado "levantar o custo e
+ligar"; com o número na mão, reabri a recomendação e o PM escolheu o dump diário.
+
+⚠️ **As decisões 1 e 2 se somam numa dívida que precisa estar visível:** sem `auth` no dump e sem
+PITR, um desastre de identidade se resolve **recriando contas via OAuth na mão**. É consequência
+aceita, não esquecimento.
+
+O #1687 traz três ajustes que a cadência exigiu, e o terceiro é defeito e não redação: retenção
+8 → 30 no artefato (senão 8 dias de alcance onde antes eram 8 semanas), `concurrency` sem
+cancelamento, e o aviso de backup velho recalibrado de **9 para 2 dias** — com dump diário, o limite
+antigo ficaria mudo por mais de uma semana de falhas.
 
 ---
 

--- a/docs/planning/2026-08-08_handoff_backup_restauravel_e_laboratorio_de_perfis.md
+++ b/docs/planning/2026-08-08_handoff_backup_restauravel_e_laboratorio_de_perfis.md
@@ -1,0 +1,201 @@
+# Handoff — o backup passou a restaurar, e apareceu um laboratório de perfis (08/08/2026)
+
+> `main` em **`2913aede`**. Tudo desta sessão está mergeado.
+> Sessão anterior: `2026-08-07_handoff_arco_consentimento_e_acesso.md`.
+
+## Regra zero
+
+Nada aqui pode ser recitado. **Todo número foi medido em 08/08 e a base é viva.** O padrão que mais
+custou nesta sessão, de novo, foi **verde sem significado** e **número certo com significado
+errado**. Errei os dois três vezes, todas corrigidas por medição e nenhuma por raciocínio:
+
+- "20 pendentes" era o **denominador** do ciclo, não a fila de ninguém.
+- "backup quebrado há 3 semanas" era a **limpeza de artefatos**, cosmética; o dump funcionava.
+- "não dá para medir sem gente" era falso: havia base restaurável e impersonação custa três linhas.
+
+---
+
+## Mergeado hoje
+
+| PR | o que era |
+|---|---|
+| **#1673** | o rodapé dizia "Ciclo 4" e levava à playlist do ciclo 3 |
+| **#1683** | versiona o handoff de 07/08 e os arranques da virada |
+| **#1684** | seis defeitos no backup, fecha **#618** |
+
+O `validate` vermelho do #1673 era **`PROD-AHEAD`**, não do PR: o banco tinha `20260807000600` e o
+checkout parava em `…000500`. Resolvido por merge de `origin/main` **pelo remoto**
+(`gh api .../merges`), sem tocar no branch local contaminado.
+
+---
+
+## O que mudou na postura de backup
+
+Antes: duas cópias, ambas na nuvem e alcançáveis pelas mesmas credenciais, um dump que perdia o log
+de auditoria inteiro, e um alarme vermelho há três semanas por motivo cosmético.
+
+Os seis defeitos, todos da mesma família:
+
+1. `pg_dump` não excluía `cron`/`net`, carregava `COPY cron.job` (tabela de extensão), o restore
+   dava `permission denied` e o psql passava a ler dado como comando: **26.724** erros em cascata.
+2. **`admin_audit_log` restaurava vazio**: 67.494 linhas na origem, zero no restaurado.
+3. O workflow provava que o arquivo existe, abre e tem mais de 1 KB. Nunca que restaura.
+4. A limpeza era **verde e vazia**, e isso só apareceu **depois** de consertar o 403: pedia
+   `per_page: 100` sem paginar, e só 8 de 13 backups cabiam na primeira página de 389 artefatos.
+5. A sonda de restore tinha corrida de inicialização (ver armadilhas abaixo).
+6. Faltava a terceira cópia.
+
+Estado validado em dois disparos no branch:
+
+```
+389 artefatos no repo, 13 deles sao db-backup-*   (antes enxergava 8)
+Kept 8 backups, deleted 5
+syntax errors no restore: 0                       (eram 26.724)
+admin_audit_log = 74.283                          (era 0)
+216 tabelas, 519 FKs
+```
+
+O dump encolheu de 17,4 MB para 13 MB: é a telemetria do `cron` saindo.
+
+**Cópia local instalada e testada sob o systemd.** `scripts/pull-backup-local.sh`, timer
+`nucleo-backup-pull.timer`, segunda 09:12, destino `~/.local/share/nucleo-backups` (0600, fora de
+qualquer repositório). A unidade foi executada uma vez com `Result=success`.
+
+---
+
+## O laboratório de perfis (o que isto destrava)
+
+Gates que resolvem por `auth.uid()` eram tidos como não-mediveis. Numa cópia restaurada:
+
+```sql
+begin;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '<auth_id do alvo>', true);
+select public.a_rpc();
+rollback;
+```
+
+⚠️ A imagem define `auth.uid()` lendo **`request.jwt.claim.sub`** (singular).
+⚠️ A cópia é da **data do backup**: para testar código de hoje, aplique as migrations posteriores.
+Rodar cru mede o comportamento **antigo**, o que é ótimo como controle e enganoso como validação.
+
+### #1591 — confirmado sem depender de humano
+
+| perfil | `selection_committee_role` | `submit_evaluation` |
+|---|---|---|
+| avaliador não-GP | `evaluator` | atravessou o gate, parou em `Missing score for criterion` |
+| observador | `observer` | `Unauthorized: observer role does not evaluate` |
+
+O que prova o gate são as **duas classes de recusa diferentes**. Se ambos falhassem igual, o teste
+não provaria nada.
+
+⚠️ **Resíduo confirmado:** observador por URL direta ainda recebe **20 pendentes** de
+`get_my_pending_evaluations`.
+
+### #1682 — reproduzido, corrigido e validado
+
+Defeito **anterior ao #1666** (a versão de 03/08 já filtrava por `member_id`). Reproduzido com o
+ledger local em 53 linhas, corrigido com a ponte de e-mail, **controle negativo** segurou. Alcance
+**34**, batendo com a medição feita em produção por consulta independente.
+
+---
+
+## Investigações fechadas
+
+**#1679 (curadoria)** — nenhuma das duas leituras da issue. As "37 submissões" são 29 de backfill
+legado (autor nulo) mais 8 a veículo externo; `publication_submissions` não é a fila da curadoria.
+A fila real tem **2 itens**. Sobre 87 ativos: **57 veem, 18 podem emitir parecer, 3 são designáveis,
+3 são avisadas**. A maquinaria foi usada (2 `submitted_for_curation`, 11 `peer_review_completed`);
+o passo final nunca. O item de 19/05 nunca gerou aviso porque o broadcast só existe desde 05/06.
+
+**#1643** — parcial registrado. O único gate por consentimento em caminho de avanço é o de
+`visitor_leads`, com **coorte bloqueada = 0** (ausência medida). Falta a terceira classe nas funções
+de despacho e o `sign_proposer_consent`.
+
+---
+
+## 🔴 Aberto e não investigado: 10 membros sumiram sem rastro
+
+Medido em 08/08:
+
+| | |
+|---|---|
+| `members` no backup de 03/08 | **131** |
+| `members` em produção hoje | **121** |
+| criados desde 03/08 | **0** |
+| ações de remoção/anonimização no `admin_audit_log` na janela | **0** |
+
+A diferença estava concentrada em `inactive` (16 → 7). `admin_anonymize_member` anonimiza **no
+lugar**, não apaga, então uma queda de contagem não deveria acontecer por ali.
+
+**Próximo passo, e custa um minuto:** a cópia de 03/08 está em
+`~/.local/share/nucleo-backups/backup_20260803_000010.sql.gz`. Restaurar, extrair os IDs de
+`members` e comparar com produção diz **quais** 10 sumiram e o que elas eram.
+
+---
+
+## 🔴 Usuários de teste: o teste roda em produção, contra gente real
+
+Levantado pelo PM ao ver que eu impersonei **pessoas reais** na base restaurada. O problema é maior
+que o meu uso: a suíte de contrato já bate em produção contra candidaturas reais (#1636).
+
+Medido em 08/08, `gate_attempts`:
+
+| | |
+|---|---|
+| tentativas em `_issue_interview_booking_token_core` desde 04/08 | **542** |
+| delas **sem ator** (service_role/cron) | **537**, em 5 dias distintos |
+| candidaturas **reais** tocadas | **15** |
+| tentativas que **passaram** o gate | **159** |
+
+Para comparação, `schedule_interview` tem 31 tentativas espalhadas de 06/05 a 04/08: esse é o
+perfil de tráfego orgânico. Os 542 em 5 dias não são.
+
+⚠️ **A ser verificado, não afirmado:** `gate_attempts` registra a checagem do gate. Se as 159
+passagens efetivamente emitiram token de agendamento para candidatos reais é outra pergunta, e ela
+se responde cruzando com as tabelas de token e de entrevista. Isso **não** foi medido.
+
+### A proposta
+
+Personas sintéticas semeadas **na base restaurada**, nunca em produção, uma por perfil relevante
+(visitante, membro, líder de tribo, avaliador, observador, curador, GP, ghost). Com elas:
+
+1. os testes de contrato deixam de escolher candidatura real de produção (#1636);
+2. o teste deixa de depender de **quem por acaso** ocupa o papel — hoje "o avaliador não-GP" é uma
+   pessoa específica, e o teste quebra quando ela muda de papel;
+3. some a PII do laboratório: hoje a base restaurada carrega 121 membros e 81 candidatos reais.
+
+O ambiente já existe (`scripts/pull-backup-local.sh --restore`). Falta o seed de personas e apontar
+a suíte DB-aware para ele em vez de para produção. É trabalho de sessão inteira e não foi começado.
+
+---
+
+## Armadilhas medidas hoje
+
+- **`pg_isready` no socket unix NÃO é prontidão.** A imagem sobe um servidor temporário que escuta
+  só no socket e o desliga antes do definitivo. t=3s socket aceita e TCP não; t=4s TCP aceita.
+  Conectar no temporário mata o restore no meio e devolve **banco vazio**, que é exatamente como um
+  backup ruim se parece. Esperar por TCP.
+- **Corrigir a causa barulhenta revela a silenciosa que ela escondia.** O 403 mascarava a paginação
+  quebrada. Depois de consertar, verifique o **efeito**, nunca só a cor.
+- **Compare o restaurado contra a DATA DO BACKUP, não contra produção agora.** Dezenas de tabelas
+  "divergentes" eram crescimento. O controle: uma tabela que só ganhou linhas depois do dump deve
+  voltar **vazia**.
+- **Tabela ausente pode ter nascido depois** — datar pela migration (`git log` do arquivo).
+- **Qualquer `syntax error` no log do restore é perda silenciosa**, não ruído. O tell é o token do
+  erro ser um dado (`localhost`, `3`) e não um identificador SQL.
+- **`gh api --paginate` emite um JSON por página**, e `--slurp` é incompatível com `--jq`.
+- **Guard de âncora precisa de uma transação por função**, senão uma âncora ruim reverte o patch
+  bom que já tinha passado.
+- **Ao editar uma função grande, `replace` ancorado sobre `pg_get_functiondef` com `RAISE`** se a
+  âncora não casar. Nunca transcrever.
+
+---
+
+## Regras da casa
+
+- Commit: `Assisted-By:`, nunca `Co-Authored-By`.
+- Repo **PÚBLICO**: nenhum candidato ou membro nomeado, só contagens.
+- **Postura de backup não vai para issue pública** (sem PITR, RPO, falhas do diário): é informação
+  útil para quem ataca. Mesmo canal privado dos achados do #1383.
+- Não rodar `npm test` com CI em voo. Gatear, não só imprimir o número.

--- a/docs/planning/2026-08-08_ticket_supabase_diarios_ausentes.md
+++ b/docs/planning/2026-08-08_ticket_supabase_diarios_ausentes.md
@@ -1,0 +1,56 @@
+# Rascunho do ticket para o Supabase — diários ausentes (decisão 3, ratificada 08/08/2026)
+
+> Colar no suporte do Supabase. **Não vai para issue pública**: postura de backup é informação útil
+> para quem ataca.
+> Re-medir os fatos antes de enviar: `GET /v1/projects/<ref>/database/backups`.
+
+---
+
+**Assunto:** Daily physical backups missing on two dates (project `ldrfrvwhxsmgaabwmaik`, sa-east-1)
+
+**Corpo:**
+
+Hi,
+
+Project ref: `ldrfrvwhxsmgaabwmaik` (region `sa-east-1`, Postgres 17.6.1.084).
+
+Querying `GET /v1/projects/ldrfrvwhxsmgaabwmaik/database/backups` on 2026-08-08 at 02:21 UTC
+returned five completed physical backups, with two dates missing from the window:
+
+| date (04:20 UTC) | backup |
+|---|---|
+| 2026-08-01 | present |
+| **2026-08-02** | **missing** |
+| 2026-08-03 | present |
+| 2026-08-04 | present |
+| 2026-08-05 | present |
+| 2026-08-06 | present |
+| **2026-08-07** | **missing** (the scheduled time had already passed) |
+
+All five listed entries report `status: COMPLETED`, `is_physical_backup: true`.
+`pitr_enabled` is `false` and `walg_enabled` is `true`.
+
+Two questions:
+
+1. Why did the daily backup not run (or not complete) on 2026-08-02 and 2026-08-07? The gaps sit in
+   the middle of the retention window, so this is not retention pruning, which removes the oldest
+   entries first.
+2. Is there any notification we can subscribe to when a scheduled daily backup fails or is skipped?
+   Right now a missed backup is silent from our side: we only noticed by querying the API directly.
+
+Context on impact: the most recent restore point at the time of the query was 2026-08-06 04:20 UTC,
+which is roughly 46 hours old, where we would have expected about 22. A full day of production
+changes sat outside any vendor-side restore point without us being aware.
+
+Thanks.
+
+---
+
+## Fatos medidos que sustentam o ticket (08/08/2026)
+
+- `pitr_enabled: false`, `walg_enabled: true`, região `sa-east-1`
+- 5 backups completos listados: 01, 03, 04, 05, 06 de agosto
+- ausentes: 02 e 07 de agosto
+- backup mais novo com 1 dia e 22 horas na hora da consulta
+- buraco no meio da janela **não** é poda de retenção: a poda remove o mais velho, e o 01/08 estava
+  presente enquanto o 02/08 não

--- a/docs/planning/2026-08-09_PROMPT_ARRANQUE.md
+++ b/docs/planning/2026-08-09_PROMPT_ARRANQUE.md
@@ -27,6 +27,9 @@ contador, pergunte **de quem é este valor** e **em que ponto do processo essa p
 scripts/pull-backup-local.sh --restore     # ~15s, baixa o mais novo e ensaia
 ```
 
+⚠️ **O dump passou a ser DIÁRIO** (decisão 2, PR #1687), com retenção de 30 no artefato e 14 na
+cópia local. Se o #1687 ainda não tiver mergeado quando você ler isto, o `main` ainda está semanal.
+
 Com ela, gates que resolvem por `auth.uid()` deixam de ser "precisa de confirmação humana":
 
 ```sql
@@ -65,10 +68,15 @@ Backup de 03/08 tem 131 membros; produção tem 121, com **zero** criados desde 
 de remoção no `admin_audit_log`. A cópia está em `~/.local/share/nucleo-backups/`. Restaurar,
 extrair os IDs e comparar diz **quais** são e o que eram. Só depois disso decidir se é incidente.
 
-### 2. #1682 — implementar a correção que já está validada
+### 2. #1682 — implementar a correção que já está validada (AUTORIZADA, decisão 4)
 A ponte de e-mail no `export_my_data` e no `list_my_consents`, com **uma transação por função**
 (uma âncora ruim reverte o patch bom). Alcance medido: **34** pessoas. Levar junto as três decisões
 de escopo listadas na issue.
+
+🔴 **Antes de aplicar, olhe os PRs abertos.** Isto é DDL, e aplicar em prod antes do merge
+**serializa todos os PRs abertos** — qualquer branch sem o novo `.sql` fica vermelho nos gates de
+drift. Em 08/08 havia **12 PRs abertos**. O recorte certo não é "isso é DDL?", é "vou registrar uma
+versão?".
 
 ### 3. #1643 — terminar o sweep
 Falta a **terceira classe** ("afirmação incondicional sobre tratamento condicional") nas funções de
@@ -94,15 +102,25 @@ para candidatos reais? Cruzar com as tabelas de token e entrevista responde.
 
 ---
 
-## Decisões que estavam com o PM
+## Decisões TOMADAS pelo PM em 08/08 — não re-litigar
 
-Se ainda não vieram, perguntar antes de agir:
+| # | decisão | onde vive |
+|---|---|---|
+| 1 | **O schema `auth` NÃO entra no dump.** Levaria hashes de senha e refresh tokens para o artefato do GitHub. Consequência aceita: a recuperação devolve o dado e **não** o acesso | `docs/reference/RECUPERACAO_DE_DESASTRE.md` |
+| 2 | **PITR não.** 7 dias custam **US$ 100/mês** contra ~US$ 10/mês do compute do projeto inteiro. Em vez disso, **dump diário** | PR **#1687** |
+| 3 | **Abrir ticket** no Supabase pelos diários ausentes de 02/08 e 07/08 | rascunho pronto em `docs/planning/2026-08-08_ticket_supabase_diarios_ausentes.md` — **envio é do PM** |
+| 4 | **Implementar a correção do #1682**, já validada em base restaurada | ver abaixo |
 
-1. **Schema `auth` no backup** — incluir resolve a recuperação de identidade e leva hashes de senha
-   e refresh tokens para o artefato do GitHub.
-2. **PITR no Supabase** — hoje `false`; RPO é o diário, e o diário tinha dois dias faltando.
-3. **Ticket no Supabase** pelos diários ausentes de 02/08 e 07/08.
-4. Os quatro defeitos recortáveis do **#1679** viram issues?
+⚠️ **A decisão 2 tem uma dívida embutida que a 1 criou.** Sem PITR não existe alvo de restauração
+não-destrutivo do lado do fornecedor, e sem o schema `auth` o dump não devolve identidade. Na
+prática, hoje, um desastre de identidade se resolve **recriando contas via OAuth na mão**. Isso está
+escrito no documento de recuperação e é a consequência aceita, não um esquecimento.
+
+### Ainda em aberto e sem decisão
+
+- Os quatro defeitos recortáveis do **#1679** viram issues?
+- O R2 não tem lifecycle: acumula ~5 GB/ano. Se ganhar poda, a retenção de 30 do artefato precisa
+  subir (está comentado no workflow).
 
 ---
 

--- a/docs/planning/2026-08-09_PROMPT_ARRANQUE.md
+++ b/docs/planning/2026-08-09_PROMPT_ARRANQUE.md
@@ -1,0 +1,115 @@
+# Prompt de arranque — depois do backup restaurável (próxima sessão)
+
+> Colar depois do `/clear`. **Effort: `xhigh`.**
+> Handoff completo: `docs/planning/2026-08-08_handoff_backup_restauravel_e_laboratorio_de_perfis.md`.
+> `main` em **`2913aede`**.
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Re-medir com tool call na mesma volta. Os dois padrões
+que custaram caro nas duas últimas sessões:
+
+- **verde sem significado** (o gate passou, o efeito não aconteceu)
+- **número certo, significado errado** (a query estava certa, a população não era a da pergunta)
+
+Depois de consertar qualquer coisa, verifique o **efeito**, nunca só a cor. E antes de citar um
+contador, pergunte **de quem é este valor** e **em que ponto do processo essa população está**.
+
+---
+
+## O que existe agora e a sessão anterior não tinha
+
+**Uma base de teste restaurável, em um comando.** É a mudança de método mais importante:
+
+```bash
+scripts/pull-backup-local.sh --restore     # ~15s, baixa o mais novo e ensaia
+```
+
+Com ela, gates que resolvem por `auth.uid()` deixam de ser "precisa de confirmação humana":
+
+```sql
+begin;
+set local role authenticated;
+select set_config('request.jwt.claim.sub', '<auth_id do alvo>', true);
+select public.a_rpc_que_voce_quer_testar();
+rollback;
+```
+
+⚠️ `auth.uid()` na imagem lê `request.jwt.claim.sub` (**singular**).
+⚠️ A cópia é da **data do backup**. Para testar código de hoje, aplique as migrations posteriores;
+rodar cru mede o comportamento **antigo** (útil como controle, enganoso como validação).
+⚠️ O dump **não traz o schema `auth`**: `auth.users` volta vazio e 100 de 131 membros ficam com
+`auth_id` órfão. Isso não atrapalha a impersonação (o `auth_id` vem de `members`), mas atrapalha
+qualquer coisa que faça JOIN com `auth.users`.
+
+Detalhes e armadilhas: `docs/reference/RECUPERACAO_DE_DESASTRE.md`.
+
+---
+
+## Não re-litigar (fechado e em produção)
+
+- **#618** fechada pelo #1684. Backup restaura, limpeza enxerga, alarme voltou a ter significado,
+  cópia local semanal instalada e testada sob systemd.
+- **#1673** e **#1683** mergeados.
+- **#1679** respondida com veredito. **#1591** confirmado por impersonação.
+- **#1682** aberta com reprodução e correção **já validada** em ambiente de teste.
+
+---
+
+## Ordem sugerida
+
+### 1. 🔴 Os 10 membros que sumiram (uma medição, não uma decisão)
+Backup de 03/08 tem 131 membros; produção tem 121, com **zero** criados desde então e **zero** ações
+de remoção no `admin_audit_log`. A cópia está em `~/.local/share/nucleo-backups/`. Restaurar,
+extrair os IDs e comparar diz **quais** são e o que eram. Só depois disso decidir se é incidente.
+
+### 2. #1682 — implementar a correção que já está validada
+A ponte de e-mail no `export_my_data` e no `list_my_consents`, com **uma transação por função**
+(uma âncora ruim reverte o patch bom). Alcance medido: **34** pessoas. Levar junto as três decisões
+de escopo listadas na issue.
+
+### 3. #1643 — terminar o sweep
+Falta a **terceira classe** ("afirmação incondicional sobre tratamento condicional") nas funções de
+despacho, mais o `sign_proposer_consent`. Método e parcial na issue.
+
+### 4. 🔴 Personas sintéticas (pedido do PM em 08/08)
+Hoje a suíte de contrato bate em **produção contra candidaturas reais**: `gate_attempts` tem **542**
+tentativas desde 04/08, **537 sem ator**, tocando **15 candidaturas reais**, com **159** passando o
+gate. Isso é #1636, e é a mesma raiz do meu uso de identidades reais na base restaurada.
+
+Semear personas sintéticas na base restaurada (visitante, membro, líder, avaliador, observador,
+curador, GP, ghost) e apontar a suíte DB-aware para ela. Ganha três coisas: para de tocar gente
+real, o teste deixa de depender de **quem** ocupa o papel, e some a PII do laboratório.
+
+⚠️ Antes disso, uma pergunta **não medida**: as 159 passagens de gate emitiram token de agendamento
+para candidatos reais? Cruzar com as tabelas de token e entrevista responde.
+
+### 5. Resíduos escolhidos
+- observador por URL direta ainda recebe a fila em `get_my_pending_evaluations`
+- `route-acl.test.mjs` **reimplementa** o `canAccess` em vez de importar `getItemAccessibility`;
+  agora dá para ancorar em comportamento real
+- exigir evidência no consentimento de IA (`RAISE`), depois de confirmado o front no ar
+
+---
+
+## Decisões que estavam com o PM
+
+Se ainda não vieram, perguntar antes de agir:
+
+1. **Schema `auth` no backup** — incluir resolve a recuperação de identidade e leva hashes de senha
+   e refresh tokens para o artefato do GitHub.
+2. **PITR no Supabase** — hoje `false`; RPO é o diário, e o diário tinha dois dias faltando.
+3. **Ticket no Supabase** pelos diários ausentes de 02/08 e 07/08.
+4. Os quatro defeitos recortáveis do **#1679** viram issues?
+
+---
+
+## Regras da casa
+
+- Merge à `main` é da sessão main; lane leva o PR até verde e para.
+- Commit: `Assisted-By:`, nunca `Co-Authored-By`.
+- Repo **PÚBLICO**: nenhum candidato ou membro nomeado, só contagens.
+- **Postura de backup não vai para issue pública.**
+- Não rodar `npm test` com CI em voo. **Monitorar por RUN**, não por `gh pr checks`.

--- a/docs/reference/RECUPERACAO_DE_DESASTRE.md
+++ b/docs/reference/RECUPERACAO_DE_DESASTRE.md
@@ -20,6 +20,23 @@ contas de nuvem.
 ⚠️ **`pitr_enabled` era `false` em 08/08.** Sem point-in-time, o RPO é a granularidade do diário,
 e uma falha do diário empurra isso para 48 h ou mais.
 
+Preço do add-on, medido em 08/08 pela API de billing (`/v1/projects/<ref>/billing/addons`), para
+comparar com o compute atual do projeto, que é **Micro a ~US$ 10/mês**:
+
+| PITR | preço |
+|---|---|
+| 7 dias | **US$ 100/mês** |
+| 14 dias | US$ 200/mês |
+| 28 dias | US$ 400/mês |
+
+O que o PITR compra que o diário não compra: RPO abaixo de um dia, restauração **para um instante**
+(por exemplo, o segundo anterior a uma migration ruim) e um alvo de restauração **não-destrutivo** —
+sem ele, o único restore do fornecedor é in-place sobre a própria produção.
+
+A alternativa barata para o **RPO**, e só para ele: tornar o dump lógico **diário** em vez de
+semanal. Custa minutos de CI e leva o RPO da cópia lógica de 7 dias para 1. Não dá
+point-in-time nem alvo não-destrutivo.
+
 ## O que o dump lógico NÃO contém
 
 O `pg_dump` do `backup-database.yml` exclui doze schemas. Dois grupos, por motivos diferentes:
@@ -45,8 +62,23 @@ As 4 FKs ausentes são `members_auth_id_fkey`, `user_profiles_id_fkey`, `events_
 consegue entrar. A recuperação completa exige, além do dump, reprovisionar as identidades (backup
 físico do Supabase, ou recriação via OAuth com re-vínculo de `members.auth_id`).
 
-Incluir o schema `auth` no dump resolveria e levaria hashes de senha e refresh tokens para o
-artefato do GitHub. É decisão de PM, e enquanto não for tomada, este documento é o registro dela.
+### Decisão do PM, ratificada em 08/08/2026: o schema `auth` NÃO entra no dump
+
+Incluir resolveria a recuperação de identidade e levaria **hashes de senha e refresh tokens** para o
+artefato do GitHub, que é o repositório de código. O risco de exfiltração de credencial supera o
+ganho de conveniência na recuperação.
+
+**Consequência aceita, e ela precisa estar escrita:** uma recuperação a partir deste dump devolve o
+dado e **não** devolve o acesso. Reprovisionar identidade passa a ser um passo explícito do
+procedimento, por uma destas vias:
+
+1. backup **físico** do Supabase (o único que carrega `auth`), o que na prática exige PITR ligado
+   para ter um alvo de restauração não-destrutivo;
+2. recriação das contas via OAuth com re-vínculo de `members.auth_id`, manual e proporcional ao
+   número de pessoas ativas.
+
+⚠️ As duas vias dependem de decisões que **não** estavam fechadas quando este parágrafo foi escrito.
+Antes de confiar nele num incidente, confira qual delas existe de fato.
 
 ## Fidelidade medida do dump lógico
 


### PR DESCRIPTION
Só documentação. Registra o que a sessão de 08/08 fechou e, principalmente, o que ela deixou **medido e aberto**:

- **10 membros sumiram** entre 03/08 e hoje, com **zero** ações de remoção no `admin_audit_log` e **zero** membros criados no período. A cópia de 03/08 está em disco, então descobrir *quais* custa um minuto — e só depois disso cabe chamar de incidente.
- **A suíte de contrato bate em produção contra candidatura real:** `gate_attempts` tem **542** tentativas desde 04/08, **537 sem ator**, tocando **15 candidaturas reais**, com **159** passando o gate. Se as 159 emitiram token de verdade **não foi medido**. É #1636, e motiva o pedido do PM por personas sintéticas.
- **O backup não restaura identidade** (`--exclude-schema=auth`): 100 de 131 membros ficam com `auth_id` órfão. Decisão segue com o PM.

O arranque de 09/08 leva a regra zero, o procedimento de impersonação com as três armadilhas medidas, e a ordem sugerida começando pela medição dos 10 membros.

Refs #618, #1636, #1682, #1643