### PR TITLE
docs(planning): atualiza o handoff com o desfecho do #1710 e da comunicacao

### DIFF
--- a/docs/planning/2026-08-10_handoff_1726_comunicacao_e_1728_escopo.md
+++ b/docs/planning/2026-08-10_handoff_1726_comunicacao_e_1728_escopo.md
@@ -1,13 +1,22 @@
-# Handoff - #1726 decidida e escrita, #1728 corrigida (10/08/2026, noite)
+# Handoff - a comunicacao saiu e os tres bloqueios do #1710 cairam (10-11/08/2026)
 
 > Continuação de `docs/planning/2026-08-10_handoff_1710_passo2_elegibilidade.md`.
-> Cobre a **PR #1730**.
+> Cobre as PRs **#1730, #1731, #1732 e #1734**. `main` em **`c2b4137a`**.
+>
+> 📖 **Se for ler so uma parte, leia "SEGUNDA PARTE DA SESSAO" e "Estado final", mais abaixo.** A
+> primeira metade descreve o caminho ate a PR #1730 e continua valendo como historico, mas o desfecho
+> (comunicacao enviada, #1727 e #1733 fechadas, tribo 2 cancelada) esta na segunda.
 
 ## Regra zero
 
-Todo numero aqui foi medido em **10/08/2026 entre 20h e 21h30 (Brasilia)**. ⚠️ Nesse intervalo o
-banco **virou o dia em UTC**, e isso mexe nos numeros: re-medir com tool call na mesma volta em que
-o numero entrar numa decisao, num commit, numa issue ou numa pergunta ao PM.
+Todo numero aqui foi medido em **10/08/2026 entre 20h e 21h30 (Brasilia)**, salvo os da segunda
+parte, medidos na madrugada de 11/08. ⚠️ Nesse intervalo o banco **virou o dia em UTC**, e isso mexe
+nos numeros: re-medir com tool call na mesma volta em que o numero entrar numa decisao, num commit,
+numa issue ou numa pergunta ao PM.
+
+⚠️ **A tabela "Os numeros do #1726" mais abaixo esta CONGELADA em 21h15 de 10/08** e serve para
+mostrar a distancia entre a abertura da issue e a medicao correta. Ela **nao** e o numero de hoje: a
+base recebe presenca continuamente, e o corte da janela mudou desde entao (#1727). Re-medir sempre.
 
 ---
 
@@ -138,28 +147,123 @@ gravados em `pg_proc`, ao contrario dos comentarios `--`).
 rename no `package.json`; matar e reiniciar foi mais barato que interpretar. `npm test` leva
 **~12 minutos**: rodar em segundo plano, nunca numa chamada com teto.
 
+⚠️ **5. Checar a faixa e IMPRIMIR o resultado nao e checar.** Uma das rodadas de `npm test` saiu com
+CI da `main` em voo porque o comando so imprimia `runs em voo: 1` e seguia adiante — a verificacao
+era informativa, nao porteiro. Nao houve dano (os dois fecharam verdes), mas foi sorte. A regra do
+`deploy.md` e prosa; **nao existe helper que a torne executavel**, e por isso e violavel sem
+perceber. Um `pretest` automatico NAO serve: o proprio CI roda `npm test` e se veria em voo,
+travando sozinho. O helper tem de ser de uso local, explicito.
+
 ---
 
-## Estado
+# SEGUNDA PARTE DA SESSAO (madrugada de 11/08)
 
-- **PR #1730 MERGEADA** (`48463fb2`), CI verde nas 11 checagens. DDL ja estava em producao
-  (`20260811000816` + `20260811001755`).
-- `npm test`: **6662 testes, 0 fail, 1 skip**. `npx astro build`: ok.
+O handoff acima foi escrito antes desta parte. O que segue e o desfecho.
+
+## O que mudou desde entao
+
+### A comunicacao SAIU (decisao do PM, 10/08)
+
+Enviada pelo **grupo de WhatsApp do Nucleo**, nao por e-mail, para nao duplicar envio nem consumir
+cota do Resend. O texto dos 3 idiomas fica como registro do que foi decidido comunicar.
+
+**Isto destrava o #1710.** Contando os 14 dias a partir de 10/08, o primeiro selo pode rodar a partir
+de **24/08/2026**.
+
+⚠️ O texto redigido dizia "a partir de 25/08" porque pressupunha envio em 11/08. **Vale a data que
+foi dita as pessoas no grupo**, nao a do documento: conferir antes de configurar o cron.
+
+⚠️ **Alcance.** O grupo alcanca quem esta no grupo, que nao e necessariamente o mesmo conjunto dos 86
+membros ativos. O selo grava falta para 48 pessoas. Mitigacao de custo zero, se o PM quiser: o
+**anuncio in-app** (tabela `announcements`) e banner na plataforma, nao passa pelo Resend e ja tem os
+3 idiomas.
+
+### Os tres bloqueios tecnicos do #1710 CAIRAM (PR #1732)
+
+| | antes | depois |
+|---|---|---|
+| **#1727** corte da janela | `e.date <= CURRENT_DATE` (data, em UTC) | instante LOCAL de termino |
+| **#1729** coorte vazia | carimbava "lista fechada" com 0 linhas | `skipped_empty_cohort`, sem carimbar |
+| **dry-run** | nao existia | `preview_seal_attendance`, 223 eventos em 480 ms |
+
+⚠️ **O #1727 estava subdimensionado no corpo da issue**, e foi corrigido la. Nao sao 3 horas, sao ate
+**23**: `e.date <= CURRENT_DATE` compara DATA, entao o evento de hoje as 20h e elegivel desde o
+instante em que o dia UTC comecou. A virada de fuso responde por 3 dessas horas; as outras 20 vem de
+comparar data em vez de instante. **Corrigir so o fuso nao resolveria.**
+
+O instante de termino virou **uma** funcao, `_event_end_instant`, usada pela elegibilidade E pela
+guarda do selo. Usa `duration_minutes` porque o corte certo e o FIM: selar durante a reuniao marcaria
+falta de quem ainda esta nela.
+
+Alcance medido antes de aplicar: `_attendance_eligible_events` e a primitiva canonica (SPEC §3b) com
+**9 consumidores**. 524 pares (pessoa, evento) → **502**; os 22 removidos sao 4 eventos por terminar,
+e **0** deles tinha presenca registrada.
+
+### Tribo 2: as 8 futuras foram canceladas
+
+Decisao do PM. Antes/depois: 8 futuras ativas → **0**; 20 passadas → **20**, nenhuma cancelada; **50**
+linhas de presenca preservadas.
+
+⚠️ **As 5 de coorte zero seguem na janela** (sao passadas, 13/07 a 10/08). Agora sao inofensivas
+— aparecem no ensaio como `skipped_empty_cohort` — mas a **causa raiz continua aberta**: por que
+arquivar a iniciativa nao parou a recorrencia.
+
+### #1733: `db:types` destruia o proprio arquivo
+
+`supabase gen types ... > src/lib/database.gen.ts`. O `>` trunca ANTES de rodar, entao a falha
+(`LegacyProjectNotLinkedError`) gravou o JSON de erro por cima: **34.288 linhas viraram 1**. Corrigido
+para gerar em `mktemp`, validar o cabecalho e mover com `&&`; e `--project-id` no lugar de `--linked`,
+alinhando com o gate.
+
+⚠️ **A versao da CLI NAO era o problema.** Medi com `npx supabase --version` (2.113.0) e quase
+reportei divergencia contra o pin 2.109.0 do workflow. O `npx` **baixa a mais recente** e nao e o
+binario que o script resolve — o global era 2.109.0, identico ao pin. **Meca o binario resolvido,
+nunca o `npx`**; mexer no pin com base nesse numero produziria drift falso.
+
+---
+
+## Estado final
+
+- **`main` em `c2b4137a`**. Quatro PRs mergeadas, **zero bypass**, CI verde em todas.
+
+| PR | entrega | commit |
+|---|---|---|
+| #1730 | escopo de recurso nas RPCs de presenca (#1728) + entregavel da #1726 | `48463fb2` |
+| #1731 | handoff (primeira parte) | `633d4170` |
+| #1732 | corte local, coorte vazia e dry-run (#1727, #1729) | `94a8f1aa` |
+| #1734 | `db:types` para de destruir o arquivo (#1733) | `c2b4137a` |
+
+- `npm test`: **6677 testes, 0 fail, 1 skip**. `npx astro build`: ok.
 - `check_schema_invariants()`: **43 invariantes, 0 violadas**.
-- md5 do corpo vivo == arquivo local nas duas funcoes.
-- Guard novo: 7 testes, 3 camadas, com inversa e **mutacao verificada** (reintroduzir o gate antigo
-  derruba exatamente 2 dos 7).
-- **#1719 fechada.** Zero bypass nesta sessao: tudo por PR.
+- md5 do corpo vivo == arquivo local em todas as funcoes tocadas.
+- **Fechadas:** #1719, #1727, #1733.
+- Guards novos: `1728-presenca-escopo-de-recurso` (7), `1727-corte-local-e-coorte-vazia` (10),
+  `1733-db-types-nao-destroi-o-arquivo` (5). Todos com a inversa e **mutacao verificada**.
 
 ## Proxima sessao
 
-1. **#1726**: o PM envia a comunicacao. Enquanto nao sair, o #1710 continua bloqueado.
-2. **#1710**, ja com duas restricoes novas no escopo (corte local do #1727, coorte vazia do #1729) e
-   um item a mais: **o dry-run tem de reportar coorte por evento**, senao os dois casos passam
-   despercebidos - os dois produzem "sucesso" com zero linhas, indistinguivel de "todo mundo ja
-   estava registrado".
+1. **#1710**, agora com caminho livre. Falta so superficie e operacao, e cabe folgado ate 24/08:
+   - [ ] caminho de reversao por evento (nao existe `unseal`; o carimbo `notes = '[roster_seal] ...'`
+         e o que permite identificar e desfazer)
+   - [ ] superficie para selar, com confirmacao dizendo quantas faltas serao gravadas
+   - [ ] a grade mostra se o evento esta selado, e desde quando
+   - [ ] tool MCP para selar, na familia do #1588
+   - [ ] contagem de eventos selados publicada depois de uma semana
+
+   ⚠️ Ao montar a superficie, lembrar que **o ensaio depende de QUEM pergunta**: `preview_seal_attendance`
+   tem o gate do #785, entao a contagem que um lider ve pode ser menor que a do GP. A decisao de selar
+   e do GP.
+
+2. **#1729** — a causa raiz da recorrencia da iniciativa arquivada.
 3. Depois: **#1654** (coluna de nome fixa nas 6 tabelas com scroll horizontal), **#1218** (presenca
    orfa de 08/07).
 4. Seguem abertas: **#1655** (unificacao dos 4 componentes + `src/pages/profile.astro` 1015/1385),
