### PR TITLE
docs: recupera o conteudo de 5 PRs encalhadas (#1738)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,3 +204,51 @@ This repo lives under Vitor's portfolio PMO. Claude Code auto-loads `CLAUDE.md`
    (`.claude/rules/bypass-protocol.md`) bind you too. Never force-push, never
    `--no-verify`, never merge a Dependabot PR (#611 policy). Work within your p201
    lane only.
+
+
+## Context & continuity (harness engineering)
+
+This project adopts Anthropic's harness engineering framework — see [Building Effective Agents](https://www.anthropic.com/research/building-effective-agents), [Effective Context Engineering for AI Agents](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents), [Effective Harnesses for Long-Running Agents](https://www.anthropic.com/engineering/effective-harnesses-for-long-running-agents). The audit in CR-052 found 5 of 7 principles already covered by the existing rules in this file; the two sections below close the remaining gaps (context engineering and mid-wave handoff).
+
+### Context strategy (principle 2: context is finite)
+
+The repo surfaces dozens of MCP tools plus dense governance docs. (The count is derived at
+runtime by `countRegisteredTools` in `supabase/functions/nucleo-mcp/index.ts` — read it there
+rather than trusting a number written into a doc; the "64 (51R + 13W)" of 05/2026 is stale.) Loading everything upfront burns 30–50k tokens of schema before useful work begins. Agents MUST follow this strategy:
+
+1. **MCP tools — route, don't preload.** Classify intent first ("board?", "governance?", "selection?", "gamification?"), then load only the relevant subset. Generic ops (search, profile) stay available; domain ops load on-demand.
+2. **Docs JIT, not upfront.** `GOVERNANCE_CHANGELOG.md`, `MIGRATION.md`, `RELEASE_LOG.md`, and ADRs in `docs/project-governance/` load **only when referenced** by the current task. The quick-reference table at the top of this file is the index.
+3. **Schema by symbol, not by file.** Don't load `src/lib/database.gen.ts` wholesale — `grep` for the specific table/RPC, read the local region. Same for `src/lib/navigation.config.ts` and `src/components/admin/constants.ts`.
+4. **Catalogs via RPC, not `SELECT *`.** Members, cycles, tribes, board cards — always via existing RPCs (`get_*`, `list_*`, `search_*`). Never `.from('table').select('*')` patterns that pull dataset-sized payloads into context.
+5. **Sub-agent isolation when the lane is clear.** If the task is wholly within one lane (Foundation / Frontend / Integration / Governance / DevOps), invoke the lane-specific sub-agent with its scoped context. The orchestrator does not need to load everything just to delegate.
+
+### Mid-wave handoff (principle 5: plan for context reset)
+
+The 5-phase sprint closure (Execute → Audit → Fix → Docs → Deploy) covers **end of sprint**. It does NOT cover **end of session within a wave in flight**. When work straddles sessions, agents MUST produce a handoff artifact so the next session opens cold and picks up cleanly.
+
+**When to write a handoff:**
+- Session ending without completing the current feature/wave.
+- More than ~1h of identifiable residual work.
+- Any blocker that requires human decision before the next session resumes.
+
+**Where it lives:**
+- Default: `docs/handoff/HANDOFF-YYYY-MM-DD-session-end.md` (same pattern Panorama uses in `docs/audits/HANDOFF-*`).
+- Alternative: draft PR description, extended with the same fields, when work is committable-as-draft.
+
+**Minimum content:**
+1. **State**: feature/wave, current phase of the 5-phase closure, last commit SHA on the working branch.
+2. **Decisions made this session**: bullet list, with link to any ADR opened or amended.
+3. **Blockers**: human decisions pending, external waits (Cloudflare deploys, Supabase migrations), or known broken state.
+4. **Next concrete step**: one sentence describing exactly what the next session opens with.
+5. **Related**: links to relevant ADRs, issues, RELEASE_LOG entries, GOVERNANCE_CHANGELOG entries.
+
+**Opening sequence for the next session:**
+1. Read the latest `docs/handoff/HANDOFF-*.md`.
+2. Verify state (run smoke tests if the handoff says environment may be dirty).
+3. Address blockers first if any; otherwise pick up the next concrete step.
+4. Append a marker to the handoff confirming pickup (or open a new handoff if you'll close the wave this session).
+
+**Anti-patterns explicitly forbidden:**
+- Declaring "complete" without a handoff when work is incomplete — leads to next session re-doing or contradicting decisions.
+- Editing/deleting handoffs from previous sessions to "tidy up". Archive to `docs/handoff/archive/` instead.
+- Skipping the handoff because "the next session will figure it out" — this section exists to prevent that failure mode.

--- a/_handoff/code-team-reverify-2026-06-17.md
+++ b/_handoff/code-team-reverify-2026-06-17.md
@@ -1,0 +1,221 @@
+# CODE team weekend re-verification — 2026-06-17
+
+> Authored by the CODE team (Claude Code) automated weekend re-verification agent.
+> Adversarial check of the work that landed on `main` during the Codex weekend
+> window (Fri 2026-06-12 to Tue 2026-06-17), against baseline `63900da1` (PR #672).
+> This report is for the LOCAL Claude to fold into memory + the [LL] issue #588.
+> It does NOT post to #588, does NOT write the Claude memory namespace, and ran
+> ZERO DDL/DML.
+
+---
+
+## TRUST VERDICT: YELLOW (needs-local-review)
+
+**No defects found in anything verifiable from this cloud environment.** Build is
+green, the offline test suite is green (0 fail), history builds cleanly and
+linearly on the documented baseline (no rewrite), the frozen governance chain was
+not modified, reserved items were respected, and no Dependabot/stale PR was merged.
+
+**Why YELLOW and not GREEN:** the Supabase MCP `execute_sql` connector reconnected
+mid-run (it and nucleo-ia were initially "Not authenticated"), so the structural DB
+checks were ultimately RUN and are CLEAN (preview-gate drift 0; all 40 schema
+invariants A1-AJ at 0 violations; `active_members` re-grounds live to 47). What
+keeps this YELLOW: (1) the DB-aware contract SUITE could not be run here (no
+secrets; 331 tests skipped), and CI `validate` on the PR-merge commit shows
+**4 / 4606 DB-aware tests failing on current `main` as of 2026-06-24** (see the
+post-window addendum) - these are a week past the verification window and, given the
+clean structural checks, look data-dependent, but a LOCAL Claude with secrets must
+run the full DB-aware suite, NAME those 4, and confirm they are out-of-window
+brittleness and not a 06-17 regression; (2) the live DB head is `20260805000242`
+(2026-06-24), 44 versions past the 06-17 file head, so a migration-head/shadow-row
+reconciliation against a 06-17 checkout was not performed (the DB reflects a week of
+post-window work).
+
+**Headline reconciliation (important):** the task premise ("Codex worked this repo
+solo") does not match the merged history. Of the 61 new commits, **zero carry the
+`Assisted-By: Codex (OpenAI)` trailer**; all feature/fix commits carry
+`Assisted-By: Claude (Anthropic)` and are authored by Vitor Maia Rodovalho. Codex's
+actual footprint on `main` is a single integrated PR (#675, "Codex queue",
+commit `30bbd4f3`) covering 14 issues + the FE2 leaf, which the CODE team
+reviewed, re-QA'd on the full payload, and merged with a Claude trailer. The other
+~57 commits (agenda recurring model, SECDEF security fixes, selection fixes,
+agenda-viva #700/#701, members #625 C1/C2, governance WS-A, onboarding waves 1-4)
+are net-new CODE-team (Claude) work done 06-14 to 06-16, not Codex.
+
+---
+
+## Per-check results
+
+| # | Check | Result | Evidence |
+|---|---|---|---|
+| 1 | Every new commit carries `Assisted-By: Codex`, one concern each | **FAIL (literal) / explained** | 61 commits `63900da1..origin/main`. 0 carry `Assisted-By: Codex`. 59 feature/fix commits carry `Assisted-By: Claude (Anthropic)`; 2 bridge commits (`4bab7a50`, `42ae6168`) reference Codex and `42ae6168`/`4bab7a50` also carry a `Co-Authored-By`. The literal requirement is unmet because Codex's work was integrated and re-attributed by the CODE team, not self-merged. Commits are one-concern, conventional-commit, PR-squashed (every subject ends `(#NNN)`). Provenance of the Codex payload is documented in prose in `30bbd4f3` ("Codex weekend queue (GPT-5) across 14 issues"). |
+| 2 | Each merged PR: CI `validate` green, not --admin-bypassed; weekly bypass-audit | **PASS / FLAG** | PR #675 merged normally by VitorMRodovalho 2026-06-14, body asserts CI validate + CodeQL green and `npm test` 3932/3932 with DB env. Latest bypass-audit = W25 (issue #715, 2026-06-15): "within threshold (2 <= 2)", **0 --admin merges**, 2 docs-only direct pushes (`040df7bc`, `54ec45c7`, both pre-window). FLAG: the 06-15 to 06-17 commits fall in W26, whose audit cron (Mon 2026-06-22) has not run yet; per-PR CI for all 61 was not individually re-fetched. |
+| 3 | Fresh `npm install` + `npx astro build` + `npm test` | **PASS / FLAG** | `npm install` exit 0. `npx astro build` exit 0 ("[build] Complete!", only pre-existing chunk-size + CSS-token warnings). `npm test`: tests 4224, pass 3893, **fail 0**, skipped 331, exit 0. The known `invariant R` flake did NOT fire. FLAG: 331 skips = DB-aware contract tests skipped (no secrets here); LOCAL Claude must re-run with `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE_KEY`. |
+| 4 | DB hygiene (migration head, shadow rows, preview-gate drift, schema invariants) | **PASS (structural, live) / FLAG (suite + temporal)** | `execute_sql` reconnected mid-run and was used (read-only). (c) preview-gate drift = **0** mismatches (live). (d) `check_schema_invariants()` = **0 violations across all 40 invariants** (A1-AJ, incl. post-window AA-AJ) (live). (a) live DB head = `20260805000242` as of 2026-06-24; 06-17 file head = `20260805000198` - the 44-version gap is a week of post-window migrations, not 06-17 drift. (b) 14 `schema_migrations` rows newer than `20260617` (post-window work); no 06-17-window shadow rows surfaced. FLAG: the `audit-rpc-body-drift.mjs` script still needs env that this container lacks, and a head/shadow reconciliation against a 06-17 checkout was not done (DB is at 06-24 state). |
+| 5 | No Dependabot PR merged; no stale #289/#154/#142 merged | **PASS** | No dependabot/bump commit in window. None of #289/#154/#142 (nor their branch names version-diff-style / agents-md-harness / curator-followup) appear in merged subjects. |
+| 6 | Frozen items not modified (`_can_sign_gate`, `sign_ip_ratification`, `resolve_default_gates`, `_gate_threshold_met`, approval chain, TAP draft html) | **PASS** | `-S` pickaxe over `supabase/`: `sign_ip_ratification`, `resolve_default_gates`, `_gate_threshold_met` not touched. `_can_sign_gate` appears in PR #675 only as **function calls** (migration 159 redefines `_enqueue_gate_notifications` which calls the gate; migration 162 references it in the draft-preview RPC) - the gate body itself is NOT redefined. `docs/drafts/v2.7_p153_tap_cpmai_r01.html` was never committed (untracked WIP, correctly absent from a fresh clone). |
+| 7 | Copy each Codex handoff's "Lessons learned" + "what Claude must re-verify" verbatim | **DONE** | See "Codex handoff verbatim extracts" below. Files present: `codex-2026-06-12.md`, `codex-2026-06-13.md` (+ the onboarding doc). |
+| 8 | Re-ground each numeric claim in Codex handoffs via onboarding §E queries | **PARTIAL PASS (live) / FLAG** | `execute_sql` re-grounded live on 2026-06-24: `active_members` = **47**, pre-onboarding cohort = **30** (matches the handoff's 47 - stable over the week). Note this is a 2026-06-24 read, NOT a retroactive reproduction of the 06-13 figure; do not treat it as confirming the point-in-time value, only the current one. Still unverified (need §E with secrets / point-in-time context): `retention_rate` 68.1, ratification gate denominator 32, `npm test` 3932/3932 with DB env, PI registry 0/0. |
+| 9 | Codex stayed in RELEASED lanes, did NOT touch RESERVED §B items (EPIC A gamification roster/tribe_selections, C2 /admin/members, `_can_sign_gate`) | **PASS** | No new gamification-roster or `tribe_selections` "destiny" migration in window (only pre-baseline `20260425205543_..._tribe_selection_v4_auth.sql`). Codex's #675 touched only the RELEASED #625 C1-b helper (migration 160), not the reserved C2 frontend. The C2 `/admin/members` V4-native work (`bf27d0df` #722, `680b1c29` #725, 06-15) was shipped by the CODE team itself, which is the party that reserved it (§B: "reserved for the CODE team / pending PM decision") - not a Codex violation. `_can_sign_gate` body intact (see #6). |
+| 10 | RELEASE_LOG / GOVERNANCE_CHANGELOG updated for production-impacting work | **PARTIAL / FLAG** | Both files updated by PR #675 (`30bbd4f3`); RELEASE_LOG head entry "2026-06-13 - Queue hardening: #234/#625/#630/..." covers Codex's queue. BUT the last RELEASE_LOG entry is 2026-06-13: the CODE team's own 06-14 to 06-16 production-impacting work is NOT logged, including three SECDEF security fixes (`dc743641` #683, `b26152d4` #685, `63001895` #686), the WS-A whatsapp-leak governance fixes, members #625 C2, and onboarding waves 1-4. This is a CODE-team release-log gap, not a Codex gap. |
+
+---
+
+## Codex commit / PR footprint on `main`
+
+Codex's substantive work reached `main` as **one** integrated PR:
+
+- **PR #675** ("Codex queue: governance/legal/MCP/DB hardening - 14 issues"),
+  merge commit **`30bbd4f3`**, merged by VitorMRodovalho 2026-06-14T04:21:11Z,
+  head branch `codex/fe2-member-drilldown-headings`, base `42ae6168`, 86 files,
+  +3833/-225. Issues: #234 #625 #630 #633 #638 #639 #640 #641 #642 #645 #646
+  #651 #670 #678 (+ the FE2 #601 MemberDrillDown headings leaf, present in
+  `src/components/tribes/TribeGamificationTab.tsx`).
+  - 10 migrations: `20260613150200`, `...150634`, `...151535`, `...152719`,
+    `...162000` (all `_630_` agenda reconciliation) + `20260805000159`
+    (#651 gate notifications), `...160` (#625 c1b helper), `...161` (#630
+    retention fold), `...162` (#646 draft preview), `...163` (#639 release
+    provenance RPC).
+
+Bridge / scaffolding commits that mention Codex (CODE-team authored):
+- **`4bab7a50`** chore: cross-tool shared-brain bridge (AGENTS.md + `_handoff/`), PR #673.
+- **`42ae6168`** docs(handoff): CODE->CODEX weekend onboarding package.
+
+Every other commit in `63900da1..origin/main` (57 commits, all `Assisted-By:
+Claude`) is net-new CODE-team work, NOT Codex.
+
+Stale Codex branches still on origin (not merged, harmless): `chore/codex-shared-brain-bridge`
+(1 ahead / 61 behind), `chore/codex-onboarding-handoff` (4 ahead / 60 behind).
+
+---
+
+## Reconciliation notes (for LOCAL Claude -> memory + [LL] #588)
+
+### Lessons learned, verbatim from Codex handoffs
+
+**From `codex-2026-06-12.md`:**
+- (bootstrap) "Codex bootstrapped against AGENTS.md, CLAUDE.md, p201, bypass
+  protocol, and the read-only memory namespace before making repo changes. ...
+  For repositories with shared-brain rules, make a first-step handoff bootstrap
+  checklist explicit before any lane work."
+- (FE2) "The first full `npm test` can appear less complete if `.env` is not
+  loaded; DB-aware tests skip themselves. ... For Codex handoffs, record both the
+  plain test run and the `.env`-loaded run when the first one skipped DB-aware
+  tests."
+
+**From `codex-2026-06-13.md`:**
+- "Codex attacked multiple GitHub issues and left evidence in repo
+  docs/tests/migrations, but did not initially leave progress comments on every
+  issue. ... In the parallel-agent operating model, absent issue comments can make
+  the team believe an issue is still untouched, causing duplicate investigation or
+  duplicate implementation attempts. ... Add a default 'issue work audit' step to
+  Codex handoff/closure: for every issue number touched, post a concise issue
+  comment with scope, files/migrations, validation, and remaining ambiguity before
+  final response."
+- "#639 initially proposed using `register_exclusion_asset` directly from
+  `release-tag.yml`, but that RPC is intentionally declarant/self-service and
+  depends on `auth.uid()` ownership. ... For automation writing into human-governed
+  registries, add a narrow service-role RPC with explicit asset type, digest-only
+  inputs, and no proof-byte forging; keep human self-service RPCs unchanged."
+- "#234 had MCP/OAuth refresh code in Worker SSR routes reading
+  `import.meta.env.PUBLIC_SUPABASE_*`, while production deployment only guaranteed
+  those values during `npm run build`. ... For Cloudflare Worker SSR OAuth/proxy
+  paths, resolve operational credentials from `env` first and add a contract that
+  `wrangler.toml` publishes any public runtime vars needed by deployed handlers;
+  build-time env alone is not enough."
+- "During #678 QA, full Supabase anon JWT literals in `wrangler.toml` were caught
+  as a release-blocking pre-commit/token-scanner risk. ... For public JWT-like
+  config values, prefer runtime secrets/vars and add a contract asserting no full
+  `eyJ...` token appears in deploy config or source."
+
+### "What Claude must re-verify", verbatim from Codex handoffs
+
+**From `codex-2026-06-12.md`:**
+- "Re-run `git status --short` before reconciling, because unrelated untracked
+  local files existed before this handoff was created."
+- "Re-run any counts, metrics, DB state, or test baselines live; this file
+  intentionally does not pin them beyond command outputs observed during this
+  session."
+- "Re-run the FE2 branch tests if this PR sits while `TribeGamificationTab.tsx`
+  changes elsewhere."
+- "Confirm the UI still looks identical in the gamification member drill-down; this
+  change relies on `m-0` preserving heading layout."
+
+**From `codex-2026-06-13.md`:**
+- "Verify `git diff` against user-owned changes before committing; worktree
+  includes unrelated tracked and untracked strategy/deck files outside the P0/P1
+  queue."
+- "Re-run route smoke if preparing a PR because nav/middleware changed for #670."
+
+### Numbers to re-ground (do NOT record as fact until re-queried live, per CLAUDE.md grounding rule)
+- `active_members` = 47, `retention_rate` = 68.1 (codex-06-13 `get_public_platform_stats`).
+- ratification gate denominator = 32; `active_members` 72->47 delta (onboarding §A, from #672).
+- `npm test` with DB env = 3932/3932 (codex-06-13 + PR #675 body).
+- PI exclusion registry: 0 declarations / 0 assets / 0 confirmed / 0 open (codex-06-13).
+- Migration DB head should equal file head `20260805000198`; 0 shadow rows; 0 preview-gate drift; `check_schema_invariants()` 0 violations - ALL still to be confirmed live.
+
+---
+
+## What the LOCAL Claude must still do (this container could not)
+
+1. **Re-run the DB-aware suite with secrets and TRIAGE THE 4 CI FAILURES:**
+   `set -a; . ./.env; set +a; npm test`. CI `validate` on PR #765 showed 4 / 4606
+   DB-aware tests failing on current `main` (2026-06-24). Name them (pull the full
+   raw `validate` log for run/job `83233616390`, grep `not ok`), confirm each is
+   out-of-window data-brittleness and NOT a 06-17 regression, and fix or quarantine.
+   Re-run the `invariant R` test isolated if it flakes.
+2. **DB hygiene (check 4) - structural checks DONE live, residual items remain:**
+   - (c) preview-gate drift = 0 (DONE live 2026-06-24). (d) `check_schema_invariants()`
+     = 0/40 (DONE live 2026-06-24). No need to re-run unless you want a fresh read.
+   - (a/b) RESIDUAL: from a current `main` checkout, confirm DB head `20260805000242`
+     equals `ls supabase/migrations | tail -1` and that all 14 post-0617
+     `schema_migrations` rows are file-backed (no shadow rows). The 06-17 file head
+     was `20260805000198`; the gap is post-window work.
+   - Run `node scripts/audit-rpc-body-drift.mjs` with env -> expect `Drifted DEFINITE: 0`
+     (still needs secrets the cloud container lacked).
+3. **Re-ground every number** in the "Numbers to re-ground" list above via the
+   onboarding §E source queries before folding any into memory or #588.
+4. **Fold the verbatim lessons above into the Claude memory namespace + post to
+   [LL] issue #588** (memory-namespace reconciliation is local-only; this agent
+   neither can nor may write `~/.claude/...` and did not post to #588).
+5. **RELEASE_LOG / GOVERNANCE_CHANGELOG backfill** for the CODE-team 06-14 to 06-16
+   production work that is not logged - prioritize the three SECDEF security fixes
+   (#683/#685/#686), the WS-A whatsapp-leak governance fixes, members #625 C2, and
+   onboarding waves 1-4.
+6. **Confirm W26 bypass-audit** (cron Mon 2026-06-22) shows 0 --admin merges for
+   the 06-15 to 06-17 commits; spot-check per-PR `validate` if any doubt.
+7. **Decide the attribution posture going forward:** Codex's payload landed under a
+   `Assisted-By: Claude` trailer (PR #675). If Codex provenance must be auditable
+   from trailers (not just commit-body prose), adjust the integration convention.
+
+---
+
+## Post-window addendum (2026-06-24, from PR #765 CI)
+
+When PR #765 (this report) ran CI, the `validate` check failed: **4606 tests,
+4571 pass, 4 fail, 31 skipped** (job `83233616390`, on the PR-merge commit
+`4acc0f6f` = this doc + current `main`). Reconciliation:
+- This PR adds ONE markdown file, so the 4 failures are NOT introduced by it.
+- They are DB-aware tests (they ran because CI has secrets; they SKIP offline -
+  the same 331-skip class as the local run). They executed against the LIVE DB as
+  of 2026-06-24, a week past the verification window.
+- Structural DB state is clean at that same moment: preview-gate drift 0, all 40
+  schema invariants 0 violations. So the 4 failures are NOT drift/invariant
+  breakage; they read as data-dependent contract assertions that diverged as live
+  data evolved over the week, on CURRENT `main`, not the 06-17 work.
+- The exact 4 test names could not be extracted here: the GitHub MCP `get_job_logs`
+  returns only the last ~308k chars (all passing TAP tail); the inline `not ok`
+  lines are earlier in the full log and unreachable via this tool.
+- This is a pre-existing failure on `main`, out of scope for a verification-report
+  PR. It is NOT being "fixed" or re-kicked here. A LOCAL Claude (or a full raw-log
+  pull) must name and triage the 4 before declaring `main`'s DB-aware suite green.
+
+## Method note
+The initial fetch produced a SHALLOW clone (boundary commits `be5af1b7`, `d9aad41a`),
+which made `origin/main` look like an orphan history with no common ancestor to
+`63900da1` (a false force-push signal). After `git fetch --unshallow`, `63900da1`
+is confirmed as the exact merge-base and ancestor of `origin/main` (0 commits on the
+baseline side absent from main); the build-on is clean and linear. Recorded here so
+the next agent does not re-trip on the shallow artifact.
+
+— CODE team re-verification complete, 2026-06-17.

--- a/docs/_deliverables/2026-08-04_webinar_t6/CAPITULOS_YOUTUBE.txt
+++ b/docs/_deliverables/2026-08-04_webinar_t6/CAPITULOS_YOUTUBE.txt
@@ -1,0 +1,26 @@
+0:00 Abertura
+1:01 A Tribo 6 e o que ela produz
+4:47 O roteiro da noite
+6:51 Fernando Carvalho: o gargalo não é o prompt
+10:04 O gargalo operacional: leads e portfólio de cursos
+13:31 Academinho, o agente de atendimento
+17:41 MIA: usar também a conversa de quem não comprou
+18:45 O curso que parou de lotar
+21:04 Cinco agentes com papéis separados
+22:55 Contexto, premissas, memória e agent.md
+27:36 O resultado: reposicionamento e turmas cheias
+29:26 Limitações e contornos
+32:19 O kit de análise de cenário e portfólio
+33:06 Perguntas ao Fernando
+38:26 Clendson Gonçalves: Shadow AI, o estagiário invisível
+39:19 O caso Samsung: o dado não foi roubado, foi entregue
+44:18 Shadow IT governa ferramentas, Shadow AI governa decisões
+48:45 O paradoxo da produtividade
+50:48 Human in the loop quando vira teatro de supervisão
+52:21 AI Act artigo 14 e LGPD artigo 20
+53:17 Segregação de funções e o agente que faz os três papéis
+57:21 O kit prático: o semáforo dos dados e as 5 ações do GP
+60:58 O que muda no papel do gestor de projetos
+63:14 Para refletir
+65:01 Perguntas e o contraponto sobre governança
+69:36 Encerramento

--- a/docs/_deliverables/2026-08-04_webinar_t6/RELATORIO_POS_EVENTO.md
+++ b/docs/_deliverables/2026-08-04_webinar_t6/RELATORIO_POS_EVENTO.md
@@ -1,0 +1,185 @@
+# Relatório pós-evento do 1º Webinar da Tribo 6 (ROI & Portfólio)
+
+**Evento:** Aplicações Práticas de IA (IA na priorização, na análise de cenário e na segurança da informação)
+**Quando:** terça, 04/08/2026, 19h00 às 20h18 (Brasília). Conteúdo de 19h05 a 20h18, 73 min.
+**Onde:** Airmeet · aberto ao público · gravado
+**Registro na plataforma:** webinar `4ff3a888-8959-4262-82e6-a6f54ffc3964` · evento `17497fca-c035-4d9a-8c37-9b721447c9fe`
+**Gravação:** https://youtu.be/__cXwlfgtwM (pública, playlist Webinars, 72min30s, com capítulos)
+
+> Fonte de todos os números: exports do Airmeet baixados em 05/08 às 00h04 (master, qna, chat, resource,
+> in_session_cta, survey) e consultas à plataforma feitas em 05/08. Os CSVs com PII ficam fora do
+> repositório. Nenhum e-mail ou nome de participante externo aparece aqui.
+
+## 1. O funil
+
+| medida | valor |
+| --- | --- |
+| inscritos | 127 |
+| presentes | 61 |
+| **taxa de comparecimento** | **48,0%** |
+| entraram na sessão ao vivo | 60 |
+| assistiram só pelo replay do Airmeet | 2 |
+| entraram no lounge / networking | 0 |
+
+Quebra por histórico, que é o dado mais acionável do lote:
+
+| | inscritos | presentes | comparecimento |
+| --- | --- | --- | --- |
+| novos (1º evento do Núcleo) | 62 | 23 | **37,1%** |
+| recorrentes | 65 | 38 | **58,5%** |
+
+Quem já veio antes comparece a uma taxa 1,6× maior. A divulgação trouxe metade da base como gente nova,
+e essa metade é a que evapora entre a inscrição e a sala.
+
+## 2. Retenção
+
+Tempo assistido, entre os 61 presentes: mediana **53 min**, média 51,5 min, sobre uma sessão de 73 min.
+Mediana equivale a **73% da sessão**.
+
+| corte | presentes |
+| --- | --- |
+| ≥ 5 min | 57 |
+| ≥ 20 min | 45 |
+| ≥ 45 min | 34 |
+| ≥ 60 min | 26 |
+
+Não houve queda concentrada: a curva é suave. Três pessoas ficaram menos de 5 min.
+
+## 3. Interação
+
+| medida | valor |
+| --- | --- |
+| mensagens no feed | 39, de 23 pessoas |
+| linhas no Q&A | 12, de 7 pessoas |
+| **perguntas de conteúdo** | **4, de 2 pessoas** |
+| reações (emojis) | 90 |
+| mãos levantadas | 0 |
+| respostas ao survey | 0 |
+| recursos publicados / baixados | 0 |
+| CTAs em sessão | 0 |
+
+⚠️ **As 12 do Q&A não são 12 perguntas.** Oito são saudação, emoji, agradecimento ou recado de áudio.
+As quatro de conteúdo foram duas sobre a arquitetura de agentes apresentada (critério de alocação de
+cada agente a um LLM diferente, e técnicas de refinamento do aprendizado, com o paralelo ao Model
+Context Protocol) e duas sobre governança (o WhatsApp como canal corporativo de facto sem versão
+Business, e o argumento de que a IA amplifica um problema cuja causa-raiz é a governança da empresa).
+Qualquer leitura de "12 perguntas" superestima o engajamento por 3×.
+
+⚠️ **As próprias abas do Airmeet divergem entre si.** A aba de resumo do chat diz 23 pessoas no feed e
+a aba de atividade diz 25; o Q&A diz 7 e a atividade diz 8. Usar sempre a mesma aba ao comparar
+edições.
+
+⚠️ **Survey com zero respostas.** Não houve pesquisa de satisfação neste webinar, então não há NPS nem
+nota. Se a avaliação importa para o relatório de portfólio, ela precisa ser configurada no Airmeet
+antes do evento, não depois.
+
+🟡 **O material do Fernando existe e está no ar, mas só como QR na tela.** Ele oferece um kit com os
+cinco agentes e os prompts que usa (planejador, crítico técnico, crítico de negócio, advogado do
+diabo e consolidador, cada um em um modelo diferente). O endereço aparece no slide de encerramento
+dele, aos 32min42s do vídeo publicado: **https://m2br.academy/materiais/pmi**, "Kit de Análise de
+cenário e gestão de portfólio com IA". Conferido em 05/08: responde **HTTP 200**, título "Kit PMI —
+Análise de cenário com IA | M2BR Academy".
+
+O que faltou foi registro em texto. O export de recursos do Airmeet veio **vazio** (nenhum recurso
+publicado, nenhum download) e o chat tem só os três links de LinkedIn dos palestrantes. Quem assiste
+ao replay precisa pausar e ler o slide, ou apontar a câmera para a tela. **A descrição do YouTube
+resolve isso**, e é onde o link foi colocado.
+
+Para os próximos: todo link mostrado por QR deveria ir também para a aba de recursos do Airmeet e
+para o chat, que são os dois lugares que viram registro.
+
+## 4. Quem esteve lá, do ponto de vista da plataforma
+
+Cruzamento dos 61 presentes contra `members` + `member_emails`, por hash de e-mail:
+
+| | valor |
+| --- | --- |
+| presentes que são membros | **28** |
+| presentes que não são membros | **33** |
+| membros com presença já registrada antes desta apuração | 5 |
+| membros com presença registrada nesta apuração | 23 |
+
+Os 28 membros vêm de **9 capítulos**: CE (7), GO (6), RS (4), MG (3), PE (2), RJ (2), DF (2), PR (1)
+e AM (1). Um webinar de tribo puxando presença de nove capítulos é o argumento multi-capítulo do KPI
+acontecendo na prática.
+
+**Os 33 externos não têm registro em lugar nenhum da plataforma.** Não são membros, não entraram como
+`visitor_leads` (a captura de lead é do formulário do site, não do Airmeet) e não há rota para gravar
+presença de não-membro. Ou seja: a plataforma enxerga 28 de 61. Aberto em **#1602**.
+
+## 5. O que foi gravado na plataforma
+
+| o quê | antes | depois |
+| --- | --- | --- |
+| presença no evento | 5 | **28** |
+| `duration_actual` | 60 | **73** |
+| `events.initiative_id` | `null` | Tribo 6 |
+| `events.is_recorded` | `false` | `true` (+ `recording_url`, `recording_type='youtube'`) |
+| `webinars.status` | `confirmed` | **`completed`** |
+| `webinars.youtube_url` | `null` | https://youtu.be/__cXwlfgtwM |
+| ata do evento | inexistente | publicada, com 4 ações e 2 decisões estruturadas |
+| card no board | `in_progress` | `done` |
+| pipeline de comms | "preparar follow-up pós-evento" | **"divulgar replay e materiais"** |
+
+A presença entrou por `attendance_record action='register'` e a ata por `meeting_minutes`, ambos pelo
+MCP. Os campos de `webinars` e de gravação do evento foram por UPDATE direto, porque não há rota MCP
+(#1600, #1601) e porque a rota da tela apagaria o `board_item_id` (#1604).
+
+## 6. Efeito nos indicadores
+
+**O contador da meta não se mexeu, e isso não é erro de execução.** Medido depois de fechar tudo:
+
+| medida | valor |
+| --- | --- |
+| webinares com `status='completed'` no banco | 2 → **3** |
+| `get_webinars_count` na janela do KPI (até 30/06) | **0** |
+| `get_webinars_count` de 01/01 até hoje | **3** |
+| Horas de Impacto, janela default do painel | **842** |
+| Horas de Impacto, de 01/01 até hoje | **1387** |
+
+A meta "6+ Webinares ou Talks" continua exibindo **0 de 6** com três webinares realizados, porque a
+janela de medição parou em 30/06/2026 e os três são de julho e agosto. O mesmo defeito segura
+"Eventos realizados" em 147 quando o número até hoje é 220, e o painel do workspace em 842 horas de
+impacto quando são 1387. As 28 presenças registradas hoje caem inteiras fora de todas as janelas
+default, porque o evento é de agosto. Aberto em **#1603**.
+
+Duração real: `duration_actual` foi de 60 para **73**, o que muda a conta de horas de impacto deste
+webinar de ≈28 h para ≈34 h. Esse ganho só aparece em superfície com janela corrigida.
+
+## 7. Pendências abertas por este evento
+
+| # | item |
+| --- | --- |
+| #1600 | `webinar_manage` não fecha o webinar (status e youtube_url fora da rota MCP) |
+| #1601 | `event_write` não alcança os campos de realização (gravação, `duration_actual`, `initiative_id`) |
+| #1602 | presença de público externo e resolução de e-mail em lote não têm rota |
+| #1603 | janela congelada em `get_annual_kpis` (meta de webinares e eventos realizados) |
+| #1604 | editar um webinar pelo modal do admin apaga o `board_item_id` |
+
+⚠️ **A #1604 saiu de uma tentativa de fazer a coisa certa.** Antes de fechar o webinar por SQL fui
+conferir se dava para fechar pelo admin, e dava: `upsert_webinar` aceita `p_status` e `p_youtube_url`,
+e o gate dela permite ao **próprio organizador** (o Denis, neste caso) fechar o webinar dele. Só que a
+função grava `board_item_id = p_board_item_id` sem `COALESCE` e o modal nunca envia esse parâmetro.
+Fechar este webinar pela tela teria apagado, em silêncio, o vínculo com o card
+`f5a77542-4007-4229-916b-ead5852b20e6`. Por isso o fechamento foi por UPDATE direto.
+
+Isso também corrigiu a #1600, que eu havia escrito afirmando que o líder de tribo dependia do owner
+para fechar um webinar. Não depende: a capacidade existe na web. O que não existe é a rota no MCP.
+
+## 8. Achados de higiene, sem issue aberta
+
+**Três webinares de abril presos no pipeline.** `comms_report scope='pending_webinars'` ainda lista
+`91759ba1`, `2ab12ccf` e `cd596843` (tribos 2, 4 e 5) em `confirmed` com "preparar follow-up
+pós-evento". Ou aconteceram e nunca foram fechados, ou não aconteceram e deveriam estar cancelados. É
+o mesmo sintoma que a #1600 descreve: sem rota de fechamento, webinar não fecha.
+
+**Cópia velha de liderança em `initiatives.metadata`.** O `metadata.leader_member_id` da Tribo 6
+aponta para o líder anterior. O SSOT (`engagements`, papel `leader` desde 23/06) e a coluna que a
+tela realmente lê (`tribes.leader_member_id`) trazem o líder atual, então **não há efeito visível
+hoje**. Fica registrado porque é uma terceira representação do mesmo fato, e a única das três que
+está errada. Detectado ouvindo o próprio webinar, onde a transição de liderança é anunciada.
+
+**Kickoff de comms nunca registrado.** `comms_kickoff_at` do webinar é `null` e
+`comms_kickoff_logged` é `false`, embora a divulgação tenha saído em 27/07 e 02/08. Marcar agora
+gravaria a data de hoje, que seria pior que o `null`: o campo aceita apenas "agora"
+(`mark_kickoff`), não uma data retroativa.

--- a/docs/planning/2026-08-07_PROMPT_ARRANQUE_1642.md
+++ b/docs/planning/2026-08-07_PROMPT_ARRANQUE_1642.md
@@ -1,0 +1,154 @@
+# Prompt de arranque — #1642 e a cauda do arco de consentimento (07/08/2026)
+
+> Colar depois do `/clear`.
+> **Effort: `xhigh`.** O que está em jogo é texto que a LGPD trata como informação prestada ao
+> titular (art. 18, VIII), em 3 idiomas, sobre uma consequência que ACABOU de deixar de existir.
+> Errar a ordem inverte a mentira em vez de removê-la.
+>
+> Handoff completo: `docs/planning/2026-08-07_handoff_1640_fechado_convites_atribuidos.md`.
+> `main` em **`54fe0eb9`**.
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Todo número aqui foi medido em 07/08 de madrugada e a
+base é viva. Re-medir com tool call na mesma volta antes de qualquer decisão.
+
+E o padrão que já custou três leituras erradas neste arco continua valendo: **número certo,
+significado errado.** O instrumento é barato — rodar o grupo de controle, ou perguntar *de quem é
+este valor* em vez de *quantos são*.
+
+Um exemplo desta própria sessão: `schedule_interview` tinha **zero** recusas `GATE_NO_AI` em 31
+tentativas. Lido como "esse gate nunca incomodou ninguém", teria ficado. Medindo o caminho vizinho:
+**14 bypasses** sobre candidaturas sem consentimento, **13 deles desnecessários** se não fosse o gate.
+Zero recusas era **contorno**, não imunidade.
+
+---
+
+## Leia antes de planejar — já medido, não re-litigar
+
+1. **#1640 está FECHADO e em produção.** O gate de IA saiu de `_issue_interview_booking_token_core`
+   (modo `full`) e de `schedule_interview` (fora do bypass). P0002 (peer-review), P0003 (nota) e
+   P0004 (status) ficaram. Isso **destrava o #1642** — e o #1642 só podia vir depois, senão o texto
+   novo afirmaria "não há consequência" enquanto ela ainda existia.
+
+2. **Os 4 convites presos já foram despachados**, pela tela, com `dispatch_source: manual` e ator
+   nominal. As outras 2 da coorte não estavam presas: têm convite vivo dentro da carência de 10 dias.
+
+3. **"Recusa" continua sendo inferência, não evento.** Só existem `consent_ai_analysis_at` e
+   `consent_ai_analysis_revoked_at`. "Abriu o portal e nada foi gravado" é compatível com recusar
+   **e** com abandonar o onboarding.
+
+4. **`gate_attempts` contém tráfego de teste** (#1636): `caller_id IS NULL` em 100% das linhas do
+   `_issue_interview_booking_token_core`. Qualquer leitura precisa separar teste, cron e humano.
+
+5. **A tela é hoje o único caminho de convite com atribuição humana** (mapa das 3 superfícies no
+   comentário do #1586). Isso não bloqueia o #1642, mas é o contexto do #1586.
+
+---
+
+## A ordem
+
+### 1. #1642 — o texto (P1, destravado)
+
+Três superfícies, âncoras já levantadas na issue:
+
+- **Tela primária de consentimento** — `src/i18n/pt-BR.ts` ~linha 6715. Hoje vende o consentimento
+  como acelerador opcional, sem dizer nada sobre efeito.
+- **E-mail de nudge** — `20260517100000_consent_nudge_template_and_dispatch_rpc.sql` (linhas 36-38).
+  Diz "opcional" e instrui *"se prefere não dar consentimento de IA, ignore esta mensagem"*.
+- **Política pública** — `src/i18n/pt-BR.ts` ~linha 3837. Cita **duas bases legais para a mesma
+  operação**: consentimento expresso E art. 7º, V. Separar: art. 7º, V para o processo seletivo;
+  art. 7º, I exclusivamente para a análise por IA, sem menção cruzada.
+
+⚠️ **Paridade nos 3 dicionários** (pt-BR, en-US, es-LATAM) — é gate de CI, não zelo.
+⚠️ O texto do e-mail vive em **migration**, não em dicionário: mexer nele é DDL, com o ritual completo
+(`apply_migration` → deletar phantom → arquivo local → `migration repair` → `NOTIFY pgrst`).
+⚠️ A redação sugerida na issue é **a validar com o comitê**, não a aplicar direto. Tom institucional.
+
+### 2. #1641 — a oportunidade de consentir (P2)
+
+33 de 34 não conseguem consentir: só 1 tem token vivo. Reemitir via `dispatch_consent_nudge`,
+**desacoplado do convite** em tempo e mensagem — senão recria "consinta para avançar", que é o
+defeito que o #1640 acabou de remover, por outra porta.
+
+### 3. #1643 — varrer outras superfícies (P2)
+
+Procurar outros consentimentos "opcionais" com gate escondido em caminho crítico. É o 2º caso no
+mesmo funil, então trate como padrão, não incidente. Inclui limpar a dica morta do
+`interview_manage` no `nucleo-mcp`, que ainda sugere `bypass_gate=true` ao ver `GATE_NO_AI` — ramo
+que não pode mais casar.
+
+### 4. #1649 — o vermelho de CI (ABERTA; a 1ª correção não pegou)
+
+⚠️ **Leia isto antes de tentar de novo.** O PR #1663 elevou o `statement_timeout` para 60s *de dentro*
+de `_alert_sweep_cron` e o `validate` dele passou. **Passou por cache quente, não por eficácia.** O
+teste seguinte, num PR de dois markdowns, falhou com `duration_ms: 8974` — parou nos 8s de sempre.
+
+Sonda que fecha a questão:
+
+```sql
+SET statement_timeout = '2s';
+SELECT set_config('statement_timeout', '60s', true), pg_sleep(4);
+-- ERROR: 57014 canceling statement due to statement timeout
+```
+
+**O `statement_timeout` é armado quando o statement COMEÇA.** Elevá-lo de dentro da função vale só
+para os statements seguintes da transação, nunca para a chamada em curso. Para este fim, aquele
+`set_config` é inerte — defesa decorativa clássica: o mecanismo existe, o teste passou, o efeito não
+acontece.
+
+O que sobrou de bom do #1663: `duration_ms` gravado em `platform.alert_sweep_run` (instrumentação
+real) e as medições. O comentário da migration e o corpo daquele PR afirmam eficácia que a sonda
+desmente — corrigir na próxima migration que tocar a função.
+
+**Saídas ainda vivas:** `ALTER ROLE service_role SET statement_timeout` (funciona, porque o statement
+nasce com o teto maior — mas é decisão de plataforma, vale para toda chamada `service_role`); ou
+tabela-sombra alimentada por cron próprio (roda como `postgres`, sem teto), tirando a varredura de
+150 MB do caminho do PostgREST.
+
+E a forma que vale como sedimento:
+
+- **8s não era o teto da função, era o teto de outra coisa.** `service_role` não define
+  `statement_timeout` e herda o do `authenticator`, que é orçamento de chamada **interativa** do
+  PostgREST. O chamador natural de `_alert_sweep_cron` é o `pg_cron`, que roda como `postgres` sem
+  teto. Uma varredura em lote estava sendo medida com a régua de uma consulta de tela.
+- **Elevar teto sozinho é máscara.** Veio casado com `duration_ms` gravado na linha de auditoria que
+  a função já escrevia — a degradação vira número observável, não vermelho intermitente.
+- **Duas saídas caíram por medição:** índice parcial em `cron.job_run_details` (`42501, must be
+  owner` — a tabela é do pg_cron) e corte por `runid` (**3.294 ms contra 152 ms**, porque troca
+  leitura sequencial por 20 mil buscas no heap). A segunda foi proposta por mim antes de medir.
+
+Se `1621 behavioural` voltar a estourar, o sintoma agora é outro: leia `duration_ms` na última linha
+de `platform.alert_sweep_run` antes de mexer em qualquer coisa.
+
+---
+
+## Armadilhas de execução (medidas 06-07/08)
+
+- **DDL em prod antes do merge serializa TODOS os PRs abertos** e, pior, faz a suíte ANTIGA rodar
+  contra o banco NOVO. Antes de aplicar: mergear o que está verde e esperar o CI da `main` terminar.
+- **Ao remover/afrouxar um gate, `grep` o código de recusa na suíte INTEIRA antes do DDL.** Um
+  predicado ancorado em "esta recusa" deixa de observar e passa a EXECUTAR o ato (emitir token,
+  mandar e-mail) sobre linha real de produção.
+- **`apply_migration` cria phantom row** com timestamp real; deletar (1 por chamada) e
+  `supabase migration repair --status applied <sintético>`.
+- **Guard de AUSÊNCIA sobre fonte crua casa o próprio comentário** que explica o defeito. Remover
+  comentários antes de assertar (vale para o arquivo E para `prosrc`).
+- **`confirm()` da página trava a extensão do Chrome** — neutralizar antes de automatizar clique.
+- **Teste novo não roda em CI** se não estiver nas **duas** whitelists do `package.json`.
+- **`npm test` com `.env` exportado**: 6460 testes, **1 skip**. ~548 skips = `.env` não subiu.
+- **Não rodar `npm test` local com CI em voo** (`gh run list`): as suítes DB-aware escrevem em prod.
+
+## Pendências que não são desta frente
+
+- **#1556**, irmã da Wave 0, segue aberta.
+- **#1637** Dependabot `astro` 6→7: não mergear (política #611); major não é higiene de rotina.
+- **#1205** só fecha com o William no `/profile` LOGADO.
+
+## Regras da casa
+
+- Merge à `main` é da sessão main; lane leva o PR até verde e para.
+- Commit: `Assisted-By: Claude (Anthropic) <noreply@anthropic.com>`, nunca `Co-Authored-By`.
+- Repo **PÚBLICO**: nenhum candidato nomeado, só contagens.

--- a/docs/planning/2026-08-07_handoff_1640_fechado_convites_atribuidos.md
+++ b/docs/planning/2026-08-07_handoff_1640_fechado_convites_atribuidos.md
@@ -1,0 +1,186 @@
+# Handoff — #1640 fechado, 4 convites despachados com atribuição humana (07/08/2026, madrugada)
+
+> Supersede `2026-08-06_handoff_wave1_consentimento_medido_1586b_e_impasse_prs.md` no que toca ao
+> ciclo seletivo. `main` em **`54fe0eb9`**. Arranque da próxima sessão:
+> `2026-08-07_PROMPT_ARRANQUE_1642.md`.
+
+---
+
+## 1. O que fechou
+
+**#1640** (PR #1648, mergeado 03:59 UTC). O gate `GATE_NO_AI` saiu da pré-condição do convite de
+entrevista **e** do agendamento. Migration `20260807000200`.
+
+### A decisão de escopo que não estava na issue
+
+A issue escrevia só `_issue_interview_booking_token_core`. Medindo antes de codar, `schedule_interview`
+tinha a **condição idêntica**, sobre a mesma população. E o argumento de "deixa para o #1643" caiu com
+uma medição:
+
+| medição pré-fix | valor |
+|---|---|
+| recusas `GATE_NO_AI` em `schedule_interview` desde 06/05 | **0** |
+| agendamentos com `bypass_granted` sobre candidatura sem consentimento | **14** |
+| desses 14, que já tinham 2 avaliações **e** nota | **13** |
+
+Zero recusas não era imunidade: era **contorno**. O comitê passava por um bypass de admin que desliga
+JUNTO o peer-review e a nota. Corrigir só o emissor deixaria o mesmo defeito um passo adiante, ainda
+exigindo a via que enfraquece os outros gates. PM aprovou as duas RPCs.
+
+### A população, re-medida na sessão
+
+- **6** candidaturas em `interview_pending` sem consentimento no `cycle4-2026`
+- **todas as 6** com 2 avaliações e nota objetiva calculada, isto é, o gate de IA era o **único** obstáculo
+- **4** nunca tinham recebido convite algum
+- os outros 28 dos 34 sem consentimento já haviam passado do ponto onde o gate morde
+
+---
+
+## 2. Os convites: 4 despachados, 2 que não precisavam
+
+Despachados pela **tela** (`/admin/selection`, bulk invite), com o Chrome dirigido na sessão logada
+do PM. Verificação pelo EFEITO, não pelo retorno:
+
+| verificação | resultado |
+|---|---|
+| `cutoff_approved_email_sent_at` carimbado | 4 |
+| tokens de agendamento emitidos | 4 |
+| linhas em `selection_dispatch_url_log` | 4 |
+| passagens no gate com `has_consent: false` no payload | 4 |
+| `admin_audit_log` do despacho | 4, `dispatch_source: manual`, ator nominal |
+
+**Nenhuma linha saiu como `cron` com `actor_id NULL`** — que era o risco inteiro de fazer isso por SQL.
+
+**As outras 2 não estavam presas.** Têm convite vivo (31/07 e 04/08; 6,6 e 3,2 dias) e a carência de
+agendamento é de **10 dias**. O rescue de não-agendados as alcança em ~10/08 e ~14/08 se não agendarem
+— e agora consegue, porque era ele que acumulava as recusas do gate.
+
+### Achado que corrige a ordem do arranque anterior
+
+O arranque dizia "reprocessar só depois do #1586(a)". Isso vale para SQL e MCP, **não para a tela**:
+`notify_selection_cutoff_approved` resolve por `auth.uid()` e só entra no ramo `v_is_cron` quando não
+acha membro (service_role). Pela tela, carimba `manual` com o ator real. Mapa das três superfícies
+comentado no #1586.
+
+⚠️ Detalhe para automação: os dois caminhos de convite da tela passam por `confirm()` do navegador
+(`selection.astro:4179` no bulk, `:4647` na linha), que **trava a extensão do Chrome**. Foi preciso
+neutralizar o `confirm` durante o clique.
+
+---
+
+## 3. Verificação pendente do #1586(b): resolvida, e não era defeito
+
+O handoff anterior pedia conferir se o cron das 16:00 UTC de 06/08 inseriu as notificações. **Zero
+foi o esperado**: o PR #1638 mergeou em `2026-08-07T01:14:17Z`, ~9h DEPOIS daquela corrida. O corpo
+com o bucket C não existia quando o cron rodou.
+
+Entrega conferida sem escrever nada, replicando as CTEs: **2 apps detectadas × 2 managers = 4 pares
+alvo, 4 sobrevivendo ao dedup de 7 dias**. A classe destinatária não está vazia.
+
+E depois dos convites o bucket foi de **2 → 0**: a corrida das 16:00 de hoje vai achar nada **pelo
+motivo certo** (a causa foi removida), não por alerta quebrado.
+
+---
+
+## 4. Os testes: três precisaram mudar de âncora, e o motivo é reutilizável
+
+`1594-1595` e `1598-1599` escolhiam alvo **por predicado sobre produção** ancorado em "sem
+consentimento → P0001". Removido o gate, o predicado continua casando e a chamada **deixa de observar
+uma recusa e passa a executar o ato**: emissão de token real para candidato real (30 de ciclo fechado
+e as 6 do ciclo aberto casavam), e no #1598 a "prova de recusa" destravaria a chamada do rescue, que
+despacha e-mail.
+
+`p472-corr3` assertava `'P0001'` sobre migration **congelada**: passaria verde para sempre afirmando
+um gate inexistente no corpo vivo.
+
+Os três reancoraram em peer-review incompleto (P0002). Memória gravada:
+`reference-test-predicate-anchored-on-the-gate-you-remove-becomes-an-actor`.
+
+⚠️ **Resíduo declarado:** a sonda do #1598 ficou **não exercida** — nenhuma candidatura
+`interview_pending` do ciclo aberto recusa mais (as 11 têm 2 avaliações e nota). A população que
+tornava a asserção exercível era, em boa parte, a que o gate barrava indevidamente. O teste imprime
+isso alto em vez de passar calado.
+
+Novo contrato: `tests/contracts/1640-ia-fora-da-precondicao-do-convite.test.mjs`, nas **duas**
+whitelists do `package.json`.
+
+---
+
+## 5. #1649 — o vermelho de CI que não é de ninguém, e trava todo mundo
+
+`1621 behavioural: estado saudável é SILENCIOSO` estoura o `statement_timeout` de **8s** que o
+`service_role` herda do `authenticator`. Derrubou **3 das últimas 5 corridas** do `validate` na `main`
+— inclusive um commit **só de docs** — e passou local com **6460 testes, 0 falhas, 1 skip**.
+
+Causa medida: `_alert_sweep_cron` varre `cron.job_run_details` por Seq Scan — **150 MB, 146.203
+linhas, só o pkey**, crescendo ~2.400 linhas/dia, e o filtro descarta 146.201 de 146.201 para
+devolver zero. `reltuples` estava em **29** (estatísticas nunca coletadas); rodei `ANALYZE` na sessão
+e foi para 146.203. A quente a RPC mede ~300 ms: o estouro é com cache frio sob a carga da suíte.
+
+### Tentativa de correção no mesmo dia (PR #1663) que NÃO pegou — issue reaberta
+
+O quadro piorou antes de fechar: o vermelho derrubou também o PR **#1659**, que tem **dois arquivos
+markdown e nada mais**, e o rerun **deixou de resolver**. Placar do dia: 5 falhas contra 2 sucessos.
+Um PR sem uma linha de código executável não causa timeout de statement — isso encerrou a discussão
+sobre atribuição.
+
+Duas direções foram descartadas **por medição, não por gosto**:
+
+- **índice parcial** em `cron.job_run_details`: `ERROR 42501: must be owner of table` — a tabela é do
+  pg_cron (dono `supabase_admin`) e o `postgres` não é membro dele;
+- **limitar por `runid`** (o único índice existente): **3.294 ms contra 152 ms** do seq scan, porque
+  troca leitura sequencial por 20 mil buscas no heap. Eu havia proposto essa saída antes de medir.
+
+O que entrou: teto próprio de 60s pedido de dentro da função, mais `duration_ms` gravado na linha de
+auditoria que ela já escrevia.
+
+⚠️ **E o teto NÃO funcionou.** O `validate` do #1663 passou, mas por cache quente. O PR seguinte —
+dois markdowns — falhou com `duration_ms: 8974`: parou nos 8s de sempre. A sonda que fecha a questão:
+
+```sql
+SET statement_timeout = '2s';
+SELECT set_config('statement_timeout', '60s', true), pg_sleep(4);
+-- ERROR: 57014 canceling statement due to statement timeout
+```
+
+**O `statement_timeout` é armado quando o statement começa.** Elevá-lo de dentro da chamada vale só
+para os statements seguintes da transação, nunca para a que está executando. Aquele `set_config` é,
+para este fim, inerte — e o teste que eu escrevi afirmava a presença do mecanismo, não o efeito dele.
+É a família da defesa decorativa, cometida por mim no mesmo dia em que este handoff a descreve.
+
+Sobrevive do #1663 o `duration_ms` (instrumentação real, e foi ele que denunciou a própria falha) e
+as medições. **#1649 reaberta**, com duas saídas ainda vivas: `ALTER ROLE service_role SET
+statement_timeout` (funciona porque o statement nasce com o teto maior, mas é decisão de plataforma)
+ou tabela-sombra alimentada por cron próprio, que roda como `postgres` e não tem teto.
+
+---
+
+## 6. Estado
+
+| item | estado |
+|---|---|
+| `main` | `54fe0eb9` |
+| #1640 | ✅ fechado (PR #1648) |
+| #1642 | 🔓 **destravado** (era bloqueado pelo #1640 em prod) |
+| #1641, #1643 | abertos, independentes |
+| #1586 | aberto, enriquecido com o mapa das 3 superfícies |
+| #1649 | novo, aberto |
+| #1556 | aberto (irmã da Wave 0) |
+| #1637 Dependabot astro 6→7 | **não mergear** (política #611) |
+| bypass, janela 7d | **1 de 2** (nenhum usado nesta sessão) |
+| migration head | `20260807000200` (phantom do `apply_migration` deletado) |
+
+---
+
+## 7. Armadilhas medidas nesta sessão
+
+- **DDL em prod antes do merge serializa os PRs abertos.** Mergeei o #1646 primeiro e esperei o CI da
+  `main` terminar antes de aplicar — porque a suíte ANTIGA rodando contra o banco NOVO cunharia token real.
+- **`apply_migration` cria a phantom row** com timestamp real, que ordena acima da sequência sintética.
+  Deletar (1 por chamada) e `supabase migration repair --status applied <sintético>`.
+- **`confirm()` da página trava a extensão do Chrome.** Neutralizar antes de clicar.
+- **`service_role` não define `statement_timeout`**: herda 8s do `authenticator`. É esse o teto de
+  qualquer RPC chamada pela suíte.
+- **Estatística de tabela de sistema pode nunca ter sido coletada.** `reltuples=29` numa tabela de
+  146 mil linhas muda o plano inteiro.
+- **`npm test` com `.env` exportado**: 6460 testes, **1 skip**. Se aparecerem ~548, o `.env` não subiu.

--- a/docs/runbooks/GO-LIVE-onda2-reacceptance.md
+++ b/docs/runbooks/GO-LIVE-onda2-reacceptance.md
@@ -1,0 +1,136 @@
+# Runbook — Go-live Onda 2 (re-aceite do Termo v9 pelos voluntários ativos)
+
+**Audiência:** GP / Gerente de Projeto (`manage_platform`).
+**Status:** DRAFT / planejamento (2026-07-07). Onda 2 é DESACOPLADA da Onda 1.
+**Spec:** `docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md`.
+**Máquina:** #976 PR-4 de #571 (`open_reacceptance_obligations` e cia), migration `20260805000304`.
+**Base legal:** Termo 15.3 (cascata material) · 15.4.3 (objeção) · 15.4.5 (licenças preservadas).
+
+> **Objetivo de negócio.** Levar os voluntários **ativos que assinaram versões antigas** do Termo
+> a **re-aceitar a v9** (mudança material — rodada jurídica Aaron/Angeline). A Onda 1 destravou a
+> assinatura para os C4 novos; a Onda 2 fecha o círculo com quem já estava dentro.
+
+> **O que Claude NÃO faz.** Claude não dispara o fan-out real (`p_dry_run=false`) nem envia e-mail
+> aos voluntários sem go explícito do GP **e** o gate OUTWARD #334 (DPO/ANPD). Claude prepara,
+> aterra ao vivo e verifica; a decisão de disparar a cascata (que pode desligar não-respondentes) é humana.
+
+---
+
+## 0. O bloqueador que a Onda 2 resolve primeiro (LER)
+
+A máquina de re-aceite faz fan-out sobre `member_document_signatures` (ledger). **Esse ledger está
+VAZIO** — as 48 assinaturas reais estão em `certificates`. Sem popular o ledger, o fan-out é vazio.
+Por isso a Onda 2 tem uma **etapa de backfill** (§2) que a Onda 1 não tinha. Detalhe e SQL na spec.
+
+---
+
+## 1. Estado aterrado (re-conferir SEMPRE antes de executar — Onda 1 está viva)
+
+```sql
+-- Template ativo + change_class (esperado: v9, material)
+SELECT gd.id, gd.current_version_id, dv.version_label, dv.change_class
+FROM governance_documents gd JOIN document_versions dv ON dv.id=gd.current_version_id
+WHERE gd.doc_type='volunteer_term_template' AND gd.status='active';
+
+-- Ledger (fonte do fan-out) — 0 ANTES do backfill; 48 DEPOIS
+SELECT count(*) AS ledger_rows FROM member_document_signatures;
+
+-- Distribuição e alvo (ver §4 da spec para a CTE completa)
+-- Esperado 2026-07-07: 40 históricos (30 active = ALVO), 8+ na v9 (excluídos)
+```
+
+Valores de referência (2026-07-07, re-aterrar):
+| Fato | Valor |
+|---|---|
+| template ativo | v9 `246ff8be`, `change_class=material` |
+| ledger | 0 linhas (bloqueio) |
+| alvo Onda 2 (active + histórico) | **30** (todos com `organization_id`) |
+| já na v9 (Onda 1) | 8 e subindo (excluídos) |
+
+---
+
+## 2. Backfill do ledger (pré-requisito — ato do GP via migration)
+
+**Antes:** confirmar D1 (versão âncora, legal) e D2 (escopo 48 vs 30) da spec §1.
+
+- [ ] Aplicar `supabase/migrations/<ts>_onda2_backfill_member_doc_signatures.sql` (SQL na spec §2)
+      via `apply_migration`. É DML idempotente.
+- [ ] Sync local + `supabase migration repair --status applied <ts>` (`feedback-apply-migration-creates-tracking-row`).
+- [ ] Verificar: ledger espelha os certs, 1 corrente por membro, v9-signers apontam v9, históricos a âncora (spec §2).
+
+---
+
+## 3. Pré-flight da cascata
+
+- [ ] **Onda 1 assentada.** E-mail C4 entregue, adesões v9 em curso estáveis. Não disparar Onda 2 no
+      mesmo dia do go-live C4.
+- [ ] **Gate OUTWARD #334 (DPO/ANPD).** SPEC_571 §208: o fan-out real (aviso-30d aos voluntários) só
+      dispara com PM-OK **e** #334. Sem isto, PARAR.
+- [ ] **change_class = material.** Confirmado na §1. Se fosse editorial, o caminho seria
+      `notify_editorial_change_awareness` (ciência tácita, sem obrigação) — NÃO é o caso.
+- [ ] **D3 (liderança).** Confirmar que GP/co-GP entram no re-aceite (assinaram versão antiga como voluntários).
+
+---
+
+## 4. Dry-run do fan-out (read-only — ato do GP autenticado)
+
+`open_reacceptance_obligations` exige `auth.uid()` + `manage_platform` (não roda por service role).
+O GP autenticado chama com `p_dry_run=>true`:
+
+```sql
+SELECT public.open_reacceptance_obligations(
+  '280c2c56-e0e3-4b10-be68-6c731d1b4520'::uuid,   -- doc
+  '246ff8be-9ed8-4a81-9211-bf097750c4c7'::uuid,   -- v9
+  true);                                          -- DRY-RUN
+```
+- [ ] `target_count` = **30** (ou o número re-aterrado). Se vier 0 → o backfill não foi aplicado. Se
+      vier 40 → D2 ficou em (a) sem filtro active; decidir antes do run real.
+- [ ] Conferir os nomes em `targets` contra o preview.
+
+---
+
+## 5. Fan-out real (ato do GP — dispara a cascata)
+
+**Só após #334 + dry-run conferido.** Idempotente (índice parcial impede dupla obrigação).
+
+```sql
+SELECT public.open_reacceptance_obligations(
+  '280c2c56-e0e3-4b10-be68-6c731d1b4520'::uuid,
+  '246ff8be-9ed8-4a81-9211-bf097750c4c7'::uuid,
+  false);   -- REAL: cria obrigações + aviso-30d in-app; e-mail via jobid 9
+```
+- [ ] `created` = alvo esperado. `admin_audit_log` action `reacceptance.obligations_opened`.
+- [ ] Prazos no retorno: `effective_from` (+30d), `window_closes_at` (+15 úteis GO), `suspended_until` (+30d).
+
+---
+
+## 6. Ciclo e monitoramento (cron dirige; humanos respondem)
+
+- **Membro** vê o banner/countdown via `get_my_reacceptance_obligations`; re-aceita via
+  `express_reacceptance(obligation)` (permitido `in_window`, `suspended` tardio, `accommodation`).
+- **Objeção fundamentada (15.4.3):** `register_reacceptance_objection` congela a cascata; Comitê
+  responde em 10 úteis via `respond_reacceptance_objection` (accepted→recircula / rejected→retoma /
+  accommodation→5 úteis). Acolhida ⇒ recircular o instrumento e `link_reacceptance_recirculation`.
+- **Recusa expressa (15.3(e)):** `refuse_reacceptance` → desligamento imediato, licenças preservadas.
+- **Lapso:** cron diário move `notified→in_window→suspended→lapsed_disengaged`; `_reacceptance_disengage`
+  desliga (status `inactive`, engagements fechados) **preservando** `member_document_signatures` (15.4.5).
+- [ ] Monitorar `member_reacceptance_obligations` por estado. Bounces do e-mail via `email_webhook_events`.
+
+---
+
+## 7. Rollback / abortar
+
+- **Antes do fan-out real:** nada a desfazer além do backfill (que é verdade do ledger — manter).
+- **Após o fan-out, antes de qualquer desligamento:** as obrigações `notified`/`in_window` podem ser
+  neutralizadas marcando `state='superseded'` (ato administrativo com `manage_platform` + nota no
+  audit log). NÃO deletar linhas (audit-trail).
+- Desligamentos por recusa/lapso **preservam licenças** — não são reversíveis por este runbook (o
+  membro retorna via re-engajamento normal, `member_status` é reversível).
+
+---
+
+## 8. Cross-ref
+- Spec: `docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md`
+- Máquina: `docs/specs/SPEC_571_CAMADA5_MATERIAL_CHANGE.md` (§5 PR-4, §9.5, §208 gate OUTWARD)
+- Onda 1: `docs/runbooks/GO-LIVE-onda1-volunteer-term.md`
+- Drift das 2 representações: memory `reference-volunteer-term-signing-representation-drift`

--- a/docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md
+++ b/docs/specs/SPEC_ONDA2_LEDGER_BACKFILL_AND_REACCEPTANCE.md
@@ -1,0 +1,188 @@
+# SPEC — Onda 2 (re-aceite dos ativos): backfill do ledger + fan-out da máquina #976
+
+**Status:** DRAFT / planejamento (2026-07-07). Nada aplicado ao banco.
+**Escopo:** habilitar a Onda 2 (re-aceite do Termo v9 pelos voluntários ativos que assinaram
+versões antigas), resolvendo o bloqueador do ledger vazio antes de qualquer fan-out.
+**Deps:** Onda 1 ATIVADA (v9 `246ff8be` = `status='active'`, `change_class='material'`).
+Máquina de estados #976 (PR-4 de #571, migration `20260805000304`) já vive DORMENTE.
+**Runbook operacional:** `docs/runbooks/GO-LIVE-onda2-reacceptance.md`.
+**Feridas legais:** Termo 15.3 (cascata de re-aceite) · 15.4.5 (licenças preservadas) · SPEC_571 §208 (OUTWARD-gate #334).
+
+---
+
+## 0. O bloqueador (aterrado ao vivo, projeto `ldrfrvwhxsmgaabwmaik`, 2026-07-07)
+
+A máquina `open_reacceptance_obligations(doc, to_version)` faz fan-out sobre
+`member_document_signatures` (`is_current=true`). **Essa tabela tem 0 linhas.** As assinaturas
+reais do Termo vivem em `certificates` (`type='volunteer_agreement'`), porque
+`sign_volunteer_agreement` escreve lá, nunca no ledger (drift das 2 representações —
+`reference-volunteer-term-signing-representation-drift`).
+
+**Consequência:** rodar `open_reacceptance_obligations('280c2c56…', '246ff8be…')` hoje →
+fan-out **VAZIO**. A Onda 2 depende de **popular o ledger primeiro**.
+
+Números aterrados (re-aterrar antes de executar — Onda 1 está viva, os `has_v9` sobem):
+
+| Fato | Valor | Query |
+|---|---|---|
+| `member_document_signatures` | **0 linhas** | `SELECT count(*) FROM member_document_signatures` |
+| certs `volunteer_agreement` | 48 membros distintos (0 fora de `members`) | ver §4 |
+| históricos (pré-v9, sem `body_version_id`) | **40** (30 active, 10 inativos) | ver §4 |
+| já na v9 (Onda 1) | **8 e subindo** → excluídos | ver §4 |
+| conjuntos | disjuntos (40+8=48; nenhum membro tem antigo E v9) | ver §4 |
+| **alvo do re-aceite (active + histórico + org≠null)** | **30** | ver §4 |
+| versão âncora candidata (última pré-v9) | v2.7 `29a2d175` (lacrada 2026-05-12) | `document_versions` |
+
+Constraints do ledger (confirmados ao vivo):
+- `uq_member_doc_sigs_current` UNIQUE `(member_id, document_id) WHERE is_current` → 1 corrente por (membro,doc)
+- `member_document_signatures_member_id_signed_version_id_key` UNIQUE `(member_id, signed_version_id)`
+- trigger `trg_member_doc_sig_supersede_previous` AFTER INSERT WHEN `is_current=true` → auto-supersede
+- `signed_version_id` é **NOT NULL** → históricos EXIGEM uma versão âncora (não podem ser NULL)
+
+---
+
+## 1. Decisões ABERTAS (confirmar antes de aplicar — impacto legal)
+
+### D1 — Versão âncora dos 40 históricos
+Os históricos assinaram **18/02→14/04**, mas a versão nº1 sob 280c2c56 só foi lacrada em
+**18/04**. Eles assinaram o **clauseN JSON pré-versionamento** (sem pin; `content_snapshot`
+só tem a chave `clauses`). Não existe `document_version` que corresponda ao que assinaram.
+Como `signed_version_id` é NOT NULL, é preciso ESCOLHER uma âncora. A escolha só afeta o
+`from_version_id` do audit-trail (todos os não-v9 disparam obrigação igual).
+
+- **Recomendado:** v2.7 `29a2d175` (última pré-v9) → delta de auditoria "v2.7 → v9" = o delta
+  jurídico real que a rodada Aaron/Angeline produziu.
+- Alternativa: v1 `0f61a8db` (mais antiga) — "assinou a linhagem mais antiga".
+- Verdade documentada: assinaram texto pré-versionamento; a âncora é uma convenção de auditoria.
+- **Confirmar com legal_counsel.**
+
+### D2 — Escopo do backfill: 48 (verdade) vs 30 (active)
+`open_reacceptance_obligations` **NÃO filtra `members.is_active`** (SPEC_571 §302, por design —
+para não perder ninguém). Se o backfill incluir os 40 históricos, o fan-out atinge **40** (inclui
+10 inativos), não 30. Opções:
+- **(a) backfill 48 (ledger = verdade) + fan-out Onda 2 restrito a active** (wrapper que filtra, ou
+  aceitar que os 10 inativos recebem obrigação no-op — já estão offboarded; `_reacceptance_disengage`
+  é idempotente em inativo). **Recomendado (a) com filtro explícito** para não mandar e-mail
+  "re-aceite ou desligamento" a alumni.
+- (b) backfill só os 30 active (ledger incompleto; se um alumnus voltar, sua assinatura não está registrada).
+- **Recomendado:** (a) — backfill dos 48 para verdade do ledger; a Onda 2 obriga só os 30 active.
+
+### D3 — Liderança na população
+Os 30 incluem **GP (Vitor)** e **co-GP/curador (Fabricio Costa)** — assinaram versão antiga como
+voluntários; ratificaram a v9 como curadores. Papéis distintos ⇒ re-aceitam como voluntários.
+Confirmar que não há exclusão de liderança desejada.
+
+### D4 — Wiring forward do `sign_volunteer_agreement` (§3) é PR separado
+Tocar a RPC do fluxo de assinatura VIVO (Onda 1 em curso) é delicado (#648 imutabilidade). NÃO
+empacotar com o backfill. PR dedicado, testado, depois que a Onda 1 assentar.
+
+---
+
+## 2. Backfill (DML idempotente) — NÃO aplicar até D1/D2 confirmados
+
+> Migration file: `supabase/migrations/<timestamp>_onda2_backfill_member_doc_signatures.sql`
+> (timestamp > head atual). DML puro (INSERT) — mesmo assim vai como migration + `migration repair`
+> per `feedback-apply-migration-creates-tracking-row`. Aplicar via `apply_migration`.
+
+```sql
+-- Onda 2 backfill: popular member_document_signatures a partir de certificates
+-- (volunteer_agreement) para a máquina de re-aceite #976 enxergar os signatários reais.
+-- Idempotente (guard NOT EXISTS). 1 linha corrente por membro (conjuntos disjuntos, ledger vazio).
+DO $$
+DECLARE
+  v_doc    uuid := '280c2c56-e0e3-4b10-be68-6c731d1b4520';  -- volunteer_term_template
+  v_v9     uuid := '246ff8be-9ed8-4a81-9211-bf097750c4c7';  -- versão material vigente
+  v_anchor uuid := '29a2d175-a9d7-4993-8147-3b476e4d896e';  -- D1: v2.7 (última pré-v9) — CONFIRMAR
+BEGIN
+  INSERT INTO public.member_document_signatures
+    (member_id, document_id, signed_version_id, certificate_id, signed_at, is_current)
+  SELECT DISTINCT ON (c.member_id)
+    c.member_id,
+    v_doc,
+    CASE WHEN (c.content_snapshot->>'body_version_id') = v_v9::text THEN v_v9 ELSE v_anchor END,
+    c.id,
+    COALESCE((c.content_snapshot->>'signed_at')::timestamptz, c.created_at, now()),
+    true
+  FROM public.certificates c
+  WHERE c.type = 'volunteer_agreement'
+    -- D2 (a): backfill dos 48 = comentar o filtro; para (b) só-active, descomentar:
+    -- AND EXISTS (SELECT 1 FROM public.members m WHERE m.id=c.member_id AND m.member_status='active')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.member_document_signatures x
+      WHERE x.member_id = c.member_id AND x.document_id = v_doc AND x.is_current)
+  ORDER BY c.member_id, (c.content_snapshot->>'signed_at') DESC NULLS LAST;
+END $$;
+```
+
+Pós-backfill (verificação):
+```sql
+-- ledger espelha os certs; v9-signers apontam v9, históricos apontam a âncora
+SELECT signed_version_id::text, count(*)
+FROM public.member_document_signatures WHERE document_id='280c2c56-e0e3-4b10-be68-6c731d1b4520'
+GROUP BY 1;
+-- 1 corrente por membro:
+SELECT count(*) FILTER (WHERE is_current) AS current_rows,
+       count(DISTINCT member_id) AS members FROM public.member_document_signatures;
+```
+
+---
+
+## 3. Wiring forward (D4 — PR separado, NÃO neste ciclo)
+
+Sem isto, todo re-aceite/adesão nova continua indo só p/ `certificates` e o ledger volta a
+divergir. Em `sign_volunteer_agreement` (após gravar o certificate), adicionar INSERT no ledger:
+
+```sql
+-- dentro de sign_volunteer_agreement, após o INSERT em certificates (v_cert_id):
+INSERT INTO public.member_document_signatures
+  (member_id, document_id, signed_version_id, certificate_id, signed_at, is_current)
+VALUES (v_member_id, v_doc_id, v_active_version_id, v_cert_id, now(), true)
+ON CONFLICT DO NOTHING;  -- trigger auto-supersede cuida da versão anterior
+```
+Exige aterrar `v_doc_id`/`v_active_version_id` dentro da RPC (hoje ela seleciona o template
+`active`). Cobrir com contract test: toda adesão nova cria 1 linha corrente no ledger.
+
+---
+
+## 4. Queries de aterramento (read-only — re-rodar antes de executar)
+
+```sql
+-- Distribuição + alvo (corrige a lógica ternária: body_version_id NULL ≠ false)
+WITH sig AS (
+  SELECT c.member_id,
+         COALESCE(bool_or((c.content_snapshot->>'body_version_id')
+                          = '246ff8be-9ed8-4a81-9211-bf097750c4c7'), false) AS has_v9
+  FROM public.certificates c WHERE c.type='volunteer_agreement' GROUP BY c.member_id)
+SELECT
+  count(*) AS distinct_cert_members,
+  count(*) FILTER (WHERE NOT s.has_v9) AS historical,
+  count(*) FILTER (WHERE NOT s.has_v9 AND m.member_status='active') AS hist_active_target,
+  count(*) FILTER (WHERE s.has_v9) AS v9_signers
+FROM sig s LEFT JOIN public.members m ON m.id=s.member_id;
+```
+
+Lista nominal (PII → não commitar; rodar ao vivo): ver o `WHERE NOT has_v9 AND active` do §4 com
+`m.name`. Preview de 2026-07-07 (30 membros) ficou no scratchpad da sessão, fora do repo.
+
+---
+
+## 5. Sequência da Onda 2 (resumo — detalhe no runbook)
+
+1. Confirmar D1–D4 (legal_counsel em D1/D3; PM em D2).
+2. Aplicar backfill (§2) via `apply_migration` + sync local + `migration repair`.
+3. **Gate OUTWARD #334 (DPO/ANPD)** — SPEC_571 §208. Sem isto, não disparar fan-out real.
+4. `open_reacceptance_obligations('280c2c56…','246ff8be…', p_dry_run=>true)` → conferir target = 30.
+5. Idem `p_dry_run=>false` (ato do GP, `manage_platform`, autenticado) → aviso-30d in-app + e-mail (jobid 9).
+6. Monitorar a cascata (30d vigência → 15 úteis janela → 30d suspensão → desligamento). UI:
+   `get_my_reacceptance_obligations`. Objeção/recusa: `register_reacceptance_objection`/`refuse_reacceptance`.
+7. **Timing:** só depois da Onda 1 / e-mail C4 assentarem. Não no mesmo dia do go-live.
+
+---
+
+## 6. Invariantes / o que NÃO fazer
+
+- NÃO rodar `open_reacceptance_obligations(p_dry_run=false)` antes do backfill (fan-out vazio) NEM
+  antes do gate #334.
+- NÃO deletar/mutar linhas de `certificates` (imutáveis #648) — o backfill só LÊ delas.
+- NÃO empacotar o wiring forward (§3, toca RPC viva) com o backfill.
+- Desligamento por lapso/recusa **preserva** `member_document_signatures` (15.4.5) — nunca deletar.

--- a/scripts/design-kit/build_t6_thumb_youtube.py
+++ b/scripts/design-kit/build_t6_thumb_youtube.py
@@ -1,0 +1,60 @@
+"""Miniatura do YouTube (1280x720) da gravação do 1o Webinar da Tribo 6, 04/08/2026.
+
+Por que não reaproveitar o banner 1440x810 do Airmeet: o texto dele é convite
+("4 de agosto · 19h às 20h30"), tempo futuro, e a miniatura do replay é lida depois
+do evento. Aqui a pílula diz gravação e data, e os dois palestrantes aparecem, que é
+o que ajuda o reconhecimento numa miniatura vista pequena.
+
+As fotos vêm do kit do webinar no Drive:
+  NUCLEO_FOTOS="<kit>/fotos-palestrantes" python build_t6_thumb_youtube.py
+"""
+from brand import *
+
+FER = img_uri(FOTOS / "fernando-900.png")
+CLE = img_uri(FOTOS / "clendson-900.png")
+
+TITULO = "Aplicações Práticas de IA"
+SUB = "IA na priorização, na análise de cenário e na segurança da informação"
+QUANDO = "Gravação · 4 de agosto de 2026"
+ASSIN = 'Realização <b>Núcleo IA &amp; GP</b> · Tribo ROI &amp; Portfólio'
+
+TIME = [(FER, "Fernando Carvalho"), (CLE, "Clendson Gonçalves, MSc.")]
+
+
+def thumb():
+    W, H = 1280, 720
+    retratos = "".join(
+        f'<div class="qi">{retrato(f, 132)}<div class="qn">{n}</div></div>'
+        for f, n in TIME
+    )
+    html = f"""<!doctype html><meta charset="utf-8"><style>{css_base(W,H)}
+.wrap {{ padding:44px 72px 104px; display:flex; align-items:center; gap:36px; }}
+.col {{ display:flex; flex-direction:column; justify-content:center; flex:1; }}
+.eyebrow {{ font-size:18px; }}
+h1 {{ font-size:74px; margin-top:16px; max-width:720px; }}
+.sub {{ margin-top:18px; font-size:24px; line-height:1.35; color:{TEXT}; max-width:660px; }}
+.quando {{ display:inline-flex; margin-top:26px; padding:14px 28px; font-size:21px; }}
+.time {{ display:flex; gap:14px; }}
+.qi {{ text-align:center; width:230px; }}
+.qn {{ font-weight:800; font-size:18px; color:{WHITE}; margin-top:6px; line-height:1.25; }}
+.rodape {{ padding:20px 72px 30px; font-size:18px; }}
+.orb-a {{ width:1000px; height:1000px; right:-380px; top:120px; }}
+/* sem dot ciano: no 1280x720 ele cai exatamente atrás da pílula (medido) */
+</style>
+<div class="orb orb-a"></div>
+<img class="faixa" src="{FAIXA}">
+<div class="wrap">
+  <div class="col">
+    <div class="eyebrow">1º Webinar · Tribo ROI &amp; Portfólio</div>
+    <h1>{TITULO}</h1>
+    <div class="sub">{SUB}</div>
+    <div><span class="pill quando">{QUANDO}</span></div>
+  </div>
+  <div class="time">{retratos}</div>
+</div>
+<div class="rodape"><div>{ASSIN}</div><div>youtube.com/@nucleo_ia</div></div>"""
+    return render("t6-youtube-thumb-1280x720", html, W, H)
+
+
+if __name__ == "__main__":
+    print("ok", thumb())


### PR DESCRIPTION
Parte 1 de 3 da varredura das PRs encalhadas. Registro de recuperação e classificação completa em **#1738**.

Supersedes #1659, #1605, #1166, #765, #154 — todas serão fechadas apontando para cá quando isto mergear.

## Por que existe

As 9 PRs abertas do repo foram investigadas uma a uma. **8 carregam conteúdo que não está na `main`** — a suposição de que PR encalhada é peso morto não se sustentou. Quatro delas (#863, #765, #289, #154) são órfãs da reescrita de histórico: compartilham o merge-base `c90c73d6` (02/05) e os 400-955 commits "à frente" são história herdada, não trabalho delas. O payload real é 1 commit em cada.

`push --force-with-lease` é bloqueado no shell do agente, então a reconstrução canônica no branch original é ato humano. Este é o caminho executável: branch novo a partir da `main`, payload por cherry-pick, um commit por origem.

## O que entra

| commit | origem | conteúdo |
|---|---|---|
| `167574df` | #1659 | handoff do #1640 + arranque do #1642 |
| `a6857a3a` | #1605 | pós-evento do webinar T6 + script da miniatura |
| `9346192f` | #1166 | runbook + spec da Onda 2 — **issue #1165 segue ABERTA** |
| `abb218ad` | #765 | relatório de re-verificação do time CODE (17/06) |
| `c34736ec` | #154 | seção de harness engineering no `AGENTS.md` |

## O que NÃO entra, e por quê

**#863** (`docs/curator-followup-2026-05-09.md`) ficou de fora. É uma **tabela de status de assinatura nominal, pessoa por pessoa**, e este repo é público. O guard de PII passa — ele não sinaliza nomes — mas a decisão é do PM, não do agente. O tip SHA está no #1738; nada se perde.

⚠️ A reescrita de 04/07 foi a sanitização (`chore(#862): canonize sanitized tree post history`), e estes branches são **anteriores** a ela. Recuperar conteúdo pré-sanitização exige varredura, não confiança no guard.

## Uma alteração editorial deliberada

O texto do #154 afirmava "64 MCP tools (51R + 13W)", número de 05/2026. Hoje a contagem é **derivada em runtime** por `countRegisteredTools`. Recuperar verbatim plantaria um fato morto num doc que agentes leem como autoridade, então a frase aponta para a fonte derivada e marca o número antigo como obsoleto.

## Verificação

- guard de PII versionada: **passa** (7 testes)
- varredura manual dos 9 arquivos: zero e-mail de pessoa, zero telefone, zero CPF, zero UUID de membro
- os nomes remanescentes (Fabricio Costa, Fernando Carvalho, Clendson Gonçalves) **já estão na `main`** hoje, em 62, 11 e 8 arquivos, em contexto de papel de governança ou de palestrante de evento público
