### PR TITLE
docs(planning): handoff do #1572/#1801 e arranque da próxima

### DIFF
--- a/docs/planning/2026-08-15_handoff_1797_mergeada_e_1572_com_o_ciclo_certo.md
+++ b/docs/planning/2026-08-15_handoff_1797_mergeada_e_1572_com_o_ciclo_certo.md
@@ -1,0 +1,142 @@
+# Handoff — 15/08/2026 (madrugada): a #1797 mergeou, o #1572 fechou, e o contador nasceu apontando para o ciclo errado
+
+> Sessão anterior: `docs/planning/2026-08-15_handoff_1783_onda_fechada_em_dois_lotes_e_1797_em_espera.md`
+> Arranque da próxima: `docs/planning/2026-08-16_PROMPT_ARRANQUE_1801_E_1710_VESPERA.md`
+
+---
+
+## Estado ao fechar
+
+`main` em **`961fc229`**. **Zero PRs abertas.** **Zero alertas Dependabot.** **Zero bypass na janela
+de 7 dias** (todos os commits PR-backed; o `a61879f2` de 08/08 saiu da janela).
+
+**4 merges na sessão, zero bypass:** #1798 (docs) · #1797 (astro 7) · #1799 (#1572) · #1802 (#1801).
+
+Worker deployado em produção, versão **`20339768`**, com smoke conferido: o texto novo aparece no
+HTML servido por `nucleoia.vitormr.dev/admin/selection`.
+
+| issue | desfecho |
+|---|---|
+| **#1783** | **FECHADA** — a #1797 mergeou e os 3 alertas do astro zeraram (8 → 0 na onda inteira) |
+| **#1572** | **FECHADA** — aceite antecipado virou estado explícito com justificativa |
+| **#1801** | **ABERTA de propósito** — 1 de 10 funções corrigida; a triagem das outras 9 é o trabalho |
+| **#1592** | números re-ancorados: **468 de 1105** SECDEF alcançáveis por chamador anônimo |
+
+---
+
+## ⚖️ Decisão do PM: mergear a #1797 agora, não esperar 24/08
+
+A recomendação registrada era segurar. O PM decidiu o contrário, aceitando trocar astro, adapter,
+integração react e bundler dentro da janela do selo do #1710. Mergeada com base re-sincronizada
+(a branch estava `BEHIND`; rebase, CI re-rodado, 11/11).
+
+⚠️ **Segue valendo, e não deve ser vendido diferente:** a #1797 **não** fecha a classe do
+`image-size`. A cópia vendorizada dentro do astro tem o mesmo laço ICNS sem guarda em 6.4.8, 7.1.0 e
+7.2.2.
+
+---
+
+## ⚖️ Decisão do PM: #1572 por justificativa, não por gate de N avaliações
+
+O ciclo se chama "Aceite Antecipado", então aprovar sem lastro é intencional por desenho. O defeito
+era a ausência de trilha.
+
+**Medido em 15/08, antes da mudança:**
+
+| ciclo | decididas com ZERO avaliação | com alguma trilha em log |
+|---|---|---|
+| `cycle2-2025` | 6 aprovadas + 2 rejeitadas | **0** |
+| `cycle3-2026` | 3 aprovadas + 3 rejeitadas | 5 de 6 |
+| `cycle4-2026` | 1 rejeitada | 1 |
+
+E `min_evaluators = 2` **declarado nos 4 ciclos**, sem nada que o consultasse no momento da decisão.
+
+**O que entrou:** `early_acceptance_at` / `_by` / `_reason` na candidatura (o carimbo **é** a flag,
+sem booleano espelho, com CHECK exigindo autor e motivo de 20+ caracteres) · portão em
+`admin_update_application` e `finalize_decisions`, contando avaliação de **qualquer tipo** ·
+`admin_decide_dual_track` repassando a justificativa para as duas pontas (assinatura 4 → 5, DROP +
+CREATE) · `decided_without_evaluation` em `get_selection_health` · painel na tela de seleção.
+
+**Dois defeitos pré-existentes que o portão tornaria alcançáveis, corrigidos junto:**
+
+1. `admin_decide_dual_track` guardava os retornos das duas pontas e **nunca os conferia**: uma ponta
+   com `{"error":...}` virava `success: true` e a tela dizia "Decisões aplicadas".
+2. `finalize_decisions` engolia falhas no `EXCEPTION WHEN OTHERS` e devolvia só um `approved` menor,
+   sem dizer quais ficaram de fora. Agora devolve `refused[]`.
+
+---
+
+## 🔴 O erro da sessão: o contador nasceu apontando para o ciclo errado
+
+Vale registrar inteiro, porque a lição não é sobre este contador.
+
+`get_selection_health` resolvia "ciclo ativo" por `ORDER BY created_at DESC LIMIT 1`. Mas
+`created_at` é a data em que a **linha** foi escrita: o backfill do `cycle2-2025` entrou em
+**2026-07-13** e fez de um ciclo **fechado de 2025** a linha mais nova da tabela.
+
+Consequência: o contador do #1572 contava o `cycle2-2025`, que tem 6 aprovadas sem avaliação e
+nenhuma justificada. O `health_signal` teria ficado **preso em amarelo** — exatamente o que o
+comentário que eu mesmo escrevi na migration dizia evitar.
+
+**É a causa 1 da #1586(b) reaparecendo.** Aquela correção já trazia a nota certa no corpo
+(*"por STATUS, nunca por `created_at`"*); o que faltou foi varrer a classe. A varredura de agora
+achou **10 funções** com a mesma resolução.
+
+Corrigido em `get_selection_health` (#1802) e a classe registrada na **#1801**.
+
+⚠️ **Nem todas as 10 são defeito.** `get_selection_cycles` LISTA ciclos e ordenar por `created_at`
+ali é legítimo. O critério de triagem é *"esta função escolhe UM ciclo para chamar de ativo?"*, não
+*"esta função cita `created_at`"*.
+
+**Efeito colateral bom da correção:** a recusa por conflito de interesse (ADR-0109) nessa superfície
+era avaliada contra o ciclo de 2025, então um candidato do ciclo **aberto** não era recusado. Agora é.
+
+---
+
+## Limites do que foi entregue, ditos de propósito
+
+1. **O portão cobre APROVAÇÃO.** Rejeição sem avaliação é contada e exposta, **não bloqueada**.
+   Estender é decisão do PM e mudaria o que o GP experimenta num ciclo aberto.
+2. **Duas RPCs de reconciliação seguem movendo status sem o portão**, por desenho, porque não
+   expressam decisão de mérito: `recompute_application_status` (`SET status = v_rec.canonical`) e
+   `reconcile_vep_terminal_status` (`SET status = v_target`, espelha o `vep_status_raw`).
+   **O portão não é universal.**
+
+---
+
+## Medições finais
+
+| medida | valor |
+|---|---|
+| aprovadas sem avaliação no ciclo **ativo** (`cycle4-2026`) | **0** |
+| rejeitadas sem avaliação no ciclo ativo | 1 |
+| aprovadas sem avaliação, todos os ciclos | 9 |
+| rejeitadas sem avaliação, todos os ciclos | 6 |
+| `open_cycles` | 1 |
+| suíte com DB | 6862 testes · 6861 pass · **0 falhas** · 1 skip · 616 s |
+| suíte offline | 6411 testes · 0 falhas · ~53 s |
+
+Com zero aprovadas sem lastro no ciclo aberto, o sinal não é puxado para amarelo por este critério.
+
+---
+
+## Como a DDL foi conferida (vale repetir)
+
+- **md5 normalizado de cada corpo vivo contra o arquivo da migration.** Foram 4 na primeira e 1 na
+  segunda, todos batendo. Fecha o risco de o payload digitado divergir do arquivo — que é real,
+  porque `apply_migration` recebe **string**, não caminho.
+- **Ensaio por impersonação em transação abortada**, exercitando o caminho inteiro em vez de só o
+  estático: sem motivo e com 19 caracteres recusam com `early_acceptance_reason_required`; com
+  motivo válido passa (`rejected → approved`, 7 passos de onboarding semeados), carimbo gravado com
+  autor resolvido e 1 linha de log com `early_acceptance=true`. Nada persistiu: 0 carimbos, 0 logs,
+  contagens intactas em 98/55.
+- ⚠️ **A primeira leitura de conferência veio vazia e eu quase li como falha de gravação.** Era a
+  RLS: eu lia a tabela **ainda como `authenticated`**. `RESET ROLE` antes da conferência.
+
+---
+
+## Aberto ao fechar
+
+**#1801** (9 funções por triar + guard ratchet) · **#1710** (re-medir em 23/08 pelos dois caminhos;
+lista nominal ao GP **fora** de issue e PR) · resto do **EPIC #1780** · **#1586** e o **funil de
+28/08**, que só fecham com uso real · **#1592** (barreira contra DDL nova).

