### PR TITLE
test(#1636): as tres tentativas manuais entram no allowlist, com a explicacao medida

### DIFF
--- a/tests/contracts/1636-suite-nao-toca-candidatura-real.test.mjs
+++ b/tests/contracts/1636-suite-nao-toca-candidatura-real.test.mjs
@@ -228,13 +228,21 @@ const OPERACOES_MANUAIS_CONHECIDAS = new Set([
   '4b99b6dc-2eb3-450e-9448-3d78ca00ed32',
 
   // 20/08/2026 02:39:24Z, 02:39:38Z e 03:10:33Z — TRÊS tentativas de emitir o convite de
-  // agendamento para a MESMA candidatura, decididas pelo PM e confirmadas por ele em 20/08.
-  // Chamadas por `_issue_interview_booking_token_core` via REST/service_role, que continua sendo
-  // a única porta enquanto a RPC não tiver superfície (#1586) — daí o `caller_id` nulo.
+  // agendamento para a MESMA candidatura, feitas pelo PM por REST/service_role (a única porta
+  // enquanto a RPC não tiver superfície, #1586 — daí o `caller_id` nulo).
+  //
+  // ⚠️ O PM declarou em 20/08 que o convite foi ERRO: não era para convidar sem o peer review
+  // completo. Esta entrada NÃO é o registro de uma operação endossada, é o registro de uma
+  // tentativa equivocada que o gate barrou. Fica aqui com essa leitura, de propósito.
   //
   // As três foram RECUSADAS pelo próprio gate (`P0002` / `GATE_NO_PEER_REVIEW`, `eval_count: 0`):
-  // nenhum token foi emitido e nenhum e-mail saiu. O que elas registram é o gate FUNCIONANDO, não
-  // uma escrita indevida — a candidatura estava (e segue) sem as duas avaliações objetivas.
+  // nenhum token foi emitido e nenhum e-mail saiu. O que elas registram é o gate FUNCIONANDO
+  // exatamente como projetado, contra uma pressão de processo — a candidatura estava (e segue)
+  // com ZERO avaliações de qualquer tipo.
+  //
+  // Contexto que o PM registrou junto: dispensar o gate por pressão de kickoff ou pedido de
+  // patrocinador aconteceu em julho e está DESCONTINUADO por decisão dele. O fluxo estruturado
+  // (2 avaliações antes do convite) é o caminho, e o gate é quem o sustenta.
   //
   // Descartada a hipótese que este guard nomeia na mensagem de falha ("algum teste voltou a
   // escolher alvo por predicado"). Três medições a derrubam: (a) a RPC resolve por

--- a/tests/contracts/1636-suite-nao-toca-candidatura-real.test.mjs
+++ b/tests/contracts/1636-suite-nao-toca-candidatura-real.test.mjs
@@ -226,6 +226,25 @@ const OPERACOES_MANUAIS_CONHECIDAS = new Set([
   // RPC não tem superfície (#1586). O e-mail foi enviado a um candidato real que esperava o
   // convite desde 04/08. Auditado em `admin_audit_log` como `selection.unbooked_invite_rescued`.
   '4b99b6dc-2eb3-450e-9448-3d78ca00ed32',
+
+  // 20/08/2026 02:39:24Z, 02:39:38Z e 03:10:33Z — TRÊS tentativas de emitir o convite de
+  // agendamento para a MESMA candidatura, decididas pelo PM e confirmadas por ele em 20/08.
+  // Chamadas por `_issue_interview_booking_token_core` via REST/service_role, que continua sendo
+  // a única porta enquanto a RPC não tiver superfície (#1586) — daí o `caller_id` nulo.
+  //
+  // As três foram RECUSADAS pelo próprio gate (`P0002` / `GATE_NO_PEER_REVIEW`, `eval_count: 0`):
+  // nenhum token foi emitido e nenhum e-mail saiu. O que elas registram é o gate FUNCIONANDO, não
+  // uma escrita indevida — a candidatura estava (e segue) sem as duas avaliações objetivas.
+  //
+  // Descartada a hipótese que este guard nomeia na mensagem de falha ("algum teste voltou a
+  // escolher alvo por predicado"). Três medições a derrubam: (a) a RPC resolve por
+  // `id = p_application_id` estrito, sem re-resolver alvo, então o id real foi passado de
+  // propósito; (b) os testes que batem nesta RPC e afirmam `GATE_NO_PEER_REVIEW` (#1640, #1594)
+  // usam fixture `@example.com`; (c) re-executada a suíte INTEIRA em 20/08 04:12Z, nenhuma linha
+  // nova apareceu. Se fosse teste, toda execução somaria uma.
+  '6b68d5f8-f82f-4a81-8130-3f4596fd20cb',
+  'ffefc7ba-48d8-48c1-9716-63ec3934c823',
+  '62d63724-8bee-41ed-a8ea-4cefba297469',
 ]);
 
 describe('#1636 B — nenhuma escrita nova de teste cai em candidatura real', {


### PR DESCRIPTION
Destrava a fila. O guard do #1636 estava vermelho e, como o `validate` é required, nenhuma PR
conseguia ficar verde — inclusive a **#1892**, que é só documentação.

## O que estava acontecendo

Três linhas em `gate_attempts` com `caller_id` nulo, depois do cutoff, que nenhum cron explica.
Eram **três**, não duas: a terceira entrou depois da medição da lane, e isso só apareceu porque
re-medi antes de agir.

São três tentativas de emitir o convite de agendamento para a **mesma** candidatura, feitas pelo
PM por REST/`service_role` — a única porta enquanto a RPC não tiver superfície (#1586), e é
justamente isso que produz o `caller_id` nulo que o guard caça.

⚠️ **O PM declarou que o convite foi erro:** não era para convidar sem o peer review completo.
Esta isenção **não** registra uma operação endossada; registra uma tentativa equivocada que o
gate barrou. A entrada no arquivo está escrita com essa leitura, de propósito.

**As três foram RECUSADAS pelo próprio gate** (`P0002` / `GATE_NO_PEER_REVIEW`, `eval_count: 0`).
Nenhum token foi emitido, nenhum e-mail saiu. O que essas linhas registram é o gate **funcionando
exatamente como projetado, contra uma pressão de processo**. A candidatura tem zero avaliações de
qualquer tipo.

Contexto que o PM registrou junto: dispensar o gate por pressão de kickoff ou pedido de
patrocinador aconteceu em julho e está **descontinuado** por decisão dele.

## A hipótese do guard foi descartada por medição, não por leitura

A mensagem de falha afirma "algum teste voltou a escolher alvo por predicado sobre produção".
Três medições derrubam isso:

1. `_issue_interview_booking_token_core` resolve por `id = p_application_id` **estrito**, sem
   re-resolver alvo — o id real foi passado de propósito, não derivado de um `WHERE`.
2. Os testes que chamam essa RPC e afirmam `GATE_NO_PEER_REVIEW` (#1640, #1594-1595) usam fixture
   `@example.com`. O #1584 até escolhe candidatura viva, mas só chama o resolvedor, que é `STABLE`
   e não escreve.
3. **Re-executei a suíte inteira** depois de medir: **zero** linhas novas. Se um teste fizesse
   isso, toda execução somaria uma.

Além disso, as duas primeiras tentativas caíram **fora** de qualquer janela de CI.

## Por que allowlist e não mover o cutoff

Mover o cutoff cegaria o guard para a janela inteira desde 09/08, que é onde está o valor dele.
Três IDs nomeados deixam o guard ver tudo e ignorar só o que já foi explicado — o padrão que a
própria docstring do arquivo estabelece.

⚠️ Repetindo o que essa docstring diz: **entrada aqui é dívida, não isenção**. Enquanto o #1586
não der superfície autenticada, toda operação manual cai aqui. A saída é a tela.

## Verificação

`node --test tests/contracts/1636-suite-nao-toca-candidatura-real.test.mjs` — **8/8**.