### PR TITLE
docs(planning): arranque de 20/08 com o #1710 no topo, e o prompt da worktree da #1877

### DIFF
--- a/docs/audit/1710_MEDICAO_SELO_23AGO.sql
+++ b/docs/audit/1710_MEDICAO_SELO_23AGO.sql
@@ -1,0 +1,73 @@
+-- #1710 — medicao do selo de presenca, caminho (b): replicacao do predicado do cron.
+--
+-- POR QUE ESTE ARQUIVO EXISTE
+-- `seal_attendance_window_cron(true)` (o ensaio oficial) devolve `skipped: before_floor`
+-- enquanto a data local for menor que o `floor_date`. Antes de 24/08 ele nao mede nada.
+-- Esta consulta replica o MESMO predicado para permitir medir na vespera.
+--
+-- FRONTEIRA (medido em 19/08/2026): esta consulta replica o CRON, que NAO tem gate de
+-- chamador. `preview_seal_attendance` tem dois (`_can_manage_event` + `rls_can_see_initiative`)
+-- e portanto mede outra coisa: o que UM chamador alcanca. Divergencia entre os dois caminhos
+-- e ESPERADA e do tamanho da grade fora do alcance do lider. Nao trate como erro.
+--
+-- Fonte do predicado: corpos vivos de `seal_attendance_window_cron`,
+-- `_seal_event_attendance_apply` e `_attendance_eligible_events`, lidos em 19/08/2026 22:1x UTC.
+-- Se qualquer um mudar, esta replicacao caduca: releia antes de confiar.
+--
+-- COMO USAR EM 23/08: rode como esta (cenario A = agora). O cenario B projeta o instante do
+-- cron no piso. Depois de 24/08 11:40 UTC, o numero que vale e o do ensaio oficial:
+--   SELECT public.seal_attendance_window_cron(true);
+
+WITH cyc AS (SELECT cycle_start FROM public.cycles WHERE is_current = true LIMIT 1),
+-- coorte operacional: UMA chamada por pessoa, como o preview faz (nao uma por par).
+coorte AS (
+  SELECT m.id AS mid, ee.event_id AS eid
+  FROM public.members m
+  CROSS JOIN LATERAL public._attendance_eligible_events(m.id, NULL) ee
+  WHERE m.is_active = true AND m.current_cycle_active = true
+    AND EXISTS (SELECT 1 FROM public.v_member_operational_tiers vt
+                WHERE vt.member_id = m.id AND vt.operational_tier IN ('researcher','tribe_leader','manager'))
+),
+-- o laco do cron, sem o corte de graca (aplicado por cenario abaixo).
+due AS (
+  SELECT e.id,
+         public._event_end_instant(e.date, e.time_start, e.duration_minutes, e.timezone) AS ends
+  FROM public.events e, cyc
+  WHERE e.roster_sealed_at IS NULL
+    AND e.status IS DISTINCT FROM 'cancelled'
+    AND e.type IN ('geral','kickoff','tribo','lideranca')
+    AND e.date >= cyc.cycle_start
+),
+agg AS (
+  SELECT d.id, d.ends,
+         count(c.mid)::int      AS cohort_n,
+         count(a.member_id)::int AS recorded_n
+  FROM due d
+  LEFT JOIN coorte c ON c.eid = d.id
+  LEFT JOIN public.attendance a ON a.event_id = d.id AND a.member_id = c.mid
+  GROUP BY d.id, d.ends
+),
+-- grace_days sai da config, nao de literal: se o PM mexer, a conta acompanha.
+cfg AS (
+  SELECT COALESCE((value->>'grace_days')::int, 14) AS grace,
+         (value->>'floor_date')::date              AS floor_date
+  FROM public.platform_settings WHERE key = 'attendance.seal_window'
+),
+sc AS (
+  SELECT 'A_agora'::text AS cenario, now() - (SELECT grace FROM cfg) * interval '1 day' AS cutoff
+  UNION ALL
+  -- o cron roda 40 11 * * * UTC; no dia do piso o corte e esse instante menos a graca.
+  SELECT 'B_piso_1140utc',
+         (((SELECT floor_date FROM cfg) + time '11:40') AT TIME ZONE 'UTC')
+           - (SELECT grace FROM cfg) * interval '1 day'
+)
+SELECT sc.cenario,
+       to_char(sc.cutoff, 'YYYY-MM-DD HH24:MI')                              AS corte_fim_evento,
+       count(*) FILTER (WHERE agg.ends <= sc.cutoff)                         AS events_due,
+       count(*) FILTER (WHERE agg.ends <= sc.cutoff AND agg.cohort_n > 0)    AS events_would_seal,
+       count(*) FILTER (WHERE agg.ends <= sc.cutoff AND agg.cohort_n = 0)    AS events_skipped_empty,
+       COALESCE(sum(GREATEST(agg.cohort_n - agg.recorded_n, 0))
+                FILTER (WHERE agg.ends <= sc.cutoff AND agg.cohort_n > 0), 0) AS absences_would_write
+FROM sc CROSS JOIN agg
+GROUP BY sc.cenario, sc.cutoff
+ORDER BY sc.cenario;

