### PR TITLE
docs(planning): o fecho da reunião geral de 13/08 e o skill de métrica de champions

### DIFF
--- a/.claude/skills/champion-metrics/SKILL.md
+++ b/.claude/skills/champion-metrics/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: champion-metrics
+description: Selects champions for a recorded meeting from measured participation instead of recall or call order. Parses the timestamped transcript, applies an eliminatory gate plus a three-axis score, and reports whether the winning set survives a change of weights. Use whenever champions are about to be awarded for a Reunião Geral or any recorded session, before calling champion_award.
+---
+
+# Champion selection from measured participation
+
+## Why this exists
+
+Champions were once awarded in the order the assistant happened to call the tool.
+Measured afterwards, that order handed a slot to the candidate ranked **last of five**
+on every axis and locked out the one ranked first, because the platform caps awards
+per event. Recall is not a ranking. Measure first, award second.
+
+## Platform constraints (verify, do not recite)
+
+The caps live in the body of `award_champion`. Re-read them before using this skill,
+because a migration can move them:
+
+```sql
+SELECT prosrc FROM pg_proc WHERE proname = 'award_champion';
+```
+
+At the time this skill was written the RPC enforced a per-event cap by surface
+(`general` / `tribe` / `deliverable`) plus a separate per-grantor cap per event, both
+labelled anti-inflation. Two consequences:
+
+- **A cap of N means the selection is a ranking problem, not a list problem.** Anyone
+  beyond N is excluded, so who is in the last slot has to be defensible.
+- `champions_awarded` has **no comments column**. The columns are `criteria_met`,
+  `justification`, `points_awarded`, `status` and the revocation fields. The metric
+  annotation therefore goes inside `justification`, as a bracketed block.
+
+Suggestion is not award: `events.suggested_champion_ids` has **no cap**, so everyone who
+presented can be confirmed there even when only N can be awarded.
+
+## The gate
+
+**Eliminatory: the candidate occupied an agenda slot with their own deliverable.**
+Someone who only debated does not qualify, however much they spoke. This keeps the
+recognition attached to work delivered, consistent with merit immutability.
+
+## The three axes
+
+All measured from the transcript, normalized 0-100 against the highest in the candidate
+group, then weighted:
+
+| axis | what it measures | default weight |
+|---|---|---|
+| **A** words spoken inside their own block | substance of the delivery | 40% |
+| **B** distinct other people who spoke during their block | whether it moved the room | 35% |
+| **C** words spoken outside their own block | help given to other tribes | 25% |
+
+## What is deliberately NOT an axis
+
+**Span (minutes between first and last utterance).** Whoever presents last in the agenda
+has a structurally short span, so the axis would measure **agenda position**, not
+contribution. Including it silently penalizes the closing presenter. If you add an axis,
+ask first whether it measures the person or the schedule.
+
+## Robustness is part of the output
+
+A ranking that only holds at one weighting is an artifact of the weighting. The script
+re-scores across every weight combination and reports how many produce the same top-N
+**set**. Report that number alongside the ranking. If the set is unstable, say so and
+bring the tie to the PM rather than resolving it silently.
+
+## Procedure
+
+1. Locate the timestamped transcript. For Google Meet it is the `Notes by Gemini` doc in
+   the recording folder. Native Google docs read as **0 bytes through the rclone mount**;
+   pull them with `rclone cat`.
+2. Run `scripts/metrica_participacao.py <transcript.md>` to produce per-speaker counts.
+   It parses `**Name:** text` turns under `### **HH:MM:SS**` headers.
+3. Define the agenda-block windows from the agenda announced in the meeting (usually
+   posted in the chat log), not from your reading of who seemed important.
+4. Run `scripts/score_champions.py` for the ranking plus the robustness sweep.
+5. Award the top-N via `champion_award`, appending the bracketed metric block to each
+   `justification`. Put **everyone who passed the gate** into `suggested_champion_ids`.
+6. If a previous award has to be undone, use `champion_award action='revoke'` with the
+   metric in the reason. Revocation works only inside the grantor window.
+
+## Reporting rule
+
+Name the axes and the weights whenever the ranking is shown. A score with no visible
+formula is indistinguishable from an opinion, which is the failure this skill exists to
+prevent.

