### PR TITLE
fix(test): #1656 o guard de escala vivia na fronteira e falhava por epsilon

### DIFF
--- a/tests/contracts/1656-escala-unica-presenca.test.mjs
+++ b/tests/contracts/1656-escala-unica-presenca.test.mjs
@@ -194,7 +194,18 @@ test('#1656 C: no vivo, *_pct fica em 0-100 e a primitiva *_rate em 0-1', { skip
       const r = Number(data.avg_rate); const p = Number(data.avg_pct);
       assert.ok(r >= 0 && r <= 1, `${rpc}.avg_rate deve ser fracao 0-1, veio ${r}`);
       assert.ok(p >= 0 && p <= 100, `${rpc}.avg_pct deve ser 0-100, veio ${p}`);
-      assert.ok(Math.abs(p - r * 100) <= 0.05, `${rpc}: avg_pct (${p}) nao e avg_rate*100 (${r * 100})`);
+      // `avg_pct` e `avg_rate` na escala de exibicao, arredondado a 1 casa — entao o delta maximo
+      // legitimo e EXATAMENTE 0.05, e um `<= 0.05` cru vive na fronteira: `0.7415 * 100` da
+      // 74.15000000000001 em ponto flutuante, o delta sai 0.050000000000011 e o guard estoura sem
+      // que nada esteja errado. Medido em 14/08/2026 com avg_rate=0.7415 / avg_pct=74.1: o teste
+      // passava por SORTE e so falhava quando a media caia num `.x5` (a asserção irmã de
+      // attendance_pct, logo abaixo, ja usava 0.5 e nunca esbarrou nisso).
+      // NAO fixar um modo de arredondamento aqui: `Math.round` sobe no `.5` e o numeric do Postgres
+      // desceu (74.15 → 74.1), entao comparar contra um valor "esperado" trocaria este defeito por
+      // outro. O invariante e "cabe em uma casa decimal", nos DOIS sentidos — a tolerancia e 0.05
+      // mais folga de ponto flutuante.
+      assert.ok(Math.abs(p - r * 100) <= 0.05 + 1e-9,
+        `${rpc}: avg_pct (${p}) nao e avg_rate*100 (${r * 100}) dentro de uma casa decimal`);
     }
   }
 


### PR DESCRIPTION
## O que aconteceu

O `validate` ficou vermelho numa PR **só de documentação** (#1781). Um único teste falhou:

```
get_attendance_engagement_summary: avg_pct (74.1) nao e avg_rate*100 (74.15)
```

## Não era a plataforma

Medido ao vivo:

| RPC | `avg_rate` | `avg_pct` | delta |
|---|---:|---:|---:|
| `get_attendance_engagement_summary` | 0,7415 | 74,1 | **0,0500** |
| `get_attendance_reliability_summary` | 0,9730 | 97,3 | 0,0000 |

`avg_pct` **é** `avg_rate` na escala de exibição. Como o arredondamento é de 1 casa, o delta máximo
legítimo é **exatamente 0,05** — e a asserção usava `<= 0.05` cru. Em ponto flutuante, `0.7415 * 100`
vale `74.15000000000001`, o delta sai `0.050000000000011`, e o guard estoura sem nada estar errado.

**Ele passava por sorte:** só falha quando a média cai num `.x5`. A asserção irmã de
`attendance_pct`, dez linhas abaixo, já usava `0.5` e por isso nunca esbarrou nisso.

O gatilho foi a normalização de 24 engajamentos feita hoje (#1777), que moveu a média para a
fronteira. Conferido que ela **não** alterou a coorte do selo: a projeção de 24/08 segue em 80
faltas, porque os 24 já estavam na coorte por outra linha de engajamento.

## A correção

Epsilon (`0.05 + 1e-9`), não afrouxamento — o guard continua pegando a inversão 1% ↔ 100% que
motivou o #1656.

⚠️ **Uma tentativa intermediária ficou registrada no comentário do teste porque erra de forma
instrutiva:** comparar contra um valor arredondado (`Math.round(r * 1000) / 10`) **falha também** —
`Math.round` sobe no `.5` (74,2) e o `numeric` do Postgres desceu (74,1). Fixar um modo de
arredondamento trocaria este defeito por outro. O invariante honesto é "cabe em uma casa decimal",
nos dois sentidos.

## Verificação

`1656-escala-unica-presenca.test.mjs` com `.env` exportado: **8/8**, incluindo os DB-aware.

Refs #1656