### PR TITLE
fix(ci): #1896 - o check required 'deno' para de resolver a arvore npm do frontend

### DIFF
--- a/.github/workflows/deno-ef-check.yml
+++ b/.github/workflows/deno-ef-check.yml
@@ -29,6 +29,25 @@ permissions:
 jobs:
   deno:
     runs-on: ubuntu-latest
+    # #1896 - o check das EFs NAO deve depender da arvore npm do frontend. Sem esta variavel o
+    # Deno descobre o package.json da raiz e resolve TUDO que esta declarado la: medido num clone
+    # limpo, o node_modules criado por este job ganhava 39 entradas de topo (astro, playwright,
+    # eslint, @radix-ui...), e nenhuma Edge Function importa qualquer uma delas -- elas usam
+    # especificadores `npm:`/`jsr:` inline, que o Deno resolve sozinho.
+    #
+    # O custo disso apareceu em 20/08/2026: `satteri@0.10.4` foi publicado declarando uma
+    # optionalDependency em `@bruits/satteri-darwin-arm64@0.10.4`, versao que nunca existiu (a
+    # lista pula de 0.10.3 para 0.10.5). O npm tolera (dep opcional, `os` nao casa com o runner
+    # Linux); o resolvedor do Deno nao. Um check REQUIRED caiu por uma publicacao quebrada num
+    # canto da arvore do site, e a fila de merge congelou.
+    #
+    # Amplificador: `deno-version: v2.x` flutua. O runner instalou 2.9.5, que falha; 2.5.6 passa.
+    #
+    # Medido com Deno 2.9.5, clone limpo e cache frio: com a variavel, node_modules cai de 39 para
+    # 4 entradas, os 56 de 56 arquivos seguem sendo checados, e um TS2322 injetado de proposito
+    # continua reprovando o job. A correcao nao afrouxa o portao, so para de acopla-lo ao frontend.
+    env:
+      DENO_NO_PACKAGE_JSON: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2

--- a/tests/contracts/1636-suite-nao-toca-candidatura-real.test.mjs
+++ b/tests/contracts/1636-suite-nao-toca-candidatura-real.test.mjs
@@ -253,6 +253,16 @@ const OPERACOES_MANUAIS_CONHECIDAS = new Set([
   '6b68d5f8-f82f-4a81-8130-3f4596fd20cb',
   'ffefc7ba-48d8-48c1-9716-63ec3934c823',
   '62d63724-8bee-41ed-a8ea-4cefba297469',
+
+  // 20/08/2026 11:50:38Z — QUARTA tentativa, mesma candidatura, mesma recusa
+  // (`GATE_NO_PEER_REVIEW`). Posterior às três acima e anterior ao momento em que o PM registrou
+  // a decisão de descontinuar a prática. Mesmo desfecho: recusada, sem token e sem e-mail.
+  //
+  // ⚠️ SINAL, não rotina: esta lista saiu de 1 para 5 entradas em UM dia, e as 4 últimas são a
+  // mesma operação repetida contra a mesma candidatura. Isso não é o guard sendo chato, é a
+  // ausência de superfície autenticada (#1586) transformando cada decisão manual em dívida de
+  // teste. Enquanto o #1586 não existir, esta lista cresce a cada tentativa.
+  'c5c2b7aa-e556-4f05-99fe-17c9f9522a93',
 ]);
 
 describe('#1636 B — nenhuma escrita nova de teste cai em candidatura real', {


### PR DESCRIPTION
Destrava a fila de merge, congelada desde 20/08 pelo check required `deno`.

## O que estava acontecendo

`deno check --node-modules-dir=auto "supabase/functions/**/*.ts"` fazia o Deno descobrir o `package.json` da
raiz e resolver **toda** a árvore npm do frontend. Medido em clone limpo: **39 entradas de topo** no
`node_modules` criado por este job (astro 7.2.4, playwright, eslint, @radix-ui), e **nenhuma Edge Function
importa qualquer uma delas** - elas usam especificadores `npm:`/`jsr:` inline.

O gatilho externo foi `satteri@0.10.4`, publicado em 19/08 10:57 UTC declarando `optionalDependencies` em
`@bruits/satteri-darwin-arm64@0.10.4`, versão que **nunca foi publicada** (a lista pula de `0.10.3` para
`0.10.5`). O npm tolera, porque a dep é opcional e o `os` não casa com o runner Linux. O resolvedor do Deno
não tolera.

Amplificador: `deno-version: v2.x` flutua, e o runner instalou **2.9.5**.

## Reprodução determinística

Mesmo commit, clone limpo, cache frio:

| Deno | resultado |
|---|---|
| 2.5.6 | exit 0 |
| **2.9.5** (o da CI) | **exit 1**, erro idêntico |

## A correção, e a prova de que não afrouxa o portão

`DENO_NO_PACKAGE_JSON=1` no job. Validado com Deno 2.9.5, clone limpo, cache frio:

| medida | sem a flag | com a flag |
|---|---|---|
| resultado | exit 1 | **exit 0** |
| `node_modules` (topo) | 39 | **4** |
| arquivos checados | (falhava antes) | **56 de 56** |
| `TS2322` injetado de propósito | n/a | **pego, exit 1** |

A última linha é a que importa. Injetei `const _guardProbe: number = "..."` numa EF e o check reprovou, então
a correção não torna o gate vácuo: ela só para de acoplá-lo ao frontend.

## Alternativas descartadas

- **Fixar `deno-version`**: trata o amplificador e deixa a causa. A próxima publicação quebrada em qualquer
  canto da árvore do site derrubaria a fila de novo.
- **Regenerar `deno.lock`**: ele está velho de fato (registra `astro@^6.4.8` enquanto o `package.json` pede
  `^7.2.2`), mas regenerar mantém o acoplamento indevido. Fica como item separado.
- **Esperar o upstream**: `0.10.5` já corrigiu o pacote em 19/08 20:38 UTC, e o Deno 2.9.5 continua parando em
  `0.10.4`. Esperar não resolveu.

Refs #1896