--- a/.claude/skills/champion-metrics/scripts/metrica_participacao.py
+++ b/.claude/skills/champion-metrics/scripts/metrica_participacao.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Per-speaker participation metrics from a timestamped meeting transcript.
+
+Every number comes from the transcript text. Nothing is estimated.
+
+Usage:
+  metrica_participacao.py <transcript.md> <blocks.json> [--out metrics.json]
+
+blocks.json maps each presenter to the [start, end) of THEIR agenda slot, as
+announced in the meeting (usually in the chat log), e.g.:
+
+  {"Some Presenter": ["00:02:54", "00:25:36"],
+   "Other Presenter": ["01:01:43", "01:26:29"]}
+
+The transcript is expected in Google "Notes by Gemini" shape: blocks headed by
+`### **HH:MM:SS**` and turns written as `**Speaker:** text`.
+"""
+import argparse, json, re, sys
+from collections import defaultdict
+
+
+def secs(t):
+    h, m, s = (int(x) for x in t.split(':'))
+    return h * 3600 + m * 60 + s
+
+
+def parse_turns(text):
+    """-> [(block_seconds, speaker, utterance)]"""
+    marker = '# **📖 Transcrição**'
+    if marker in text:  # drop the summary section, keep the transcript
+        text = text.split(marker, 1)[1]
+    turns, cur = [], None
+    for line in text.splitlines():
+        h = re.match(r'^### \*\*(\d{2}:\d{2}:\d{2})\*\*', line)
+        if h:
+            cur = h.group(1)
+            continue
+        t = re.match(r'^\*\*(.+?):\*\* (.*)$', line)
+        if t and cur:
+            turns.append((secs(cur), t.group(1).strip(), t.group(2).strip()))
+    return turns
+
+
+def compute(turns, blocks):
+    stats = defaultdict(lambda: {'turnos': 0, 'palavras': 0, 'blocos': set(),
+                                 'primeiro': None, 'ultimo': None})
+    for t, n, x in turns:
+        s = stats[n]
+        s['turnos'] += 1
+        s['palavras'] += len(x.split())
+        s['blocos'].add(t)
+        s['primeiro'] = t if s['primeiro'] is None else min(s['primeiro'], t)
+        s['ultimo'] = max(s['ultimo'] or 0, t)
+
+    rows = []
+    for n, s in stats.items():
+        jan = blocks.get(n)
+        inside = (lambda t: jan and jan[0] <= t < jan[1])
+        fora = [(t, x) for t, nn, x in turns if nn == n and not inside(t)]
+        rows.append({
+            'nome': n,
+            'palavras': s['palavras'],
+            'turnos': s['turnos'],
+            'blocos': len(s['blocos']),
+            'span_min': round((s['ultimo'] - s['primeiro']) / 60, 1),
+            'bloco_pauta': bool(jan),
+            # distinct OTHER people who spoke during this presenter's slot
+            'debate_no_bloco': len({nn for t, nn, _ in turns
+                                    if inside(t) and nn != n}) if jan else 0,
+            'turnos_fora_do_bloco': len(fora),
+            'palavras_fora_do_bloco': sum(len(x.split()) for _, x in fora),
+        })
+    rows.sort(key=lambda r: -r['palavras'])
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('transcript')
+    ap.add_argument('blocks', help='JSON: {"Presenter": ["HH:MM:SS","HH:MM:SS"]}')
+    ap.add_argument('--out', default='metrics.json')
+    a = ap.parse_args()
+
+    turns = parse_turns(open(a.transcript, encoding='utf-8').read())
+    if not turns:
+        sys.exit('ABORT: no turns parsed. Check the transcript shape '
+                 '(### **HH:MM:SS** headers and **Speaker:** turns).')
+    blocks = {k: (secs(v[0]), secs(v[1]))
+              for k, v in json.load(open(a.blocks, encoding='utf-8')).items()}
+
+    unknown = [k for k in blocks if k not in {n for _, n, _ in turns}]
+    if unknown:
+        sys.exit(f'ABORT: presenter(s) in blocks.json never speak in the '
+                 f'transcript, so a name variant is wrong: {unknown}')
+
+    rows = compute(turns, blocks)
+    hdr = f"{'speaker':32}{'words':>8}{'turns':>7}{'blocks':>7}{'span':>7}{'slot':>6}{'debate':>8}{'outside':>8}"
+    print(hdr)
+    for r in rows:
+        print(f"{r['nome'][:32]:32}{r['palavras']:8}{r['turnos']:7}{r['blocos']:7}"
+              f"{r['span_min']:7}{('yes' if r['bloco_pauta'] else '-'):>6}"
+              f"{r['debate_no_bloco']:8}{r['turnos_fora_do_bloco']:8}")
+    print(f"\nspeakers: {len(rows)} | turns: {len(turns)} | "
+          f"words: {sum(r['palavras'] for r in rows)}")
+    json.dump(rows, open(a.out, 'w', encoding='utf-8'), ensure_ascii=False, indent=1)
+    print(f'wrote {a.out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/.claude/skills/champion-metrics/scripts/score_champions.py
+++ b/.claude/skills/champion-metrics/scripts/score_champions.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Rank champion candidates from measured participation, and test the ranking
+against a change of weights.
+
+Usage:
+  score_champions.py metrics.json [--top 3] [--weights 0.40,0.35,0.25]
+
+GATE (eliminatory): the candidate occupied an agenda slot with their own
+deliverable (`bloco_pauta` true). Debating alone does not qualify.
+
+AXES, each normalized 0-100 against the highest in the candidate group:
+  A  words spoken inside their own block      substance of the delivery
+  B  distinct other people who spoke in it     whether it moved the room
+  C  words spoken outside their own block      help given to other tribes
+
+SPAN IS NOT AN AXIS. Whoever presents last has a structurally short span, so it
+would measure agenda position rather than contribution.
+
+The robustness sweep re-scores over every weight combination on a coarse grid and
+reports how many yield the same top-N SET. A set that only holds at one weighting
+is an artifact of that weighting; report the number, and escalate an unstable set
+to the PM instead of resolving it silently.
+"""
+import argparse, itertools, json
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('metrics', help='metrics.json from metrica_participacao.py')
+    ap.add_argument('--top', type=int, default=3, help='per-event cap for the surface')
+    ap.add_argument('--weights', default='0.40,0.35,0.25', help='wA,wB,wC')
+    a = ap.parse_args()
+
+    w = tuple(float(x) for x in a.weights.split(','))
+    if abs(sum(w) - 1.0) > 1e-9:
+        raise SystemExit(f'ABORT: weights must sum to 1.0, got {sum(w)}')
+
+    rows = json.load(open(a.metrics, encoding='utf-8'))
+    cand = [r for r in rows if r['bloco_pauta']]
+    if len(cand) <= a.top:
+        print(f'NOTE: {len(cand)} candidate(s) for {a.top} slot(s). '
+              'No ranking needed, but the metric still belongs in the justification.')
+
+    for r in cand:
+        r['A'] = r['palavras'] - r['palavras_fora_do_bloco']
+        r['B'] = r['debate_no_bloco']
+        r['C'] = r['palavras_fora_do_bloco']
+    mx = {k: max(r[k] for r in cand) or 1 for k in 'ABC'}
+    for r in cand:
+        r['nA'], r['nB'], r['nC'] = (100 * r[k] / mx[k] for k in 'ABC')
+        r['score'] = round(w[0] * r['nA'] + w[1] * r['nB'] + w[2] * r['nC'], 1)
+
+    cand.sort(key=lambda r: -r['score'])
+    print(f'CANDIDATES (gate = own agenda slot): {len(cand)} of {len(rows)} speakers')
+    print(f'weights A={w[0]} B={w[1]} C={w[2]}\n')
+    print(f"{'#':>2} {'speaker':24}{'A words':>9}{'B debate':>9}{'C outside':>10}{'score':>8}")
+    for i, r in enumerate(cand, 1):
+        mark = '*' if i <= a.top else ' '
+        print(f"{i:2}{mark}{r['nome'][:24]:24}{r['A']:9}{r['B']:9}{r['C']:10}{r['score']:8}")
+
+    grid = [c for c in itertools.product([0.2, 0.3, 0.4, 0.5], repeat=3)
+            if abs(sum(c) - 1.0) < 1e-9]
+    tops = {}
+    for g in grid:
+        s = sorted(cand, key=lambda r: -(g[0] * r['nA'] + g[1] * r['nB'] + g[2] * r['nC']))
+        key = frozenset(x['nome'] for x in s[:a.top])
+        tops[key] = tops.get(key, 0) + 1
+    best, hits = max(tops.items(), key=lambda kv: kv[1])
+    print(f'\nROBUSTNESS: same top-{a.top} SET in {hits}/{len(grid)} weight combinations')
+    for k, v in sorted(tops.items(), key=lambda kv: -kv[1]):
+        print(f'  {v:3}/{len(grid)}  {", ".join(sorted(k))}')
+    if hits < len(grid):
+        print('\nThe set is NOT weight-invariant. Report this and take the tie to the PM.')
+
+
+if __name__ == '__main__':
+    main()