-   **#1656** (3 dos 5 itens), **#1724** e **#1725** (higiene de CI), e as **20** RPCs restantes da
-   classe do #1728.
+   **#1656** (3 dos 5 itens), **#1724** (ampliada com a inanicao da faixa) e **#1725**, e as **20**
+   RPCs restantes da classe do #1728.
+
+## Duas ofertas em aberto, decisao do PM
+
+- **Anuncio in-app** da mudanca de presenca, para cobrir quem nao esta no grupo de WhatsApp. Custo
+  zero de e-mail.
+- **Helper de faixa livre** para uso local, tornando executavel a regra do `deploy.md` que hoje e so
+  prosa (ver armadilha 5).


### PR DESCRIPTION
O handoff foi escrito no meio da sessão e parava na PR #1730. Ganha uma **segunda parte** com o desfecho, e o cabeçalho passa a apontar para ela (quem ler só uma parte deve ler a segunda).

## O que entrou

- **A comunicação da #1726 saiu** (WhatsApp, decisão do PM), o que destrava o #1710. Janela de 14 dias conta de 10/08 → primeiro selo a partir de **24/08**, com a ressalva de que vale a data dita às pessoas no grupo, não a do documento redigido.
- **Os três bloqueios técnicos caíram** (PR #1732): corte por instante local (#1727), coorte vazia não sela (#1729), e o dry-run.
- **8 reuniões futuras da tribo 2 canceladas**, com as 20 passadas e 50 presenças intactas. As 5 de coorte zero seguem na janela, agora inofensivas.
- **#1733 corrigido e fechado** (`db:types` destruía o próprio arquivo).

## Duas correções de diagnóstico, registradas de propósito

Ambas são minhas, e a versão errada custaria caro a quem repetisse:

1. **O #1727 não era uma faixa de 3 horas, e sim de até 23.** A comparação é de **data**, então a virada de fuso explica só 3 delas. Corrigir apenas o fuso não resolveria.
2. **A versão da CLI do `db:types` nunca esteve divergente.** `npx supabase` baixa a mais recente e não é o binário que o script resolve; o global era idêntico ao pin. Mexer no pin com base nesse número produziria drift falso no gate.

## Armadilha nova

**Checar a faixa do banco e imprimir o resultado não é checar.** Uma rodada de `npm test` saiu com CI da `main` em voo porque a verificação era informativa, não porteiro. Não houve dano, mas foi sorte. A regra do `deploy.md` é prosa e não tem helper que a torne executável.

## Estado final registrado

`main` em `c2b4137a`, 4 PRs mergeadas, **zero bypass**, 6677 testes com 0 fail, 43 invariantes limpas. Fechadas: #1719, #1727, #1733.

Doc-only. Refs #1710, #1726, #1729