--- a/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
+++ b/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
@@ -105,7 +105,21 @@ em arquivo.** Recupere-os do handoff ou refaça:
 
 - **A** → Marcelo Pereira (na tribo desde 07/08, Drive desde 08/08, falta `start_trail`).
 - **B** → Jefferson Pinto (líder), sobre o Pereira + manter horário publicado.
-- **C** → líderes das **6 tribos sem horário publicado**. Falta levantar quem são.
+- **C** → 🔴 **"6 tribos sem horário publicado" NÃO EXISTE pela definição do produto. Medido em
+  19/08 22:2x UTC.** A tela da tribo (`src/pages/tribe/[id].astro:585`) mostra
+  `tribes.meeting_schedule` e, na falta dele, `tribe_meeting_slots`. Contar por
+  `recurring_meeting_rules` dá 6, mas essa tabela **não é a que a tela lê**, e 4 das tais 6 têm de
+  17 a 22 encontros futuros marcados. É o mesmo erro de denominador do #1875, repetido.
+
+  O real são **dois casos opostos, e duas mensagens diferentes**, entre as 12 tribos ativas:
+
+  | tribo | o que a tela mostra | encontros futuros | o problema |
+  |---|---|---|---|
+  | 13 · Dados em Projetos de IA | **nada** | **17** | reúne e não publica |
+  | 10 · Governança Assistida | "Quinta-Feira - 18:00" | **0** (1 evento na vida) | publica e não reúne |
+
+  As outras 10 estão cobertas: 3 pelos slots (5, 7, 8) e 7 pelo texto. **Confirme com o PM qual das
+  duas mensagens ele quer antes de escrever**, porque elas não são a mesma.
 
 ⚠️ **Não use o rascunho antigo.** Ele dá boas-vindas ao Figueiredo, que **não está em tribo** (a
 alocação foi revertida em 19/08 a pedido do PM: ele escolhe a tribo dele depois do onboarding).

