### PR TITLE
docs(planning): landa os dois handoffs de 21/08 que so existiam em branch

### DIFF
--- a/docs/planning/2026-08-21_handoff_fila_destravada_e_tres_lanes.md
+++ b/docs/planning/2026-08-21_handoff_fila_destravada_e_tres_lanes.md
@@ -1,0 +1,90 @@
+# Handoff 21/08: fila destravada duas vezes, e tres lanes abertas
+
+> Medido ao vivo em 21/08/2026 (UTC). **Re-medir antes de agir.** Repositorio PUBLICO:
+> sem nome de pessoa e sem identificador de candidato.
+
+---
+
+## 1. Estado da fila
+
+`main` em **`fe268cf2`**.
+
+| PR | o que e | estado |
+|---|---|---|
+| **#1904** | data do card le as atribuicoes (#1903) | rebaseada, **2 checks vermelhos por causa ALHEIA** |
+| **#1905** | cron do card de jornada (outra lane) | **draft**, vermelha por causa alheia |
+| **#1894** | arranque de 21/08 | 1 vermelho, mesma causa |
+
+**O que trava TODAS:** uma linha de `gate_attempts` criada em producao em **21/08 14:18:47**
+(`_issue_interview_booking_token_core`, sem ator, barrada por `GATE_NO_PEER_REVIEW`). Reprova 2
+testes da familia **#1636** em qualquer branch.
+
+Confirmado dos dois lados que **nenhum cron a explica**: os que rodam perto batem em `:15`, `:20`,
+`:23`, `:25`, `:28`, e nenhum emite token de entrevista. Sobra chamada manual sem rastro de ator.
+
+**O desbloqueio e o allowlist de `gate_attempts.id` do #1636.** Sem dono.
+
+📌 **O guard reporta `application_id`, o allowlist guarda `gate_attempts.id`.** Sao colunas
+diferentes: "o ID que falhou nao esta na lista" NAO prova ofensor novo. Cruze pelas duas chaves.
+
+## 2. Mergeado nesta sessao, zero bypass
+
+| PR | entrega |
+|---|---|
+| **#1897** | `DENO_NO_PACKAGE_JSON=1`: o check das EFs parou de resolver a arvore npm do frontend |
+| **#1902** | os 2 defeitos de `get_portfolio_items` + os 5 `.sql` + tipos + alvo estavel do #1113 |
+| **#1899** | (outra lane) drift de flag/tag + card de jornada |
+
+**A listagem de portfolio voltou a funcionar**: 94 itens onde antes era excecao em toda chamada.
+
+## 3. Issues abertas nesta sessao
+
+- **#1895** a tela de selecao deriva TUDO de um eixo pessoal; quem entrevista nunca ve o
+  consolidado; **145 RPCs de leitura** pedem capacidade de GP. ⚖️ **Decisao do PM ja tomada:**
+  comite (`evaluator`/`lead`) + `view_pii` le todo o dossie. **Isso destrava a varredura.**
+- **#1896** o check `deno` resolvia a arvore do frontend (corrigido)
+- **#1901** `get_portfolio_items`: dois defeitos em serie (corrigido)
+- **#1903** a data do card lia a coluna legada: **51 pessoas, 154 cards** (PR #1904)
+- **#1906** cron de agenda rara nao se recupera: **53 dos 68 ativos**
+
+## 4. Tres lanes abertas, cada uma no proprio worktree
+
+| lane | worktree | escopo |
+|---|---|---|
+| **video** | `.claude/worktrees/lane-video-shorts` | Lideranca #10 (`f77a91d2`): sem youtube, sem recording, sem ata, status ainda `scheduled`. Depois: shorts do ciclo. Prompt commitado na branch. |
+| **auditoria CI** | `.claude/worktrees/lane-ci-audit` | 16 workflows, 3 required, 611 testes, `validate` ~13 min. Diagnostico, NAO conserto. Prompt commitado. |
+| **#1904** | `scratchpad/wt-1903` | so falta a fila destravar |
+
+⚠️ **A arvore principal e COMPARTILHADA.** Em 20/08 um checkout de outra sessao passou por cima de
+edicao em andamento; salvou-se por auto-stash, que levou junto **300 arquivos nao rastreados**.
+Trabalhe em worktree e nao troque a branch da arvore principal.
+
+## 5. Pendencias com nome
+
+- **5 commits so existem nesta maquina**, em 3 branches sem remoto:
+  `feat/1153-volunteer-term-signing-sync` (2), `feat/1209-credly-keyword-tuning` (2),
+  `feat/1148-curation-xp-backfill` (1). Empurrar ou decidir descartar.
+- **`stash@{0}`** ("Teleport auto-stash") ainda e copia redundante dos deliverables nao rastreados.
+  O conserto do #1903 que estava la **ja esta commitado**, entao essa parte nao depende mais dele.
+- **Tres candidaturas com ZERO avaliacao**, uma travada em `interview_pending` (medido 21/08 14:35).
+  O lembrete original citava duas; sao tres.
+- **#1881 segue aberto** e e a raiz do card de XP: o gatilho vigia as 3 colunas, mas o corpo ainda
+  exige transicao de status. A ordem natural na tela (marcar done, depois marcar entregavel) nao
+  paga. **Vai repetir.**
+- **Follow-up da outra lane na #1906**: tornar a escrita da reconciliacao CONDICIONAL (so escrever
+  quando algum dos 8 passos mudou; tirar o timestamp da `description`; nao mencionar `assignee_id`
+  no `SET`). Medido: 0,26 s para 12 tribos, entao o intervalo semanal nao existe por custo.
+
+## 6. Armadilhas medidas hoje
+
+- **`npm test` local nao emite TAP.** Node 24 usa reporter `spec` (`✔`/`✖`/`ℹ`). Filtro que procura
+  `not ok` volta VAZIO mesmo com falha. Use:
+  `npm test 2>&1 | grep -E '^[[:space:]]*(not ok|✖)|^(#|ℹ) (fail|pass|tests|skipped)'`
+- **Carregue o `.env`** (`set -a; . ./.env; set +a`): medimos **744 skipped** local contra **1** na
+  CI. `fail 0` com 744 skipped nao e suite verde.
+- **`deno-version: v2.x` FLUTUA.** Reproduzir com outra minor PASSA e inocenta o repo por engano.
+  Leia no log do job qual versao o runner instalou.
+- **Ao consertar portao, injete o defeito e prove que ele ainda REPROVA.** Verde por conserto e
+  verde por vacuo tem a mesma cor.
+- **`git ... | tail -1 && echo ok`** reporta o sucesso do `tail`, nao do `git`. Cheque `$?` do
+  comando certo (isso produziu 5 "removido" falsos hoje).