--- a/docs/planning/2026-08-16_PROMPT_ARRANQUE_1801_E_1710_VESPERA.md
+++ b/docs/planning/2026-08-16_PROMPT_ARRANQUE_1801_E_1710_VESPERA.md
@@ -1,0 +1,204 @@
+# Prompt de arranque — a triagem do #1801, a véspera do #1710 e o resto do #1780
+
+> Colar depois do `/clear`.
+> **Modelo: Opus 5 (auto, não pinar). Effort: `xhigh`.**
+> Handoff anterior: `docs/planning/2026-08-15_handoff_1797_mergeada_e_1572_com_o_ciclo_certo.md`
+> Mapa da Fase 1 do EPIC: `docs/audit/EPIC_1780_FASE1_MAPA_BOARD_CARD.md`
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Todo número foi medido em **15/08/2026** e vários se
+movem sozinhos. Re-meça com tool call na mesma volta em que o número entrar numa decisão, num commit,
+numa issue ou numa pergunta ao PM.
+
+Regras de varredura que já custaram caro:
+
+- **Uma listagem não sustenta afirmação de ausência.** Custou de novo em 15/08: `gh api
+  dependabot/alerts` **sem `--paginate`** devolveu **0 abertos** quando havia **3**. A primeira
+  página não é a coleção.
+- **`gh pr checks` cresce durante a espera.** Foi de 10 → 11 → **12** linhas nesta sessão: o
+  `quality_gate` chega por último, e o `check-advisors` só aparece em PR que toca SQL. Espere os
+  pendentes; não conte linhas.
+- **Ausência de par só é conclusiva se o carimbo cobre a janela inteira.**
+- **Varra `pg_proc`, não o repositório** — e conte quantas funções têm o nome antes de confiar nele.
+- **Conte pelo predicado INTEIRO da policy, não pela capacidade que a issue nomeia.**
+- **Um guard verde fala de UM eixo.** Pergunte de que direção o verde está falando.
+- 🆕 **`created_at` não é a data do fato, é a data da LINHA.** Um backfill histórico torna o registro
+  antigo o mais novo da tabela. Qualquer `ORDER BY created_at DESC LIMIT 1` que signifique "o atual"
+  é suspeito até prova em contrário.
+- 🆕 **Leitura que volta vazia sob impersonação pode ser RLS, não ausência.** `RESET ROLE` antes de
+  conferir o efeito de uma escrita, senão o veredito mede o papel, não o dado.
+
+---
+
+## Estado (16/08, madrugada)
+
+`main` em **`961fc229`**. **Zero PRs abertas. Zero alertas Dependabot. Zero bypass na janela de 7
+dias.** Worker em produção na versão `20339768`.
+
+A sessão fechou **4 merges com zero bypass** e as issues **#1783** e **#1572**.
+
+⚠️ **Re-medir a janela de bypass** antes de qualquer `--admin`. Não recitar.
+
+---
+
+## 🔎 ITEM 1 — #1801, a triagem que sobrou
+
+Uma de 10 funções foi corrigida (`get_selection_health`). **Faltam 9**, e o trabalho é de leitura,
+não de sweep.
+
+`selection_cycles.created_at` é a data de **escrita da linha**. O backfill do `cycle2-2025` entrou em
+2026-07-13 e virou a linha mais nova; o ciclo aberto é o `cycle4-2026`.
+
+Candidatas medidas em 15/08 (ordenam por `created_at DESC` sem consultar `status`):
+`compute_ai_calibration_weekly` · `get_diversity_dashboard` · `get_evaluator_calibration_stats` ·
+`get_my_pending_evaluations` · `get_selection_cycles` · `get_selection_pipeline_metrics` ·
+`get_selection_rankings` · `recompute_all_active_pert_cutoffs` ·
+`_test_invariants_with_synthetic_breach`.
+
+⚠️ **O critério é "esta função escolhe UM ciclo para chamar de ativo?", não "esta função cita
+`created_at`".** `get_selection_cycles` **lista** ciclos e ordenar assim ali é legítimo. Ler o corpo
+antes de mudar.
+
+📌 **Referência de quem já faz certo:** `get_selection_dashboard`, `get_chapter_selection_summary`,
+`get_affiliation_verification_queue` (usam `status = 'open'`), e o corpo do
+`detect_stuck_selection_funnel`, que traz a nota da #1586(b).
+
+📌 **O entregável que evita a terceira rodada:** um contract test ratchet que reprove resolução de
+ciclo **ativo** por `created_at`, para a classe não voltar pela próxima função nova.
+
+---
+
+## ⏰ ITEM 2 — #1710, e o prazo é 24/08
+
+Config **conferida no banco em 15/08**, não recitada:
+
+```
+platform_settings['attendance.seal_window'] = {"floor_date": "2026-08-24", "grace_days": 14}
+cron attendance-seal-window-daily · 40 11 * * * · active = true
+```
+
+**Re-medir em 23/08 (a véspera), pelos dois caminhos independentes** — a consulta externa que
+reproduz coorte + carência, e o ensaio da própria função — e só então levar o número ao PM.
+⚠️ **É teto, e encolhe a cada presença registrada por um líder.**
+
+**Como ensaiar sem esperar:** bloco `DO` que faz `UPDATE` em `platform_settings` deslocando
+`grace_days` para dar o mesmo corte que 14 darão em 24/08, recuando também o `floor_date` (senão
+volta `skipped: before_floor`), e terminando em `RAISE EXCEPTION` com o resultado. A exceção aborta o
+bloco inteiro e o `UPDATE` volta sozinho. **Confira a config depois do ensaio.**
+
+⚖️ **DECIDIDO pelo PM (15/08), NÃO re-litigar:** as células que nenhum líder de tribo alcança ficam
+com o **GP, pela grade geral**. Nada muda no código.
+📌 **Ação da véspera:** levar ao GP a lista **nominal** dessas células — **na conversa, não em issue
+nem em PR** (repo público).
+
+✅ **Já fechado, não re-investigar:** zero faltas ficariam sem superfície · `unseal_event_attendance`
+**existe** · o selo grava **só `present=false`**, com `ON CONFLICT DO NOTHING`.
+
+---
+
+## ITEM 3 — o resto do EPIC #1780
+
+A Fase 1 mediu e quatro cortes saíram (#1778, #1784, #1791, #1779). Segue aberto:
+
+- **Agregada de comentário e de anexo não existe nem em SQL** — não é falta de porta MCP, é falta da
+  função. Decidir com o PM se entra.
+- **4 definições de autoridade para a mesma ação** — o #1778 unificou a do checklist num predicado
+  só; as outras seguem espalhadas.
+- **8 verbos de curadoria sem porta MCP nenhuma** — um ciclo inteiro de trabalho só alcançável pela
+  tela. **Escopo é do PM.**
+- **Linha de base do #1791:** 7 filhas seguem decidindo escrita só por capacidade, todas com **zero**
+  linhas confidenciais hoje. O contrato falha se aparecer uma nova.
+- **Linha de base do #1784:** 10 filhas de outros domínios seguem sem gate de leitura, idem.
+
+---
+
+## ITEM 4 — o que fecha com uso real, não com código
+
+- **#1586** fecha na primeira chamada real de `interview_manage action='rescue_unbooked'`, conferindo
+  na linha nova do audit `actor_id` **não nulo** e `dispatch_source='manual'`.
+  ⚠️ **Não despachar para testar.** Re-medir a idade dos despachos sem reserva antes de sugerir.
+- **Funil, prazo 28/08.** Falta `booked_at`. **Nenhum número de conversão pode ser publicado** até uma
+  linha carimbar reserva. **Não provocar despacho** — o cron gera linhas sozinho. Exigir
+  `instrumented = true` **e** `booking_token_md5` na linha nova.
+
+---
+
+## ITEM 5 — o que o #1572 deixou explicitamente de fora
+
+Não é dívida escondida, é escopo declarado. Reabrir só com decisão do PM:
+
+- **Rejeição sem avaliação não é bloqueada**, só contada e exposta. Estender o portão muda o que o GP
+  experimenta num ciclo aberto.
+- **Duas RPCs de reconciliação movem status sem o portão**, por desenho:
+  `recompute_application_status` e `reconcile_vep_terminal_status`. **O portão não é universal.**
+- **9 aprovadas e 6 rejeitadas sem avaliação seguem no histórico**, sem carimbo — as 8 mais antigas
+  do `cycle2-2025` sem trilha em log nenhum. Não há como justificá-las retroativamente sem inventar
+  autoria.
+
+---
+
+## Depois desses
+
+**#1777** (o fluxo que gravou o papel divergente; o dado já está normalizado), **#1776**, **#1664
+fase 2**, **#1762** (corrigir muda quem recebe candidato → precisa do PM), **#1729**, **#1742**,
+**#1744**, **#1728** (20 RPCs da mesma classe, sem detalhe na issue), **#1592** (barreira contra DDL
+nova; números re-ancorados em 15/08: **468 de 1105** SECDEF alcançáveis por chamador anônimo).
+**Onda E:** #1575, #1574, #1573, #1576, #1634, #1581, #1579.
+
+---
+
+## Armadilhas da vizinhança, com o preço que já custaram
+
+1. **`apply_migration` recebe o SQL como STRING.** Feche o risco comparando
+   `md5(regexp_replace(prosrc,'\s+',' ','g'))` do corpo vivo com o do arquivo. O parser canônico é
+   `tests/helpers/rpc-body-drift-parser.mjs` (`parseMigration` + `normalizeBody` + `md5`); o lado
+   vivo é `_audit_list_public_function_bodies()`. Bateu 5 de 5 em 15/08.
+2. **`apply_migration` cria a linha de tracking com timestamp PRÓPRIO.** Renomeie o arquivo local
+   para casar, ou o gate ADR-0097 fica vermelho. Com UMA chamada, não há fantasma a apagar.
+3. **DDL aplicada ANTES do merge deixa toda branch aberta vermelha.** Aplique com **zero PRs abertas**
+   e mergeie antes de aplicar a próxima. Foi o que permitiu duas migrations em sequência nesta sessão.
+4. **Mudança de schema exige `npm run db:types` na MESMA PR.**
+5. **`CREATE FUNCTION` concede EXECUTE a PUBLIC.** O `REVOKE ... FROM PUBLIC, anon` vai na MESMA
+   migration — inclusive quando a função é RECRIADA por mudança de assinatura, porque a nova nasce
+   aberta mesmo que a antiga estivesse fechada.
+6. **`SECURITY DEFINER` contorna a RLS.** O gate do #785 tem de estar **dentro** da função.
+7. **A versão da superfície semântica tem QUATRO pins em arquivos que não se conhecem.**
+8. **Teste novo entra nas DUAS whitelists do `package.json`** (`test` e `test:contracts`).
+9. **Suíte offline (~53 s) é o gate barato:**
+   `env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u PUBLIC_SUPABASE_URL npm run test:contracts`.
+   ⚠️ **Skip ≡ pass:** rode o arquivo novo **com** `.env` antes de acreditar no guard (`set -a;
+   source ./.env; set +a`) e confira que ele reporta **zero skips**. Confira `gh run list` antes: o
+   `validate` com DB não tolera execução concorrente (#1505).
+10. ⚠️ **`Fecha #N` em português NÃO fecha a issue.** Use `Closes #N`. E o espelho: **nunca escrever
+    `close #N` sem intenção de fechar, nem para CITAR o padrão.**
+11. ⚠️ **Branch nova nasce do HEAD, não da main.** `git checkout -b <nome> origin/main` explícito, e
+    confira com `git merge-base --is-ancestor origin/main HEAD`.
+12. ⚠️ **`supabase` CLI aqui não está linkado:** `--project-ref ldrfrvwhxsmgaabwmaik`.
+13. ⚠️ **O conector cacheia `tools/list`.** Ação nova dentro de tool existente evita o problema.
+14. ⚠️ **Repo é PÚBLICO.** Achado de segurança se **corrige primeiro e descreve depois**. Nome de
+    pessoa não entra em issue, PR nem doc — conte a população, não a pessoa.
+15. ⚠️ **RPC que resolve o chamador por `auth.uid()` devolve "Not authenticated" para
+    `service_role`.** Derive do catálogo (`_audit_function_source`) ou impersone em transação
+    abortada. **Ordem:** `set_config('request.jwt.claims', ...)` **antes** do `SET LOCAL ROLE`.
+16. ⚠️ **`pg_get_function_identity_arguments` devolve nome E tipo** (`p_board_id uuid, ...`).
+17. ⚠️ **NUNCA canalize a suíte por `| tail -N` rodando em background.** O pipe segura TODA a saída
+    até o fim. Redirecione para arquivo (`> log 2>&1`).
+18. ⚠️ **Para distinguir suíte LENTA de suíte TRAVADA, amostre os processos FILHOS** (`pgrep -P
+    <pid>`): o pai fica em `ep_poll` com 0% de CPU nos dois casos.
+19. ⚠️ **Um contract test que faz shell-out de lint pode TRAVAR em vez de falhar.** Rode os lints
+    **separadamente ANTES** da suíte (`npm run lint:client-scripts`, ~20 s).
+20. ⚠️ **O build para no primeiro erro e mente sobre o tamanho do estrago.** Rode o compilador sobre
+    `git ls-files '*.astro'` de uma vez em vez de iterar build-corrige-build.
+21. ⚠️ **Antes de propor "subir o pai" para um transitivo sem patch, leia a FAIXA que o pai declara**
+    (`npm view <pai>@<nova> dependencies`). Pin exato (sem `^`) não alcança a versão nova do filho.
+22. 🆕 ⚠️ **`pkill -f "<padrão>"` casa com a PRÓPRIA linha de comando do shell que o executa** e mata
+    a si mesmo. Monte o padrão quebrado em duas partes, ou filtre `$$`.
+23. 🆕 ⚠️ **Editar arquivos-fonte no meio de uma suíte em andamento invalida o resultado**, porque os
+    testes que leem do disco leem o estado novo. Mate e rode de novo contra a árvore final, em vez de
+    reportar um verde de entradas misturadas.
+24. 🆕 ⚠️ **A UI não deve reimplementar a regra da RPC.** A linha do dashboard de seleção só carrega
+    `peer_eval_count` (avaliação `objective`); o portão do #1572 conta **qualquer tipo**. Recalcular
+    no cliente esconderia o campo justamente na candidatura que o servidor vai recusar.


### PR DESCRIPTION
Handoff da sessão e prompt de arranque da próxima.

**Fechado:** #1783 (a #1797 mergeou por decisão do PM, 8 → 0 alertas) e #1572 (aceite antecipado com
justificativa obrigatória, deployado em produção).

**Aberto de propósito:** #1801, com 9 de 10 funções por triar. O contador do #1572 nasceu apontando
para o ciclo errado porque `get_selection_health` resolvia "ciclo ativo" por `created_at`, e o
backfill do `cycle2-2025` fez de um ciclo fechado a linha mais nova da tabela. É a causa 1 da
#1586(b) reaparecendo em outra função.

O arranque ganha quatro armadilhas pagas nesta sessão: `gh api` sem `--paginate` devolveu 0 alertas
quando havia 3 · `pkill -f` casa com a própria linha de comando e mata o shell que o executa ·
editar fonte no meio de uma suíte invalida os testes que leem do disco · a UI não deve reimplementar
a regra da RPC quando só tem um campo mais estreito que o predicado do servidor.

Assisted-By: Claude (Anthropic) <noreply@anthropic.com>