### PR TITLE
docs(planning): a tarde de 17/08, o import do VEP e o arranque com as entrevistas vivas no topo

### DIFF
--- a/docs/planning/2026-08-17_handoff_tarde_1833_mergeada_1834_import_vep.md
+++ b/docs/planning/2026-08-17_handoff_tarde_1833_mergeada_1834_import_vep.md
@@ -1,0 +1,152 @@
+# Handoff: a tarde de 17/08, duas reservas invisíveis, o import do VEP e a #1833 mergeada
+
+> Sessão de 17/08/2026, tarde UTC (14:30 a 17:00). Anterior:
+> `2026-08-17_handoff_item1_verificado_1586_fechada_1829_aberta.md`.
+>
+> ⚠️ **Repo público.** Este documento conta população, nunca pessoa, e não publica e-mail nem
+> identificador. Os nomes vivem na plataforma e no export do VEP, que é git-ignored e cuja própria
+> nota de minimização manda apagar as cópias locais depois do import.
+
+---
+
+## O que entrou
+
+| entrega | antes | depois |
+|---|---|---|
+| entrevistador no histórico de `/admin/selection` | não aparecia | **nome, ou "não registrado"** |
+| `get_application_interviews` | só `interviewer_ids` | **+ `interviewers` com nome** |
+| entrevistas registradas no ciclo | 2 | **3** |
+| reservas medidas no funil | 0 | **1** |
+| invariantes | **43, com 1 violação** | 43, **zero** |
+
+`main` em **`c30f481d`** (PR #1833, **12/12 verde, sem `--admin`**), migration `20260817145902`,
+zero PRs abertas, zero eventos de bypass em 7 dias. EF `nucleo-mcp` em `ef_version` **2.102.0**.
+
+## Duas reservas de entrevista chegaram, e nenhuma pela plataforma
+
+O PM mandou print de duas reservas feitas no calendário de agendamento de um entrevistador. As
+duas eram invisíveis para a plataforma: zero linha em `selection_interviews`, `booked_at` nulo.
+
+A primeira tinha risco de relógio: a candidatura estava em `interview_pending` e **o cron das 15:30
+mandaria convite para quem já tinha marcado**, porque o predicado dele exclui quem tem entrevista
+futura agendada e não havia linha. Registrada à mão pela porta MCP às 14:36, ela saiu do predicado
+por dois caminhos independentes (status e linha futura).
+
+✅ **O cron rodou às 15:30 e resgatou exatamente 2**, com `refused_count: 0` e `error_count: 0`.
+Eram 3 elegíveis pela manhã; a intervenção tirou uma. Convite duplicado não aconteceu.
+
+📌 A segunda reserva é **a primeira conversão da rodada de resgates manuais de 02:45**: a pessoa
+recebeu o convite, abriu e agendou. `schedule` carimbou `booked_at` sozinho e ligou
+`booked_interview_id`, porque a linha de despacho dela é instrumentada.
+
+⚠️ **Duas ressalvas que precisam viajar com esse número:** `booked_at` guarda a hora do REGISTRO
+manual, não a da reserva; e `first_opened_at` segue nulo, embora ela obviamente tenha aberto. A
+outra reserva não entra na conta porque o convite dela é anterior à instrumentação. **Há 2 reservas
+reais e 1 medida.** Não carimbar a outra à mão foi decisão consciente: inventar `booked_at`
+transformaria estimativa em medição.
+
+## #1614: a causa está na CLASSIFICAÇÃO, não no casamento
+
+Proposta medida publicada na issue. O matcher casa por `guest_email` e teria funcionado: o endereço
+usado na reserva era o mesmo da candidatura. O que falhou foi antes.
+
+O Apps Script decide quem é o candidato com **uma lista fixa de três e-mails**, e quem não está
+nela vira candidato. Medido em `selection_booking_attempts`:
+
+| lido como candidato | tentativas | desfecho |
+|---|---|---|
+| endereço pessoal do operador (o institucional está na lista, o pessoal não) | **11** | `no_application` |
+| um entrevistador do comitê | 2 | `cycle_closed` |
+| outro integrante do comitê | 1 | `cycle_closed` |
+| três endereços institucionais do capítulo | 1 cada | `no_application` |
+
+📌 **Os 11 registros "do endereço do próprio operador" da #1664 são este defeito.**
+
+Proposta em três camadas: completar a lista para destravar, **tirar a classificação do script** e
+devolvê-la ao servidor que tem o catálogo, e filtrar por **organizador do comitê** em vez de
+título de calendário. Filtrar por título foi considerado e descartado: é texto livre, editável pelo
+dono, e a captura pararia sem erro nenhum.
+
+## #1832, fechada pela #1833: a tela passa a dizer com QUEM
+
+O dado já existia; a RPC devolvia `interviewer_ids` e a UI nunca lia. Agora a RPC devolve também os
+nomes, resolvidos **no servidor**: um mapa montado no cliente a partir do comitê atual quebraria
+calado quando alguém saísse. `LEFT JOIN` de propósito, para que id sem membro mantenha a posição.
+
+E quando não há entrevistador a tela **diz isso**, em vez de omitir a linha:
+
+| origem da entrevista | total | sem entrevistador |
+|---|---|---|
+| webhook de calendário | 55 | **24 (44%)** |
+| plataforma (com nota) | 10 | 2 |
+| plataforma (sem nota) | 64 | **0** |
+
+Omitir tornaria "não temos o dado" indistinguível de "não mostramos o dado".
+
+## #1834: o import do VEP, e a correção que a origem impôs
+
+O CI da #1833 ficou vermelho em dois gates, e **nenhum dos dois era do PR**. Investigar rendeu o
+achado do dia.
+
+`import_vep_applications` gravou o estado de **83 candidaturas** às 13:03-13:05 UTC e **não chama
+`approve_selection_application()`**. Com isso pulou três garantias que moram lá dentro:
+
+1. **auditoria** (zero linhas em `admin_audit_log`);
+2. **vínculo do membro** (`R_approved_application_has_member`);
+3. **sincronia da janela de autoridade ao contrato** (a da #1362).
+
+🔴 **A terceira é a pior e a mais invisível.** O import escreveu contrato novo terminando em
+30/06/2027 e deixou o vínculo terminando em 11/02/2027: a pessoa **perderia acesso quatro meses e
+meio antes do fim do contrato**, sem alarme e sem e-mail.
+
+⚖️ **Correção publicada na própria issue.** Eu havia escrito que as decisões não tinham registro de
+"quem, quando e por qual caminho". O **quando** é conhecível: o export do VEP traz carimbo por
+decisão (**69 Active e 18 Complete com `acceptanceDateUTC`; 50 de 51 recusas com
+`declinedDateUTC`**), cobrindo de 02/09/2025 a 16/07/2026. As decisões foram tomadas ao longo de
+dez meses no sistema do PMI; o import apenas as sincronizou. **Aquele minuto é o carimbo do
+transporte, não o do fato.** O defeito real, mais preciso, é que a plataforma não guarda vestígio
+da sincronização nem carrega o carimbo de origem.
+
+## Dois reparos em dado de produção, ambos com antes e depois medidos
+
+1. **Vínculo de e-mail alternativo.** A candidatura trazia o endereço institucional e o cadastro o
+   pessoal. Identidade corroborada por **chave estrutural** (identificador do PMI idêntico nos dois
+   lados, mesmo capítulo), não por nome. Pela porta MCP, que preserva o autor. Invariante fechou.
+2. **Backfill da janela de autoridade**, com a sentença idempotente que a própria migration da
+   #1362 declara. Alcance medido **antes** (81 ativos, 1 violando) e **depois** (81, zero).
+
+📌 **Consequência operacional até a #1834 ser resolvida: rodar o import exige conferir os
+invariantes logo depois.** Sem isso, os defeitos ficam latentes até o CI de terceiros reclamar, que
+foi exatamente o que aconteceu.
+
+## O ITEM 2 se dissolveu
+
+O arranque anterior trazia "2 aprovados já ativos que nunca foram entrevistados", com decisão de
+agendar direto e pendência de data e hora. Hoje são **3** (o import acrescentou um), e o export do
+VEP mostra por que a pergunta não se aplica: os três estão **Active na mesma vaga**, com
+`submittedDateUtc` **nulo** e oferta estendida e aceita em julho.
+
+**Eles nunca se candidataram.** Entraram por oferta direta, então não havia etapa de entrevista a
+cumprir. "Nunca foram entrevistados" não era lacuna, era a forma correta de quem entra por outra
+porta. 📌 Falta o PM ratificar, e a pendência deixa de ser "marcar horário".
+
+## Rastreado
+
+- **#1834 aberta** (`type:bug`, `priority:high`, `audit-trail`, `selection`), com o segundo achado
+  e a correção anexados.
+- **#1829** e **#1614** com material medido.
+- **LL no #588**: 8 lições e 4 notas de método, incluindo os erros próprios (normalização com
+  `trim` que fabricou falso drift; espaçamento de carimbo lido como "humano clicando" quando era
+  laço de import).
+- **Memória:** 3 lições duráveis novas, índice compactado de 19,7KB para 17,2KB sem perda.
+
+## Aberto, para a próxima
+
+- 🔴 **Entrevistas em 18/08 e 19/08**, as duas registradas à mão. Enquanto a #1614 não for
+  resolvida, **toda reserva nova pelo calendário do entrevistador precisa de registro manual**, e
+  só se descobre por print.
+- ⏰ **#1710, prazo 24/08**, re-medir em 23/08 pelos dois caminhos.
+- **Funil, prazo 28/08:** 105 linhas, 11 instrumentadas, 3 aberturas, **1 reserva medida contra 2
+  reais**. Publicar sem o denominador explícito diria conversão falsa.
+- **Decisões do PM:** o que fazer com a #1834, se reabre a #1614, a triagem das 56 do #1822, e a
+  ratificação dos três de oferta direta.

--- a/docs/planning/2026-08-18_PROMPT_ARRANQUE_ENTREVISTAS_VIVAS_E_IMPORT_VEP.md
+++ b/docs/planning/2026-08-18_PROMPT_ARRANQUE_ENTREVISTAS_VIVAS_E_IMPORT_VEP.md
@@ -1,0 +1,235 @@
+# Prompt de arranque: entrevistas vivas, o import do VEP e a véspera do #1710
+
+> Colar depois do `/clear`.
+> **Modelo: Opus 5 (auto, não pinar). Effort: `xhigh`.**
+> **Supersede** `docs/planning/2026-08-17_PROMPT_ARRANQUE_POS_CRON_1530_E_VESPERA_1710.md`
+> (o ITEM 1 dele, a corrida do cron das 15:30, foi cumprido: 2 resgates, zero duplicados).
+> Handoff da sessão: `docs/planning/2026-08-17_handoff_tarde_1833_mergeada_1834_import_vep.md`
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Todo número foi medido em **17/08/2026, entre 14:30 e
+17:00 UTC**. Re-meça com tool call na mesma volta em que o número entrar numa decisão, num commit,
+numa issue ou numa pergunta ao PM.
+
+Regras de varredura que já custaram caro:
+
+- **Uma listagem não sustenta afirmação de ausência.**
+- **Varra `pg_proc`, não o repositório**, e leia o corpo antes de confiar na varredura.
+- **A lista da issue não é a classe.** Derive do catálogo, sempre.
+- **`replace_all` casa a string, não a intenção.** Conte as ocorrências e diffe.
+- **"Zero linhas hoje" não é ausência de risco.** O que decide é a data da primeira mordida.
+- **Se a API tem TETO, a ordem em que você chama VIRA o critério.**
+- **O conector CACHEIA `tools/list`.** Leia o `z.enum` em `nucleo-mcp/index.ts` antes de dizer que
+  uma ação não existe.
+- **Amostre os VALORES antes de classificar pelo nome da coluna.**
+- **Driver de saúde que lê o AGENDADOR não vê a falha.** *"Se o job rodar e quebrar todo dia, este
+  sinal acende?"*
+- 🆕 🔴 **Caminho em LOTE não herda as garantias da RPC canônica.** Antes de confiar num import,
+  pergunte **quais garantias moram na RPC que ele não chama**. Auditoria é a mais fácil de notar e
+  raramente é a única.
+- 🆕 🔴 **O carimbo do TRANSPORTE não é o carimbo do FATO.** 83 linhas com `updated_at` no mesmo
+  minuto eram sincronização de decisões tomadas ao longo de dez meses. Antes de ler um agrupamento
+  temporal como evento, **procure o carimbo de origem**.
+- 🆕 ⚠️ **Espaçamento de carimbo separa LOTE de LAÇO, não humano de máquina.** Idêntico ao
+  microssegundo = transação única. Espaçado de 1 a 2 segundos = laço por linha, que tanto um humano
+  clicando quanto um import produzem.
+- 🆕 ⚠️ **Comparar hash exige normalização byte-idêntica dos DOIS lados.** Use o helper do projeto
+  (`tests/helpers/rpc-body-drift-parser.mjs`); um `trim` a mais fabrica falso drift.
+
+---
+
+## Estado (17/08, 17:00 UTC)
+
+`main` em **`c30f481d`**, **zero PRs abertas**, **43 invariantes com zero violações**,
+**zero eventos de bypass** em 7 dias. EF `nucleo-mcp` em `ef_version` **2.102.0**.
+Migration mais recente: `20260817145902` (#1832).
+
+---
+
+## 🔴 ITEM 1: duas entrevistas vivas, e toda reserva nova depende de print
+
+Há **3 entrevistas agendadas** no ciclo aberto: **18/08**, **19/08** e 24/08. As duas primeiras
+foram registradas **à mão**, porque as reservas chegaram pelo calendário de agendamento de um
+entrevistador e **a plataforma não as viu**.
+
+📌 **Conferir:** as de 18/08 e 19/08 aconteceram, e marcar o desfecho com
+`interview_manage action='mark'` (`completed` | `noshow` | `cancelled`).
+
+🔴 **Enquanto a #1614 não for resolvida, toda reserva nova é invisível.** Ela só chega por print do
+PM. Se aparecer uma, o procedimento medido é:
+
+1. resolver a candidatura pelo e-mail do convidado (`selection_applications.email`);
+2. **conferir se o cron a alcança** antes de qualquer coisa (`status='interview_pending'` mais
+   `auto_rescue_count < 1` mais carência vencida), porque senão ela recebe convite duplicado;
+3. registrar com `interview_manage action='schedule'` (é **silencioso**, não dispara e-mail),
+   nomeando o entrevistador e convertendo o horário local para UTC.
+
+⚠️ `schedule` **carimba `booked_at` sozinho** quando a linha de despacho é instrumentada. Isso é
+bom, e cria uma armadilha de leitura: o carimbo é o do REGISTRO, não o da reserva.
+
+## ITEM 2: os três de oferta direta, só falta ratificar
+
+O arranque anterior pedia data e hora para "2 aprovados já ativos nunca entrevistados". **A
+pergunta não se aplica.** Hoje são 3, e o export do VEP mostra os três **Active na mesma vaga**,
+com `submittedDateUtc` **nulo** e oferta estendida e aceita em julho.
+
+Eles entraram por **oferta direta**, não pelo funil, então não havia etapa de entrevista a cumprir.
+📌 **Falta apenas o PM ratificar** que oferta direta dispensa entrevista. Não marcar horário.
+
+## ⏰ ITEM 3: #1710, prazo 24/08
+
+Config conferida em 17/08 e intacta:
+
+```
+platform_settings['attendance.seal_window'] = {"floor_date": "2026-08-24", "grace_days": 14}
+cron attendance-seal-window-daily · 40 11 * * * · active = true
+```
+
+**Re-medir em 23/08, a véspera, pelos dois caminhos independentes** e só então levar ao PM.
+⚠️ **É TETO e encolhe a cada presença registrada.** Última medição conhecida (15/08): 43 selam,
+80 faltas, 40 pessoas. **Não recitar.** A coorte mudou em 16/08 (presença da geral de 13/08 subiu
+de 31 para 45), então não reaproveitar recorte anterior.
+
+⚖️ **Decidido (15/08):** células fora do alcance de líder ficam com o GP pela grade geral, e a
+lista **nominal** vai ao GP **na conversa, não em issue nem PR**.
+
+## ITEM 4: funil de entrevistas, prazo 28/08
+
+Medido em 17/08: **105 linhas, 11 instrumentadas, 3 aberturas, 1 reserva medida.**
+
+🔴 **Há 2 reservas reais e 1 medida.** A não medida tem convite anterior à instrumentação. E o
+`booked_at` da medida guarda a hora do registro manual, com `first_opened_at` nulo apesar de a
+pessoa ter aberto.
+
+📌 **Nenhum número de conversão é publicável sem o denominador explícito.** Publicar "1 em 11" sem
+dizer que a instrumentação começou no meio do ciclo, e que uma reserva real ficou de fora, diz
+conversão falsa. **Não provocar despacho para testar:** o cron gera linhas sozinho.
+
+## ITEM 5: #1834, o import do VEP
+
+`import_vep_applications` grava estado em massa **sem passar pela RPC canônica**, e com isso pula
+auditoria, vínculo de membro e sincronia da janela de autoridade. Os três efeitos foram medidos e
+os dois últimos já derrubaram o CI uma vez.
+
+📌 **Consequência operacional imediata: depois de cada import, rodar
+`SELECT * FROM public.check_schema_invariants() WHERE violation_count > 0`.** Isso resolve a
+detecção, não a causa.
+
+⚖️ **Decisão do PM:** auditar a sincronização, carregar o carimbo de origem (o export traz
+`acceptanceDateUTC` para 87 e `declinedDateUTC` para 50), ou fazer o import **delegar para a RPC
+canônica**, que é a saída mais forte e provavelmente a mais barata no longo prazo.
+
+⚠️ **Antes de editar a função:** ela teve drift recuperado na p176. Confirme por md5 normalizado
+que a captura no repositório ainda é idêntica ao corpo vivo.
+
+## ITEM 6: #1614, que virou gargalo ativo
+
+Deixou de ser dívida adiada. Em um único dia ela custou **duas reservas invisíveis**, **11
+registros de ruído** na fila da #1664 e **um gate de CI vermelho**.
+
+A proposta medida está publicada na issue, em três camadas: completar a lista literal de e-mails do
+Apps Script para destravar, **tirar a classificação do script** e devolvê-la ao servidor que tem o
+catálogo, e filtrar por **organizador do comitê** em vez de título de calendário.
+
+📌 **Reabrir a decisão de 05/08 é conversa com o PM**, não conserto unilateral.
+
+## ITEM 7: #1829, o painel que fica verde com a varredura falhando
+
+O driver mede o agendador (`max(start_time)` sem filtro de status) e não o trabalho, e
+`_data_retention_sweep_cron()` não tem handler, então no modo de falha o audit não ganha linha.
+Latente: a estreia de 17/08 às 04:25 foi `succeeded` com `affected_total = 0`.
+
+📌 Correção mais forte proposta: **vermelho quando o job rodou e o audit não gravou**.
+
+## ITEM 8: #1822, a triagem das 56 é decisão do PM
+
+**270 colunas examinadas, 208 com domínio, 6 por FK, 56 sem guarda** em 44 tabelas, triadas em
+cinco classes (detalhe no handoff de 17/08 madrugada). A classe de **enumeração técnica fechada**
+é a de melhor razão custo/benefício. A classe de **geografia não é caso de `CHECK`**, e o dado dela
+**já está sujo** (mesma localidade sob duas grafias, três grafias de um lugar, valor numérico
+solto, string vazia). Conserto é FK para `chapter_registry`, e é **item próprio ainda sem issue**.
+
+## ITEM 9: o resto, com dono
+
+- **#1664** sem movimento: 36 não resolvidas, 31 acionáveis, **36 de 36 já suprimidas**. Raiz é a
+  #1614. Os 11 do "endereço do operador" agora têm causa nomeada.
+- **#1826** (métrica de champions vira dado e rota de decisão no MCP): fases A, B e C.
+- **#1814** (`archive` sem destino), na base do ratchet de retenção (**base = 3**).
+- **EPIC #1780**: agregada de comentário e anexo não existe nem em SQL; 4 definições de autoridade
+  para a mesma ação; 8 verbos de curadoria sem porta MCP.
+- **#1805 / #1809**: **238 pares de ambiguidade real**, só saem por resolução por STATEMENT.
+  🔴 **O atalho dos 48 foi ensaiado e não existe.** Não refazer a medição.
+- **#1592** (barreira contra DDL nova): 468 de 1105 SECDEF alcançáveis por anônimo (15/08).
+- **#1205** só fecha com o membro do caso acessando o `/profile` **LOGADO**.
+- **#905**, portão legal R1 a R5, prazo **30/09**.
+- As **10 ações** da reunião de 13/08 seguem **sem prazo**, e `roster_sealed_at` segue **nulo**,
+  com **45 de piso**.
+
+---
+
+## Armadilhas da vizinhança
+
+1. ⚠️ **`CREATE OR REPLACE` exige o corpo INTEIRO.** Prove por md5 normalizado que a captura no
+   repositório é idêntica ao corpo vivo, extraia o bloco **do arquivo**, substituição **contada**,
+   **diffe**, e monte a migration por concatenação. Use o helper do projeto para normalizar.
+2. ⚠️ **Captura antiga pode usar `CREATE FUNCTION` sem `OR REPLACE`.** Troque, que `OR REPLACE`
+   **preserva as ACLs**.
+3. 🔴 **`ADD CONSTRAINT` com nome auto-gerado mais `WHEN duplicate_object THEN NULL` engole a
+   MUDANÇA de domínio.** Troca de domínio é `DROP CONSTRAINT IF EXISTS` mais `ADD`.
+4. **`apply_migration` cria a linha de tracking com timestamp PRÓPRIO**: renomeie o arquivo local
+   para esse timestamp, e `migration repair` é desnecessário.
+5. **DDL aplicada ANTES do merge deixa toda branch aberta vermelha.** Aplique com zero PRs abertas.
+6. **Mudança de schema exige `npm run db:types` na MESMA PR** (gate `gen-types-drift`).
+7. **Mexeu em descrição de tool? Regenere o manifesto** e confira o `ef_version` ANTES de deployar.
+   ⚠️ `deno` **não está instalado nesta máquina**; quem roda lint e check é o CI.
+8. **`CREATE FUNCTION` concede EXECUTE a PUBLIC.** `REVOKE ... FROM PUBLIC, anon` na MESMA migration.
+9. **`SECURITY DEFINER` contorna a RLS.** O gate do #785 vai **dentro** da função.
+10. ⚠️ **No ARE do Postgres, `\b` é BACKSPACE**; fronteira de palavra é `\y`.
+11. 📌 **Prove que o guard fica VERMELHO** numa transação abortada, e faça-o devolver **todos** os
+    itens examinados com um booleano, senão lista vazia não se distingue de cegueira.
+12. **Teste novo entra nas DUAS whitelists do `package.json`.**
+13. **Suíte offline (~57 s) é o gate barato:**
+    `env -u SUPABASE_URL -u SUPABASE_SERVICE_ROLE_KEY -u PUBLIC_SUPABASE_URL npm run test:contracts`.
+    ⚠️ **Skip ≡ pass.** Suíte com DB: ~13 min, **escreve em produção e não tolera concorrência**.
+    📌 Ela roda local com `set -a; . ./.env; set +a` e foi assim que a causa do CI vermelho apareceu
+    quando os logs do GitHub estavam fora do ar.
+14. ⚠️ **`Fecha #N` em português NÃO fecha a issue.** Use `Closes #N`, e nunca escreva o padrão sem
+    intenção de fechar, **nem para citá-lo**.
+15. ⚠️ **Branch nova nasce do HEAD, não da main.** `git checkout -b <nome> origin/main` e confirme
+    com `git merge-base --is-ancestor origin/main HEAD`. **Nunca `git add -A`**: há dezenas de
+    handoffs de julho não rastreados em `docs/planning/`.
+16. ⚠️ **Repo é PÚBLICO.** Nome, e-mail e identificador de pessoa não entram em issue, PR nem doc.
+    **Conte a população.** O export do VEP é git-ignored e a nota de minimização dele manda apagar
+    as cópias locais depois do import.
+17. ⚠️ **RPC com `auth.uid()` devolve "Not authenticated" para `service_role`.** Impersone em
+    transação abortada, `set_config('request.jwt.claims', ...)` **antes** do `SET LOCAL ROLE`.
+18. ⚠️ **NUNCA canalize a suíte por `| tail -N` em background**: o pipe segura a saída.
+19. ⚠️ **O build leva 2m30s a 4m40s: rode em background e confira o `Complete!`.**
+20. ⚠️ **Drive:** barra fullwidth (`／`), gravação do Meet **sem extensão**, doc nativo com 0 bytes
+    pelo mount (só `rclone cat`). E `~/.local/bin/rclone` (1.74), nunca o do apt.
+21. ⚠️ **A capacidade pode estar FORA do repo.** O ferramental de YouTube vive em
+    `~/projects/_pmo/youtube/` (venv `~/.venvs/youtube`, `token.json` OAuth vivo).
+22. ⚠️ **Corte as DUAS pontas de uma gravação.** E **capítulo com título parece decisão**, então
+    não batize resto de material.
+23. 🔴 **"YouTube não substitui arquivo" vale para SUBSTITUIR e não impede APARAR.** O editor do
+    Studio apara mantendo URL, views, playlist e os campos do banco. É navegador, não API. O
+    diálogo final avisa: **permanente e sem desfazer**. Processou em ~29 min.
+24. 🔴 **A API do YouTube mente por propagação nos DOIS sentidos**, inclusive **relendo a descrição
+    logo após o `update`**, que devolve o valor ANTIGO. Não conclua falha, releia depois.
+25. ⚠️ **`videos.update` com `part='snippet'` substitui o snippet INTEIRO.** Leia o vivo e troque só
+    o campo alvo.
+26. ⚠️ **`rescue` e `rescue_unbooked` são casos COMPLEMENTARES.** `rescue` exige
+    `interview_scheduled` e levanta `P0023` fora disso; `rescue_unbooked` exige `interview_pending`.
+27. 🔴 **Despacho em LOTE quebra o rodízio.** `now()` é da transação e os `dispatched_at` empatam.
+    Despache **um a um** e confira `resolved_evaluator_id` a cada volta.
+28. 🔴 **SQL direto por `service_role` registra ato humano como 'cron' com actor nulo.** Use a porta
+    MCP. Vale também para `member_add_alternate_email`, que **não audita**: prefira
+    `member_emails action='add'`.
+29. 🆕 ⚠️ **O GitHub caiu por mais de uma hora em 17/08** (503 em GraphQL e REST, escrita e logs;
+    leitura funcionava). Repetidor **idempotente** resolve: confira se o artefato já existe antes de
+    tentar de novo, para não duplicar comentário nem PR.
+30. 🆕 📌 **Reparo de dado tem forma canônica.** Procure o **backfill idempotente na migration que
+    criou o invariante** antes de inventar `UPDATE`. Meça alcance ANTES, rode, meça DEPOIS.


### PR DESCRIPTION
Handoff da segunda metade de 17/08 e o arranque que o supersede. Só `docs/planning/`.

## O que a tarde rendeu

**Duas reservas de entrevista chegaram pelo calendário de um entrevistador e nenhuma foi vista pela plataforma.** A primeira tinha risco de relógio: o cron das 15:30 mandaria convite para quem já tinha marcado. Registrada à mão às 14:36, ela saiu do predicado, e o cron resgatou **exatamente 2, com zero duplicados**. A segunda é a **primeira conversão** da rodada de resgates manuais de 02:45.

**#1832 fechada pela #1833** (12/12 verde): a tela passa a dizer com quem, e diz "não registrado" quando não há dado. Isso torna visível que **24 de 55 entrevistas vindas do calendário (44%) não têm entrevistador gravado**.

## O achado do dia veio de um CI vermelho que não era do PR

O import do VEP grava estado em massa **sem passar pela RPC canônica**, e com isso pula três garantias: auditoria, vínculo de membro e sincronia da janela de autoridade. A terceira era a mais invisível: a pessoa **perderia acesso quatro meses e meio antes do fim do contrato**, sem alarme e sem e-mail. Rastreado na **#1834**, com dois reparos aplicados e antes/depois medidos.

**Correção publicada na própria issue:** as decisões não foram tomadas no minuto do import. O export do VEP traz carimbo por decisão cobrindo dez meses, então aquele minuto é o **carimbo do transporte**, não o do fato.

## E um item que se dissolveu

O ITEM 2 pedia data e hora para "aprovados nunca entrevistados". O export mostra os três **Active na mesma vaga com submissão nula**: entraram por **oferta direta**, então não havia etapa de entrevista a cumprir. Falta só o PM ratificar.

---

Zero migrations e zero mudanças de schema nesta PR.