--- a/docs/planning/2026-08-21_handoff_fila_destravada_impasse_de_duas_metades.md
+++ b/docs/planning/2026-08-21_handoff_fila_destravada_impasse_de_duas_metades.md
@@ -1,0 +1,129 @@
+# Handoff 21/08 (2a sessao): a fila era um impasse de DUAS metades
+
+> Medido ao vivo em 21/08/2026 (UTC). **Re-medir antes de agir.** Repositorio PUBLICO:
+> sem nome de pessoa e sem identificador de candidatura.
+
+---
+
+## 1. Estado da fila
+
+`main` em **`d4c20a00`** (era `fe268cf2`). **A fila andou.**
+
+| PR | desfecho |
+|---|---|
+| **#1905** | **MERGEADA** 19:41:41Z, sem bypass. Carrega as duas metades. |
+| **#1907** | fechada como superseded (o commit dela foi por `cherry-pick -x`) |
+| **#1904**, **#1894** | branches atualizadas a partir da main, CI re-rodando |
+
+## 2. O achado: o handoff anterior nomeava UM bloqueador, e eram DOIS
+
+O handoff das 14h atribuiu o vermelho das tres PRs a linha `gate_attempts` `ec7336f2`
+(criada 21/08 14:18:47). Para a #1905 isso era verdade. Para a #1904 nao: o ultimo
+`validate` dela rodou as **04:07**, dez horas ANTES da linha existir, e falhava com **3**
+testes de outra familia.
+
+**Bloqueador A, PROD-AHEAD (#1900).** As 3 funcoes do cron (`_tribe_journey_health_data`,
+`_sync_tribe_journey_card`, `sync_tribe_journey_cards_cron`) estavam vivas em producao e
+**nenhuma migration na main as capturava**: o `.sql` existia so na branch da lane. Isso
+derrubava Q-C (orfas), Phase C (body-hash) e ADR-0097 (missing-file) na main e em **toda**
+branch tirada dela, mais o `gen-types-drift`.
+
+**Bloqueador B, a linha `ec7336f2`.** Derrubava o guard do #1636 em toda branch, inclusive
+na da lane.
+
+**O impasse:** cada PR tinha metade do verde.
+
+| branch | tem | `validate` |
+|---|---|---|
+| #1904 (run das 04:07) | nada | `fail 3` (PROD-AHEAD) |
+| #1907 (allowlist) | metade B | `fail 3` (so PROD-AHEAD) |
+| #1905 (migration + tipos) | metade A | `fail 1` (so o gate) |
+| #1905 + cherry-pick | **as duas** | **verde** |
+
+A saida foi `cherry-pick -x` do commit de 1 linha para a branch que destrava (a #1905, que
+e quem encerra o PROD-AHEAD), feito em **worktree destacado**: a arvore principal nao foi
+tocada.
+
+## 3. Por que isso ficou invisivel
+
+> ⚠️ CORRIGIDO em 23:15. Este trecho dizia que `validate` nao roda em push para a main.
+> **Errado**: `ci.yml` declara `on: push: branches: [ main, dev ]`. O erro veio de listar
+> `gh run list --branch main --limit 8`, onde o `CI Heartbeat Monitor` (a cada ~30 min)
+> ocupou as 8 posicoes e escondeu os runs de push. Ver #1910.
+
+`validate` roda na main, mas so em **push**. Aplicar DDL num banco compartilhado nao e um
+push, entao a verdade que o guard afere muda **fora do repositorio** e nada dispara a
+reafericao:
+
+| horario | fato |
+|---|---|
+| 03:23:39Z | ultimo `CI Validate` da main (`fe268cf2`): success, e legitimamente |
+| 03:54:35Z | a DDL entra no banco, 31 min depois |
+| 03:54 -> 19:41 | nenhum push na main, logo nenhum run novo |
+
+Por **15h47m** a main exibiu um verde pre-DDL. Ele nao estava errado quando foi calculado;
+ele nunca foi recalculado.
+
+📌 **Um required verde e um carimbo de tempo, nao um estado.** Quando parte da verdade mora
+num banco compartilhado, a validade do carimbo expira sem aviso e sem mudar de cor. Foi
+assim tambem que o verde da #1904 virou retrato velho.
+
+## 4. O sinal de governanca, que nao e de fila
+
+A `ec7336f2` e a **QUINTA** tentativa de emitir convite de agendamento sobre a MESMA
+candidatura, e a **primeira posterior a decisao do PM** de 20/08 de descontinuar a dispensa
+do gate. As quatro anteriores sao todas do dia 20; esta e do dia 21.
+
+Medido ao vivo: a candidatura segue com **zero avaliacoes** de qualquer tipo, **0 tokens**
+vivos e status `interview_pending`. Nenhum token emitido, nenhum e-mail enviado. O gate
+recusou pela quinta vez, exatamente como projetado.
+
+O allowlist saiu de 1 para **6** entradas, e as cinco ultimas sao a mesma operacao repetida.
+Isso mede a ausencia de superficie autenticada (**#1586**), nao chatice do guard: enquanto a
+RPC nao tiver tela, toda decisao manual entra por `service_role` e vira divida de teste.
+
+## 5. Como a hipotese do guard foi descartada
+
+A mensagem de falha nomeia "algum teste voltou a escolher alvo por predicado sobre
+producao". Isso e hipotese, nao diagnostico. Descartada por medicao:
+
+- arco do gate re-executado (71 testes, 5 arquivos): `gate_attempts` em **697 antes e 697
+  depois**, com as **mesmas 9** sem ator pos-cutoff dos dois lados;
+- Camada A passou inteira;
+- `admin_audit_log` sem **nenhuma** linha na janela de +/-10min;
+- e o guard nao esta cego: as outras 3 linhas sem ator fora da lista (14/08 15:00, 17/08
+  15:30 x2) **tem** carimbo de cron e por isso nunca foram acusadas.
+
+Prova de que o verde e por conserto: trocar **um caractere** do UUID deixa os DOIS testes
+vermelhos (a correlacao e o ratchet de sincronia).
+
+## 6. Pendencias
+
+- **#1881** segue aberto e e a raiz do card de XP (o gatilho vigia as 3 colunas, o corpo
+  ainda exige transicao de status). Vai repetir.
+- **#1906**: escrita condicional da reconciliacao + agenda diaria (follow-up da lane).
+- **5 commits so nesta maquina**, em 3 branches sem remoto:
+  `feat/1153-volunteer-term-signing-sync` (2), `feat/1209-credly-keyword-tuning` (2),
+  `feat/1148-curation-xp-backfill` (1).
+- **`stash@{0}`** nao descartar: o conserto do `CardDetail.tsx` do #1903 ainda esta la.
+- **Tres candidaturas com ZERO avaliacao**, uma travada em `interview_pending`.
+- Duas branches liberadas para apagar (registro de recuperacao):
+  `backup/pre-rebase-1899` = `80035339395aa358e18608329374177e730e2ebb` (so local),
+  `claude/portfolio-cards-flags-tags-e7x1ar` = `d236e843150be13884cb653f1fd47efb59a5f462`.
+  Nenhuma guarda trabalho nao-landado: a segunda tem arvore identica a main (assinatura de
+  squash-merge) e a primeira so tem, de exclusivo, as 4 linhas do teste do #1113 que
+  escolhiam alvo por predicado, justamente o anti-padrao que a #1902 consertou.
+
+## 7. Armadilhas medidas nesta sessao
+
+- **Run de CI ANTERIOR ao incidente nao e explicado por ele.** Compare os timestamps, e
+  **conte as falhas**: o guard do #1636 derruba 1 teste, e o run mostrava 3.
+- **`--log` da API vem truncado na cauda** e some com o nome da falha. Use
+  `gh run view --job N --log-failed | grep 'not ok'`.
+- **A saida local e colorida**, entao `grep -E '^ℹ'` nao casa (o ANSI vem antes do `ℹ`) e o
+  filtro volta VAZIO mesmo com falha. Passe `sed -r 's/\x1B\[[0-9;]*[mK]//g'` antes.
+- **`cmd | tail` reporta o exit do `tail`.** Um `npm test` que falhou saiu com "code 0".
+- **Nem todo check vermelho e required.** Aqui os required sao `validate`, `browser_guards`
+  e `deno`; o `gen-types-drift` nao e. Confira antes de declarar impasse.
+- **`node_modules/` no `.gitignore` e padrao de DIRETORIO**, entao um *symlink* com esse
+  nome aparece como nao rastreado e um `git add -A` o comitaria.


