### PR TITLE
fix(security): #1783 lote 2 — nanoid e js-yaml sobem para a versao com patch

### DIFF
--- a/cloudflare-workers/pmi-vep-sync/package-lock.json
+++ b/cloudflare-workers/pmi-vep-sync/package-lock.json
@@ -2851,9 +2851,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10909,9 +10909,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## O que é

Lote 2 do #1783: os **dois transitivos da onda que têm patch publicado**, um em cada lockfile do repo.

| pacote | de → para | lockfile | escopo |
|---|---|---|---|
| `nanoid` | 3.3.17 → **3.3.18** | `package-lock.json` | runtime (2 pais: `@turbodocx/html-to-docx`, `postcss` via `eslint-plugin-astro`) |
| `js-yaml` | 4.3.0 → **4.3.1** | `cloudflare-workers/pmi-vep-sync/package-lock.json` | dev |

Ambos os pais declaram faixa compatível (`^3` e `^4`), então o patch coube **sem tocar em nenhum `package.json`**. O diff é literalmente 3 linhas por lockfile (`version` / `resolved` / `integrity`).

Fecha **2 dos 5 high** da onda.

## Por que PR local, e não a PR do Dependabot

Política **#611** (Option A, ratificada 2026-06-10), não re-litigar: o GitHub não injeta repo secrets em runs disparados pelo Dependabot, então o sentinel do `validate` falha em **todo** PR dele. Mergear pularia os contract tests DB-aware. Cada onda vira PR local, onde o CI roda completo.

## Gates

- `npx astro build` — verde
- suíte completa com `.env` — **6846 testes, 0 falhas, 1 skip**
- os **dois** lockfiles tratados (o segundo é fácil de esquecer)

## O que este PR NÃO faz

- **Lote 1** (`astro` 6→7, fecha 3 alertas): major, PR própria.
- **Lote 3** (`extract-zip`, `image-size`): sem patch publicado. A avaliação está feita e o veredito vai na issue; a análise de alcançabilidade fica fora do repo (público), pela fronteira que o próprio #1783 definiu.

Refs #1783