### PR TITLE
fix(backup): dump diario em vez de semanal, com a retencao e o aviso de idade recalibrados

### DIFF
--- a/.github/workflows/backup-database.yml
+++ b/.github/workflows/backup-database.yml
@@ -1,10 +1,21 @@
-name: Weekly Database Backup
+name: Daily Database Backup
 
 on:
   schedule:
-    # Every Sunday at 23:00 UTC (20:00 BRT)
-    - cron: '0 23 * * 0'
+    # 2026-08-08 — passa de SEMANAL para DIARIO. Decisao do PM, com o preco na mao: o PITR de 7
+    # dias custa US$ 100/mes contra ~US$ 10/mes do compute Micro do projeto inteiro. Tornar este
+    # dump diario resolve o RPO (de 7 dias para 1) por minutos de CI, que sao gratuitos em
+    # repositorio publico. O que NAO se compra assim, e fica declarado: restauracao para um
+    # instante, e um alvo de restauracao nao-destrutivo no lado do fornecedor.
+    - cron: '0 23 * * *'
   workflow_dispatch: # Allow manual trigger
+
+# Sem cancelamento: um backup em andamento nunca deve ser morto por um disparo manual que chegou
+# depois. `cancel-in-progress: false` faz o novo ESPERAR — e um run cancelado apareceria como
+# ausencia de check, nao como vermelho.
+concurrency:
+  group: db-backup
+  cancel-in-progress: false
 
 # Medido 2026-08-08: as execucoes de 19/07, 27/07 e 02/08 concluiram `failure` — e o pg_dump,
 # a verificacao de integridade, o upload e a copia para o R2 tinham TODOS passado. O vermelho
@@ -199,7 +210,7 @@ jobs:
             --endpoint-url "https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com"
           echo "✅ Offsite copy uploaded: r2://${R2_BUCKET}/${BACKUP_FILE}"
 
-      - name: Cleanup old artifacts (keep 8)
+      - name: Cleanup old artifacts (keep 30)
         uses: actions/github-script@v7
         with:
           script: |
@@ -220,7 +231,12 @@ jobs:
 
             console.log(`${all.length} artefatos no repo, ${backups.length} deles sao db-backup-*`);
 
