### PR TITLE
chore(ci): B1 - pina o deno-version numa versao exata em vez de faixa

### DIFF
--- a/.github/workflows/deno-ef-check.yml
+++ b/.github/workflows/deno-ef-check.yml
@@ -42,6 +42,9 @@ jobs:
     # canto da arvore do site, e a fila de merge congelou.
     #
     # Amplificador: `deno-version: v2.x` flutua. O runner instalou 2.9.5, que falha; 2.5.6 passa.
+    # ^ HISTORICO de 20/08, antes do `DENO_NO_PACKAGE_JSON` abaixo. Com a variavel, 2.9.5 PASSA
+    #   (run 32537672003, 21/08 23:39, verde). A faixa flutuante foi eliminada em separado: ver
+    #   o pin exato em `deno-version` mais abaixo (B1).
     #
     # Medido com Deno 2.9.5, clone limpo e cache frio: com a variavel, node_modules cai de 39 para
     # 4 entradas, os 56 de 56 arquivos seguem sendo checados, e um TS2322 injetado de proposito
@@ -52,7 +55,19 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v2.x
+          # B1 (auditoria de 21/08) — versao EXATA, nao faixa. `v2.x` flutua, e o comentario
+          # acima ja registra o custo disso: o runner instalou 2.9.5, que falhava, enquanto
+          # 2.5.6 passava. Uma faixa flutuante faz a NAO-reproducao mentir: reproduzir com
+          # outra minor passa e inocenta o repo por engano.
+          #
+          # 2.9.5 e a versao que o runner instalou no ultimo run VERDE medido (run 32537672003,
+          # 21/08 23:39), ja com `DENO_NO_PACKAGE_JSON=1`. Ou seja: e a versao verificada, nao
+          # a mais nova.
+          #
+          # Para subir: troque aqui, confirme no log do job que o runner baixou o que voce pediu
+          # (`Downloading Deno from .../vX.Y.Z/`), e so entao mergeie. Nao leia a versao daqui,
+          # leia do log -- e esse o ponto de pinar.
+          deno-version: v2.9.5
 
       # CLI flags (not a committed deno.json) so this CI config never touches how the
       # Supabase bundler deploys the functions. no-explicit-any + no-import-prefix are


### PR DESCRIPTION
Item **B1** da auditoria de CI (#1908 / #1912). Uma linha de mudanca funcional.

## O que muda

`deno-version: v2.x` passa a `v2.9.5` em `deno-ef-check.yml`.

## Por que

Faixa flutuante faz a **nao-reproducao mentir**. O comentario do #1896 ja registrava o custo no
proprio arquivo: o runner instalou 2.9.5, que falhava, enquanto 2.5.6 passava. Quem tentasse
reproduzir com outra minor veria verde e inocentaria o repo por engano.

O #1897 consertou a causa (`DENO_NO_PACKAGE_JSON=1`), mas deixou a faixa flutuante de pe. Este e o
outro lado.

## Por que 2.9.5, e nao a mais nova

Medicao, nao preferencia: **2.9.5 e a versao que o runner baixou no ultimo run verde**
(`Downloading Deno from .../v2.9.5/...`, run 32537672003, 21/08 23:39, ja com
`DENO_NO_PACKAGE_JSON=1`). Pinar na mais nova reintroduziria exatamente o risco que o pin existe
para eliminar.

## Um ajuste junto, e o motivo dele

O comentario historico de 20/08 no mesmo arquivo diz "o runner instalou 2.9.5, **que falha**".
Deixa-lo intacto ao lado de um pin em 2.9.5 criaria uma contradicao para o proximo leitor. Ele foi
marcado como historico, com a medicao de que 2.9.5 passa **com** a variavel.

## Verificacao

`deno` e check required. O proprio CI desta PR e o teste: se o pin estiver errado, ele reprova
aqui. Confirme no log do job que o runner baixou o que foi pedido, que e o ponto de pinar.

Nao altera protecao de branch, nao altera quais checks sao required, nao altera o contrato do
portao. Refs #1896