### PR TITLE
fix(board): #1887 - assign e unassign de membro em card decidem olhando o recurso

### DIFF
--- a/src/pages/tribe/[id].astro
+++ b/src/pages/tribe/[id].astro
@@ -512,7 +512,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
   // #161 (2026-06-06): V4 scoped gate for tribe board/edit authority (broadcast tab, minutes/board
   // edit). Mirrors write_board on the page's initiative (tribe fallback). Replaces the V3 global
   // hasPermission('board.edit_tribe_items') && tribe_id===TRIBE_ID under-grant pattern.
-  function isLeaderOfThisTribeV4(): boolean {
+  function canWriteThisTribeBoardV4(): boolean {
     if (!currentMember) return false;
     // Admin simulation overlay (see canSeeTribeContacts): preview the simulated V3 tier + tribe.
     const sim = getSimulation();
@@ -523,6 +523,19 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
     if (typeof cf !== 'function') return false;
     if (INITIATIVE_ID && cf('write_board', { type: 'initiative', id: INITIATIVE_ID }) === true) return true;
     return cf('write_board', { type: 'tribe', id: TRIBE_ID }) === true;
+  }
+
+  // #1887: lideranca REAL desta tribo, que NAO e a mesma pergunta que write_board.
+  // canWriteThisTribeBoardV4() responde "pode escrever no board desta tribo", e uma pesquisadora
+  // com write_board escopado responde true. Usar aquela funcao como se fosse lideranca fazia a
+  // tela chamar list_tribe_pending_requests para nao-lideres, que a RPC recusa com 403 a cada
+  // carga da pagina. Espelha o gate da RPC: GP (manage_member) OU lider volunteer/leader DESTA
+  // tribo (operational_role e o cache mantido por sync_operational_role_cache).
+  function isTribeLeaderOfThisTribeV4(): boolean {
+    if (!currentMember) return false;
+    if (isHighManagement(currentMember)) return true;
+    return currentMember.operational_role === 'tribe_leader'
+      && getEffectiveTribeId(currentMember) === TRIBE_ID;
   }
 
   let membersMap: Map<string, any> = new Map();
@@ -1050,7 +1063,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
   function renderRoadmap() {
     const el = document.getElementById('tribe-roadmap-section');
     if (!el) return;
-    const canAuthor = isLeaderOfThisTribeV4();
+    const canAuthor = canWriteThisTribeBoardV4();
     const editBtn = canAuthor
       ? `<button data-action="open-roadmap-modal" class="px-3 py-1.5 bg-navy text-white rounded-lg text-xs font-semibold cursor-pointer border-0 hover:opacity-90 transition-all shrink-0">${escapeHtml(I18N.roadmapEdit || 'Editar roadmap')}</button>`
       : '';
@@ -1143,7 +1156,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
 
   // ── Tribe Selection Híbrida PR3: leader's join-request queue ──
   // Leader/GP-only section atop the Members tab. The server RPC enforces the real authority
-  // (Caminho-3: GP or volunteer/leader of THIS tribe); isLeaderOfThisTribeV4() is the display gate.
+  // (Caminho-3: GP or volunteer/leader of THIS tribe); isTribeLeaderOfThisTribeV4() mirrors it (#1887).
   // Returns '' for non-leaders, RPC errors, or an empty queue (so the section never shows blank).
   // #1139 Item 2: mirror the leader's pending-request count onto the Membros tab, so it is visible
   // from any tab (the queue itself only renders inside the Membros panel). Called on load (via
@@ -1163,7 +1176,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
   }
 
   async function tribeRequestsSectionHtml(): Promise<string> {
-    if (!isLeaderOfThisTribeV4()) return '';
+    if (!isTribeLeaderOfThisTribeV4()) return '';
     const sb = getSb();
     if (!sb) return '';
     let rows: any[] = [];
@@ -1886,7 +1899,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
 
   function checkBroadcastAccess() {
     if (!currentMember) return;
-    const isLeaderOfThisTribe = isLeaderOfThisTribeV4(); // #161: V4 scoped write_board (was global board.edit_tribe_items)
+    const isLeaderOfThisTribe = canWriteThisTribeBoardV4(); // #161: V4 scoped write_board (was global board.edit_tribe_items)
     if (isLeaderOfThisTribe || isHighManagement(currentMember)) {
       showBroadcastTab();
       renderBroadcastPanel();
@@ -2326,7 +2339,7 @@ const pageTitle = t('tribe.meta', lang).replace('{name}', staticFallback?.name |
         || desigs.includes('comms_member')
       );
     canEdit = isHighManagement(currentMember) ||
-      isLeaderOfThisTribeV4() || // #161: V4 scoped write_board (was global board.edit_tribe_items)
+      canWriteThisTribeBoardV4() || // #161: V4 scoped write_board (was global board.edit_tribe_items)
       canOperateComms;
   }
 

--- a/supabase/migrations/20260820014622_1887_assign_e_unassign_de_membro_em_card_decidem_olhando_o_recurso.sql
+++ b/supabase/migrations/20260820014622_1887_assign_e_unassign_de_membro_em_card_decidem_olhando_o_recurso.sql
@@ -1,0 +1,157 @@
+-- #1887: assign/unassign de membro em card decidem olhando o RECURSO.
+--
+-- Defeito: o gate de assign_member_to_item tem 5 ramos e NENHUM consulta `write_board`,
+-- a capacidade canonica de escrita no board. Uma pesquisadora com write_board=true so
+-- conseguia se auto-atribuir como `author`; atribuir qualquer outra pessoa levantava
+-- excecao (PostgREST -> 400). Medido em 19/08: 69 dos 94 membros ativos tem write_board,
+-- e 52 deles eram barrados por este gate.
+--
+-- Correcao: resolver a tribo do board (via initiatives.legacy_tribe_id, mesmo formato que
+-- update_board_item e move_board_item ja usam) e decidir contra ELA, com
+-- rls_can_for_tribe('write_board', <tribo do board>) -- que respeita o `scope` do catalogo
+-- (initiative vs organization). NAO se acrescenta can_by_member('write_board') ao OR:
+-- essa e capacidade organizacional SEM escopo, e deixaria uma pesquisadora de uma tribo
+-- atribuir gente em card de qualquer outra -- o defeito que o epico #1780 aponta.
+--
+-- Boards sem tribo resolvida (legacy_tribe_id NULL) mantem exatamente o gate antigo:
+-- onde nao ha recurso para escopar, nao se amplia.
+--
+-- unassign_member_from_item entra na mesma passagem por SIMETRIA: hoje ela tem apenas 2
+-- ramos (participate_in_governance_review OR tribe_leader), entao sem isso o conserto
+-- criaria uma porta so de ida -- inclusive board admin e o auto-atribuido como `author`
+-- podiam atribuir e nao podiam remover. O gate passa a ser identico ao de assign.
+--
+-- O DEFAULT de p_role fica preservado: sem ele, CREATE OR REPLACE recusa com 42P13.
+
+CREATE OR REPLACE FUNCTION public.assign_member_to_item(
+  p_item_id uuid, p_member_id uuid, p_role text DEFAULT 'author'::text
+) RETURNS uuid
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_caller members%rowtype;
+  v_item board_items%rowtype;
+  v_board record;
+  v_member members%rowtype;
+  v_assignment_id uuid;
+  v_is_board_admin boolean;
+  v_board_legacy_tribe_id int;
+BEGIN
+  SELECT * INTO v_caller FROM members WHERE auth_id = auth.uid();
+  IF v_caller IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+  SELECT * INTO v_item FROM board_items WHERE id = p_item_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Item not found'; END IF;
+  SELECT pb.* INTO v_board FROM project_boards pb WHERE pb.id = v_item.board_id;
+
+  -- #1887: resolve o recurso para poder escopar a autoridade.
+  SELECT i.legacy_tribe_id INTO v_board_legacy_tribe_id
+  FROM public.initiatives i WHERE i.id = v_board.initiative_id;
+
+  v_is_board_admin := EXISTS (
+    SELECT 1 FROM board_members bm
+    WHERE bm.board_id = v_board.id AND bm.member_id = v_caller.id AND bm.board_role = 'admin'
+  );
+
+  -- ADR-0041: V4 catalog OR Path Y (tribe_leader op-role / board_admin / self+author claim / curator+curation_reviewer)
+  -- p200 ADR-0087: curator V3 designation -> V4 can_by_member('curate_content')
+  -- #1887: + write_board ESCOPADO a tribo do board (nao a capacidade organizacional solta)
+  IF NOT (
+    public.can_by_member(v_caller.id, 'participate_in_governance_review')
+    OR v_caller.operational_role = 'tribe_leader'
+    OR v_is_board_admin
+    OR (p_role = 'curation_reviewer' AND public.can_by_member(v_caller.id, 'curate_content'))
+    OR (v_caller.id = p_member_id AND p_role = 'author')
+    OR (v_board_legacy_tribe_id IS NOT NULL
+        AND public.rls_can_for_tribe('write_board', v_board_legacy_tribe_id))
+  ) THEN
+    RAISE EXCEPTION 'Requires participate_in_governance_review, tribe_leader, board admin, curate_content (for curation_reviewer), self-claim (author), or write_board on this board''s tribe';
+  END IF;
+
+  IF p_role NOT IN ('author', 'reviewer', 'contributor', 'curation_reviewer') THEN
+    RAISE EXCEPTION 'Invalid role: %. Must be author|reviewer|contributor|curation_reviewer', p_role;
+  END IF;
+  SELECT * INTO v_member FROM members WHERE id = p_member_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Member not found'; END IF;
+
+  INSERT INTO board_item_assignments (item_id, member_id, role, assigned_by)
+  VALUES (p_item_id, p_member_id, p_role, v_caller.id)
+  ON CONFLICT (item_id, member_id, role) DO NOTHING
+  RETURNING id INTO v_assignment_id;
+
+  IF v_assignment_id IS NOT NULL THEN
+    INSERT INTO board_lifecycle_events (board_id, item_id, action, reason, actor_member_id)
+    VALUES (v_item.board_id, p_item_id, 'member_assigned',
+      v_member.name || ' como ' || p_role, v_caller.id);
+    PERFORM create_notification(
+      p_member_id, 'card_assigned', 'board_item', p_item_id, v_item.title, v_caller.id,
+      v_caller.name || ' atribuiu voce como ' || p_role
+    );
+  END IF;
+
+  RETURN coalesce(v_assignment_id, (
+    SELECT bia.id FROM board_item_assignments bia
+    WHERE bia.item_id = p_item_id AND bia.member_id = p_member_id AND bia.role = p_role
+  ));
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.unassign_member_from_item(
+  p_item_id uuid, p_member_id uuid, p_role text
+) RETURNS void
+LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_caller members%rowtype;
+  v_item board_items%rowtype;
+  v_board record;
+  v_member_name text;
+  v_deleted int;
+  v_is_board_admin boolean;
+  v_board_legacy_tribe_id int;
+BEGIN
+  SELECT * INTO v_caller FROM members WHERE auth_id = auth.uid();
+  IF v_caller IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+
+  SELECT * INTO v_item FROM board_items WHERE id = p_item_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'Item not found'; END IF;
+  SELECT pb.* INTO v_board FROM project_boards pb WHERE pb.id = v_item.board_id;
+
+  -- #1887: resolve o recurso para poder escopar a autoridade.
+  SELECT i.legacy_tribe_id INTO v_board_legacy_tribe_id
+  FROM public.initiatives i WHERE i.id = v_board.initiative_id;
+
+  v_is_board_admin := EXISTS (
+    SELECT 1 FROM board_members bm
+    WHERE bm.board_id = v_board.id AND bm.member_id = v_caller.id AND bm.board_role = 'admin'
+  );
+
+  -- #1887: gate IDENTICO ao de assign_member_to_item -- quem pode atribuir pode remover.
+  -- Antes eram apenas 2 ramos, o que deixava board admin e o auto-atribuido sem volta.
+  IF NOT (
+    public.can_by_member(v_caller.id, 'participate_in_governance_review')
+    OR v_caller.operational_role = 'tribe_leader'
+    OR v_is_board_admin
+    OR (p_role = 'curation_reviewer' AND public.can_by_member(v_caller.id, 'curate_content'))
+    OR (v_caller.id = p_member_id AND p_role = 'author')
+    OR (v_board_legacy_tribe_id IS NOT NULL
+        AND public.rls_can_for_tribe('write_board', v_board_legacy_tribe_id))
+  ) THEN
+    RAISE EXCEPTION 'Requires participate_in_governance_review, tribe_leader, board admin, curate_content (for curation_reviewer), self-claim (author), or write_board on this board''s tribe';
+  END IF;
+
+  SELECT name INTO v_member_name FROM members WHERE id = p_member_id;
+
+  DELETE FROM board_item_assignments
+  WHERE item_id = p_item_id AND member_id = p_member_id AND role = p_role;
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  IF v_deleted > 0 THEN
+    INSERT INTO board_lifecycle_events
+      (board_id, item_id, action, reason, actor_member_id)
+    VALUES
+      (v_item.board_id, p_item_id, 'member_unassigned',
+       coalesce(v_member_name, 'membro') || ' removido de ' || p_role,
+       v_caller.id);
+  END IF;
+END;
+$$;

--- a/tests/contracts/tribe-selection-hybrid-pr3-leader.test.mjs
+++ b/tests/contracts/tribe-selection-hybrid-pr3-leader.test.mjs
@@ -68,8 +68,19 @@ test('tribe page renders the leader queue from list_tribe_pending_requests', () 
   assert.match(PAGE, /tribeRequestsSectionHtml/);
 });
 
-test('tribe page gates the queue on isLeaderOfThisTribeV4 (leader/GP display gate)', () => {
-  assert.match(PAGE, /if \(!isLeaderOfThisTribeV4\(\)\) return ''/);
+// #1887: o portao da fila NAO pode ser o de escrita no board. `canWriteThisTribeBoardV4`
+// (ex-`isLeaderOfThisTribeV4`, cujo nome mentia) e satisfeito por qualquer pesquisadora com
+// `write_board` escopado, e era isso que fazia a tela chamar `list_tribe_pending_requests`
+// para nao-lideres e colher 403 a cada carga. O guard aceita o identificador renomeado, mas
+// exige que ele seja o de LIDERANCA, e proibe explicitamente o de escrita.
+test('tribe page gates the queue on a LEADERSHIP predicate, not on board-write (#1887)', () => {
+  assert.match(PAGE, /if \(!isTribeLeaderOfThisTribeV4\(\)\) return ''/);
+  assert.doesNotMatch(PAGE, /if \(!canWriteThisTribeBoardV4\(\)\) return ''/);
+  // e o predicado espelha o gate da RPC: manage_member OU volunteer/leader DESTA tribo
+  assert.match(
+    PAGE,
+    /function isTribeLeaderOfThisTribeV4\(\)[\s\S]*?isHighManagement\(currentMember\)[\s\S]*?operational_role === 'tribe_leader'[\s\S]*?getEffectiveTribeId\(currentMember\) === TRIBE_ID/
+  );
 });
 
 test('accept/decline call review_tribe_request (the PR1 write) with approve/decline', () => {


### PR DESCRIPTION
Fecha #1887 (item do banco) e o item 2 (portão de tela).

## O defeito do banco

`assign_member_to_item` tinha cinco ramos de autoridade e **nenhum consultava
`write_board`**, a capacidade canônica de escrita no board. Quem a tinha só conseguia
se auto-atribuir como `author`; atribuir qualquer outra pessoa levantava exceção e o
PostgREST devolvia 400.

Medido ao vivo em 19/08: **69 dos 94 membros ativos** têm `write_board`, e **52 eram
barrados** por este gate, todos com tribo.

## Por que não bastava somar `write_board` ao OR

`can_by_member('write_board')` é capacidade organizacional **sem escopo**. Acrescentá-la
deixaria uma pesquisadora de uma tribo atribuir gente em card de **qualquer outra** — que
é exatamente o defeito que o épico #1780 aponta nessa mesma tabela.

A correção resolve a tribo do board (via `initiatives.legacy_tribe_id`, mesmo formato que
`update_board_item` e `move_board_item` já usam) e decide contra ELA, com
`rls_can_for_tribe('write_board', <tribo>)`, que respeita o `scope` do catálogo
(`initiative` vs `organization`).

**Exercido por impersonação depois de aplicar**, com uma pesquisadora da tribo 8:

| tribo consultada | resultado |
|---|---|
| 8 (a dela) | `true` |
| 5 | `false` |
| 13 | `false` |

Boards sem tribo resolvida (`legacy_tribe_id` NULL) mantêm o gate antigo: onde não há
recurso para escopar, não se amplia.

## `unassign_member_from_item` entra por simetria

Ela tinha apenas **dois** ramos (`participate_in_governance_review` OR `tribe_leader`),
mais estreita que a `assign`. Consertar só a `assign` criaria uma porta **só de ida**:
até o board admin e o auto-atribuído como `author` podiam atribuir e não podiam remover.
O gate das duas agora é idêntico.

## Portão de tela (o 403 do console)

`isLeaderOfThisTribeV4()` **não testava liderança**, apesar do nome: testava `write_board`
escopado. Uma pesquisadora passava por ele, a tela chamava `list_tribe_pending_requests`
para quem não é líder, e a RPC recusava com 403 a cada carga da página — poluindo o console
e fazendo parecer que o 400 seguinte tinha a ver com ela.

Renomeada para `canWriteThisTribeBoardV4()` (o nome mentia, e três dos quatro usos falam
mesmo de escrita no board, então ficam como estavam) e criada
`isTribeLeaderOfThisTribeV4()`, que espelha o gate real da RPC: `manage_member` **ou**
engajamento `volunteer/leader` ativo **nesta** tribo. Só a fila de pedidos passa a usá-la.

## Escopo que ficou de fora, e por quê

A issue pedia também `board_item_tag_assignments`. A medição mostrou que essa tabela
**não tem nenhuma RPC de escrita** — só leitores. A escrita passa direto pela policy
`tag_assignments_write_leaders`, que já aceita `rls_can('write_board')` sem escopo. É item
de **policy**, não de função, e não cabe nesta PR.

Fica registrado também que `update_board_item`, apesar de resolver a tribo, ainda passa no
gate principal com `can_by_member('write_board')` **sem escopo** — ou seja, esta PR deixa a
`assign` mais estrita que a irmã. Vale item do épico #1780.

## Verificação

- `npx astro build` — passou
- `node --test tests/contracts/rpc-migration-coverage.test.mjs` — **22/22**, incluindo
  Phase C (body-hash) e os dois ADR-0097 (orphan-local e missing-file)
- Migration aplicada e registrada como `20260820014622`; `NOTIFY pgrst, 'reload schema'` executado