--- a/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
+++ b/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
@@ -1,0 +1,142 @@
+# Prompt de arranque: #1710 com prazo em 24/08, e a fila finalmente livre
+
+> Colar depois do `/clear`. **Modelo: Opus 5 (auto, não pinar). Effort: `xhigh`.**
+> **Supersede** `2026-08-19_PROMPT_ARRANQUE_FILA_TRAVADA_E_FILIACAO.md`, cujo item 1 (fila travada)
+> foi **resolvido** e cujo item 2 (#1855) foi **entregue**.
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Todo número foi medido em 19/08/2026 até 22:10 UTC.
+Re-meça com tool call na mesma volta em que o número entrar numa decisão, commit, issue ou pergunta.
+
+🔴 **Confira o RELÓGIO antes de executar a ordem sugerida.** `date -u` **e** `now()` do banco, e leia
+os passos pela **pré-condição**, não pela data.
+
+Regras de varredura ganhas em 19/08:
+
+- 🔴 **Contar da tabela de LINHAS em vez do CATÁLOGO produz um denominador que não é o do produto.**
+  Contei 12 linhas de `onboarding_progress` e conclui "4 de 12" sobre alguém que a plataforma mostra
+  como **4 de 7**. Publiquei errado na #1875 e tive que corrigir.
+- 🔴 **Um caso não é uma causa.** Atribuí a lentidão do CI à contenção que eu tinha criado; o modo de
+  falha já existia em duas branches alheias no dia anterior.
+- 🔴 **Sondar com nome de chave errado devolve o `ELSE` e parece resposta.** Sondei `_delivery_mode_for`
+  com `affiliation_renewal_30d` (inexistente), todos caíram no default e quase publiquei que nenhuma
+  faixa dispara e-mail imediato. Com o nome real, `affiliation_renewal_d7_urgent` é imediato.
+- ⚠️ **Ler código não é exercer o caminho.**
+- ⚠️ **Envelope não é prova.** Confirme o EFEITO na fonte.
+
+---
+
+## Estado
+
+`main` em **`dbf7a6fc`** + os merges de 19/08. **Fila VAZIA** (0 PRs abertas ao fim da sessão).
+**Bypass na janela: 0 de 2.** Invariantes: **1 violação, a declarada** (`U`, #1850).
+
+### O que entrou em 19/08
+
+| PR | o que |
+|---|---|
+| #1868 | mecanismo de exceção declarada de invariante |
+| #1871 | conserto do laço do `usePageI18n` (**verificado em uso**) |
+| #1874 | orçamento de saturação do CI |
+| #1872 | captura da migration do #1855 |
+| #1864 #1861 #1865 #1859 | a fila que estava travada |
+
+📌 **`check-invariants` vermelho é ESPERADO e correto.** A violação do #1850 está declarada em
+`tests/helpers/invariant-exceptions.mjs`, com issue e vencimento em **30/09**. O job dedicado roda com
+`INVARIANT_STRICT=1` e fica vermelho de propósito; o `validate` (required) fica verde. **Não conserte isso.**
+Quando a Diretoria verificar o caso, **a entrada sai do arquivo**.
+
+---
+
+## 🔴 ITEM 1: #1710, prazo 24/08. É o único item com data irreversível.
+
+**Config conferida em 19/08 22:05 UTC, e ela está intacta:**
+
+| | |
+|---|---|
+| `platform_settings['attendance.seal_window']` | `{"floor_date":"2026-08-24","grace_days":14}` |
+| hoje (local, America/Sao_Paulo) | 2026-08-19 |
+| **dias até o piso** | **5** |
+| cron | `attendance-seal-window-daily`, `40 11 * * *`, **ativo** |
+
+⚠️ **A medição de 15/08 (43 selam, 80 faltas, 40 pessoas) é TETO e encolhe a cada presença registrada.**
+**RE-MEDIR EM 23/08, a véspera, pelos DOIS caminhos independentes. Não recitar.**
+
+📌 **`preview_seal_attendance()` exige `auth.uid()`** e recusa `service_role` com "Not authenticated"
+(medido em 19/08). Os dois caminhos são: (a) a porta MCP, que carrega identidade, e (b) SQL direto
+replicando o predicado. **Divergência entre os dois é achado, não erro de digitação.**
+
+⚠️ **A entrevista de 24/08 23:30 UTC cai no MESMO dia do prazo.** Não deixe os dois para a mesma sessão.
+
+⚖️ **Já decidido, não re-litigar:** células fora do alcance de líder ficam com o GP pela grade geral;
+lista nominal ao GP **fora de issue e PR**. Ensaio antes do piso devolve `skipped: before_floor`.
+
+## ⏰ ITEM 2: relógios de amanhã
+
+- **09:00 UTC** — o cron do **#1855** roda **sem freio pela primeira vez**. Esperado: **9 notificações**
+  (7 da faixa d30 + 2 da faixa nova de vencidas), todas `digest_weekly`. **Confirme que saiu o esperado**
+  e que nenhuma virou e-mail imediato. `affiliation_renewal_d7_urgent` É imediato, mas tinha 0 pessoas.
+- **14:00 UTC** — `nudge-reschedule-pending-daily` pega os **9 candidatos** em `needs_reschedule`.
+
+## ITEM 3: comunicações aguardando aprovação do PM
+
+Arquivo: `docs/_deliverables/2026-08-19_comunicados_tribo_talentos_e_horarios.md` (rascunho antigo, com
+o Figueiredo). **Os textos A e B foram REESCRITOS para o Marcelo Pereira na conversa e ainda não estão
+em arquivo.** Recupere-os do handoff ou refaça:
+
+- **A** → Marcelo Pereira (na tribo desde 07/08, Drive desde 08/08, falta `start_trail`).
+- **B** → Jefferson Pinto (líder), sobre o Pereira + manter horário publicado.
+- **C** → líderes das **6 tribos sem horário publicado**. Falta levantar quem são.
+
+⚠️ **Não use o rascunho antigo.** Ele dá boas-vindas ao Figueiredo, que **não está em tribo** (a
+alocação foi revertida em 19/08 a pedido do PM: ele escolhe a tribo dele depois do onboarding).
+
+## ITEM 4: worktree paralela em curso
+
+**#1877** (auditoria da jornada de onboarding) roda em worktree própria, com prompt em
+`docs/planning/2026-08-20_PROMPT_ARRANQUE_WORKTREE_1877_JORNADA_ONBOARDING.md`.
+Ela **não mergeia**: entrega handoff + PR verde, e **esta sessão faz o QA e o merge**.
+
+⚠️ **Não disputem CI.** O `validate` fala com produção. Combine a janela antes de as duas abrirem PR.
+
+## ITEM 5: o resto, com dono
+
+- **#1876** (não existe porta de reenvio do convite) · **#1875** (120 linhas órfãs de onboarding)
+- **#1869** entregue em parte: o orçamento existe, **a causa da saturação era a #1870 e saiu**. A suíte
+  ainda roda contra produção, que é a saída estrutural (#1844).
+- **#1870 FECHÁVEL:** consertado e **verificado em uso** (1 chamada, 0 backends, site público em 0,27 s).
+- **#1863 #1866 #1867 #1854 #1852** (filiação) · **#1842 #1829 #1822 #1592 #1205 #905** (30/09)
+- **#588** `[LL]` do PMO · **#92** (raiz da #1614)
+- 🆕 **Três candidaturas com `interview_status='scheduled'` sem entrevista agendada** (família do #1842).
+  Sem issue. Some se ninguém abrir.
+
+---
+
+## Ordem sugerida
+
+1. **Conferir o cron do #1855** (pós 09:00 UTC): saiu o esperado?
+2. **#1710**: preparar os dois caminhos de medição AGORA, para que 23/08 seja só executar.
+3. **Textos A, B e C** ao PM, se ele aprovar.
+4. **23/08: re-medir o #1710** pelos dois caminhos.
+
+---
+
+## Armadilhas
+
+1. ⚠️ **`preview_seal_attendance` recusa `service_role`.** Use a porta MCP ou replique o predicado.
+2. ⚠️ **`CURRENT_DATE` é UTC.** O cron do selo já usa `America/Sao_Paulo` de propósito (#1727). Ao
+   replicar o predicado, **use o mesmo fuso**, senão sua contagem diverge da do cron por algumas horas.
+3. 🔴 **`check-invariants` vermelho é o desenho.** Ver acima.
+4. ⚠️ **DDL exige ZERO PRs abertas.** Com a worktree ativa, isso agora precisa de combinação.
+5. ⚠️ **`apply_migration` cria o timestamp**: renomeie o arquivo local para ele. A CLI não está linkada.
+6. ⚠️ **Teste novo entra nas DUAS whitelists do `package.json`.**
+7. ⚠️ **`Fecha #N` NÃO fecha. Use `Closes #N`** — e escrever sobre a palavra-chave dispara.
+8. ⚠️ **`git checkout -b <nome> origin/main`. Nunca `git add -A`** (~60 arquivos não rastreados).
+9. ⚠️ **Repo PÚBLICO.** Nome, e-mail e identificador não entram em issue, PR nem doc.
+10. ⚠️ **O build leva 4 a 6 min:** background + confira o `Complete!`.
+11. 🔴 **SQL direto por `service_role` grava ato humano como 'cron' com actor nulo.** Use a porta MCP,
+    ou o cliente autenticado da página via `window.navGetSb()` (foi assim que os 8 convites saíram).
+12. ⚠️ **Não rode a suíte inteira sem necessidade.** Ela fala com produção.

--- a/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
+++ b/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
@@ -62,12 +62,28 @@ Quando a Diretoria verificar o caso, **a entrada sai do arquivo**.
 | **dias até o piso** | **5** |
 | cron | `attendance-seal-window-daily`, `40 11 * * *`, **ativo** |
 
-⚠️ **A medição de 15/08 (43 selam, 80 faltas, 40 pessoas) é TETO e encolhe a cada presença registrada.**
-**RE-MEDIR EM 23/08, a véspera, pelos DOIS caminhos independentes. Não recitar.**
+🔴 **CORREÇÃO (medida em 19/08 22:14 UTC): o número NÃO é teto.** Ele tem DUAS forças opostas. As
+faltas encolhem a cada presença registrada, mas o conjunto de eventos devidos **CRESCE** conforme a
+janela de graça (14 dias) desliza e mais eventos cruzam o corte. Replicando o predicado do cron:
 
-📌 **`preview_seal_attendance()` exige `auth.uid()`** e recusa `service_role` com "Not authenticated"
-(medido em 19/08). Os dois caminhos são: (a) a porta MCP, que carrega identidade, e (b) SQL direto
-replicando o predicado. **Divergência entre os dois é achado, não erro de digitação.**
+| cenário | corte (fim do evento) | devidos | selam | coorte vazia | faltas |
+|---|---|---|---|---|---|
+| agora (19/08) | 2026-08-05 22:14 | 42 | **38** | 4 | **76** |
+| piso (24/08 11:40 UTC) | 2026-08-10 11:40 | 47 | **43** | 4 | **83** |
+
+A linha do piso é **simulação, não medição**: a coorte é lida de hoje. Que ela caia em 43 selos, o
+mesmo número de 15/08, é **coincidência de duas partes móveis**, não estabilidade. **RE-MEDIR EM 23/08.**
+Distribuição das 83 faltas: **41 pessoas**, sendo 17 com uma, 13 com duas, 8 com três, e uma com sete.
+
+📌 **Os dois caminhos medem COISAS DIFERENTES, e divergir é o desenho, não achado.**
+`seal_attendance_window_cron` (o ato) **não tem gate de chamador**. `preview_seal_attendance` tem
+**dois** (`_can_manage_event` + `rls_can_see_initiative`) e mede o que UM chamador alcança: a
+diferença entre os dois É a grade fora do alcance do líder, que já foi decidida como sendo do GP.
+O preview também exige `auth.uid()` e recusa `service_role` com "Not authenticated" (medido em 19/08).
+
+⚙️ **A consulta do caminho (b) está congelada em `docs/audit/1710_MEDICAO_SELO_23AGO.sql`**, já
+parametrizada por `grace_days` e `floor_date` da config, e conferida contra os números acima. Em
+23/08 é só executar. Ela caduca se o corpo de qualquer uma das três funções mudar.
 
 ⚠️ **A entrevista de 24/08 23:30 UTC cai no MESMO dia do prazo.** Não deixe os dois para a mesma sessão.
 
@@ -117,10 +133,11 @@ Ela **não mergeia**: entrega handoff + PR verde, e **esta sessão faz o QA e o 
 
 ## Ordem sugerida
 
-1. **Conferir o cron do #1855** (pós 09:00 UTC): saiu o esperado?
-2. **#1710**: preparar os dois caminhos de medição AGORA, para que 23/08 seja só executar.
-3. **Textos A, B e C** ao PM, se ele aprovar.
-4. **23/08: re-medir o #1710** pelos dois caminhos.
+1. **Conferir o cron do #1855** (pré-condição: passou das 09:00 UTC de 20/08): saiu o esperado?
+2. ✅ **FEITO em 19/08 22:1x UTC.** Caminho (b) congelado em `docs/audit/1710_MEDICAO_SELO_23AGO.sql`,
+   e o item 1 acima corrigido: o número não é teto, e os dois caminhos divergem por desenho.
+3. **Textos A, B e C** ao PM, se ele aprovar. **C ainda exige levantar as 6 tribos sem horário.**
+4. **23/08: re-medir o #1710** pelos dois caminhos, sabendo que eles medem recortes diferentes.
 
 ---
 

--- a/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
+++ b/docs/planning/2026-08-20_PROMPT_ARRANQUE_1710_E_FILA_LIVRE.md
@@ -105,7 +105,10 @@ em arquivo.** Recupere-os do handoff ou refaça:
 
 - **A** → Marcelo Pereira (na tribo desde 07/08, Drive desde 08/08, falta `start_trail`).
 - **B** → Jefferson Pinto (líder), sobre o Pereira + manter horário publicado.
-- **C** → 🔴 **"6 tribos sem horário publicado" NÃO EXISTE pela definição do produto. Medido em
+- **C** → ✅ **ESCRITO para a tribo 13** (decisão do PM em 19/08: essa primeiro), em
+  `docs/_deliverables/2026-08-19_comunicado_C_tribo13_horario.md`, **não versionado**. Verificado por
+  impersonação que o líder consegue corrigir sozinho. **Falta o texto da tribo 10**, o caso oposto.
+  🔴 **"6 tribos sem horário publicado" NÃO EXISTE pela definição do produto. Medido em
   19/08 22:2x UTC.** A tela da tribo (`src/pages/tribe/[id].astro:585`) mostra
   `tribes.meeting_schedule` e, na falta dele, `tribe_meeting_slots`. Contar por
   `recurring_meeting_rules` dá 6, mas essa tabela **não é a que a tela lê**, e 4 das tais 6 têm de
@@ -142,6 +145,16 @@ Ela **não mergeia**: entrega handoff + PR verde, e **esta sessão faz o QA e o 
 - **#588** `[LL]` do PMO · **#92** (raiz da #1614)
 - 🆕 **Três candidaturas com `interview_status='scheduled'` sem entrevista agendada** (família do #1842).
   Sem issue. Some se ninguém abrir.
+- 🆕 **#1881 (aberta 19/08):** o gatilho de XP de entregável dispara só na transição de `status`, mas a
+  elegibilidade tem QUATRO campos. Quem entra pelos outros três nunca paga. Travou o `validate` numa
+  PR só de docs. **Contido pagando o card pela função canônica** (30 pts, sem bônus, ator sistema;
+  7 de 7 elegíveis pagos), mas a raiz continua: o próximo card volta a travar a fila.
+- 🆕 **#1882 (aberta 19/08):** `volunteer/leader` concede `write` com escopo **`organization`**,
+  enquanto todo outro tipo de liderança é `initiative`. São **13 pessoas**. Exercido por impersonação
+  com rollback: escreve em tribo alheia, e lê **e-mail e telefone** de 7 e 8 pessoas de tribos que não
+  são dela (contra 2 da própria). A mitigação documentada em `get_tribe_member_contacts` só vale para
+  `caller_chapter_scope() IS NOT NULL`, e para líder de tribo ela é NULL. **Não estreitar o escopo sem
+  decidir antes se a largura é intencional.**
 
 ---
 

--- a/docs/planning/2026-08-20_PROMPT_ARRANQUE_WORKTREE_1877_JORNADA_ONBOARDING.md
+++ b/docs/planning/2026-08-20_PROMPT_ARRANQUE_WORKTREE_1877_JORNADA_ONBOARDING.md
@@ -1,0 +1,154 @@
+# Prompt de arranque: worktree da #1877, auditoria da jornada de onboarding
+
+> Colar numa sessão NOVA, em worktree própria. **Modelo: Opus 5 (auto, não pinar). Effort: `xhigh`.**
+> Esta worktree **não mergeia**. Ela entrega handoff + PR verde; a sessão principal faz o QA e o merge.
+
+---
+
+## Missão
+
+Auditar a jornada de onboarding **exercendo-a**, agrupar o que já existe aberto, e devolver o material
+para uma sessão de planejamento. **Não desenhar a melhoria.** Metade das perguntas da Diretoria já tem
+resposta "existe e não é usado", e desenhar por cima disso constrói a segunda cópia do que está lá.
+
+---
+
+## Regra zero
+
+**Nada deste documento pode ser recitado.** Todo número foi medido em 19/08/2026, entre 21:20 e 22:00 UTC.
+Re-meça com tool call na mesma volta em que o número entrar numa conclusão, issue ou comentário.
+
+Regras de varredura que já custaram caro **nesta investigação**:
+
+- 🔴 **Contar da tabela de LINHAS em vez do CATÁLOGO produz um denominador que não é o do produto.**
+  Consultei `onboarding_progress` direto, contei 12 linhas e conclui "4 de 12" sobre um membro que a
+  plataforma mostra como **4 de 7**. Publiquei a conclusão errada na #1875 e tive que corrigir. O
+  catálogo é `onboarding_steps`; a tabela de progresso aceita qualquer `step_key`.
+- 🔴 **Ausência de dado só vale COM o controle do campo.** Meça a taxa de preenchimento na população
+  antes de afirmar que algo não existe.
+- 🔴 **`instrumented` separa "não mediu" de "não aconteceu".** Vale para toda tabela que tenha a coluna.
+- ⚠️ **Ler código não é exercer o caminho.** A pergunta "o candidato consegue X?" só se responde
+  **logado, com o estado dele**. Foi assim que o beco sem saída apareceu.
+
+---
+
+## O que JÁ está medido. NÃO refaça.
+
+### O passo 5 é beco sem saída sem tribo
+
+`src/components/onboarding/OnboardingChecklist.tsx`:
+
+```jsx
+{s.step_id === 'meet_tribe' && member?.tribe_id && (
+  <a href={`${lp}/tribe/${member.tribe_id}`}>🔬 Visitar tribo</a>
+)}
+```
+
+Sem `tribe_id`, o botão **não renderiza**. O passo aparece sem ação e sem explicação. O comentário no
+mesmo arquivo promete o oposto: *"so no step is ever a dead-end"*.
+
+### O fluxo de escolha e aprovação existe, e parou
+
+| notificação | destinatário | linhas | mais recente |
+|---|---|---|---|
+| `tribe_request` | o líder | 40 | **20/07/2026** |
+| `tribe_request_reviewed` | o candidato | 39 | **20/07/2026** |
+| `tribe_request_nudge` | lembrete | 2 | 10/07/2026 |
+| `engagement_welcome` (controle) | — | 142 | **19/08/2026** |
+
+O componente que oferece a escolha é `TribeRequestBlock`, e ele mora em **`/workspace`**, não na jornada.
+
+### O catálogo tem 11 passos, não 12
+
+`onboarding_steps`: 7 gerais (`code_of_conduct`, `complete_profile`, `volunteer_term`, `vep_acceptance`,
+`meet_tribe`, `start_trail`, `first_meeting`) + 4 só de `tribe_leader` (`leader_*`).
+`get_my_onboarding` calcula contra esse catálogo.
+
+### Conclusão por passo, população inteira
+
+| step_key | linhas | concluídas | % |
+|---|---|---|---|
+| `volunteer_term` | 96 | 91 | 94,8 |
+| `first_meeting` | 112 | 101 | 90,2 |
+| `complete_profile` | 100 | 85 | 85,0 |
+| `vep_acceptance` | 97 | 80 | 82,5 |
+| `meet_tribe` | 97 | 71 | 73,2 |
+| `code_of_conduct` | 97 | 70 | 72,2 |
+| `leader_capture_video` | 13 | 4 | 30,8 |
+| **`start_trail`** | **98** | **20** | **20,4** |
+| `leader_refine_theme` / `leader_review_tribe` | 13 | 3 | 23,1 |
+| `leader_roadmap` | 13 | 2 | 15,4 |
+| **5 chaves órfãs** (`accept_terms`, `join_whatsapp`, `kick_off`, `platform_access`, `profile_complete`) | 24 cada | **0** | **0,0** |
+
+As 5 órfãs **não estão no catálogo** e nenhuma tela as lê. São 120 linhas de dívida (#1875).
+
+### Tribos
+
+12 tribos de pesquisa ativas. **6 não publicam nenhum horário de reunião** (Dados em Projetos de IA,
+Fluência em IA, Governança Assistida, IA em Projetos & Construção, PMO Inteligente, Produtividade
+Aumentada). Menores: Governança Assistida (2), Dados em Projetos de IA (2), Talentos & Upskilling (3).
+
+---
+
+## O TRABALHO: o que NÃO está medido
+
+1. **Exercer a jornada logado**, com um membro sem tribo, e registrar o que ele vê em cada um dos 7 passos.
+2. **`EntryChapterNudge`** (`src/components/onboarding/`): está montado? Dispara quando? Para quem?
+3. **Filiação e capítulo na jornada**: aparece? E a escolha entre múltiplos capítulos?
+4. **Não filiado**: a jornada informa que filiar-se é pré-requisito e benefício?
+5. **Vídeos**: existe vídeo de tribo que ajude a escolher? (Há `leader_capture_video`, só de líder.)
+6. **Por que `start_trail` está em 20,4%.** É o passo visível mais abandonado.
+7. **Por que `tribe_request` parou em 20/07.** Mudança de processo, defeito, ou decisão?
+
+---
+
+## Issues a triar (18 levantadas, agrupadas na #1877)
+
+**Jornada:** #1277 · #873 · #1014 · #809 · #1875 · #1171
+**Tribo:** #1219 · #1356 · #1777
+**Filiação e capítulo:** #1863 · #1866 · #1867 · #1852 · #1581 · #1580 · #1095 · #1358
+**Adjacentes:** #1876 · #617
+
+Para cada uma: **é a mesma coisa que outra? está obsoleta? entra no redesenho ou sai?**
+
+---
+
+## Critério de aceite / encerramento
+
+A worktree encerra quando entregar, num documento em `docs/audit/`:
+
+1. **Mapa do estado atual por passo**, com o que o membro **vê** (exercido logado, não lido do código).
+2. **As 7 lacunas acima respondidas**, cada uma com medição ou com "não deu para medir, e por quê".
+3. **Triagem das 18 issues** em: mesma-coisa-que-#N · obsoleta · entra no escopo · fica fora.
+4. **A decisão pendente formulada**, não tomada: qual caminho de entrada em tribo é o oficial,
+   `tribe_request` ou alocação administrativa. Hoje existem os dois e nenhum é.
+5. **Handoff** em `docs/planning/`, no formato dos existentes, com o que a sessão de planejamento
+   precisa decidir.
+
+**PR verde** com esses arquivos. Sem migration, sem mudança de código de produto.
+
+---
+
+## Armadilhas desta worktree
+
+1. 🔴 **NÃO rode a suíte completa.** O `validate` fala com o **banco de produção** e a lane serializa.
+   Duas worktrees testando ao mesmo tempo reproduzem a saturação da #1869. Rode só os arquivos que
+   você tocar.
+2. 🔴 **Banco é somente LEITURA aqui.** Esta worktree audita. Qualquer escrita é da sessão principal.
+3. ⚠️ **Repo PÚBLICO.** Nome, e-mail e identificador não entram em issue, PR nem doc. **Conte a população.**
+4. ⚠️ **`git checkout -b <nome> origin/main`.** Branch nova nasce do HEAD, e a árvore é compartilhada.
+   **Nunca `git add -A`** (há ~60 arquivos não rastreados).
+5. ⚠️ **`Fecha #N` NÃO fecha. Use `Closes #N`**, e nunca escreva o padrão sem intenção — escrever
+   sobre a palavra-chave dispara.
+6. ⚠️ **O build leva 4 a 6 min:** rode em background e confira o `Complete!`.
+7. 📌 **`check-invariants` vermelho é ESPERADO.** A violação do #1850 está declarada em
+   `tests/helpers/invariant-exceptions.mjs` e o job dedicado roda em modo estrito de propósito.
+   O `validate` (required) fica verde. **Não tente consertar isso.**
+8. ⚠️ **Merge à main é só da sessão principal.** Entregue PR verde e handoff.
+
+---
+
+## Contexto de fila
+
+A sessão principal está atacando o **#1710 (prazo 24/08)**. Não disputem CI: se você precisar de
+`validate`, avise no handoff antes de abrir a PR.


### PR DESCRIPTION
Dois documentos de planejamento.

**Arranque de 20/08:** a fila foi destravada e o #1855 entregue, então o próximo item com data irreversível é o **#1710, piso em 24/08, cinco dias**. Config conferida ao vivo e intacta (`floor_date` 2026-08-24, `grace_days` 14, cron ativo). A medição de 15/08 é **teto** e encolhe a cada presença registrada: o arranque manda re-medir em 23/08 pelos dois caminhos, e registra que `preview_seal_attendance` recusa `service_role`.

**Prompt da worktree da #1877:** auditoria da jornada de onboarding, em worktree paralela. Ela audita e não desenha, e não mergeia — entrega handoff e PR verde para esta sessão fazer o QA. Carrega tudo que já foi medido marcado como "não refaça".

Os dois avisam que **`check-invariants` vermelho é o desenho**, não defeito. Sem isso, a primeira coisa que uma sessão nova faz é tentar apagar o sinal honesto que a #1868 construiu.

Refs #1710, #1877