### PR DESCRIPTION
Refs #1929

A higiene de branches achou que **a memória do projeto aponta para estes dois arquivos** como ponteiro de arranque, e que eles **não estavam na `main`** — viviam só em `docs/handoff-21ago-sessao-fila` e `docs/handoff-21ago-fila-destravada`.

Apagar aquelas branches, como fiz com as outras 58, teria levado o conteúdo **e** quebrado a referência junto. Foi a falsificação da premissa que pegou, não o classificador — os sinais de git puro davam as duas como iguais a qualquer branch entregue.

| arquivo | linhas |
|---|---|
| `2026-08-21_handoff_fila_destravada_e_tres_lanes.md` | 90 |
| `2026-08-21_handoff_fila_destravada_impasse_de_duas_metades.md` | 129 |

**Trazidos por `checkout` dos arquivos sobre a main atual, não por merge das branches.** O payload de cada uma é exatamente 1 arquivo novo, e elas estão 14+ commits atrás com base de merge colapsada pelo rewrite de 04/07 — copiar o arquivo evita arrastar história irrelevante.

Repo é público, então varridos antes: **0** e-mails, **0** segredos/chaves, **0** CPF ou telefone, **0** UUID, **0** menção a advisory privado.

Depois que isto mergear, as duas branches de origem podem ser apagadas.