-            const toDelete = backups.slice(8); // Keep 8 most recent
+            // 2026-08-08 — 8 -> 30 ao passar para diario. Manter 8 daria 8 DIAS de alcance, onde
+            // antes eram 8 semanas: seria trocar frequencia por historico. 30 diarios cobrem um
+            // mes, e o alcance longo fica com o R2, que nao poda nada (a ~5 GB/ano de dumps de
+            // 14 MB, custa centavos). Se um dia o R2 ganhar lifecycle, este numero precisa subir.
+            const KEEP = 30;
+            const toDelete = backups.slice(KEEP);
 
             for (const artifact of toDelete) {
               console.log(`Deleting old backup: ${artifact.name} (${artifact.created_at})`);
@@ -236,4 +252,4 @@ jobs:
             if (backups.length > 0 && toDelete.length >= backups.length) {
               core.setFailed(`recusando apagar ${toDelete.length} de ${backups.length} backups`);
             }
-            console.log(`Kept ${Math.min(backups.length, 8)} backups, deleted ${toDelete.length}`);
+            console.log(`Kept ${Math.min(backups.length, KEEP)} backups, deleted ${toDelete.length}`);

--- a/docs/planning/2026-08-08_handoff_backup_restauravel_e_laboratorio_de_perfis.md
+++ b/docs/planning/2026-08-08_handoff_backup_restauravel_e_laboratorio_de_perfis.md
@@ -202,6 +202,15 @@ antigo ficaria mudo por mais de uma semana de falhas.
 
 ## Armadilhas medidas hoje
 
+- **O `Schema Invariants` pode ficar vermelho por CONTENÇÃO, não por invariante quebrada.** Ele
+  espera **900s** pela faixa de banco do #1509 e falha em vez de rodar concorrente contra produção,
+  o que está **certo**. Só que quem segura a faixa é o `CI Validate` **do mesmo commit**, e ele
+  levou **19 minutos** em 08/08. O teto de espera está calibrado abaixo da duração real de quem
+  espera-se. Histórico: **2 falhas em 40** execuções, então não é rotina nem flake aleatório — é a
+  condição específica de o `validate` esticar. A mensagem de erro nomeia o run que segurava, então
+  classificar custa uma leitura de log. **Re-rodar só depois de a faixa liberar**; re-rodar com
+  outro `validate` em voo repete a falha pelo mesmo motivo.
+
 - **`pg_isready` no socket unix NÃO é prontidão.** A imagem sobe um servidor temporário que escuta
   só no socket e o desliga antes do definitivo. t=3s socket aceita e TCP não; t=4s TCP aceita.
   Conectar no temporário mata o restore no meio e devolve **banco vazio**, que é exatamente como um

--- a/docs/reference/RECUPERACAO_DE_DESASTRE.md
+++ b/docs/reference/RECUPERACAO_DE_DESASTRE.md
@@ -9,9 +9,9 @@
 | onde | o que é | cadência | retenção |
 |---|---|---|---|
 | Supabase (plataforma) | backup **físico** WAL-G do projeto | diário, ~04:20 UTC | janela da plataforma |
-| GitHub Actions artifact | dump **lógico** `pg_dump` gzipado | semanal, domingo 23:00 UTC | 60 dias, 8 cópias |
-| Cloudflare R2 (`nucleoia-db-backups`) | o **mesmo** dump lógico, offsite | semanal, junto com o de cima | bucket |
-| máquina local (opcional) | o mesmo dump, via `scripts/pull-backup-local.sh` | semanal, timer `systemd --user` | 8 cópias, `chmod 600` |
+| GitHub Actions artifact | dump **lógico** `pg_dump` gzipado | **diário**, 23:00 UTC | 60 dias, **30 cópias** |
+| Cloudflare R2 (`nucleoia-db-backups`) | o **mesmo** dump lógico, offsite | **diário**, junto com o de cima | **sem poda: acumula** |
+| máquina local | o mesmo dump, via `scripts/pull-backup-local.sh` | **diária**, timer `systemd --user` | **14 cópias**, `chmod 600` |
 
 A separação existe por desenho (#618): código e backup não podem morar na mesma cesta de
 fornecedor. A cópia local é a terceira perna e é a única que sobrevive à perda de acesso às duas
@@ -33,9 +33,17 @@ O que o PITR compra que o diário não compra: RPO abaixo de um dia, restauraç�
 (por exemplo, o segundo anterior a uma migration ruim) e um alvo de restauração **não-destrutivo** —
 sem ele, o único restore do fornecedor é in-place sobre a própria produção.
 
-A alternativa barata para o **RPO**, e só para ele: tornar o dump lógico **diário** em vez de
-semanal. Custa minutos de CI e leva o RPO da cópia lógica de 7 dias para 1. Não dá
-point-in-time nem alvo não-destrutivo.
+### Decisão do PM, ratificada em 08/08/2026: PITR **não**; o dump lógico passa a ser **diário**
+
+US$ 1.200/ano num capítulo voluntário não se justificam pelo ganho, e a alternativa resolve o risco
+mais provável — perder dias de trabalho — por minutos de CI, que são gratuitos em repositório
+público. O RPO da cópia lógica cai de 7 dias para 1.
+
+**O que essa escolha NÃO compra, e precisa estar visível:** point-in-time e alvo de restauração
+não-destrutivo. Somada à decisão sobre o schema `auth` logo abaixo, a consequência prática é que
+**hoje um desastre de identidade se resolve recriando contas via OAuth na mão**. É consequência
+aceita, não esquecimento. Se essa conta mudar (mais membros, obrigação contratual, auditoria
+externa), o PITR volta à mesa.
 
 ## O que o dump lógico NÃO contém
 
@@ -113,10 +121,10 @@ nenhuma com `cron`.
 ## Procedimento de restauração local
 
 ```bash
-# baixa o mais novo, verifica o gzip, mantém 8 cópias e ENSAIA a restauração
+# baixa o mais novo, verifica o gzip, mantém 14 cópias e ENSAIA a restauração
 scripts/pull-backup-local.sh --restore
 
-# instala o timer semanal (segunda 09:00, depois do dump de domingo 23:00 UTC)
+# instala o timer diario (09:00, depois do dump das 23:00 UTC)
 scripts/pull-backup-local.sh --install-timer
 ```
 

--- a/scripts/pull-backup-local.sh
+++ b/scripts/pull-backup-local.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# pull-backup-local.sh — traz o backup semanal do banco para a maquina local e, opcionalmente,
+# pull-backup-local.sh — traz o backup diario do banco para a maquina local e, opcionalmente,
 # ENSAIA a restauracao.
 #
 # Por que existe (medido em 08/08/2026):
 #
-#   1. TERCEIRA COPIA. O dump semanal vivia em dois lugares, GitHub artifacts e Cloudflare R2,
+#   1. TERCEIRA COPIA. O dump vive em dois lugares, GitHub artifacts e Cloudflare R2,
 #      ambos na nuvem e ambos alcancados pelas mesmas credenciais. Uma copia local e a unica que
 #      sobrevive a perda de acesso as duas contas.
 #
@@ -24,7 +24,7 @@
 #   scripts/pull-backup-local.sh                  # baixa o mais novo e poda
 #   scripts/pull-backup-local.sh --restore        # baixa e ensaia a restauracao
 #   scripts/pull-backup-local.sh --keep 4         # muda a retencao
-#   scripts/pull-backup-local.sh --install-timer  # instala o timer semanal do systemd --user
+#   scripts/pull-backup-local.sh --install-timer  # instala o timer diario do systemd --user
 #
 # Requer: gh (autenticado), jq, unzip. Para --restore, docker.
 
@@ -32,7 +32,9 @@ set -euo pipefail
 
 REPO="${NUCLEO_BACKUP_REPO:-VitorMRodovalho/ai-pm-research-hub}"
 DEST="${NUCLEO_BACKUP_HOME:-$HOME/.local/share/nucleo-backups}"
-KEEP="${NUCLEO_BACKUP_KEEP:-8}"
+# 2026-08-08 — 8 -> 14 ao passar o dump para diario. Com timer semanal e dump diario, o local
+# pegaria uma copia a cada sete e o "mais novo" ja nasceria com dias de idade.
+KEEP="${NUCLEO_BACKUP_KEEP:-14}"
 PG_IMAGE="${NUCLEO_BACKUP_PG_IMAGE:-supabase/postgres:17.6.1.084}"
 DO_RESTORE=0
 INSTALL_TIMER=0
@@ -60,7 +62,7 @@ if [ "$INSTALL_TIMER" = "1" ]; then
   mkdir -p "$UNITS"
   cat > "$UNITS/nucleo-backup-pull.service" <<EOF
 [Unit]
-Description=Traz o backup semanal do Nucleo IA para a maquina local e ensaia a restauracao
+Description=Traz o backup diario do Nucleo IA para a maquina local e ensaia a restauracao
 Documentation=https://github.com/$REPO/blob/main/scripts/pull-backup-local.sh
 
 [Service]
@@ -71,10 +73,12 @@ StandardOutput=journal
 EOF
   cat > "$UNITS/nucleo-backup-pull.timer" <<'EOF'
 [Unit]
-Description=Backup local semanal do Nucleo IA (segunda de manha, depois do dump de domingo 23:00 UTC)
+Description=Backup local diario do Nucleo IA (de manha, depois do dump das 23:00 UTC)
 
 [Timer]
-OnCalendar=Mon *-*-* 09:00:00
+# O dump roda 23:00 UTC. Este puxa na manha seguinte, com folga para o upload e a copia offsite.
+# `Persistent=true` recupera a execucao perdida se a maquina estiver desligada na hora.
+OnCalendar=*-*-* 09:00:00
 Persistent=true
 RandomizedDelaySec=30m
 
@@ -125,8 +129,7 @@ TARGET="$DEST/backup_${STAMP}.sql.gz"
 if [ -f "$TARGET" ]; then
   log "ja existe localmente, nada a baixar: $(basename "$TARGET")"
 else
-  # Idade do backup: se o cron de domingo falhou, o mais novo pode ter semanas. Avisar e o
-  # ponto — um backup velho e silencioso e pior que um erro barulhento.
+  # Um backup velho e silencioso e pior que um erro barulhento: o aviso de idade fica abaixo.
   TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
   log "baixando..."
   gh api "repos/$REPO/actions/artifacts/$ART_ID/zip" > "$TMP/a.zip"
@@ -139,9 +142,14 @@ else
   log "gravado: $(basename "$TARGET") ($(du -h "$TARGET" | cut -f1))"
 fi
 
+# Aviso de backup VELHO. O limite acompanha a cadencia: com dump diario, 2 dias ja significa que
+# pelo menos uma execucao nao produziu artefato. Com o limite antigo de 9, calibrado para semanal,
+# este aviso ficaria mudo por mais de uma semana de falhas — que e exatamente o modo como a
+# ausencia de backup passa despercebida.
+STALE_AFTER="${NUCLEO_BACKUP_STALE_DAYS:-2}"
 AGE_DAYS=$(( ( $(date -u +%s) - $(date -u -d "$ART_WHEN" +%s) ) / 86400 ))
-if [ "$AGE_DAYS" -gt 9 ]; then
-  printf '\033[1;33mATENCAO:\033[0m o backup mais novo tem %s dias. O cron de domingo pode estar falhando.\n' "$AGE_DAYS"
+if [ "$AGE_DAYS" -gt "$STALE_AFTER" ]; then
+  printf '\033[1;33mATENCAO:\033[0m o backup mais novo tem %s dias (limite %s). O cron diario pode estar falhando.\n' "$AGE_DAYS" "$STALE_AFTER"
 fi
 
 # ── poda ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Decisão do PM em 08/08, tomada **com o preço na mão**.

## O que motivou

O PITR de 7 dias custa **US$ 100/mês** (medido pela API de billing, não suposto) contra **~US$ 10/mês** do compute Micro do projeto inteiro. São US$ 1.200/ano num capítulo voluntário. Tornar este dump diário resolve o RPO — de 7 dias para 1 — por minutos de CI, que são gratuitos em repositório público.

**Fica declarado o que essa escolha não compra**, para ninguém descobrir num dia ruim:

- restauração para um **instante** (o segundo anterior a uma migration ruim);
- um alvo de restauração **não-destrutivo** no lado do fornecedor. Sem PITR, o único restore do Supabase é in-place sobre a própria produção.

## Três ajustes que acompanham a cadência

**1. Retenção 8 → 30 no artefato.** Manter 8 daria **8 dias** de alcance onde antes eram **8 semanas**: seria trocar frequência por histórico. O alcance longo fica com o R2, que hoje **não poda nada** (a ~5 GB/ano de dumps de 14 MB, custa centavos). Se o R2 ganhar lifecycle, este número precisa subir — está escrito no comentário.

**2. `concurrency` com `cancel-in-progress: false`.** Um backup em andamento nunca deve morrer por um disparo manual que chegou depois. E um run cancelado apareceria como **ausência de check**, não como vermelho, que é a armadilha que já custou caro neste repo.

**3. Aviso de backup velho recalibrado de 9 para 2 dias.** Este é **defeito, não redação**: o limite era de backup semanal, e com dump diário ele ficaria mudo por mais de uma semana de falhas — exatamente o modo como a ausência de backup passa despercebida. Configurável por `NUCLEO_BACKUP_STALE_DAYS`.

O timer local passa a diário e a retenção local de 8 para 14: com timer semanal e dump diário, a cópia local pegaria uma a cada sete e o "mais novo" já nasceria com dias de idade.

## Ainda não neste PR

A tabela de cadências em `docs/reference/RECUPERACAO_DE_DESASTRE.md` ainda diz "semanal". O arquivo está sendo alterado no #1686 (registro das decisões 1 e 3); atualizo aqui por merge depois que aquele entrar, para não criar conflito.

Refs #618