### PR TITLE
fix(credly): recupera o fix do 504 do sync-credly-all (#1738)

### DIFF
--- a/supabase/functions/sync-credly-all/index.ts
+++ b/supabase/functions/sync-credly-all/index.ts
@@ -36,12 +36,34 @@ function extractUsername(url: string): string | null {
 }
 
 async function fetchBadges(username: string): Promise<CredlyBadge[]> {
+  // Per-fetch timeout so a single slow/hanging Credly response cannot stall the
+  // whole batch (root cause of the 504 gateway timeout on the full sync).
   const resp = await fetch(`https://www.credly.com/users/${username}/badges.json`, {
     headers: { 'Accept': 'application/json', 'User-Agent': 'NucleoIA-GP/1.0' },
+    signal: AbortSignal.timeout(15000),
   })
   if (!resp.ok) throw new Error(`Credly ${resp.status}: ${username}`)
   const data = await resp.json()
   return data.data || data || []
+}
+
+// Bounded-concurrency worker pool. The batch sync is network-bound (one external
+// Credly fetch per member); running every member serially exceeds the gateway
+// wall-clock limit (504). A small pool keeps total time to ~fetch_time × ceil(N/limit)
+// while staying gentle enough not to trip Credly rate limits.
+async function runPool<T, R>(items: T[], limit: number, worker: (item: T) => Promise<R>): Promise<R[]> {
+  const results: R[] = new Array(items.length)
+  let next = 0
+  async function runner() {
+    while (true) {
+      const i = next++
+      if (i >= items.length) return
+      results[i] = await worker(items[i])
+    }
+  }
+  const runners = Array.from({ length: Math.min(limit, items.length) }, () => runner())
+  await Promise.all(runners)
+  return results
 }
 
 // classifyBadge imported from _shared/classify-badge.ts (GC-083)
@@ -348,23 +370,20 @@ Deno.serve(async (req) => {
       )
     }
 
+    const CONCURRENCY = 6
+    const details = await runPool(members, CONCURRENCY, async (member) => {
+      try {
+        return await processMember(sb, member)
+      } catch (err: any) {
+        return { member_id: member.id, success: false, error: err?.message || 'Unknown error' }
+      }
+    })
+
     let successCount = 0
     let failCount = 0
-    const details: { member_id: string; success: boolean; error?: string; total_points?: number }[] = []
-
-    for (const member of members) {
-      try {
-        const result = await processMember(sb, member)
-        if (result.success) {
-          successCount++
-        } else {
-          failCount++
-        }
-        details.push(result)
-      } catch (err: any) {
-        failCount++
-        details.push({ member_id: member.id, success: false, error: err?.message || 'Unknown error' })
-      }
+    for (const r of details) {
+      if (r.success) successCount++
+      else failCount++
     }
 
     return new Response(


### PR DESCRIPTION
> ⚠️ **CORREÇÃO (12/08, ver comentário abaixo):** o "68 membros" e o "504 em produção" desta
> descrição estão **errados**. O denominador ignorava o `is_active = true` que a própria função
> aplica (o conjunto real é **61**), e **não há 504 acontecendo**: 60 dos 61 foram verificados
> em 11/08. O fix é defesa preventiva, não conserto de produção quebrada.

Parte 2 de 3 da varredura das PRs encalhadas. Registro em **#1738**.

Supersedes #1066 — será fechada apontando para cá quando isto mergear.

## O que é

Recupera o payload da PR #1066, encalhada desde 02/07 e orfanada pela reescrita de histórico. A PR original mostra 75 commits e 212 arquivos, mas isso é história herdada: **o trabalho real é 1 commit, 1 arquivo**.

Verificado em 12/08: `supabase/functions/sync-credly-all/index.ts` **existe** na `main` e o fix **não** — zero ocorrências de `CONCURRENCY|AbortSignal|timeout`. Cherry-pick colou limpo sobre a `main` atual.

## O fix

- **`AbortSignal.timeout(15000)` por fetch** — uma resposta pendurada da Credly deixa de consumir o orçamento do lote inteiro.
- **Pool de concorrência limitada (6)** — o trabalho é limitado por rede, uma chamada externa por membro. Em série o relógio estoura o gateway.

## O problema PIOROU enquanto a PR esperava

O comentário original dizia "all 44 members", medição de 07/2026. Medido agora via `execute_sql`:

```sql
SELECT count(*) FROM members WHERE credly_url IS NOT NULL AND credly_url <> '';
-- 68
```

**68 membros, 55% a mais que os 44 de julho.** O 504 ficou mais provável, não menos. Tirei o número do comentário em vez de atualizá-lo, porque ele envelhece de novo.

## Verificação

- cherry-pick sem conflito sobre a `main` em `130cfeda`
- o `deno` check do CI valida o parse da Edge Function (que é o que o deploy pega — tipo o esbuild apaga)

⚠️ Isto **não** deploya a EF. O deploy é passo próprio (`supabase functions deploy sync-credly-all`) e continua sendo ato de quem mergear.