--- a/docs/planning/2026-08-17_PROMPT_ARRANQUE_1710_RETENCAO_E_1826.md
+++ b/docs/planning/2026-08-17_PROMPT_ARRANQUE_1710_RETENCAO_E_1826.md
@@ -1,0 +1,332 @@
+# Prompt de arranque — a véspera do #1710, a estreia da retenção, o funil de 28/08 e o #1826
+
+> Colar depois do `/clear`.
+> **Modelo: Opus 5 (auto, não pinar). Effort: `xhigh`.**
+> **Supersede** `docs/planning/2026-08-17_PROMPT_ARRANQUE_REUNIAO_13AGO_1710_E_905.md` (o ITEM 1 dele,
+> a reunião geral de 13/08, foi entregue por inteiro).
+> Handoff anterior: `docs/planning/2026-08-17_handoff_reuniao_geral_13ago_publicada.md`
+> Mapa da Fase 1 do EPIC: `docs/audit/EPIC_1780_FASE1_MAPA_BOARD_CARD.md`
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Todo número foi medido em **17/08/2026, 02:25 UTC** e
+vários se movem sozinhos. Re-meça com tool call na mesma volta em que o número entrar numa decisão,
+num commit, numa issue ou numa pergunta ao PM.
+
+Regras de varredura que já custaram caro:
+
+- **Uma listagem não sustenta afirmação de ausência.** `gh api dependabot/alerts` **sem `--paginate`**
+  já devolveu 0 abertos havendo 3.
+- **`gh pr checks` cresce durante a espera.** Espere os pendentes; não conte linhas.
+- **Varra `pg_proc`, não o repositório** — e leia o corpo antes de confiar na varredura.
+- **A lista da issue não é a classe.** Derive do catálogo, sempre.
+- **Um verificador que lê o diretório inteiro inclui o artefato que está sendo verificado.**
+- **`replace_all` casa a string, não a intenção.** **Conte as ocorrências** e **diffe contra o
+  original**. (Funcionou em 16/08: script que exige casamento exato de 1 por par e aborta fora disso.)
+- **Corrigir UM literal morto pode ser conserto INERTE.** Varra todas as colunas do predicado.
+- **"Zero linhas hoje" não é ausência de risco.** O número que decide é a **data da primeira mordida**.
+- **Antes de implementar política declarada em tabela, procure quem já a executa.** **Cron inativo
+  pode ser governança.**
+- **Estreitar o conjunto de candidatos para forçar unicidade não é resolver, é chutar.**
+- **No predicado que CONTA, use só sinal do mesmo grão do que está sendo medido.** Trigger é de tabela,
+  não de coluna.
+- **Filtrar por EXTENSÃO perde arquivo cujo nome não tem extensão.** Filtre por MIME.
+- 🆕 🔴 **Se a API tem TETO, a ordem em que você chama VIRA o critério de seleção.** No 13/08 concedi
+  reconhecimentos na ordem em que lembrei dos nomes; o teto barrou os dois últimos, e medido depois
+  **a última vaga tinha ficado com o 5º colocado em todos os eixos**. Cada chamada devolvia `ok:true`.
+  Pergunta de triagem: *"se eu chamar N+1 vezes, o que decide quem fica de fora?"*
+- 🆕 ⚠️ **Publicar mídia gravada exige conferir o FIM, não a duração.** Ver ITEM 12.
+- 🆕 📌 **Métrica gravada em campo de prosa é registro, não é dado.** Decida onde o critério vai morar
+  **antes** de calculá-lo.
+- 🆕 📌 **Ranking sem teste de robustez é opinião com número.** Re-pontue variando pesos e publique em
+  quantas combinações o **conjunto** do top-N se mantém. Compare conjunto, não ordem.
+- ⚠️ **Antes de escalar a gravidade, confira QUEM CHAMA.**
+
+---
+
+## Estado (17/08, 02:25 UTC)
+
+`main` em **`a5793a35`**, **zero PRs abertas**, **43 invariantes com zero violações**.
+**Zero eventos de bypass na janela de 7 dias** (69 commits em `main`, **todos** com `(#N)` no assunto;
+nenhum push direto). Nenhuma migration nem mudança de schema na sessão de 16/08.
+EF `nucleo-mcp` em **`ef_version` 2.102.0**, medido ao vivo.
+
+🆕 **O `/health` responde em `https://ldrfrvwhxsmgaabwmaik.supabase.co/functions/v1/nucleo-mcp/health`.**
+`https://nucleoia.vitormr.dev/mcp/health` devolve **404** (a rota do domínio custom é o transporte MCP,
+não o health). O mesmo payload mostra as três superfícies: `/mcp` 342 tools, `/semantic` 54, `/actions`.
+
+⚠️ **Não rastreados, criados em 16/08 e aguardando decisão do PM:**
+`.claude/skills/champion-metrics/` e `docs/planning/2026-08-17_handoff_reuniao_geral_13ago_publicada.md`.
+**Nunca `git add -A`** — há dezenas de docs de planning não rastreados; adicione por nome.
+
+---
+
+## ⏰ ITEM 1 — #1710, prazo 24/08. É o item de maior risco de data.
+
+Config **conferida no banco em 17/08 02:25 UTC** (re-conferir):
+
+```
+platform_settings['attendance.seal_window'] = {"floor_date": "2026-08-24", "grace_days": 14}
+cron attendance-seal-window-daily · 40 11 * * * · active = true
+```
+
+**Re-medir em 23/08 (a véspera), pelos dois caminhos independentes** — a consulta externa que reproduz
+coorte + carência, e o ensaio da própria função — e só então levar o número ao PM.
+⚠️ **É TETO, e encolhe a cada presença registrada por um líder.** Última medição conhecida (15/08):
+43 selam, 80 faltas, 40 pessoas. **Não recitar — re-medir.**
+
+**Como ensaiar sem esperar:** bloco `DO` que faz `UPDATE` em `platform_settings` deslocando `grace_days`
+para dar o mesmo corte que 14 darão em 24/08, **recuando também o `floor_date`** (senão volta
+`skipped: before_floor`), e terminando em `RAISE EXCEPTION` com o resultado. **Confira a config depois.**
+
+⚖️ **DECIDIDO pelo PM (15/08), NÃO re-litigar:** as células que nenhum líder de tribo alcança ficam com
+o **GP, pela grade geral**. Nada muda no código.
+📌 **Ação da véspera:** levar ao GP a lista **nominal** dessas células — **na conversa, não em issue nem
+em PR** (repo público).
+
+🆕 **Cuidado novo, vindo do fecho de 13/08:** a presença daquela reunião subiu de 31 para 45 porque 14
+membros foram **cobertos por líder** com base em prova documental. `registered_by` distingue cobertura
+de auto-check-in, e **o #1710 raciocina sobre a coorte de presenças**. Re-meça depois dessa mudança;
+não reaproveite recorte anterior a 16/08.
+
+---
+
+## 🔔 ITEM 2 — a primeira corrida da varredura de retenção (imediato)
+
+O cron `data-retention-sweep-daily` (`25 4 * * *`, **ativo**) tinha, às **02:25 UTC de 17/08**,
+**zero corridas** (`admin_audit_log` com `action='data_retention.sweep'` = 0, `max(created_at)` nulo).
+A estreia é **04:25 UTC de 17/08** — ou seja, provavelmente **já aconteceu** quando esta sessão abrir.
+
+**Conferir no arranque:**
+- `get_lgpd_cron_health` **impersonado** deve ter saído de `never_ran: true` para `days_since_last_run`
+  perto de zero. ⚠️ RPC que resolve o chamador por `auth.uid()` devolve "Not authenticated" para
+  `service_role`: impersone em transação abortada, `set_config('request.jwt.claims', ...)` **antes** do
+  `SET LOCAL ROLE`, e `RESET ROLE` antes de conferir o efeito.
+- `admin_audit_log` deve ter ganhado **uma** linha `action = 'data_retention.sweep'` com
+  `affected_total = 0` (nenhuma política morde antes de **09/09**).
+
+🔴 **Se a corrida falhou, o painel só vira vermelho depois de 2 dias de silêncio.** Não espere o
+vermelho para investigar.
+
+📅 Calendário de mordidas: `notifications` **09/09**, `visitor_leads` 03/10, `data_anomaly_log` 2027,
+archive 2028/2029.
+
+---
+
+## ITEM 3 — funil de entrevistas, prazo 28/08
+
+Última medição conhecida (15/08): 97 linhas, 3 instrumentadas, 1 abertura, 0 reservas. **Re-medir.**
+
+🔴 **Nenhum número de conversão é publicável** até uma linha carimbar `booked_at`. Exigir
+`instrumented = true` **e** `booking_token_md5` na linha nova.
+⚠️ **Não provocar despacho para testar** — o cron gera linhas sozinho.
+
+🔁 **#1586 fica ABERTA de propósito:** fecha na primeira chamada **real** de
+`interview_manage action='rescue_unbooked'`, conferindo na linha nova do audit `actor_id` **não nulo**
+e `dispatch_source='manual'` (cap 3, separado do cap 1 do cron).
+
+---
+
+## ITEM 4 — o não commitado de 16/08 é decisão do PM
+
+A sessão de 16/08 fez **zero commits, zero PRs, nenhuma migration**. Ficaram em disco:
+
+- `.claude/skills/champion-metrics/` — SKILL.md + 2 scripts, já exercidos de ponta a ponta contra a
+  transcrição real (reproduziram 26 falantes, 429 turnos, 13.832 palavras e o mesmo top-3).
+- `docs/planning/2026-08-17_handoff_reuniao_geral_13ago_publicada.md`.
+
+Suíte offline passou em 16/08: **6.482 testes, 0 falhas, 732 skips**, ~57 s. **Re-rodar antes da PR.**
+
+📌 **Perguntar ao PM se abre a PR.** Se abrir: branch de `origin/main` explícito, teste novo (se
+houver) nas **duas** whitelists do `package.json`, e `Closes` só se for para fechar.
+
+---
+
+## ITEM 5 — o portão legal do SPEC #905, prazo 30/09
+
+O cron `lgpd-anonymize-premember-monthly` está **inativo de propósito** (confirmado em 17/08:
+`active = false`, `15 4 1 * *`). O SPEC #905 o registrou dormante atrás de um checklist de parecer
+legal (**R1–R5**), com prazo máximo de ativação em **2026-09-30**.
+
+R1–R5 são decisões **de fora da engenharia**: ratificar a janela de retenção (recomendação legal:
+2 anos rejeitado / 1 ano desistente, contra os 5 anos do comando atual), limitar no tempo a exclusão da
+coorte #935, mapear e purgar os **binários externos de vídeo** (não alcançáveis por SQL — precisa de EF
+ou runbook), confirmar a **base legal Art. 11 I** para coleta de voz/vídeo, e as entradas de RoPA.
+
+**Lacuna é LATENTE, não viva.** ⚠️ **Re-medir pelo anchor da própria função, nunca por `created_at`** —
+o `created_at` mínimo é a data da migração da plataforma, não do fato.
+
+📌 O guard do #1812 exige que o horizonte declarado na tabela seja igual ao argumento do job: ratificar
+a janela move os dois juntos.
+
+---
+
+## ITEM 6 — #1826, aberta em 16/08 (nova)
+
+**Seleção por métrica: tornar o critério um dado e abrir a rota de decisão no MCP.** `type:feature`,
+`priority:low`, `mcp-server`, `meeting-notes`.
+
+O achado que a originou: `award_champion` tem teto no corpo da função (`general` 3, `tribe` 2,
+`deliverable` 1, mais 3 por concedente), e **o teto só se descobre batendo em `per_event_cap_reached`**.
+A descrição da tool não o menciona.
+
+- **Fase A (barata):** `champions_awarded` **não tem coluna de comentário**. A métrica de 13/08 está
+  gravada como texto entre colchetes dentro de `justification`. Guardar estruturado (`jsonb`) torna a
+  seleção auditável e comparável entre reuniões.
+- **Fase B:** o MCP cobre o **ato** (`award`/`revoke`) e não a **decisão**. Falta `action='rank'` de
+  leitura e o teto exposto no envelope, **derivado do corpo da RPC** e não duplicado como literal.
+- **Fase C (cara):** ingestão da transcrição, que é o que destrava o cálculo server-side.
+
+📌 Conversa com o **EPIC #1780**: lá são verbos de curadoria sem porta MCP; aqui a porta que **muda
+estado** existe e a que **informa a decisão** falta, que é a ordem mais perigosa das duas.
+
+---
+
+## ITEM 7 — #1822: a triagem das 56 é decisão do PM
+
+`_audit_undeclared_state_domain()` fixou a base: **270 colunas examinadas, 208 com domínio declarado,
+6 por FK, 56 sem guarda** em 44 tabelas (medido 16/08). O ratchet só encolhe, e o #1822 **não declarou
+domínio em nada**.
+
+📌 **Decisão:** quais das 56 merecem `CHECK`. Nem todas devem — `admin_audit_log.action` é vocabulário
+que cresce de propósito. E declarar domínio sobre dado vivo tem risco próprio: o ensaio bateu em linha
+de `pilots` fora do domínio na primeira tentativa (lição do #1587). **A lista sai da própria RPC.**
+
+---
+
+## ITEM 8 — o resto da classe do #1805/#1809: resolução por STATEMENT
+
+**Já medido no #1822, não refazer:** o ponto cego tem **377 pares em 294 funções** — 91 inertes, 48 com
+uma só relação com domínio, **238 de ambiguidade real**.
+
+🔴 **O atalho dos 48 foi ensaiado e não existe** (51 violações, zero defeitos). Sobram os **238**, e
+fechá-los exige **resolver por STATEMENT** (qual tabela cada `UPDATE`/`DELETE`/`FROM` alcança), não por
+corpo. Não há caminho barato.
+
+---
+
+## ITEM 9 — #1814, o `archive` sem destino (aberta de propósito)
+
+`cleanup_type='archive'` declara duas políticas e não há destino de arquivamento na plataforma. Seguem
+ativas e descobertas, na base declarada do ratchet `_audit_retention_policy_coverage()` (**base
+declarada = 3**; a 4ª derruba o CI). Primeira mordida em **2028-03-13** e **2029-03-05** — sem urgência.
+
+⚠️ **Risco de produto:** pontos de gamificação leem histórico de presença (`sync-attendance-points`).
+Tirar linhas da tabela quente pode mudar cálculo retroativo.
+
+---
+
+## ITEM 10 — o resto do EPIC #1780
+
+A Fase 1 mediu e quatro cortes saíram (#1778, #1784, #1791, #1779). Segue aberto:
+
+- **Agregada de comentário e de anexo não existe nem em SQL** — não é falta de porta MCP, é falta da
+  função. Decidir com o PM se entra.
+- **4 definições de autoridade para a mesma ação** — o #1778 unificou a do checklist.
+- **8 verbos de curadoria sem porta MCP nenhuma. Escopo é do PM.**
+- **Linha de base do #1791:** 7 filhas decidem escrita só por capacidade. **Do #1784:** 10 filhas sem
+  gate de leitura. Todas com zero linhas confidenciais hoje.
+
+---
+
+## ITEM 11 — dívida conhecida, com dono
+
+- **#1592** — barreira contra DDL nova. **468 de 1105** SECDEF alcançáveis por chamador anônimo
+  (15/08). Todas gateiam por `auth.uid()` — profundidade, não porta aberta.
+- **#1777**, **#1776**, **#1664 fase 2**, **#1762** (corrigir muda quem recebe candidato → precisa do
+  PM), **#1729**, **#1742**, **#1744**, **#1728** (20 RPCs da mesma classe).
+  **Onda E:** #1575, #1574, #1573, #1576, #1634, #1581, #1579.
+- **#1205** só fecha com o membro do caso acessando o `/profile` **LOGADO** (o nome está na issue).
+- **Follow-ups:** #1004, #1008, #1403 (~set/2026), #1494, classe B do #1487, 20 termos não-GO.
+
+---
+
+## ITEM 12 — o que ficou da reunião de 13/08 (fechada, mas com pendências do PM)
+
+Entregue: ata **22.081 chars**, **10 ações**, presença **45** (48 linhas), **3 champions metrificados**
++ 5 confirmados, vídeo publicado com 37 capítulos na playlist `PLanpm8h-DzgQ`.
+
+📌 **Pendências do PM:** as **10 ações estão sem prazo** (a reunião não declarou nenhum), e
+`roster_sealed_at` **segue nulo** nas duas gerais. **45 é PISO, não total** — quem assistiu calado não
+deixa rastro, e **não existe Meeting Report do Google para 13/08** contra o que reconciliar.
+
+🔴 **O erro que não pode repetir:** a primeira publicação subiu íntegra e ficou pública ~3 min com
+**69,5 s do bloco reservado aos líderes**, incluindo chamada nominal. A gravação do Meet **não para
+quando a pauta pública acaba**.
+
+**O procedimento que funcionou, para reusar:**
+1. Ler o **fim** da transcrição procurando o handoff ("aos líderes de tribo, quem puder ficar").
+2. O corte **não sai** do índice da transcrição (blocos grossos demais): sai da faixa **`mov_text`**
+   embutida no MP4 — `ffmpeg -map 0:s:0 -c:s srt` dá timing por legenda.
+3. Cortar sem reencode: `-t <fim> -map 0 -c copy`.
+4. **Provar por grep** que os marcadores do trecho restrito voltam **zero** no SRT do cortado.
+5. Publicar como **não-listado** se ninguém revisou o fim.
+
+---
+
+## Armadilhas da vizinhança, com o preço que já custaram
+
+1. ⚠️ **`CREATE OR REPLACE` exige o corpo INTEIRO — nunca o fragmento da varredura.** Rota que
+   funcionou no #1805/#1809/#1813: prove por md5 normalizado que a captura no repositório é idêntica ao
+   corpo vivo (`scripts/audit-rpc-body-drift.mjs` com `drifted_definite = 0`), extraia o bloco **do
+   arquivo**, aplique substituição **contada**, **diffe**, e monte a migration por concatenação.
+2. ⚠️ **Captura antiga pode usar `CREATE FUNCTION` sem `OR REPLACE`.** Troque por `CREATE OR REPLACE`,
+   que ainda **preserva as ACLs**.
+3. 🔴 **`ADD CONSTRAINT` com nome auto-gerado bate `duplicate_object`, e `WHEN duplicate_object THEN
+   NULL` engole a MUDANÇA de domínio.** Troca de domínio é `DROP CONSTRAINT IF EXISTS` + `ADD`.
+4. **`apply_migration` recebe o SQL como STRING.** Feche o risco rodando `audit-rpc-body-drift.mjs`
+   depois: `drifted_definite` tem de voltar a **0**.
+5. **`apply_migration` cria a linha de tracking com timestamp PRÓPRIO.** Renomeie o arquivo local para
+   casar; `migration repair` é desnecessário.
+6. 📌 **Divida a migration quando uma parte for crítica e a outra cosmética.**
+7. **DDL aplicada ANTES do merge deixa toda branch aberta vermelha.** Aplique com **zero PRs abertas**.
+8. **Mudança de schema exige `npm run db:types` na MESMA PR** (gate `gen-types-drift`). RPC nova, RPC
+   removida e coluna nova contam.
+9. **Mexeu em descrição de tool no `nucleo-mcp/index.ts`? Regenere o manifesto:**
+   `node scripts/generate-mcp-manifest.mjs`. **E confira o `ef_version` ANTES de deployar** contra o
+   literal em `index.ts` — se estiverem IGUAIS, bumpe. Pós-deploy o smoke tem de incluir **`tools/list`**.
+   ⚠️ `deno` **não está instalado nesta máquina**; quem roda `deno lint`/`check` é o CI.
+10. **`CREATE FUNCTION` concede EXECUTE a PUBLIC.** O `REVOKE ... FROM PUBLIC, anon` vai na MESMA
+    migration. (`CREATE OR REPLACE` de função **existente** preserva as ACLs.)
+11. **`SECURITY DEFINER` contorna a RLS.** O gate do #785 tem de estar **dentro** da função.
+12. ⚠️ **No ARE do Postgres, `\b` é BACKSPACE** — fronteira de palavra é `\y`. E o Postgres **recusa
+    contagem acima de 255**.
+13. ⚠️ **Guard de texto acusa a própria documentação.** Separe prosa de SQL antes do assert (o filtro de
+    `--` **não** pega blocos `COMMENT ON`).
+14. 📌 **Prove que o guard fica VERMELHO.** Plante a violação numa transação abortada, **e faça-o
+    devolver todos os itens examinados com um booleano** — senão lista vazia não se distingue de cegueira.
+15. 📌 **Ensaie o ramo que nunca rodou.**
+16. **Teste novo entra nas DUAS whitelists do `package.json`** (`test` e `test:contracts`).
+17. **Suíte offline (~57 s) é o gate barato:**
+    `env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u PUBLIC_SUPABASE_URL npm run test:contracts`.
+    ⚠️ **Skip ≡ pass:** rode o arquivo novo **com** `.env` e confira **zero skips**. Suíte com DB:
+    ~13 min no CI, **escreve em produção e não tolera concorrência** (#1505).
+18. ⚠️ **`Fecha #N` em português NÃO fecha a issue.** Use `Closes #N`. E nunca escreva o padrão de
+    fechamento sem intenção de fechar, **nem para CITÁ-lo**.
+19. ⚠️ **Branch nova nasce do HEAD, não da main.** `git checkout -b <nome> origin/main` explícito, e
+    confira com `git merge-base --is-ancestor origin/main HEAD`.
+20. ⚠️ **O `git status` do início da sessão pode estar STALE.** `git fetch` antes. E **nunca
+    `git add -A`** — adicione por nome.
+21. ⚠️ **`supabase` CLI aqui não está linkado**: `--project-ref ldrfrvwhxsmgaabwmaik` onde aceitar.
+22. ⚠️ **Repo é PÚBLICO.** Achado de segurança se **corrige primeiro e descreve depois**. Nome de pessoa
+    não entra em issue, PR nem doc — **conte a população, não a pessoa**. (Em 16/08 a varredura de nome
+    próprio rodou antes de publicar issue, LL e handoff, e voltou zero nos três.)
+23. ⚠️ **RPC que resolve o chamador por `auth.uid()` devolve "Not authenticated" para `service_role`.**
+24. ⚠️ **NUNCA canalize a suíte por `| tail -N` em background** — o pipe segura toda a saída.
+25. ⚠️ **Um contract test que faz shell-out de lint pode TRAVAR em vez de falhar.** Rode os lints antes.
+26. ⚠️ **`pgrep -f "<padrão>"` casa o PRÓPRIO watcher.** **O build leva 2m30s–4m40s: rode em background
+    e confira o `Complete!`.**
+27. ⚠️ **O conector cacheia `tools/list`.** Ação nova dentro de tool existente evita o problema.
+28. ⚠️ **Drive: barra fullwidth (`／`) nos nomes, gravação do Meet SEM extensão, doc nativo com 0 bytes
+    pelo mount** (só `rclone cat`). E `~/.local/bin/rclone` (1.74), nunca o do apt.
+29. 🆕 ⚠️ **A capacidade pode estar FORA do repo.** O ferramental de publicação no YouTube vive em
+    `~/projects/_pmo/youtube/` (`upload.py`, `token.json` OAuth vivo, venv `~/.venvs/youtube`, pastas de
+    precedente por reunião). O ponteiro está no **header de `scripts/refresh-youtube-playlists.mjs`**.
+    A playlist sai do SSOT `src/data/youtube-playlists.ts` por **chave semântica**
+    (`generalMeetings`), nunca por id colado. Varra `supabase/functions/` **e** `scripts/`, e siga
+    ponteiros para `~/projects/_pmo/`.
+30. 🆕 ⚠️ **YouTube não substitui arquivo** — corrigir é sempre vídeo novo. **E a API mente por
+    propagação:** `videos.list` já devolvia 0 enquanto `playlistItems.list` ainda mostrava o item.
+    Reconfira antes de declarar limpo, e remova o `playlistItem` órfão à mão.

--- a/docs/planning/2026-08-17_handoff_reuniao_geral_13ago_publicada.md
+++ b/docs/planning/2026-08-17_handoff_reuniao_geral_13ago_publicada.md
@@ -1,0 +1,141 @@
+# Handoff — a reunião geral de 13/08 fechada: ata, presença, protagonistas, ações e vídeo
+
+> Sessão de 16/08/2026, noite (madrugada de 17/08 UTC). Anterior:
+> `2026-08-16_handoff_1822_dominio_nao_declarado.md`.
+> Arranque que a originou: `2026-08-17_PROMPT_ARRANQUE_REUNIAO_13AGO_1710_E_905.md` (ITEM 1).
+>
+> ⚠️ **Repo público.** Este documento conta população, nunca pessoa. Os nomes vivem na plataforma
+> (ata, presença, champions) e no material git-ignored de `_drive-docs/`.
+
+---
+
+## O que entrou
+
+O ITEM 1 do arranque fechou inteiro, pela porta do MCP em todos os writes que têm porta.
+
+| entrega | antes | depois |
+|---|---|---|
+| `minutes_text` | 0 chars | **22.081** (a de 30/07, que é a forma-alvo, tem 14.473) |
+| ações rastreáveis | 0 | **10** (7 com responsável, **0 com prazo**) |
+| presenças | 31 presentes / 34 linhas | **45 presentes / 48 linhas** |
+| champions ativos | 0 | **3**, com métrica dentro da `justification` |
+| `suggested_champion_ids` | 0 | **5** (todos os que passaram no gate) |
+| `recording_type` | nulo | `youtube` |
+| `recording_url` / `youtube_url` | nulos | o vídeo publicado, ambos |
+
+`roster_sealed_at` segue **nulo de propósito** nas duas gerais. Nada foi selado.
+
+Estado de partida conferido no início: **43 invariantes, zero violações**; `main` em `a5793a35`;
+zero PRs abertas. Nada de schema mudou nesta sessão.
+
+## O buraco da presença, resolvido por prova e não por estimativa
+
+O arranque trazia "31 presentes contra 51 em 30/07" como queda de público. **Não era.**
+
+A medição mostrou que **as 34 linhas de 13/08 tinham `registered_by` nulo — 100% auto-check-in.**
+Em 30/07, 52 das 54 também eram. Comparação justa, então: 51 auto contra 31 auto.
+
+O cruzamento contra as fontes documentais (transcrição, log do chat e a chamada nominal do
+encerramento) achou **14 membros com prova citável de participação e zero linha de presença**, entre
+eles quem conduziu a reunião. Registrados os 14 com `attendance_record`, o que grava `registered_by`
+e mantém a distinção entre auto-check-in e cobertura de líder. **31 + 14 = 45.**
+
+📌 **45 é PISO, não total.** Quem assistiu calado não deixa rastro em transcrição nem em chat. E não
+existe Meeting Report do Google para 13/08 contra o que reconciliar (a pasta para em 09/07 e guarda
+analytics de YouTube, não lista de presença).
+
+⚖️ **Decisão do PM (16/08):** registrar os 14 com prova documental. A governança declarada na própria
+ata de 30/07 já previa: a marcação é do participante, e "o líder de tribo pode cobrir o registro
+depois". Foi exatamente isso.
+
+## Protagonistas: o teto transformou ordem de chamada em critério
+
+`award_champion` tem **teto anti-inflação no corpo da função**: `general` 3, `tribe` 2,
+`deliverable` 1, mais 3 por concedente por evento. Concedi na ordem em que pensei nos nomes, e os
+dois últimos voltaram `per_event_cap_reached`.
+
+**Medido depois, quem entrou em 3º era o 5º colocado em todos os eixos, e o 1º em volume ficou de
+fora.** O acaso da chamada virou a seleção.
+
+O PM mandou metrificar. Nasceu o skill **`champion-metrics`** (`.claude/skills/champion-metrics/`,
+SKILL.md + 2 scripts), que lê a transcrição carimbada e aplica:
+
+- **Gate eliminatório:** ocupou bloco de pauta com entrega própria. Só debater não qualifica.
+- **Eixo A** palavras dentro do próprio bloco (40%) · **B** pessoas distintas que intervieram no
+  bloco (35%) · **C** palavras fora do próprio bloco (25%). Normalizados pelo maior do grupo.
+- **`span` NÃO é eixo, de propósito:** quem apresenta por último tem span curto por posição de
+  agenda, então o eixo mediria a agenda e não a pessoa.
+- **Robustez publicada junto:** o conjunto do top-3 se manteve em **12 de 12** combinações de peso.
+  Conjunto que só vale num peso é artefato do peso.
+
+Base medida: **26 falantes, 429 turnos, 13.832 palavras, 5 candidatos passaram no gate.**
+Resultado aplicado: 1 revogação (com a métrica na razão), 1 concessão nova, e a métrica anexada em
+bloco entre colchetes na `justification` dos três.
+
+🔎 **`champions_awarded` não tem coluna de comentário.** Os campos são `criteria_met`,
+`justification`, `points_awarded`, `status` e os de revogação. A anotação só cabe em `justification`.
+`events.suggested_champion_ids` **não tem teto**, e é por isso que a forma de 5 de 30/07 existia:
+30/07 sugeriu 5 e não premiou ninguém (zero linhas em `champions_awarded`). **13/08 é o primeiro
+prêmio formal da série.**
+
+## O vídeo, e o erro que ele custou
+
+Publicado com 37 capítulos, todos ancorados em carimbo real da transcrição (71 disponíveis), título
+90/100 chars, descrição 3.457/5.000, 16 tags, na playlist de reuniões gerais do ciclo resolvida pelo
+SSOT `src/data/youtube-playlists.ts` por chave semântica.
+
+🔴 **A primeira publicação saiu errada e ficou pública por ~3 minutos.** A gravação do Meet não para
+no encerramento da pauta: seguiu por **69,5 s** dentro do **bloco reservado aos líderes**, com chamada
+nominal de quem ficou. O PM pegou. Sequência de correção: privar imediatamente, achar o corte,
+cortar, republicar, apagar o antigo, remover o `playlistItem` órfão.
+
+**O corte não sai da transcrição** (os blocos do Gemini são grossos e a virada caía no meio de um).
+Sai da **faixa `mov_text` embutida no MP4**: `ffmpeg -map 0:s:0 -c:s srt` dá timing por legenda e o
+segundo exato. Corte com `-t <fim> -map 0 -c copy`, sem reencode, e **prova por grep** dos marcadores
+do bloco restrito no SRT do cortado, esperando zero. Deu zero em 4 de 4 marcadores; 1438 → 1421
+blocos de legenda.
+
+⚠️ **YouTube não substitui arquivo.** Corrigir é sempre novo vídeo. E a API mente por propagação:
+`videos.list` já devolve 0 enquanto `playlistItems.list` ainda mostra o item. **Reconfira.**
+
+## A capacidade estava fora do repo, e eu disse que não existia
+
+Declarei que não tinha credencial de publicação e ofereci passar o upload ao PM. Errado, e é
+reincidência do mesmo eixo do incidente de 25/07 com o Drive.
+
+O ferramental existe em **`~/projects/_pmo/youtube/`**: `upload.py` (Data API v3), `token.json` OAuth
+vivo, venv `~/.venvs/youtube`, e a pasta do precedente de 30/07 com `meta.json` e log. O ponteiro
+está **no header de um script deste repo** (`scripts/refresh-youtube-playlists.mjs`).
+
+📌 Varrer `supabase/functions/` não basta. Varra `scripts/` pelo domínio e siga os ponteiros para
+`~/projects/_pmo/`.
+
+## Rastreado
+
+- **#1826 aberta** (`type:feature`, `priority:low`, `mcp-server`, `meeting-notes`): tornar o critério
+  de seleção um **dado** (hoje mora como texto dentro de `justification`, porque `champions_awarded`
+  não tem coluna de comentário) e abrir a **rota de decisão** no MCP, já que `champion_award` cobre o
+  ato (`award`/`revoke`) e não a decisão. Três fases: A guardar métrica estruturada, B porta MCP de
+  ranking com o teto exposto e derivado do corpo da RPC, C ingestão da transcrição. Conversa com o
+  **EPIC #1780**, com a diferença de que aqui a porta que **muda estado** existe e a que **informa a
+  decisão** falta, que é a ordem mais perigosa das duas.
+- **LL registrada no intake #588** (6 lições + 3 notas de método). As de maior alcance: teto de API
+  transforma ordem de chamada em critério; métrica em campo de prosa não é dado; publicar gravação
+  exige conferir o FIM e não a duração; ranking sem teste de robustez é opinião com número; eixo de
+  métrica que muda ao embaralhar o processo mede o processo; e a reincidência de "a capacidade pode
+  estar fora do repo", que agora inclui `~/projects/_pmo/`.
+
+## Aberto, para a próxima
+
+- **O skill `champion-metrics` está NÃO RASTREADO** (`.claude/skills/champion-metrics/`), junto com
+  este handoff. Nada foi commitado nesta sessão: **zero commits, zero PRs, zero `--admin`, nenhuma
+  migration.** Abrir a PR é decisão do PM. ⚠️ Nunca `git add -A` neste repo.
+- **As 10 ações estão sem prazo** porque a reunião não declarou nenhum. Definir os prazos é do PM.
+- **`roster_sealed_at` continua nulo.** Não selar sem decidir o que fazer com o piso de 45.
+- **A varredura `data-retention-sweep-daily` estreia às 04:25 UTC de 17/08** e ainda não tinha rodado
+  quando esta sessão fechou (era 01:30 UTC no arranque). Conferir: `get_lgpd_cron_health` impersonado
+  sai de `never_ran:true`, e `admin_audit_log` ganha linha `action='data_retention.sweep'` com
+  `affected_total = 0`. Falha só pinta o painel de vermelho depois de 2 dias.
+- Os demais itens do arranque seguem intactos: **#1710 re-medir em 23/08** (prazo 24/08), portão legal
+  **R1–R5 do SPEC #905** (30/09), triagem das **56** do #1822, os **238 pares** do #1805/#1809,
+  **#1814** sem urgência, e o resto do **EPIC #1780**.


### PR DESCRIPTION
Fecha documentalmente a Reunião Geral de 13/08 e entra com o skill que nasceu do erro cometido nela. **Nenhuma mudança de código de aplicação, schema, RPC ou CI** — só `.claude/skills/` e `docs/planning/`.

## O que entra

| arquivo | o que é |
|---|---|
| `.claude/skills/champion-metrics/SKILL.md` | o critério de seleção de champions, e por que ele existe |
| `.claude/skills/champion-metrics/scripts/metrica_participacao.py` | extrai contagens por falante da transcrição carimbada |
| `.claude/skills/champion-metrics/scripts/score_champions.py` | ranqueia e varre a robustez sobre os pesos |
| `docs/planning/2026-08-17_handoff_reuniao_geral_13ago_publicada.md` | handoff do fecho |
| `docs/planning/2026-08-17_PROMPT_ARRANQUE_1710_RETENCAO_E_1826.md` | arranque da próxima, supersede o anterior |

## Por que o skill existe

`award_champion` tem teto anti-inflação **no corpo da função** (`general` 3, `tribe` 2, `deliverable` 1, mais 3 por concedente por evento). Concedi na ordem em que lembrei dos nomes, e as duas últimas chamadas voltaram `per_event_cap_reached`.

Medido depois na transcrição, **a última vaga tinha ficado com o 5º colocado em todos os eixos (205 palavras no próprio bloco) e o 1º em volume (2.951) tinha sido barrado.** Corrigido na mesma sessão com 1 revogação e 1 concessão nova, ambas com a métrica na razão.

> Sem teto, a concessão é lista aditiva e a ordem não importa. Com teto, **a ordem da chamada É a seleção** — e cada chamada individual devolve `ok:true`, então nada no caminho denuncia o problema.

## O critério

- **Gate eliminatório:** ocupou bloco de pauta com entrega própria. Só debater não qualifica.
- **Eixo A** palavras dentro do próprio bloco (40%) · **B** pessoas distintas que intervieram no bloco (35%) · **C** palavras fora do próprio bloco (25%). Normalizados pelo maior do grupo.
- **Robustez publicada junto:** re-pontua sobre uma grade de pesos e reporta em quantas combinações o **conjunto** do top-N se mantém. Compara conjunto, não ordem — trocar 1º com 2º não muda quem entra.

**`span` fica fora de propósito.** Quem apresenta por último tem span curto **por posição de agenda**, então o eixo mediria a agenda e não a pessoa. A exclusão está documentada no SKILL.md com o motivo, para não ser re-adicionada por alguém bem-intencionado.

## Verificação

- Skill **exercido de ponta a ponta contra a transcrição real** antes de entrar: reproduziu 26 falantes, 429 turnos, 13.832 palavras e o mesmo top-3 do script ad-hoc que originou a análise. Skill não testado contra entrada real é rascunho.
- Conjunto do top-3 estável em **12 de 12** combinações de peso.
- Suíte offline: **6.482 testes, 0 falhas, 732 skips**.
- Varredura de nome próprio nos 5 arquivos antes de subir (repo público): **zero**.
- O gate `issue-reference` não se aplica: nenhum caminho crítico (`src/`, `supabase/`, `scripts/`, `.github/workflows/`, `package.json`, `astro.config.`) foi tocado.

## Rastreamento

- **#1826** (aberta, `nice to have`): tornar o critério um **dado** — hoje a métrica mora como texto dentro de `justification`, porque `champions_awarded` **não tem coluna de comentário** — e abrir a **rota de decisão** no MCP, que hoje cobre o ato (`award`/`revoke`) e não a decisão.
- **#588**: lições da sessão no intake do PMO de portfólio.

Nenhuma das duas é fechada por esta PR.
