### PR TITLE
chore(deps): js-yaml 4.3.0 -> 4.3.1, e o Dependabot que a config nao segurava

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,24 @@
 # o feed de SECURITY ALERTS continua ativo e cada onda de alertas é resolvida
 # por PR local de higiene (ex.: #609), onde o CI roda completo com secrets.
 # Nunca mergear/--admin um PR do Dependabot — supersede local é o caminho canônico.
+#
+# COMPLEMENTO (PM 2026-08-09): ESTE ARQUIVO SOZINHO NÃO SEGURA O DEPENDABOT.
+# `open-pull-requests-limit: 0` governa apenas VERSION updates. SECURITY updates
+# IGNORAM esse limite, e foi por isso que o #1637 (bump major do astro) nasceu em
+# 07/08 apesar da política — medido em 09/08, `automated-security-fixes` estava
+# `enabled=true`. O custo não era só o PR imergeável: os runs dele disputam a faixa
+# serializada do banco (`wait-for-db-lane`, #1509) e deixaram o gate `Schema
+# Invariants` de um PR SÓ DE DOCUMENTAÇÃO vermelho depois de esperar 900s, com o
+# banco vivo em 43 invariantes / 0 violadas. Vermelho sem defeito.
+#
+# Correção aplicada no ajuste do REPOSITÓRIO, não aqui:
+#   gh api -X DELETE repos/<owner>/<repo>/automated-security-fixes   # desliga os PRs
+# O feed de ALERTAS continua ativo (`vulnerability-alerts`), que é o que a #611 usa
+# para dirigir o trabalho. Conferido depois de desligar: security updates
+# `enabled=false`, alertas ativos, 7 alertas abertos ainda visíveis.
+#
+# Para reverter (se um dia os secrets alcançarem runs do Dependabot):
+#   gh api -X PUT repos/<owner>/<repo>/automated-security-fixes
 
 version: 2
 updates:

--- a/package-lock.json
+++ b/package-lock.json
@@ -9380,9 +9380,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## O que muda

Duas linhas de trabalho, uma pequena e uma de registro.

### 1. `js-yaml` 4.3.0 -> 4.3.1

Fecha os **2 alertas high** de js-yaml (consumo quadrático de CPU na resolução de `!!omap`). PR local de higiene, que é o caminho da política **#611**: o CI aqui roda completo, com secrets, ao contrário de qualquer PR do Dependabot.

**O range nunca foi o problema.** O `astro` pede `js-yaml: ^4.3.0`, e o `^` já permitia 4.3.1 - o que estava velho era a resolução no lock. Por isso o diff tem **3 linhas** e não encosta no `package.json`.

### 2. O `dependabot.yml` passa a dizer o que ele não segura

`open-pull-requests-limit: 0` governa apenas **version updates**. **Security updates ignoram** esse limite, e foi assim que o #1637 (bump major do astro) nasceu em 07/08 apesar da política. Medido em 09/08: `automated-security-fixes` estava `enabled=true, paused=false`.

O custo não era só um PR imergeável parado. Os runs dele disputam a faixa serializada do banco (`wait-for-db-lane`, #1509): em 09/08 o gate `Schema Invariants` de um PR **só de documentação** ficou vermelho depois de esperar 900s pela faixa, enquanto o banco vivo respondia 43 invariantes e 0 violadas. Vermelho sem defeito, num PR que não tocava em schema.

**A correção é no ajuste do repositório, não neste arquivo** - e é por isso que o arquivo tinha de registrá-la, senão o próximo lê `open-pull-requests-limit: 0` e conclui que a config basta:

```
gh api -X DELETE repos/<owner>/<repo>/automated-security-fixes
```

Conferido depois de desligar: security updates `enabled=false`, feed de **alertas** ativo, **7 alertas abertos ainda visíveis**. O feed é o que a #611 usa para dirigir o trabalho; o que sai são só os PRs que nunca poderiam passar.

O #1637 foi fechado como superseded, com a medição no comentário.

## O que sobra dos 7 alertas

| pacote | severidade | patch | destino |
|---|---|---|---|
| `js-yaml` ×2 | high | 4.3.1 | **este PR** |
| `astro` ×3 | 2 medium, 1 low | só em 7.0.4 / 7.0.6 / 7.1.0 | #1617, o major, sessão própria |
| `image-size` ×2 | high | **sem patch** | decisão de alcance |

As do `image-size` entram por `@turbodocx/html-to-docx`, carregado como bundle de browser no `ChainDocxExportIsland` para exportar DOCX. A falha é DoS nos parsers ICNS/JXL/HEIF, e o insumo é o documento que o próprio usuário está exportando, na aba dele. Sem patch upstream e com essa superfície, o caminho é dispensa com justificativa registrada, não upgrade - mas isso é decisão, não código, e não entra aqui.

## Verificação

- `npx astro build` passa
- `npm test`: **6.614 testes, 6.613 pass, 0 fail, 1 skip**
- diff do lock conferido linha a linha: só `js-yaml`, nenhum outro pacote carona