### PR TITLE
feat(mcp): #1780 os papeis do card ganham porta no semantico, e a Fase 1 entrega o mapa

### DIFF
--- a/docs/audit/EPIC_1780_FASE1_MAPA_BOARD_CARD.md
+++ b/docs/audit/EPIC_1780_FASE1_MAPA_BOARD_CARD.md
@@ -1,0 +1,118 @@
+# EPIC #1780, Fase 1 — o mapa medido do domínio board / card / tarefa
+
+> Auditoria, não correção. Medido em **15/08/2026** por consulta viva; os números se movem, e a
+> regra da casa vale aqui: re-medir antes de usar qualquer um deles numa decisão.
+>
+> O detalhe do achado de segurança **não** está neste arquivo (repositório é público). Ele foi
+> corrigido antes de ser descrito, e o relato está na issue #1784.
+
+O EPIC nasceu de uma queixa de campo — "sou autor e contribuidor do card e não consigo inserir
+atividade" — que revelou **três defeitos de causas independentes** na mesma tarde. A Fase 1 pedia
+medir antes de propor. As cinco varreduras abaixo foram executadas; o corte da Fase 2 é decisão do
+PM, tomada com este mapa na mão.
+
+---
+
+## 1 · Sobrecargas
+
+Varridas todas as `proname` duplicadas em `public`. Fora das funções do `citext` (extensão), existem
+quatro: `create_notification` (3 assinaturas), `get_board_activities` (2),
+`get_offboarded_member_emails` (2) e `set_site_config` (2). Procedimentos e agregados: **zero**.
+
+**No domínio board/card há exatamente uma sobrecarga**, e é a que o #1779 já registra. A pergunta do
+EPIC ("quantas mais existem") tem resposta: nenhuma.
+
+## 2 · Portas agregada × varejo
+
+Para cada entidade-filha do card, a leitura existe em SQL? E está exposta no semântico?
+
+| entidade | agregada (por board) | varejo (por card) | exposta no MCP |
+|---|---|---|---|
+| checklist / tarefa | existe (`get_board_activities` 4-arg) | `get_card_detail` | **só o varejo** (é o #1779) |
+| comentário | **não existe** | `list_card_comments` | só o varejo |
+| anexo / arquivo | **não existe** | `list_card_drive_files` | só o varejo |
+| papel no card | `get_board` | `get_item_assignments` | leitura em `card_get.assignments`; escrita: ver §5 |
+| tag | `get_board_tags` | dentro do card detail | agregada |
+| drive do board | `get_board_drive_links` | `list_card_drive_files` | as duas |
+| log de ciclo de vida | `get_board_activities` 2-arg | `get_card_timeline` | as duas |
+
+Duas formas distintas de "porta quebrada", e elas pedem correções diferentes: a que **existe e não é
+exposta** (tarefa) e a que **não existe em lugar nenhum** (agregada de comentário e de anexo).
+
+## 3 · Gates sem recurso
+
+**Escrita.** Três policies do domínio decidem só por capacidade e nunca olham o recurso, não uma:
+`board_item_checklists`, `board_item_assignments` e `board_item_tag_assignments` (as três com
+`rls_is_superadmin() OR rls_can('write') OR rls_can('write_board')`).
+
+O achado que mudou o escopo do #1778: **a regra de autoria que a issue pedia já existia**, e no lugar
+certo. `add/update/delete_checklist_item` já autorizavam `write_board` **ou** responsável do card
+**ou** `board_members` admin/editor. São `SECURITY DEFINER` de dono `postgres` sobre tabela do mesmo
+dono com `force_rls=false`, logo contornam a RLS. **A UI não as chamava:** `CardDetail.tsx` fazia
+`INSERT` e `DELETE` diretos na tabela — o **único** acesso direto do domínio inteiro — enquanto
+`complete` e `assign` já passavam pelas RPCs.
+
+Duas consequências que a issue não registrava: o `INSERT` falhava em silêncio e o `DELETE` sumia com
+a linha da tela mesmo quando o banco recusava.
+
+**População.** 64 pessoas carregam trabalho atribuído; 15 estão sem `write_board`. Contar barrados
+por essa capacidade dá 3 — mas a policy tem **três ramos**, e 2 das 3 passavam por
+`rls_is_superadmin()`. **Barrado de verdade: 1 pessoa.** `board_members`, a terceira noção de
+autoridade do domínio, tem **2 linhas na plataforma inteira**.
+
+**Leitura.** A mesma varredura, no sentido inverso, encontrou tabelas-filhas do card sem o gate de
+visibilidade confidencial (ADR-0105). Corrigido e descrito na #1784.
+
+## 4 · Divergência UI × MCP
+
+A mesma ação, "adicionar atividade ao card", tinha **quatro** definições de autoridade:
+
+1. o gate de tela (`useBoardPermissions.ts`: tabela `ROLE_TIER` + `canFor`), que decide se o botão aparece;
+2. a policy RLS, só capacidade, que decidia a escrita direta;
+3. a RPC, capacidade **ou** recurso;
+4. o MCP, que exigia `canV4('write_board')` **antes** de chamar a RPC — ou seja, **mais estrito que a
+   RPC que ele mesmo chama**.
+
+Vocabulário: "Atividades" é *checklist item* na UI e *log de lifecycle* no `board_overview` — três
+nomes para dois conceitos, que é o #1779.
+
+## 5 · Cobertura
+
+**13 verbos** que a UI usa no domínio não têm porta em superfície MCP nenhuma (nem semântico, nem
+raw, nem `/actions`):
+
+- **ciclo de curadoria (8):** `submit_for_curation`, `advance_board_item_curation`,
+  `complete_peer_review`, `complete_leader_review`, `curate_item`,
+  `list_curation_pending_board_items`, `publish_board_item_from_curation`,
+  `get_item_curation_history`
+- **papéis no card (3):** `assign_member_to_item`, `unassign_member_from_item`, `get_item_assignments`
+- **outros (2):** `get_board_item_drive_access`, `admin_manage_board_member`
+
+Conferido por duas fontes independentes: os 418 nomes de tool registrados no EF e as 323 RPCs
+efetivamente despachadas por ele.
+
+Os **papéis no card** eram justamente o vocabulário da queixa que abriu o EPIC ("sou autor e
+contribuidor"), e a entidade que a RLS ignorava. A leitura já existia em `card_get.assignments`; a
+escrita entrou em `card_write` (`assign_role` / `unassign_role`).
+
+---
+
+## O que a Fase 2 fez com o mapa
+
+| corte | resultado |
+|---|---|
+| #1784 — gate confidencial nas tabelas-filhas | fechado, com guard derivado por FK em vez de lista |
+| #1778 — autoria vira predicado único, UI re-roteada | fechado, com o caminho exercido por impersonação |
+| #1780 — papéis do card no semântico | `card_write assign_role` / `unassign_role` |
+
+## O que segue aberto
+
+- **#1779** — a porta agregada de tarefas e o desfazer da colisão de nome (`get_board_activities`
+  significando log numa assinatura e tarefas na outra).
+- **Agregada de comentário e de anexo** — não existem nem em SQL.
+- **Escrita** de `board_item_assignments` e `board_item_tag_assignments`, que decide por capacidade
+  organizacional sem olhar o recurso: mesma classe do #1778, outras tabelas.
+- **Curadoria no semântico** — 8 verbos, decisão de escopo do PM.
+- **#1777** — o fluxo que gravou o papel divergente (o dado já foi normalizado).
+- **Quatro definições de autoridade** para a mesma ação: duas foram reconciliadas (RPC e MCP), o gate
+  de tela e a policy seguem como estão.

--- a/docs/reference/SEMANTIC_TOOL_CATALOG.md
+++ b/docs/reference/SEMANTIC_TOOL_CATALOG.md
@@ -71,13 +71,14 @@ The contract is guarded statically by `tests/contracts/semantic-envelope-w1.test
 - **Intent:** the card checklist writer — the platform's #1 write path (345 calls/180d).
 - **`action`:** `add` (card_id + text) · `update` (checklist_item_id) · `complete` (checklist_item_id; `completed` default true) · `assign` (checklist_item_id + assigned_to) · `delete` (checklist_item_id).
 - **Absorbs:** `add_checklist_item`, `update_checklist_item`, `complete_checklist_item`, `assign_checklist_item`, `delete_checklist_item`.
-- **Gate:** `write_board` + #785 (`rls_can_see_item`). `complete` is RPC-self-gated to the activity owner (no `write_board` required).
+- **Gate (#1778):** `can_manage_card_checklist` + #785 (`rls_can_see_item`, agora DENTRO do predicado) — `write_board` **ou** ser responsável/autor/contribuidor do card, board admin/editor, ou comms no board de comunicação. `complete` é RPC-self-gated ao dono da atividade.
 
 ### `card_write` (W)
 - **Intent:** create/mutate/move/lifecycle a single card (297 calls/180d).
-- **`action`:** `create` (board_id + title) · `update` · `move` · `move_to_board` · `archive`* · `restore` · `delete`* · `duplicate` · `mirror` · `forecast`. (*destructive → `confirm=true`.)
-- **Absorbs:** `create_board_card`, `update_card_fields`, `update_card_status`, `move_card`, `move_card_to_board`, `archive_card`, `restore_card`, `delete_card`, `duplicate_card`, `create_mirror_card`, `update_card_forecast`.
-- **Gate:** `write_board`, **board-scoped** via #785 on the target card (`create` gates the target board). Closes the Wave-0 resourceless-write concern for delete/duplicate/mirror.
+- **`action`:** `create` (board_id + title) · `update` · `move` · `move_to_board` · `archive`* · `restore` · `delete`* · `duplicate` · `mirror` · `forecast` · `assign_role` / `unassign_role` (card_id + member_id + `assignment_role`). (*destructive → `confirm=true`.)
+- **Absorbs:** `create_board_card`, `update_card_fields`, `update_card_status`, `move_card`, `move_card_to_board`, `archive_card`, `restore_card`, `delete_card`, `duplicate_card`, `create_mirror_card`, `update_card_forecast`, `assign_member_to_item`, `unassign_member_from_item`.
+- **Gate:** `write_board`, **board-scoped** via #785 on a target card (`create` gates the target board). Closes the Wave-0 resourceless-write concern for delete/duplicate/mirror.
+- **#1780:** `assign_role`/`unassign_role` NÃO passam pelo `write_board` do resto da tool — a autoridade é a da própria RPC (`participate_in_governance_review` / líder de tribo / board admin / `curate_content` para `curation_reviewer` / autoatribuição como `author`). Um `write_board` aqui seria mais estrito que a RPC chamada, o defeito que o #1778 corrigiu no `card_checklist`. A LEITURA dos papéis já existia em `card_get` (`assignments`).
 
 ### `card_comment` (W)
 - **Intent:** comment on a card (create/edit/soft-delete), with @mentions.

--- a/src/lib/mcp-manifest.json
+++ b/src/lib/mcp-manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-08-15T13:48:45.166Z",
+  "generated_at": "2026-08-15T14:25:24.807Z",
   "source": "supabase/functions/nucleo-mcp/index.ts",
   "total": 396,
   "by_domain": {
@@ -1145,7 +1145,7 @@
     },
     {
       "name": "card_write",
-      "description": "Semantic card writer (absorbs create/update/move/move_to_board/archive/restore/delete/duplicate/mirror/forecast — 297 calls/180d). Set `action`: 'create' (board_id + title), 'update' (card_id + any of title/description/assignee_id/reviewer_id/due_date/tags/forecast_date/is_portfolio_item), 'move' (card_id + status; optional position/reason), 'move_to_board' (card_id + target_board_id), 'archive' (card_id; DESTRUCTIVE→confirm), 'restore' (card_id; optional restore_status), 'delete' (card_id + reason; DESTRUCTIVE→confirm), 'duplicate' (card_id; optional target_board_id), 'mirror' (card_id + target_board_id), 'forecast' (card_id + forecast_date + justification). Authority: write_board, BOARD-SCOPED via the #785 gate on the target card/board (fixes the Wave-0 resourceless-write findings for delete/duplicate/mirror). archive+delete return a preview unless confirm=true (ADR-0018). Stable envelope.",
+      "description": "Semantic card writer (absorbs create/update/move/move_to_board/archive/restore/delete/duplicate/mirror/forecast — 297 calls/180d). Set `action`: 'create' (board_id + title), 'update' (card_id + any of title/description/assignee_id/reviewer_id/due_date/tags/forecast_date/is_portfolio_item), 'move' (card_id + status; optional position/reason), 'move_to_board' (card_id + target_board_id), 'archive' (card_id; DESTRUCTIVE→confirm), 'restore' (card_id; optional restore_status), 'delete' (card_id + reason; DESTRUCTIVE→confirm), 'duplicate' (card_id; optional target_board_id), 'mirror' (card_id + target_board_id), 'forecast' (card_id + forecast_date + justification), 'assign_role' / 'unassign_role' (card_id + member_id + assignment_role author|reviewer|contributor|curation_reviewer — quem e autor/revisor/contribuidor DAQUELE card; le-se em card_get.assignments). Authority: write_board, BOARD-SCOPED via the #785 gate on the target card/board (fixes the Wave-0 resourceless-write findings for delete/duplicate/mirror). archive+delete return a preview unless confirm=true (ADR-0018). Stable envelope.",
       "domain": "board",
       "permission": "read",
       "is_sensitive": false

--- a/supabase/functions/nucleo-mcp/index.ts
+++ b/supabase/functions/nucleo-mcp/index.ts
@@ -8842,9 +8842,9 @@ function registerSemanticTools(mcp: McpServer, sb: Sb) {
   // ── W1 · card_write (W) — 297 calls/180d; 10 actions over one card ──────────
   mcp.tool(
     "card_write",
-    "Semantic card writer (absorbs create/update/move/move_to_board/archive/restore/delete/duplicate/mirror/forecast — 297 calls/180d). Set `action`: 'create' (board_id + title), 'update' (card_id + any of title/description/assignee_id/reviewer_id/due_date/tags/forecast_date/is_portfolio_item), 'move' (card_id + status; optional position/reason), 'move_to_board' (card_id + target_board_id), 'archive' (card_id; DESTRUCTIVE→confirm), 'restore' (card_id; optional restore_status), 'delete' (card_id + reason; DESTRUCTIVE→confirm), 'duplicate' (card_id; optional target_board_id), 'mirror' (card_id + target_board_id), 'forecast' (card_id + forecast_date + justification). Authority: write_board, BOARD-SCOPED via the #785 gate on the target card/board (fixes the Wave-0 resourceless-write findings for delete/duplicate/mirror). archive+delete return a preview unless confirm=true (ADR-0018). Stable envelope.",
+    "Semantic card writer (absorbs create/update/move/move_to_board/archive/restore/delete/duplicate/mirror/forecast — 297 calls/180d). Set `action`: 'create' (board_id + title), 'update' (card_id + any of title/description/assignee_id/reviewer_id/due_date/tags/forecast_date/is_portfolio_item), 'move' (card_id + status; optional position/reason), 'move_to_board' (card_id + target_board_id), 'archive' (card_id; DESTRUCTIVE→confirm), 'restore' (card_id; optional restore_status), 'delete' (card_id + reason; DESTRUCTIVE→confirm), 'duplicate' (card_id; optional target_board_id), 'mirror' (card_id + target_board_id), 'forecast' (card_id + forecast_date + justification), 'assign_role' / 'unassign_role' (card_id + member_id + assignment_role author|reviewer|contributor|curation_reviewer — quem e autor/revisor/contribuidor DAQUELE card; le-se em card_get.assignments). Authority: write_board, BOARD-SCOPED via the #785 gate on the target card/board (fixes the Wave-0 resourceless-write findings for delete/duplicate/mirror). archive+delete return a preview unless confirm=true (ADR-0018). Stable envelope.",
     {
-      action: z.enum(["create", "update", "move", "move_to_board", "archive", "restore", "delete", "duplicate", "mirror", "forecast"]).describe("Card operation."),
+      action: z.enum(["create", "update", "move", "move_to_board", "archive", "restore", "delete", "duplicate", "mirror", "forecast", "assign_role", "unassign_role"]).describe("Card operation."),
       card_id: z.string().optional().describe("Card UUID — required for every action EXCEPT 'create'."),
       board_id: z.string().optional().describe("Board UUID — required for action='create'."),
       target_board_id: z.string().optional().describe("Destination board UUID — move_to_board (required), duplicate/mirror (optional/required)."),
@@ -8860,6 +8860,8 @@ function registerSemanticTools(mcp: McpServer, sb: Sb) {
       forecast_date: z.string().optional().describe("action='forecast' new forecast date (YYYY-MM-DD); also settable via update."),
       justification: z.string().optional().describe("action='forecast' — required justification."),
       is_portfolio_item: z.boolean().optional().describe("update — mark portfolio deliverable (Leader/GP)."),
+      member_id: z.string().optional().describe("assign_role/unassign_role — member UUID whose role on the card changes."),
+      assignment_role: z.enum(["author", "reviewer", "contributor", "curation_reviewer"]).optional().describe("assign_role/unassign_role — the role on THIS card (#1780: quem e autor/revisor/contribuidor; ate agora so existia na UI)."),
       priority: z.string().optional().describe("create — low|medium|high|urgent (stored as a tag)."),
       notes: z.string().optional().describe("mirror — optional notes on the copy."),
       reason: z.string().optional().describe("delete (required) / move / archive / restore — audit reason."),
@@ -8882,7 +8884,12 @@ function registerSemanticTools(mcp: McpServer, sb: Sb) {
         gateKind = "item"; resourceId = params.card_id;
       }
       if (!(await canSee(sb, gateKind, resourceId))) { await logUsage(sb, member.id, "card_write", false, "Confidential/no access", start); return ok(buildSemanticError({ tool: "card_write", semantic_domain: dom, code: "unauthorized", message: `You cannot see this ${gateKind} (confidential initiative or no access).`, action: "This resource belongs to a confidential initiative you are not engaged in." })); }
-      if (!(await canV4(sb, member.id, "write_board"))) { await logUsage(sb, member.id, "card_write", false, "Unauthorized", start); return ok(buildSemanticError({ tool: "card_write", semantic_domain: dom, code: "unauthorized", message: "Requires write_board.", action: "Ask a tribe leader / GP." })); }
+      // #1780: assign_role/unassign_role passam pela autoridade da PROPRIA RPC
+      // (participate_in_governance_review / lider de tribo / board admin / curate_content para
+      // curation_reviewer / autoatribuicao como 'author'). Um canV4('write_board') aqui seria mais
+      // ESTRITO que a RPC chamada — o mesmo defeito que o #1778 corrigiu no card_checklist.
+      const ROLE_ACTIONS = new Set(["assign_role", "unassign_role"]);
+      if (!ROLE_ACTIONS.has(params.action) && !(await canV4(sb, member.id, "write_board"))) { await logUsage(sb, member.id, "card_write", false, "Unauthorized", start); return ok(buildSemanticError({ tool: "card_write", semantic_domain: dom, code: "unauthorized", message: "Requires write_board.", action: "Ask a tribe leader / GP." })); }
 
       // Per-action input validation
       if (params.action === "create" && (!params.title || !params.title.trim())) return invalid("action='create' requires title.", "Pass title.");
@@ -8892,6 +8899,7 @@ function registerSemanticTools(mcp: McpServer, sb: Sb) {
       if (params.action === "duplicate" && params.target_board_id && !isUUID(params.target_board_id)) return invalid("target_board_id must be a UUID.", "Fix target_board_id.");
       if (params.action === "delete" && (!params.reason || !params.reason.trim())) return invalid("action='delete' requires reason (audit).", "Pass reason.");
       if (params.action === "forecast" && (!params.forecast_date || !params.justification || !params.justification.trim())) return invalid("action='forecast' requires forecast_date + justification.", "Pass forecast_date and justification.");
+      if (ROLE_ACTIONS.has(params.action) && (!isUUID(params.member_id ?? "") || !params.assignment_role)) return invalid(`action='${params.action}' requires member_id (UUID) + assignment_role (author|reviewer|contributor|curation_reviewer).`, "Pass member_id and assignment_role.");
 
       // ADR-0018 confirm-gate for destructive verbs (archive/delete) — return a preview unless confirm=true.
       if ((params.action === "archive" || params.action === "delete") && params.confirm !== true) {
@@ -8935,6 +8943,8 @@ function registerSemanticTools(mcp: McpServer, sb: Sb) {
         case "duplicate": rpc = "duplicate_board_item"; rpcArgs = { p_item_id: params.card_id, p_target_board_id: params.target_board_id || null }; break;
         case "mirror": rpc = "create_mirror_card"; rpcArgs = { p_source_item_id: params.card_id, p_target_board_id: params.target_board_id, p_target_status: params.restore_status || "backlog", p_notes: params.notes || null }; break;
         case "forecast": rpc = "update_card_forecast"; rpcArgs = { p_board_item_id: params.card_id, p_new_forecast: params.forecast_date, p_justification: params.justification }; break;
+        case "assign_role": rpc = "assign_member_to_item"; rpcArgs = { p_item_id: params.card_id, p_member_id: params.member_id, p_role: params.assignment_role }; break;
+        case "unassign_role": rpc = "unassign_member_from_item"; rpcArgs = { p_item_id: params.card_id, p_member_id: params.member_id, p_role: params.assignment_role }; break;
         default: return invalid(`Unknown action '${params.action}'.`);
       }
       const { data, error } = await sb.rpc(rpc!, rpcArgs!);
@@ -12624,7 +12634,7 @@ app.get("/health", (c) => c.json({
   // #1598 — bumpado de propósito: no arco anterior o ef_version ficou igual no vivo e no fonte, e
   // o /health não serviu de testemunha do deploy (a prova teve de ser grep de sentinela no corpo
   // baixado). Bumpar aqui torna o deploy verificável por UMA chamada.
-  ef_version: "2.99.0",
+  ef_version: "2.100.0",
   surfaces: {
     "/mcp": { server: "nucleo-ia-hub", version: "2.80.0", tools: MCP_TOOL_COUNT },
     "/semantic": { server: "nucleo-ia-semantic", version: SEMANTIC_SURFACE_VERSION, tools: SEMANTIC_TOOL_COUNT },

--- a/tests/contracts/mcp-lgpd-retroactive-operator-tools.test.mjs
+++ b/tests/contracts/mcp-lgpd-retroactive-operator-tools.test.mjs
@@ -218,8 +218,11 @@ test('#1418: nucleo-ia-hub MCP server bumped to 2.80.0 (was 2.79.0 pre-#1418 raw
 // #1778 (15/08/2026): 2.98.0 -> 2.99.0. O fail-fast do card_checklist passou a ler
 // can_manage_card_checklist em vez de canV4('write_board'): o MCP era mais ESTRITO que a RPC que
 // ele mesmo chama, e recusava o autor do card que o SQL aceitava.
-test('ef_version is 2.99.0 (#1778 card_checklist le o predicado; 2.98.0 no #1586; 2.97.0 na onda D do #1590)', () => {
-  assert.match(EF, /ef_version:\s*"2\.99\.0"/, '/health must report ef_version 2.99.0');
+// #1780 (15/08/2026): 2.99.0 -> 2.100.0. card_write ganhou assign_role/unassign_role. A auditoria
+// da Fase 1 achou 13 verbos do dominio sem porta MCP nenhuma, e os papeis do card (autor,
+// revisor, contribuidor) eram justamente o vocabulario da queixa que abriu o EPIC.
+test('ef_version is 2.100.0 (#1780 papeis do card; 2.99.0 no #1778; 2.98.0 no #1586)', () => {
+  assert.match(EF, /ef_version:\s*"2\.100\.0"/, '/health must report ef_version 2.100.0');
 });
 
 test('#1392: /health /mcp surface derives its tool count + keeps version 2.80.0', () => {


### PR DESCRIPTION
Fecha a **Fase 1** do EPIC #1780 (auditoria) e entrega o terceiro corte decidido pelo PM.

## A Fase 1, em uma tabela

| varredura | resultado |
|---|---|
| **sobrecargas** | 4 em `public` fora do citext; **exatamente 1 no dominio**, a do #1779. A pergunta do EPIC tem resposta: nao ha outras. |
| **portas agregada x varejo** | duas formas distintas de porta quebrada: a que **existe e nao e exposta** (tarefa, #1779) e a que **nao existe** (agregada de comentario e de anexo) |
| **gates sem recurso** | **3** policies de escrita, nao 1. E a regra de autoria que o #1778 pedia **ja existia na RPC** — a UI e que nao a chamava |
| **divergencia UI x MCP** | **4** definicoes de autoridade para "adicionar atividade": tela, RLS, RPC e MCP; o MCP era mais estrito que a RPC que ele chama |
| **cobertura** | **13** verbos da UI sem porta em superficie MCP nenhuma |

Mapa completo em `docs/audit/EPIC_1780_FASE1_MAPA_BOARD_CARD.md`, sem o detalhe do achado de seguranca (repo e publico; esse esta na #1784, ja corrigida e fechada).

## O que entra de codigo

`card_write` ganha `assign_role` e `unassign_role` (card_id + member_id + `assignment_role`). Dos 13 verbos sem porta, os papeis no card sao os que o proprio EPIC nomeia: "autor e contribuidor" e o vocabulario da queixa de campo e a entidade que a RLS do #1778 ignorava.

A **leitura** ja existia e foi conferida, nao suposta: `get_card_detail` devolve `assignments` (member_id, member_name, role, assigned_at) e `card_get` a expoe. Faltava so a escrita.

**As duas acoes nao passam pelo `canV4('write_board')` do resto da tool.** A autoridade e a da propria RPC: `participate_in_governance_review` / lider de tribo / board admin / `curate_content` para `curation_reviewer` / autoatribuicao como `author`. Um `write_board` ali seria mais **estrito** que a RPC chamada — exatamente o defeito que o #1778 corrigiu no `card_checklist` e que a varredura 4 registrou como classe.

Dobrado dentro de `card_write` em vez de tool nova, porque o conector cacheia `tools/list`.

## Verificacao

- suite offline: 6375 testes, **0 fail**
- manifesto `/docs/mcp` regenerado (o guard de drift pega isso)
- `ef_version` **2.100.0**, deployada e conferida no `/health` vivo
- catalogo do operador atualizado nas duas entradas afetadas (`card_write` e `card_checklist`)