### PR TITLE
fix(db): #1910 - captura as 3 migrations vivas em producao que so existiam na lane

### DIFF
--- a/src/lib/database.gen.ts
+++ b/src/lib/database.gen.ts
@@ -30215,6 +30215,14 @@ export type Database = {
       }
       can_manage_comms_metrics: { Args: never; Returns: boolean }
       can_manage_knowledge: { Args: never; Returns: boolean }
+      can_org: {
+        Args: { p_action: string; p_person_id: string }
+        Returns: boolean
+      }
+      can_org_by_member: {
+        Args: { p_action: string; p_member_id: string }
+        Returns: boolean
+      }
       can_read_internal_analytics: { Args: never; Returns: boolean }
       can_view_comms_analytics: { Args: never; Returns: boolean }
       cancel_agenda_block: {

--- a/supabase/migrations/20260822032921_activate_deputy_manager_tier_for_co_gp.sql
+++ b/supabase/migrations/20260822032921_activate_deputy_manager_tier_for_co_gp.sql
@@ -1,0 +1,85 @@
+-- Wave 1 (PM 2026-08-21, direcao A): ativar o degrau Vice-GP.
+--
+-- Antes: o CASE mapeava volunteer/co_gp -> 'manager', tornando GP e co-GP
+-- indistinguiveis em toda tela movida por operational_role, e deixando o tier
+-- 'deputy_manager' INALCANCAVEL (0 pessoas, sempre) apesar de ter lista propria
+-- de 21 permissoes em permissions.ts, rank proprio (2.5) em useBoardPermissions
+-- e rotulo proprio nos 3 dicionarios.
+--
+-- Depois: co_gp e deputy_manager compartilham o degrau 'deputy_manager'.
+-- Medido antes de aplicar: 1 pessoa afetada, is_superadmin=true, portanto
+-- hasPermission() curto-circuita e nenhuma permissao efetiva muda hoje. O efeito
+-- real e estrutural (GP vira distinguivel de co-GP) e vale para co-GPs futuros
+-- que nao sejam superadmin.
+--
+-- Medicao antes/depois (ambas ao vivo, 2026-08-21):
+--   antes: operational_role manager=2, deputy_manager=0, colapsados=1
+--   depois: operational_role manager=1, deputy_manager=1, colapsados=0
+--
+-- NAO altera engagement_kind_permissions: volunteer/co_gp mantem os 19 combos em
+-- escopo organization. A matriz cliente fica mais estreita que a autoridade
+-- servidor, que e a direcao fail-closed.
+
+CREATE OR REPLACE FUNCTION public.sync_operational_role_cache()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_new_role text;
+BEGIN
+  SELECT id INTO v_member_id FROM public.members WHERE person_id = COALESCE(NEW.person_id, OLD.person_id);
+  IF v_member_id IS NULL THEN RETURN COALESCE(NEW, OLD); END IF;
+
+  SELECT CASE
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+      -- Wave 1 (2026-08-21): co_gp deixa de colapsar em 'manager'. GP e co-GP
+      -- passam a ser distinguiveis, e o tier 2.5 ja desenhado passa a existir.
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('co_gp','deputy_manager')) THEN 'deputy_manager'
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+      -- Wave 1 fix: sponsor outranks researcher (committee/workgroup) so a sponsor who also sits on a
+      -- committee (e.g. the governance committee) shows as a sponsor, not a researcher.
+      WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+      -- Wave 2 WS-1 (PM 2026-06-28 'governança vence'): chapter_board (chapter director) outranks
+      -- researcher/observer so a chapter director who also sits on a committee or observes a
+      -- tribe still shows as 'Ponto Focal do Capítulo' (chapter_liaison). Stays BELOW sponsor
+      -- and operational leaders (manager/deputy/tribe_leader) — those who lead operationally keep that role.
+      WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+      WHEN bool_or(
+        (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+        OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+            AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+        OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+            AND ae.role IN ('leader','co_leader','owner','coordinator'))
+      ) THEN 'researcher'
+      WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+      WHEN bool_or(ae.kind = 'institutional_auditor') THEN 'institutional_auditor'
+      WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+      WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+      WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+      ELSE 'guest'
+    END INTO v_new_role
+  FROM public.auth_engagements ae
+  WHERE ae.person_id = COALESCE(NEW.person_id, OLD.person_id) AND ae.is_authoritative = true;
+
+  UPDATE public.members SET operational_role = COALESCE(v_new_role, 'guest'), updated_at = now()
+    WHERE id = v_member_id AND operational_role IS DISTINCT FROM COALESCE(v_new_role, 'guest');
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$function$;
+
+-- Backfill ALVEJADO: so quem esta cacheado como 'manager' por causa do colapso
+-- do co_gp. Nao recalcula a base inteira de proposito -- um recalculo geral
+-- mudaria papeis por motivos alheios a esta migration e esconderia o efeito.
+UPDATE public.members m
+   SET operational_role = 'deputy_manager', updated_at = now()
+ WHERE m.operational_role = 'manager'
+   AND EXISTS (SELECT 1 FROM public.auth_engagements ae
+                WHERE ae.person_id = m.person_id AND ae.is_authoritative
+                  AND ae.kind = 'volunteer' AND ae.role = 'co_gp')
+   AND NOT EXISTS (SELECT 1 FROM public.auth_engagements ae
+                    WHERE ae.person_id = m.person_id AND ae.is_authoritative
+                      AND ae.kind = 'volunteer' AND ae.role = 'manager');

--- a/supabase/migrations/20260822033913_wave1_restore_adr0023_ladder_parity.sql
+++ b/supabase/migrations/20260822033913_wave1_restore_adr0023_ladder_parity.sql
@@ -1,0 +1,852 @@
+-- Wave 1 corretiva (2026-08-21): restaura a PARIDADE ADR-0023.
+--
+-- A migration 20260822032921 mudou so a escada de sync_operational_role_cache e
+-- deixou a escada A3 de check_schema_invariants com a regra antiga (co_gp ->
+-- 'manager'). Medido logo apos aplicar: A3_active_role_engagement_derivation
+-- passou a acusar 1 violacao. ADR-0023 exige que as DUAS escadas sejam iguais
+-- clausula a clausula, e tests/contracts/role-ladder-parity.test.mjs as compara.
+--
+-- Esta migration corrige os dois lados:
+--   1. sync_operational_role_cache: troca o `role IN ('co_gp','deputy_manager')`
+--      por DOIS ramos separados. O IN(...) tinha apagado o literal
+--      `ae.role = 'deputy_manager'`, que e o DISCRIMINADOR usado por
+--      findLadderCaseBlock() para localizar a escada -- sem ele o parser devolvia
+--      null e o teste falhava por nao conseguir extrair o bloco.
+--   2. check_schema_invariants: a clausula co_gp da escada A3 passa a devolver
+--      'deputy_manager'. Corpo herdado de 20260805000478 (hash conferido
+--      identico ao vivo antes de editar: 1d998a15ff3a3124ddb4284f1c9cafb6) com
+--      essa unica troca.
+--
+-- Aplicado no banco por um DO block que faz a mesma troca sobre a definicao viva
+-- (para nao transcrever 46 KB a mao). A igualdade entre este arquivo e o corpo
+-- vivo esta provada por hash: ver verificacao no commit.
+--
+-- Medicao depois: A3 = 0 violacoes, e todas as demais invariantes = 0.
+
+CREATE OR REPLACE FUNCTION public.sync_operational_role_cache()
+ RETURNS trigger
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_member_id uuid;
+  v_new_role text;
+BEGIN
+  SELECT id INTO v_member_id FROM public.members WHERE person_id = COALESCE(NEW.person_id, OLD.person_id);
+  IF v_member_id IS NULL THEN RETURN COALESCE(NEW, OLD); END IF;
+
+  SELECT CASE
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'co_gp')          THEN 'deputy_manager'
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'deputy_manager') THEN 'deputy_manager'
+      WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+      -- Wave 1 fix: sponsor outranks researcher (committee/workgroup) so a sponsor who also sits on a
+      -- committee (e.g. the governance committee) shows as a sponsor, not a researcher.
+      WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+      -- Wave 2 WS-1 (PM 2026-06-28 'governança vence'): chapter_board (chapter director) outranks
+      -- researcher/observer so a chapter director who also sits on a committee or observes a
+      -- tribe still shows as 'Ponto Focal do Capítulo' (chapter_liaison). Stays BELOW sponsor
+      -- and operational leaders (manager/deputy/tribe_leader) — those who lead operationally keep that role.
+      WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+      WHEN bool_or(
+        (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+        OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+            AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+        OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+            AND ae.role IN ('leader','co_leader','owner','coordinator'))
+      ) THEN 'researcher'
+      WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+      WHEN bool_or(ae.kind = 'institutional_auditor') THEN 'institutional_auditor'
+      WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+      WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+      WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+      ELSE 'guest'
+    END INTO v_new_role
+  FROM public.auth_engagements ae
+  WHERE ae.person_id = COALESCE(NEW.person_id, OLD.person_id) AND ae.is_authoritative = true;
+
+  UPDATE public.members SET operational_role = COALESCE(v_new_role, 'guest'), updated_at = now()
+    WHERE id = v_member_id AND operational_role IS DISTINCT FROM COALESCE(v_new_role, 'guest');
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.check_schema_invariants()
+ RETURNS TABLE(invariant_name text, description text, severity text, violation_count integer, sample_ids uuid[])
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+BEGIN
+  IF auth.uid() IS NULL
+     AND current_setting('role', true) NOT IN ('service_role', 'postgres')
+     AND current_user NOT IN ('postgres', 'supabase_admin') THEN
+    RAISE EXCEPTION 'Unauthorized: check_schema_invariants requires authentication';
+  END IF;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'alumni' AND operational_role IS DISTINCT FROM 'alumni'
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A1_alumni_role_consistency'::text,
+         'member_status=alumni must coerce operational_role=alumni (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status = 'observer' AND operational_role NOT IN ('observer','guest','none')
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'A2_observer_role_consistency'::text,
+         'member_status=observer must coerce operational_role IN (observer,guest,none) (B7 trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH computed AS (
+    SELECT m.id AS member_id,
+      CASE
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'manager')        THEN 'manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'co_gp')          THEN 'deputy_manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role = 'deputy_manager') THEN 'deputy_manager'
+        WHEN bool_or(ae.kind = 'volunteer' AND ae.role IN ('leader','comms_leader')) THEN 'tribe_leader'
+        -- Wave 1 fix: sponsor outranks researcher (committee/workgroup) so a sponsor who also sits on a
+        -- committee (e.g. the governance committee) shows as a sponsor, not a researcher.
+        WHEN bool_or(ae.kind = 'sponsor') THEN 'sponsor'
+        -- Wave 2 WS-1 (PM 2026-06-28 'governança vence'): chapter_board (chapter director) outranks
+        -- researcher/observer so a chapter director who also sits on a committee or observes a
+        -- tribe still shows as 'Ponto Focal do Capítulo' (chapter_liaison). Stays BELOW sponsor
+        -- and operational leaders (manager/deputy/tribe_leader) — those who lead operationally keep that role.
+        WHEN bool_or(ae.kind = 'chapter_board') THEN 'chapter_liaison'
+        WHEN bool_or(
+          (ae.kind = 'volunteer' AND ae.role IN ('researcher','facilitator','communicator','curator'))
+          OR (ae.kind IN ('committee_member','workgroup_member','study_group_owner')
+              AND ae.role IN ('leader','co_leader','owner','coordinator','researcher','contributor','member','participant'))
+          OR (ae.kind IN ('committee_coordinator','workgroup_coordinator')
+              AND ae.role IN ('leader','co_leader','owner','coordinator'))
+        ) THEN 'researcher'
+        WHEN bool_or(ae.kind = 'external_signer') THEN 'external_signer'
+        WHEN bool_or(ae.kind = 'institutional_auditor') THEN 'institutional_auditor'
+        WHEN bool_or(ae.kind = 'observer') THEN 'observer'
+        WHEN bool_or(ae.kind = 'alumni') THEN 'alumni'
+        WHEN bool_or(ae.kind = 'candidate') THEN 'candidate'
+        ELSE 'guest'
+      END AS expected_role
+    FROM public.members m
+    LEFT JOIN public.auth_engagements ae ON ae.person_id = m.person_id AND ae.is_authoritative = true
+    WHERE m.member_status='active' AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT c.member_id FROM computed c
+    JOIN public.members m ON m.id = c.member_id
+    WHERE m.operational_role IS DISTINCT FROM c.expected_role
+  )
+  SELECT 'A3_active_role_engagement_derivation'::text,
+         'active member operational_role must equal priority-ladder derivation from active engagements (cache trigger)'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE ((member_status='active' AND is_active=false) OR (member_status IN ('observer','alumni','inactive') AND is_active=true))
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B_is_active_status_mismatch'::text,
+         'members.is_active must match member_status mapping (active=true, terminal=false)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND designations IS NOT NULL AND array_length(designations,1)>0
+  )
+  SELECT 'C_designations_in_terminal_status'::text,
+         'members.designations must be empty when member_status is observer/alumni/inactive'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    JOIN public.persons p ON p.id = m.person_id
+    WHERE m.auth_id IS NOT NULL AND p.auth_id IS NOT NULL AND m.auth_id IS DISTINCT FROM p.auth_id
+  )
+  SELECT 'D_auth_id_mismatch_person_member'::text,
+         'persons.auth_id and members.auth_id must agree when both are set (ghost resolution sync)'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ae.engagement_id AS e_id FROM public.auth_engagements ae
+    JOIN public.members m ON m.person_id = ae.person_id
+    WHERE ae.status='active' AND m.member_status IN ('observer','alumni','inactive')
+      AND ae.kind NOT IN ('observer','alumni','external_signer','sponsor','chapter_board','partner_contact')
+  )
+  SELECT 'E_engagement_active_with_terminal_member'::text,
+         'engagement.status=active is inconsistent with member.member_status in (observer/alumni/inactive) unless kind matches'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(e_id ORDER BY e_id) FROM (SELECT e_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT i.id AS initiative_id FROM public.initiatives i
+    WHERE i.legacy_tribe_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.tribes t WHERE t.id = i.legacy_tribe_id)
+  )
+  SELECT 'F_initiative_legacy_tribe_orphan'::text,
+         'initiatives.legacy_tribe_id must point to an existing tribe (bridge integrity)'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(initiative_id ORDER BY initiative_id) FROM (SELECT initiative_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    LEFT JOIN public.document_versions dv ON dv.id = gd.current_version_id
+    WHERE gd.current_version_id IS NOT NULL
+      AND (dv.id IS NULL OR dv.locked_at IS NULL)
+      AND NOT EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status IN ('review','approved','activated')
+          AND ac.closed_at IS NULL
+      )
+  )
+  SELECT 'J_current_version_published'::text,
+         'governance_documents.current_version_id must point to a document_versions row with locked_at IS NOT NULL — unless an open approval_chain (review/approved/activated, closed_at NULL) is in flight that will lock the version on close (Phase IP-1, chain-aware).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.operational_role='external_signer'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.auth_engagements ae
+        WHERE ae.person_id=m.person_id AND ae.kind='external_signer' AND ae.status='active' AND ae.is_authoritative=true
+      )
+  )
+  SELECT 'K_external_signer_integrity'::text,
+         'members.operational_role=external_signer must have an active auth_engagements row with kind=external_signer (Phase IP-1).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id FROM public.members m
+    WHERE m.member_status IN ('alumni','observer','inactive') AND m.anonymized_at IS NULL
+      AND NOT EXISTS (SELECT 1 FROM public.member_offboarding_records r WHERE r.member_id=m.id)
+  )
+  SELECT 'L_offboarding_record_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have a member_offboarding_records row (#91 G3 trigger).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH expected AS (
+    -- Audit A2 (mig 20260805000478): derive research_score from the already-consolidated PERT
+    -- columns objective_score_avg (min-2 gated) + interview_score (min-1 gated), EXACTLY as
+    -- public.compute_application_scores does (mig 20260805000475). research_score is NULL when
+    -- objective_score_avg is NULL (a single-evaluator app is not rankable). The prior raw
+    -- AVG(subtotais objetivos) + AVG(subtotais entrevista) derivation lacked the min_evaluators
+    -- gate and flagged the correctly-nulled single-evaluator apps as false drift.
+    SELECT a.id AS application_id, a.research_score AS cached,
+      CASE
+        WHEN a.objective_score_avg IS NOT NULL AND a.interview_score IS NOT NULL THEN round(a.objective_score_avg + a.interview_score, 2)
+        WHEN a.objective_score_avg IS NOT NULL THEN round(a.objective_score_avg, 2)
+        ELSE NULL
+      END AS expected
+    FROM public.selection_applications a
+  ),
+  drift AS (
+    SELECT application_id FROM expected
+    WHERE (cached IS NULL) IS DISTINCT FROM (expected IS NULL)
+       OR (cached IS NOT NULL AND expected IS NOT NULL AND ABS(cached - expected) > 0.01)
+  )
+  SELECT 'M_application_score_consistency'::text,
+         'selection_applications.research_score must equal compute_application_scores(application_id) derivation: objective_score_avg (PERT, min-2 gated) + interview_score (PERT, min-1 gated), NULL when objective_score_avg is NULL (sync trigger trg_recompute_application_scores; Audit A2 mig 20260805000478 replaced the pre-min-gate raw-AVG derivation).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive')
+      AND offboarded_at IS NULL AND anonymized_at IS NULL
+      AND name <> 'VP Desenvolvimento Profissional (PMI-GO)'
+  )
+  SELECT 'N_terminal_status_offboarded_at_present'::text,
+         'members in alumni/observer/inactive (not anonymized) must have offboarded_at NOT NULL (ARM-9 G6 defense-in-depth complement to L).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT ma.id AS artifact_id FROM public.meeting_artifacts ma
+    WHERE ma.event_id IS NOT NULL
+      AND NOT EXISTS (SELECT 1 FROM public.events e WHERE e.id = ma.event_id)
+  )
+  SELECT 'O_meeting_artifact_event_orphan'::text,
+         'meeting_artifacts.event_id must point to an existing event when not NULL (FK defense).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(artifact_id ORDER BY artifact_id) FROM (SELECT artifact_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  SELECT 'P_tribe_initiative_bridge_complete'::text,
+         'tribes.is_active=true must have at least one initiative.legacy_tribe_id pointing to it (V3-V4 bridge; cron leader digest depends).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM public.tribes t
+          WHERE t.is_active = true
+            AND NOT EXISTS (SELECT 1 FROM public.initiatives i WHERE i.legacy_tribe_id = t.id)),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS engagement_id FROM public.engagements
+    WHERE status = 'expired' AND end_date > CURRENT_DATE
+  )
+  SELECT 'Q_expired_engagement_end_date'::text,
+         'engagements.status=expired requires end_date <= CURRENT_DATE (impossible to be expired in the future; VEP service_latest_end_date is source of truth).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT a.id AS application_id
+    FROM public.selection_applications a
+    WHERE a.status = 'approved'
+      AND a.email IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.members m WHERE lower(m.email) = lower(a.email)
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM public.member_emails me WHERE lower(me.email) = lower(a.email)
+      )
+  )
+  SELECT 'R_approved_application_has_member'::text,
+         'selection_applications.status=approved must have a matching members row by lower(email). Bypass of approve_selection_application() canonical RPC creates this drift (Issue #180).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(application_id ORDER BY application_id) FROM (SELECT application_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT DISTINCT m.id AS member_id
+    FROM public.selection_applications a
+    JOIN public.members m ON lower(m.email) = lower(a.email)
+    WHERE a.status = 'approved' AND m.person_id IS NULL
+  )
+  SELECT 'S_approved_member_has_person_id'::text,
+         'members tied to an approved selection_applications row must have person_id NOT NULL (V4 graph anchor for engagements). Issue #180.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH primary_email_counts AS (
+    SELECT m.id AS member_id,
+           COUNT(me.id) FILTER (WHERE me.is_primary = true) AS primary_count
+    FROM public.members m
+    LEFT JOIN public.member_emails me ON me.member_id = m.id
+    WHERE m.name NOT LIKE '%_synthetic%'
+    GROUP BY m.id
+  ),
+  drift AS (
+    SELECT member_id FROM primary_email_counts
+    WHERE primary_count <> 1
+  )
+  SELECT 'T_member_has_exactly_one_primary_email'::text,
+         'Every member must have exactly one primary email in member_emails (Issue #205).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status = 'pending_proposer_consent'
+      AND EXISTS (
+        SELECT 1 FROM public.approval_chains ac
+        WHERE ac.document_id = gd.id
+          AND ac.status NOT IN ('withdrawn','superseded')
+      )
+  )
+  SELECT 'V_prime_pending_proposer_consent_no_open_chain'::text,
+         'status=pending_proposer_consent must not have non-cancelled approval_chains rows (#315 P0-Q7 + Amendment A2 — pending_proposer_consent precedes any chain).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id FROM public.governance_documents gd
+    WHERE gd.status IN ('approved','active')
+      AND gd.current_ratified_chain_id IS NULL
+  )
+  SELECT 'V_status_chain_coherence'::text,
+         'governance_documents with status approved/active must have current_ratified_chain_id NOT NULL (#315 P0-Q6 + #367 Wave 1b first leaf). NO carve-out: 7 legacy pre-chain docs backfilled with PM-designated synthetic chains via migration 20260805000038 (acknowledge signoffs, metadata.legacy_migration=true, role=migration_attestation).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT cp.id AS product_id
+    FROM public.content_products cp
+    WHERE
+      CASE cp.source_kind
+        WHEN 'governance_document_version' THEN
+          NOT (cp.source_document_version_id IS NOT NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'board_item' THEN
+          NOT (cp.source_board_item_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'publication_idea' THEN
+          NOT (cp.source_publication_idea_id IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        WHEN 'external' THEN
+          NOT (cp.source_external_uri IS NOT NULL
+               AND cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL)
+        WHEN 'none' THEN
+          NOT (cp.source_document_version_id IS NULL
+               AND cp.source_board_item_id IS NULL
+               AND cp.source_publication_idea_id IS NULL
+               AND cp.source_external_uri IS NULL)
+        ELSE TRUE
+      END
+  )
+  SELECT 'W_content_product_source_integrity'::text,
+         'content_products row must satisfy chk_content_products_source_integrity CHECK semantics (exactly one source FK populated per source_kind; ADR-0099 §2.2 + §6 step 9). Defense-in-depth complement to the CHECK constraint; mirrors V/V''/T pattern.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(product_id ORDER BY product_id) FROM (SELECT product_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT p.id AS parecer_id
+    FROM public.blind_review_pareceres p
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.blind_review_assignments a
+      WHERE a.session_id = p.session_id
+        AND a.reviewer_member_id = p.reviewer_member_id
+        AND a.status = 'active'
+    )
+  )
+  SELECT 'X_blind_review_pareceres_session_product_match'::text,
+         'blind_review_pareceres.reviewer_member_id must have an active blind_review_assignments row in the same session (assignment-parecer integrity; ADR-0099 §2.7 + §7 step 11). Defense-in-depth complement to FK constraints; catches drift if assignment is withdrawn while parecer remains. #382 PR-B.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(parecer_id ORDER BY parecer_id) FROM (SELECT parecer_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH pe AS (
+    SELECT name AS k FROM public.partner_entities
+    WHERE entity_type = 'pmi_chapter' AND status = 'active' AND NOT COALESCE(is_international, false)
+  ),
+  ch AS (
+    SELECT 'PMI-' || code AS k FROM public.chapters WHERE status = 'active'
+  ),
+  drift AS (
+    SELECT k FROM pe WHERE k NOT IN (SELECT k FROM ch)
+    UNION ALL
+    SELECT k FROM ch WHERE k NOT IN (SELECT k FROM pe)
+  )
+  SELECT 'Y_chapter_pipeline_parity'::text,
+         'every active domestic pmi_chapter in partner_entities must have a matching active chapters row (by name = ''PMI-'' || chapters.code) and vice-versa — MEMBERSHIP parity (not just count), so it catches single-table inserts/archives even when row counts coincide. Drift = get_chapter_metrics()->>signed forks from the V4 chapters table (#481).'::text,
+         'medium'::text,
+         (SELECT COUNT(*)::integer FROM drift),
+         NULL::uuid[];
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS webinar_id FROM public.webinars
+    WHERE status IS NULL OR status NOT IN ('planned','confirmed','completed','cancelled')
+  )
+  SELECT 'Z_webinar_status_domain'::text,
+         'webinars.status must be within planned|confirmed|completed|cancelled (the realized=completed canonical definition depends on it; defense-in-depth complement to webinars_status_check — #479/#481).'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(webinar_id ORDER BY webinar_id) FROM (SELECT webinar_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS member_id FROM public.members
+    WHERE member_status IN ('observer','alumni','inactive') AND current_cycle_active = true
+      AND name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND name NOT LIKE '%_synthetic%'
+  )
+  SELECT 'B2_current_cycle_active_terminal_status'::text,
+         'members in observer/alumni/inactive must have current_cycle_active=false (#483 sync_member_status_consistency B-trigger; CCA gates the get_gamification_leaderboard/get_public_leaderboard cohort).'::text,
+         'low'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id
+    FROM public.members m
+    WHERE m.member_status = 'active'
+      AND m.person_id IS NOT NULL
+      AND m.name != 'VP Desenvolvimento Profissional (PMI-GO)'
+      AND m.name NOT LIKE '%_synthetic%'
+      AND replace(m.chapter, 'PMI-', '') IN (SELECT chapter_code FROM public.chapter_registry)
+      AND NOT (m.operational_role = 'guest' AND m.entry_chapter_code IS NULL)
+      AND (SELECT COUNT(*) FROM public.member_chapter_affiliations a
+            WHERE a.person_id = m.person_id AND a.is_primary) <> 1
+  )
+  SELECT 'U_active_person_has_primary_chapter_affiliation'::text,
+         'every active registry-chaptered member''s person_id must have exactly one is_primary=true member_chapter_affiliations row, else the members.chapter COALESCE(entry, primary, legacy) derivation breaks silently (ADR-0104 Wave 3b-ii). Excluded: operational_role=''guest'' AND entry_chapter_code IS NULL (pre-onboarding, entry-chapter choice not yet made — affiliation is seeded by set_my_entry_chapter, Wave 3b-i; until then the COALESCE falls through to the legacy default). Non-registry chapters (Outro/Externo) excluded — legitimately unaffiliated.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT op.member_id
+    FROM public.onboarding_progress op
+    WHERE op.step_key = 'volunteer_term'
+      AND op.status <> 'completed'
+      AND op.member_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM public.certificates c
+        WHERE c.member_id = op.member_id
+          AND c.type = 'volunteer_agreement'
+          AND c.status = 'issued'
+      )
+  )
+  SELECT 'AA_volunteer_term_complete_when_cert_issued'::text,
+         'a member holding an issued volunteer_agreement certificate must have their volunteer_term onboarding_progress step at status=completed. Guaranteed by the cert-side AFTER trigger (_trg_complete_volunteer_term_on_cert on certificates) plus the seed-side BEFORE guard (_trg_complete_volunteer_term_on_seed on onboarding_progress), p233 / issue #766. A non-completed step alongside an issued cert means a trigger was bypassed (service_role direct INSERT, or a cert backfill that did not fire the AFTER trigger). Directional: a member with no volunteer_term row, or a completed step without an issued cert (all certs rejected or superseded), is NOT a violation.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'term_signed'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.certificates c
+        WHERE c.member_id = mm.member_id
+          AND c.type = 'volunteer_agreement'
+      )
+  )
+  SELECT 'AB_term_signed_milestone_has_cert_ancestry'::text,
+         'a term_signed member_milestone must have at least one volunteer_agreement certificate of any status (issued/rejected/superseded) for the same member. Wave 3c reject/reissue is valid ancestry — the milestone persists after a cert is rejected or superseded because the member did sign once. A milestone with NO cert in any state indicates fabrication or a bad backfill (service_role direct INSERT into member_milestones; source_id is informational-only without FK). #766 PR2, mig 20260805000202. Directional complement to AA.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'first_attendance'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.attendance a
+        WHERE a.member_id = mm.member_id
+          AND a.present = true
+      )
+  )
+  SELECT 'AC_first_attendance_milestone_has_attendance'::text,
+         'a first_attendance member_milestone must have at least one present=true attendance row for the same member. source_id is informational-only (no FK), so a milestone with no present attendance indicates fabrication or a bad backfill (service_role direct INSERT into member_milestones). #766 PR3, mig 20260805000203. Directional, mirrors AA/AB.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'first_deliverable'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.tribe_deliverables td
+        WHERE td.assigned_member_id = mm.member_id
+          AND td.status = 'completed'
+      )
+  )
+  SELECT 'AD_first_deliverable_milestone_has_completed_deliverable'::text,
+         'a first_deliverable member_milestone must have at least one tribe_deliverable with status=''completed'' assigned to the same member. Keyed on status=''completed'' (same signal as the trigger and the XP sibling trg_tribe_deliverable_completed_xp; NOT completed_at, a derived audit column). A milestone with no completed deliverable indicates fabrication, a bad backfill, or a status reverted via service_role after the milestone fired. #766 PR3, mig 20260805000203. Directional, mirrors AA/AB.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT mm.member_id
+    FROM public.member_milestones mm
+    WHERE mm.milestone_key = 'profile_complete'
+      AND NOT EXISTS (
+        SELECT 1 FROM public.members m
+        WHERE m.id = mm.member_id
+          AND m.profile_completed_at IS NOT NULL
+      )
+  )
+  SELECT 'AE_profile_complete_milestone_has_profile_completed_at'::text,
+         'a profile_complete member_milestone must have members.profile_completed_at set. The column is monotonic — only update_my_profile writes it (NULL -> now() once, never cleared) — so this directional check is false-positive-free, unlike promotion whose mutable operational_role cache demotes routinely (hence PR4 added no invariant). A milestone with a NULL profile_completed_at indicates fabrication, a bad backfill (service_role direct INSERT into member_milestones; source_id is informational-only without FK), or the column cleared via a manual UPDATE after the milestone fired. #766 PR5, mig 20260805000205. Directional, mirrors AA/AB/AC/AD.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT si.id AS interview_id
+    FROM public.selection_interviews si
+    WHERE si.status IN ('scheduled','rescheduled')
+      AND EXISTS (
+        SELECT 1 FROM public.selection_interviews si2
+        WHERE si2.application_id = si.application_id
+          AND si2.created_at > si.created_at
+      )
+  )
+  SELECT 'AF_open_interview_is_newest_row'::text,
+         'a selection_interviews row in an open status (scheduled/rescheduled) must be the most-recently-created interview row for its application. An open row older than another interview row of the same application indicates a reschedule/re-booking that did not close the prior open row (bypass of the AFTER INSERT trigger trg_supersede_prior_open_interviews, or pre-fix legacy drift). Root cause: sync_calendar_booking_to_interview / schedule_interview INSERTing a new scheduled row without superseding the prior open one (D4/D5, mig 20260805000210). KNOWN directional gap (defense-in-depth): a TERMINAL row inserted newer than an open row (only import_historical_interviews) is not superseded by the trigger and would surface here; the live path reaches completed via UPDATE in-place, so it is covered.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(interview_id ORDER BY interview_id) FROM (SELECT interview_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT e.id AS engagement_id
+    FROM public.engagements e
+    JOIN public.initiatives i ON i.id = e.initiative_id AND i.kind = 'research_tribe'
+    JOIN public.members m ON m.person_id = e.person_id
+    WHERE e.kind = 'volunteer' AND e.status = 'active'
+      AND m.tribe_id IS DISTINCT FROM i.legacy_tribe_id
+  )
+  SELECT 'AG_tribe_engagement_has_tribe_id'::text,
+         'every active volunteer engagement in a research_tribe initiative must have member.tribe_id = initiative.legacy_tribe_id (the correctness contract of the bridge trigger trg_sync_tribe_id_from_engagement; count_tribe_slots reads members.tribe_id, so a divergence corrupts the slot count). A violation means the bridge was bypassed (service_role direct INSERT into engagements) or a stale legacy tribe_id conflicts with the engagement. Tribe Selection Híbrida PR1, mig 20260805000216. Baseline 0.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT e.person_id
+    FROM public.engagements e
+    JOIN public.initiatives i ON i.id = e.initiative_id AND i.kind = 'research_tribe'
+    WHERE e.kind = 'volunteer' AND e.status = 'active'
+    GROUP BY e.person_id
+    HAVING COUNT(*) > 1
+  )
+  SELECT 'AH_research_tribe_single_active_engagement'::text,
+         'a person must have at most one active volunteer engagement across research_tribe initiatives. members.tribe_id is a single scalar and the bridge trigger trg_sync_tribe_id_from_engagement (admission + demotion branch) assumes a single active tribe engagement; two make tribe_id ambiguous and can leave a stale tribe_id after one is demoted. Supersedes the SPEC''s I_research_tribe_no_dual_pending (which false-positives on a legitimate tribe-move and whose committed-divergence sibling is already non-zero from frozen legacy tribe_selections staleness, below the bridge since AG=0). Tribe Selection Híbrida PR1, mig 20260805000216. Baseline 0.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(person_id ORDER BY person_id) FROM (SELECT person_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id FROM public.selection_applications WHERE interview_auto_rescue_count > 1
+  )
+  SELECT 'AI_unbooked_rescue_cap_respected'::text,
+         'selection_applications with interview_auto_rescue_count > 1 (above cap=1). _selection_unbooked_rescue_cron + selection_rescue_unbooked_invite enforce the cap via a RAISE guard at count>=1; a value >1 means a re-entry bug or a service_role direct UPDATE bypassed the guard. D3 auto-rescue, mig 20260805000219. Baseline 0.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(id ORDER BY id) FROM (SELECT id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  RETURN QUERY
+  WITH expected(tbl) AS (
+    VALUES ('initiatives'),('events'),('project_boards'),('board_items'),
+           ('meeting_artifacts'),('tribe_deliverables'),('recurring_meeting_rules'),('governance_documents')
+  ),
+  drift AS (
+    SELECT e.tbl FROM expected e
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_policies p
+      WHERE p.schemaname = 'public'
+        AND p.tablename = e.tbl
+        AND p.permissive = 'RESTRICTIVE'
+        AND p.cmd IN ('SELECT','ALL')
+        AND p.qual ILIKE '%rls_can_see_%'
+    )
+  )
+  SELECT 'AJ_confidential_visibility_gate_present'::text,
+         'each of the 8 initiative-dependent tables (initiatives/events/project_boards/board_items/meeting_artifacts/tribe_deliverables/recurring_meeting_rules/governance_documents) must carry a RESTRICTIVE SELECT policy whose USING calls a rls_can_see_* helper — the confidential-initiative visibility gate (#785 PR-2, mig 20260805000232). A missing policy means the gate was dropped and a confidential initiative''s rows leak to non-engaged members. Structural catalog check (pg_policies); baseline 0.'::text,
+         'high'::text,
+         (SELECT COUNT(*)::integer FROM drift),
+         NULL::uuid[];
+
+
+  -- #333 (Wave 4, #221/#218): voice-biometric consent enforcement — periodic detector that
+  -- complements the write-time trigger trg_pmi_video_screening_voice_consent.
+  RETURN QUERY
+  WITH ack AS (
+    -- Applications with a documented LGPD Art.18 retroactive-notification retention basis
+    -- (the #332 acknowledged pre-block row). The application id is parsed from the pii_access_log
+    -- audit record so NO candidate identifier is hardcoded in this migration; the exclusion IS the
+    -- documented retention, and it self-heals to nothing if the row is eventually deleted.
+    SELECT (substring(pal.reason FROM 'application_id=([0-9a-fA-F-]+)'))::uuid AS application_id
+    FROM public.pii_access_log pal
+    WHERE pal.context = 'lgpd_art_18_retroactive_notification'
+      AND pal.reason ~ 'application_id='
+  ),
+  drift AS (
+    SELECT vs.id
+    FROM public.pmi_video_screenings vs
+    WHERE vs.transcription IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM public.selection_applications sa
+        WHERE sa.id = vs.application_id
+          AND sa.consent_voice_biometric_at IS NOT NULL
+          AND sa.consent_voice_biometric_revoked_at IS NULL
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM ack WHERE ack.application_id = vs.application_id
+      )
+  )
+  SELECT 'AK_voice_biometric_consent_enforcement'::text,
+         'every pmi_video_screenings row with transcription IS NOT NULL must have a matching selection_applications row where consent_voice_biometric_at IS NOT NULL AND consent_voice_biometric_revoked_at IS NULL (voice-biometric consent, LGPD Art.11), UNLESS its application has a documented Art.18 retroactive-notification retention basis logged in pii_access_log. The BEFORE INSERT/UPDATE trigger trg_pmi_video_screening_voice_consent is the write-time moat; this invariant is the periodic detector for any NEW drift (trigger disabled, consent revoked without deleting the row, raw SQL bypass). #333/#221/#218 Wave 4. The 1 acknowledged pre-block row (#332, tacit Art.18 retention; PM path (b) 2026-06-27) is EXCLUDED via its retention record, so baseline is 0; a new non-consented transcription with no retention basis is flagged. Named AK because the U_ code is already held by U_active_person_has_primary_chapter_affiliation.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(id ORDER BY id) FROM (SELECT id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- #209 / ADR-0107 (amended #1039 / ADR-0107 Amendment 1): Drive offboarding revocation
+  -- queue state-machine integrity, auto-approve provenance included.
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS audit_id FROM public.drive_offboarding_audit
+    WHERE
+      (status = 'revoked' AND (revoked_at IS NULL
+        OR (approved_by IS NULL AND approval_mode IS DISTINCT FROM 'auto')))
+      OR (approval_mode = 'auto' AND (approved_by IS NOT NULL OR status = 'pending_revoke'))
+      OR (status = 'skipped' AND skip_reason IS NULL)
+      OR (status IN ('pending_revoke','approved') AND EXISTS (
+            SELECT 1 FROM public.members m
+            WHERE m.id = drive_offboarding_audit.member_id
+              AND (m.member_status = 'active' OR m.offboarded_at IS NULL)))
+  )
+  SELECT 'AL_drive_revocation_terminal_consistency'::text,
+         'drive_offboarding_audit (#209/ADR-0107, amended #1039/Amendment 1): a revoked row must carry revoked_at AND either approved_by (manual GP approve path) or approval_mode=''auto'' (alumni-only system approve via auto_approve_alumni_drive_revocations; already_absent is excluded from provenance checks by design — the grant was already gone, no proof of revocation is required); an auto row may never carry a human approver nor sit in pending_revoke (provenance coherence: auto is written exactly at the pending→approved flip; the write-side alumni-only filter is the moat — member_status is NOT re-checked here because a legitimately auto-revoked alumni can later return to active via the re-engagement pipeline); a skipped row must carry skip_reason (owner_permission | member_reactivated — structural Art. 37 evidence, council COND-2); and no OPEN row (pending_revoke/approved) may reference a member who is active / not offboarded — admin_reactivate_member cancels open rows to skipped/member_reactivated in the same transaction (#1039). A violation means a service_role direct write bypassed the RPC path, or a reactivation cleared offboarding without clearing the queue. Baseline 0.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(audit_id ORDER BY audit_id) FROM (SELECT audit_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- #301 / ADR-0108: curation temporary Drive grant state-machine integrity.
+  RETURN QUERY
+  WITH drift AS (
+    SELECT id AS grant_id FROM public.drive_curation_grants
+    WHERE (status = 'granted' AND (permission_id IS NULL OR granted_at IS NULL))
+       OR (status = 'granted' AND revoked_at IS NOT NULL)
+       OR (status = 'revoked' AND revoked_at IS NULL)
+  )
+  SELECT 'AM_drive_curation_grant_terminal_consistency'::text,
+         'drive_curation_grants (#301/ADR-0108): a granted row must carry permission_id AND granted_at (proof the Drive POST succeeded) and must NOT carry revoked_at; a revoked row must carry revoked_at. The grant/revoke EF mark RPCs (mark_curation_grant_done/mark_curation_grant_revoked) are the only legitimate writers of these terminal states; a violation means a service_role direct write bypassed them. Named AM (AL is the #209 sibling). Baseline 0.'::text,
+         'medium'::text, COUNT(*)::integer,
+         (SELECT array_agg(grant_id ORDER BY grant_id) FROM (SELECT grant_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- #974 (PR-2 of #571) — no dynamic remission: every active cooperation_agreement
+  -- must carry an active instrument_version_bindings pin to the IP policy (a hard
+  -- document_versions.id), never a free-text "Política vigente" dynamic remission.
+  -- GATED on a ratified (active) cooperation_addendum: dormant until the Adendo
+  -- imports the policy into the agreements (pre-ratification no ratified instrument
+  -- obliges the agreements to pin the policy — §9.7 / legal review 2026-06-30).
+  RETURN QUERY
+  WITH drift AS (
+    SELECT gd.id AS doc_id
+    FROM public.governance_documents gd
+    WHERE gd.doc_type = 'cooperation_agreement'
+      AND gd.status = 'active'
+      AND EXISTS (
+        SELECT 1 FROM public.governance_documents addn
+        WHERE addn.doc_type = 'cooperation_addendum' AND addn.status = 'active'
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.instrument_version_bindings ivb
+        JOIN public.governance_documents ref ON ref.id = ivb.referenced_document_id
+        WHERE ivb.bound_document_id = gd.id
+          AND ref.doc_type = 'policy'
+          AND ivb.status = 'active'
+      )
+  )
+  SELECT 'AN_no_dynamic_remission_cooperation'::text,
+         'every active cooperation_agreement must carry an active instrument_version_bindings row pinning the IP policy to a hard document_versions.id (referenced doc_type=policy, status=active) — never a free-text "Política vigente" dynamic remission. The Adendo de PI aos Acordos de Cooperação (cooperation_addendum, under_review at mig 20260805000302) PROPOSES to import the IP policy into all 4 bilateral agreements; this invariant is GATED on an active (ratified) cooperation_addendum and is dormant until then — pre-ratification no ratified instrument obliges the agreements to pin the policy (legal review 2026-06-30, SPEC §9.7). #974 PR-2 materializes 4 anticipatory pins now (pinned_version_id is NOT NULL by table constraint, so the pin can never be a dynamic reference). Once a cooperation_addendum ratifies, an active cooperation_agreement with no active policy pin = dynamic remission reintroduced (#974, mig 20260805000302). Baseline 0.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(doc_id ORDER BY doc_id) FROM (SELECT doc_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- AO (#1269) regression guard for the dual-write leave-tribe orphan surfaced by live QA on
+  -- 2026-07-10 (Andre Abreu, tribe 7). See AG (the opposite direction) and mig 20260805000396 (#1270).
+  RETURN QUERY
+  WITH drift AS (
+    SELECT m.id AS member_id
+    FROM public.members m
+    JOIN public.initiatives i ON i.legacy_tribe_id = m.tribe_id AND i.kind = 'research_tribe'
+    WHERE m.member_status = 'active'
+      AND m.tribe_id IS NOT NULL
+      AND m.person_id IS NOT NULL
+      AND m.name NOT LIKE '%_synthetic%'
+      AND EXISTS (
+        SELECT 1 FROM public.engagements e
+        WHERE e.person_id = m.person_id AND e.initiative_id = i.id
+          AND e.kind = 'volunteer' AND e.status IN ('offboarded','expired')
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM public.engagements e2
+        JOIN public.initiatives i2 ON i2.id = e2.initiative_id AND i2.kind = 'research_tribe'
+        WHERE e2.person_id = m.person_id AND e2.kind = 'volunteer' AND e2.status = 'active'
+      )
+  )
+  SELECT 'AO_active_member_stale_tribe_id_after_leave'::text,
+         'an active member whose members.tribe_id points at a research_tribe they already LEFT (a terminal offboarded/expired volunteer engagement on that initiative) while holding NO active research_tribe engagement. The dual-write leave-tribe orphan surfaced by live QA on 2026-07-10 (Andre Abreu, tribe 7): the pre-#1270 demotion path cleared only ONE of members.tribe_id/initiative_id, so the bridge BEFORE trigger re-derived the stale side and the member was stranded in a cannot-leave empty-state while inflating count_tribe_slots. The #1270 fix (mig 20260805000396) now clears BOTH columns on demotion; this invariant is the periodic detector for any residual or bypass orphan (service_role direct write, pre-fix staleness). It deliberately does NOT flag legacy select_tribe members (engagement absent, not terminal) who keep a legitimate tribe_id with no engagement. Opposite-direction complement to AG. Baseline 0.'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(member_id ORDER BY member_id) FROM (SELECT member_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+  -- AP (#1221 fatia 1 / ADR-0121): interim leader-grant reversion integrity. The interim grant
+  -- (engagements.metadata->>'interim_grant' = true) activates authority AHEAD of the signed term;
+  -- when the real term is signed the engagement gets agreement_certificate_id AND the interim flag
+  -- MUST be removed (ADR-0121 reversion rule). A row carrying BOTH is a stale interim grant whose flag
+  -- was never reverted. Deferred from #1117. Baseline 0 (zero interim_grant flags live 2026-07-10).
+  RETURN QUERY
+  WITH drift AS (
+    SELECT e.id AS engagement_id
+    FROM public.engagements e
+    WHERE COALESCE((e.metadata ->> 'interim_grant')::boolean, false) = true
+      AND e.agreement_certificate_id IS NOT NULL
+  )
+  SELECT 'AP_interim_grant_reverted_when_cert_issued'::text,
+         'an engagement carrying metadata->>''interim_grant''=true must NOT also have agreement_certificate_id set: the ADR-0121 interim leader-grant (mig 20260805000341) activates authority ahead of the signed volunteer term, and when the real term is signed (agreement_certificate_id set) the interim flag MUST be removed (the reversion rule). A row with both is a stale interim grant whose flag was never reverted — the engagement is authoritative via TWO paths at once, masking whether authority still rests on the honest-but-reversible interim basis. Deferred from #1117. Baseline 0 (zero interim_grant flags live 2026-07-10).'::text,
+         'high'::text, COUNT(*)::integer,
+         (SELECT array_agg(engagement_id ORDER BY engagement_id) FROM (SELECT engagement_id FROM drift LIMIT 10) s)
+  FROM drift;
+
+END;
+$function$;

--- a/supabase/migrations/20260822120649_hardening_escopo_org_em_leitores_pii_e_board.sql
+++ b/supabase/migrations/20260822120649_hardening_escopo_org_em_leitores_pii_e_board.sql
@@ -1,0 +1,316 @@
+-- Hardening de escopo de autoridade em leitores de PII de admin e na escrita de
+-- board (decisao do PM 2026-08-22).
+--
+-- Esta migration e ADITIVA no nivel do gate: public.can() fica INTOCADA. Ela
+-- introduz um helper que pergunta a mesma coisa aceitando apenas combo de
+-- escopo organization/global, e passa a usa-lo nos chamadores que precisam de
+-- autoridade independente de recurso. Onde o chamador ja tem o recurso em maos,
+-- ele passa a ser repassado ao gate em vez de omitido.
+--
+-- Funcoes tocadas:
+--   can_org / can_org_by_member          (novas, aditivas)
+--   admin_get_member_details             (leitor de PII)
+--   admin_list_members_with_pii          (leitor de PII)
+--   admin_list_member_consents           (leitor de PII)
+--   board_write_authority                (escrita de board)
+--
+-- Verificado apos aplicar: nenhum papel legitimo perdeu acesso -- sponsors,
+-- pontos focais, GP e co-GP ficaram inalterados, e lideres de tribo seguem
+-- lendo os contatos da propria tribo.
+--
+-- O contexto de seguranca, a exposicao medida antes/depois e o trabalho ainda
+-- em aberto estao registrados em advisory PRIVADO do repositorio. Este arquivo
+-- nao o referencia por identificador: o repositorio e PUBLICO e a correcao de
+-- raiz ainda nao foi entregue.
+-- ─────────────────────────────────────────────────────────────────────────────
+-- B1. Helper: a MESMA pergunta de can(), mas so aceitando combo de escopo
+-- organization/global. Serve a quem precisa de autoridade que nao depende de
+-- recurso -- e que, por isso, nunca deve ser satisfeita por um combo escopado.
+-- Aditivo: can() fica intocada.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.can_org(p_person_id uuid, p_action text)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.auth_engagements ae
+    JOIN public.engagement_kind_permissions ekp
+      ON ekp.kind = ae.kind AND ekp.role = ae.role AND ekp.action = p_action
+    WHERE ae.person_id = p_person_id
+      AND (
+        ae.is_authoritative = true
+        -- mesmo carve-out p195 de can(): comentario em governanca nao exige termo
+        OR (p_action = 'participate_in_governance_review' AND ae.status = 'active')
+      )
+      AND ekp.scope IN ('organization', 'global')
+  );
+$function$;
+
+CREATE OR REPLACE FUNCTION public.can_org_by_member(p_member_id uuid, p_action text)
+ RETURNS boolean
+ LANGUAGE sql
+ STABLE
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+  SELECT public.can_org(
+    (SELECT id FROM public.persons WHERE legacy_member_id = p_member_id),
+    p_action
+  );
+$function$;
+
+-- CREATE FUNCTION nasce com EXECUTE para PUBLIC (logo, anon). Estes helpers sao
+-- SECDEF e so precisam ser chamados de dentro de outras SECDEF e por sessao
+-- autenticada.
+REVOKE EXECUTE ON FUNCTION public.can_org(uuid, text) FROM PUBLIC, anon;
+REVOKE EXECUTE ON FUNCTION public.can_org_by_member(uuid, text) FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.can_org(uuid, text) TO authenticated, service_role;
+GRANT EXECUTE ON FUNCTION public.can_org_by_member(uuid, text) TO authenticated, service_role;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- B2. Os tres leitores de PII de admin passam a exigir view_pii de escopo
+-- ORGANIZATION. Nenhum deles recebe recurso, e nenhum deveria ser satisfeito por
+-- um view_pii de tribo. O resto do corpo fica identico ao anterior.
+-- (Aplicado no banco por um DO block sobre a definicao viva, para nao transcrever
+-- os corpos a mao; o CREATE literal abaixo e a captura para o gate de drift, e a
+-- igualdade com o vivo esta provada por hash -- ver o commit.)
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.admin_get_member_details(p_member_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_result jsonb;
+  v_scope text;
+BEGIN
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF NOT public.can_org_by_member(v_caller_id, 'view_pii') THEN
+    RAISE EXCEPTION 'Access denied: requires view_pii permission (LGPD-sensitive data)';
+  END IF;
+
+  -- FU-2 Slice A: chapter-scope — non-GP/non-sede callers may not read out-of-chapter member details.
+  v_scope := public.caller_chapter_scope();
+  IF v_scope IS NOT NULL
+     AND p_member_id <> v_caller_id
+     AND (SELECT chapter FROM public.members WHERE id = p_member_id) IS DISTINCT FROM v_scope THEN
+    RAISE EXCEPTION 'Access denied: cross-chapter member details';
+  END IF;
+
+  PERFORM public.log_pii_access(
+    p_member_id,
+    ARRAY['name','email','phone','photo_url','role','designations','is_active','cycles']::text[],
+    'admin_get_member_details',
+    NULL
+  );
+
+  SELECT jsonb_build_object(
+    'id', m.id,
+    'name', m.name,
+    'email', m.email,
+    'phone', m.phone,
+    'photo_url', m.photo_url,
+    'tribe_id', m.tribe_id,
+    'operational_role', m.operational_role,
+    'designations', m.designations,
+    'is_superadmin', m.is_superadmin,
+    'is_active', m.is_active,
+    'cycle_active', m.current_cycle_active,
+    'cycles', m.cycles,
+    'created_at', m.created_at
+  ) INTO v_result
+  FROM public.members m
+  WHERE m.id = p_member_id;
+
+  RETURN v_result;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.admin_list_members_with_pii(p_tribe_id integer DEFAULT NULL::integer)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_result jsonb;
+  v_accessed_ids uuid[];
+  v_scope text;
+BEGIN
+  SELECT id INTO v_caller_id FROM public.members WHERE auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF NOT public.can_org_by_member(v_caller_id, 'view_pii') THEN
+    RAISE EXCEPTION 'Access denied: requires view_pii permission (LGPD-sensitive data)';
+  END IF;
+
+  -- FU-2 Slice A: chapter-scope — non-GP/non-sede callers see only their own chapter's members.
+  v_scope := public.caller_chapter_scope();
+
+  SELECT array_agg(m.id) INTO v_accessed_ids
+  FROM public.members m
+  WHERE (p_tribe_id IS NULL OR m.tribe_id = p_tribe_id)
+    AND (v_scope IS NULL OR m.chapter = v_scope)
+    AND m.id <> v_caller_id;
+
+  PERFORM public.log_pii_access_batch(
+    v_accessed_ids,
+    ARRAY['name','email','phone','role','designations']::text[],
+    'admin_list_members_with_pii',
+    CASE WHEN p_tribe_id IS NOT NULL THEN 'filtered by tribe ' || p_tribe_id ELSE 'all members' END
+  );
+
+  SELECT coalesce(jsonb_agg(jsonb_build_object(
+    'id', m.id,
+    'name', m.name,
+    'email', m.email,
+    'phone', m.phone,
+    'tribe_id', m.tribe_id,
+    'operational_role', m.operational_role,
+    'designations', m.designations,
+    'is_active', m.is_active,
+    'cycle_active', m.current_cycle_active
+  ) ORDER BY m.name), '[]'::jsonb) INTO v_result
+  FROM public.members m
+  WHERE (p_tribe_id IS NULL OR m.tribe_id = p_tribe_id)
+    AND (v_scope IS NULL OR m.chapter = v_scope);
+
+  RETURN v_result;
+END;
+$function$;
+
+CREATE OR REPLACE FUNCTION public.admin_list_member_consents(p_member_id uuid)
+ RETURNS jsonb
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_caller_id uuid;
+  v_caller_org_id uuid;
+  v_target_org_id uuid;
+  v_scope text;
+  v_result jsonb;
+BEGIN
+  SELECT m.id, m.organization_id INTO v_caller_id, v_caller_org_id
+  FROM public.members m WHERE m.auth_id = auth.uid();
+  IF v_caller_id IS NULL THEN RAISE EXCEPTION 'Not authenticated'; END IF;
+  IF NOT public.can_org_by_member(v_caller_id, 'view_pii') THEN
+    RAISE EXCEPTION 'Access denied: requires view_pii permission (LGPD-sensitive data)';
+  END IF;
+
+  -- Multi-tenant fence (CRITICAL): SECDEF bypasses the RESTRICTIVE org-scope RLS policy, and
+  -- can_by_member('view_pii') is satisfied by the caller holding view_pii in ANY engagement —
+  -- it does NOT bound the TARGET. Re-enforce org isolation here.
+  SELECT m.organization_id INTO v_target_org_id FROM public.members m WHERE m.id = p_member_id;
+  IF v_target_org_id IS NULL OR v_caller_org_id IS NULL OR v_target_org_id <> v_caller_org_id THEN
+    RAISE EXCEPTION 'Access denied: target member not in caller organization';
+  END IF;
+
+  -- FU-2 Slice C: chapter-scope — a non-GP/non-sede caller may not read another chapter's consent
+  -- history (the org fence above is a no-op while all chapters share one organization). Self always allowed.
+  v_scope := public.caller_chapter_scope();
+  IF v_scope IS NOT NULL AND p_member_id <> v_caller_id
+     AND (SELECT chapter FROM public.members WHERE id = p_member_id) IS DISTINCT FROM v_scope THEN
+    RAISE EXCEPTION 'Access denied: cross-chapter member consents';
+  END IF;
+
+  SELECT COALESCE(jsonb_agg(jsonb_build_object(
+    'id', cr.id,
+    'member_id', cr.member_id,
+    'application_id', cr.application_id,
+    'policy_type', cr.policy_type,
+    'policy_version', cr.policy_version,
+    'policy_document_id', cr.policy_document_id,
+    'accepted_at', cr.accepted_at,
+    'channel', cr.channel,
+    -- capture-evidence hashes (pseudonymized) — relevant to a consent audit; view_pii-gated + logged.
+    'email_hash', cr.email_hash,
+    'ip_hash', cr.ip_hash,
+    'user_agent_hash', cr.user_agent_hash,
+    'revoked_at', cr.revoked_at,
+    'revocation_reason', cr.revocation_reason,
+    'is_active', (cr.revoked_at IS NULL),
+    'created_at', cr.created_at
+  ) ORDER BY cr.accepted_at DESC), '[]'::jsonb)
+  INTO v_result
+  FROM public.consent_records cr
+  WHERE cr.member_id = p_member_id
+    AND cr.organization_id = v_caller_org_id;
+
+  -- Accountability (Art. 37): log EVERY admin read of consent history, incl. self-reads via this path.
+  INSERT INTO public.pii_access_log (accessor_id, target_member_id, fields_accessed, context, reason, accessed_at)
+  VALUES (v_caller_id, p_member_id, ARRAY['consent_history']::text[], 'admin_list_member_consents', 'consent audit', now());
+
+  RETURN v_result;
+END;
+$function$;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- A. board_write_authority: a funcao JA recebe p_board_id e ja resolveu
+-- v_board.initiative_id. O ultimo ramo perguntava sem passar nada, o que fazia
+-- qualquer write_board escopado valer para QUALQUER board. Agora o ramo se parte
+-- em dois: autoridade de organizacao (vale para todo board, que e o desenho dos
+-- seeds) e autoridade escopada A ESTA iniciativa.
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION public.board_write_authority(p_member_id uuid, p_board_id uuid)
+ RETURNS boolean
+ LANGUAGE plpgsql
+ STABLE SECURITY DEFINER
+ SET search_path TO 'public', 'pg_temp'
+AS $function$
+DECLARE
+  v_actor record;
+  v_board record;
+  v_board_legacy_tribe_id int;
+BEGIN
+  SELECT * INTO v_actor FROM public.members WHERE id = p_member_id;
+  IF NOT FOUND THEN RETURN false; END IF;
+  SELECT * INTO v_board FROM public.project_boards WHERE id = p_board_id;
+  IF NOT FOUND THEN RETURN false; END IF;
+  SELECT legacy_tribe_id INTO v_board_legacy_tribe_id
+  FROM public.initiatives WHERE id = v_board.initiative_id;
+
+  RETURN (
+    -- GP
+    coalesce(v_actor.is_superadmin, false)
+    OR v_actor.operational_role IN ('manager', 'deputy_manager')
+    OR coalesce('co_gp' = ANY(v_actor.designations), false)
+    -- tribe leader deste board
+    OR (v_actor.operational_role = 'tribe_leader' AND v_actor.tribe_id = v_board_legacy_tribe_id)
+    -- comms team num board de dominio 'communication'
+    OR (coalesce(v_board.domain_key, '') = 'communication' AND (
+         v_actor.operational_role = 'communicator'
+         OR coalesce('comms_team' = ANY(v_actor.designations), false)
+         OR coalesce('comms_leader' = ANY(v_actor.designations), false)
+         OR coalesce('comms_member' = ANY(v_actor.designations), false)))
+    -- lider/coordenador/manager/co_gp da iniciativa deste board
+    OR (v_board.initiative_id IS NOT NULL AND v_actor.person_id IS NOT NULL AND EXISTS (
+         SELECT 1 FROM public.engagements e
+         WHERE e.person_id = v_actor.person_id
+           AND e.initiative_id = v_board.initiative_id
+           AND e.status = 'active'
+           AND e.role IN ('leader', 'coordinator', 'manager', 'co_gp')))
+    -- GHSA-jpq5: write_board de escopo ORGANIZATION vale para qualquer board
+    -- (desenho dos seeds: manager, co_gp, deputy_manager, comms_leader, curator,
+    -- volunteer/leader). Antes esta linha era can_by_member/2, que tambem aceitava
+    -- combo de escopo initiative e por isso valia para board ALHEIO.
+    OR public.can_org_by_member(p_member_id, 'write_board')
+    -- ...e write_board escopado passa a valer SO para a iniciativa DESTE board.
+    OR (v_board.initiative_id IS NOT NULL
+        AND public.can_by_member(p_member_id, 'write_board', 'initiative', v_board.initiative_id))
+  );
+END;
+$function$;

--- a/tests/contracts/rpc-acl.test.mjs
+++ b/tests/contracts/rpc-acl.test.mjs
@@ -60,12 +60,15 @@ for (const rpcName of LGPD_RPCS) {
     assert.ok(body, `RPC ${rpcName} not found`);
 
     // Must check admin tier via legacy direct pattern OR V4 can_by_member() gate (ADR-0011).
+    // `can_org_by_member` is the STRICTER form of the same gate: it only accepts a combo of
+    // organization/global scope, so it can never be satisfied by an initiative-scoped combo.
+    // It must be accepted here, or hardening a caller turns this guard red for improving it.
     const checksAdmin =
       /is_superadmin\s*=\s*true/i.test(body) ||
       /operational_role\s+IN\s*\(/i.test(body) ||
-      /can_by_member\s*\([^)]*,\s*'view_pii'/i.test(body);
+      /can(?:_org)?_by_member\s*\([^)]*,\s*'view_pii'/i.test(body);
     assert.ok(checksAdmin,
-      `RPC ${rpcName} must check admin tier (is_superadmin / operational_role / can_by_member 'view_pii')`);
+      `RPC ${rpcName} must check admin tier (is_superadmin / operational_role / can_by_member|can_org_by_member 'view_pii')`);
 
     const raisesException = /RAISE\s+EXCEPTION/i.test(body);
     assert.ok(raisesException, `RPC ${rpcName} must RAISE EXCEPTION on unauthorized access`);
@@ -75,12 +78,13 @@ for (const rpcName of LGPD_RPCS) {
     const body = findFunctionBody(rpcName);
     assert.ok(body);
 
-    // Accept either legacy `IF NOT ( ... OR ... )` boolean gate or V4 `IF NOT can_by_member(...)` form.
+    // Accept legacy `IF NOT ( ... OR ... )`, V4 `IF NOT can_by_member(...)`, or the stricter
+    // `IF NOT can_org_by_member(...)` form.
     const hasLegacyGate = /IF\s+NOT\s*\(/i.test(body);
-    const hasV4Gate = /IF\s+NOT\s+(?:public\.)?can_by_member\s*\(/i.test(body);
+    const hasV4Gate = /IF\s+NOT\s+(?:public\.)?can(?:_org)?_by_member\s*\(/i.test(body);
     const hasRaise = /RAISE\s+EXCEPTION\s+'Access denied/i.test(body);
     assert.ok((hasLegacyGate || hasV4Gate) && hasRaise,
-      `RPC ${rpcName} must have IF NOT (admin) or IF NOT can_by_member(...) gate + RAISE EXCEPTION 'Access denied`);
+      `RPC ${rpcName} must have IF NOT (admin) or IF NOT can_by_member(...)/can_org_by_member(...) gate + RAISE EXCEPTION 'Access denied`);
   });
 }
 


### PR DESCRIPTION
## O que isto conserta

A `main` esta vermelha em **dois checks nao-required** desde a madrugada de 22/08:

| check | estado antes |
|---|---|
| `Schema Invariants (ADR-0012 B10)` | `fail 3` de 76 - Track Q-C, Phase C, ADR-0097 |
| `DB Types Drift (#1410)` | `can_org` / `can_org_by_member` ausentes de `database.gen.ts` |

Causa unica: **tres versoes vivas em producao sem `.sql` na main**. Confirmado em
`supabase_migrations.schema_migrations`:

- `20260822032921_activate_deputy_manager_tier_for_co_gp`
- `20260822033913_wave1_restore_adr0023_ladder_parity`
- `20260822120649` (hardening de escopo)

Os arquivos existiam apenas em `lane/video-reunioes-e-shorts`. E a instancia de 22/08
da classe descrita em #1910.

O portao required (`validate`, `structural`, `browser_guards`, `deno`) **estava verde** -
a A2 (#1914) fez seu trabalho e a fila nunca congelou. Isto conserta o relatorio, nao um
bloqueio.

## O renome do terceiro arquivo (leia antes de aprovar)

O nome original e as **29 primeiras linhas** do terceiro arquivo nomeavam um advisory de
seguranca ainda em **DRAFT** (nao publicado) e transcreviam **a clausula SQL exata** do
buraco cuja **correcao de raiz continua em aberto**. Este repositorio e publico.

Reescrevi o cabecalho e renomeei o arquivo. Por que isso e inerte para os guards:

- **ADR-0097 casa por VERSAO**, nunca por nome: `base.split('_')[0]`
  (`tests/contracts/rpc-migration-coverage.test.mjs:303`). A versao `20260822120649`
  esta preservada.
- **O cabecalho fica fora de qualquer bloco `CREATE FUNCTION`** (o primeiro comeca na
  linha 36 do original), logo nao entra no `prosrc` que o Phase C mede.

Provado, nao presumido: o `md5` do trecho `CREATE FUNCTION` em diante e **identico** ao
da lane em ambos os arquivos - `6d0c693ed12c193948100746e2fd36bb` - e o Phase C passa.

**Fica um residuo, e e decisao sua:** uma ocorrencia de `GHSA-jpq5` (ID parcial) sobrevive
num comentario **dentro** de `board_write_authority`, descrevendo comportamento **ja
corrigido**. Tira-la exigiria re-aplicar a funcao em producao, porque `board_write_authority`
**nao** esta no allowlist do Phase C - editar o comentario criaria drift novo. Achei o preco
alto (DDL numa porta viva de PII/board por causa de um comentario) e parei aqui.

> Nota separada: o ID **completo** ja esta publico em 2 assuntos de commit na branch
> `lane/video-reunioes-e-shorts`, que esta empurrada. Esta PR nao piora isso e da um caminho
> que nao exige force-push: a captura entra limpa na main, e a lane pode ser descartada.

## Os tipos

`src/lib/database.gen.ts` foi regerado com a CLI **2.109.0** - a versao **pinada** em
`gen-types-drift.yml` - e nao com a **2.115.0** instalada localmente. Gerar com a errada
produziria drift falso. Diff: **+8 linhas**, so `can_org` e `can_org_by_member`.

## O guard que a captura quebrou

Landar o `.sql` deixou **4 testes estruturais vermelhos** - e os 4 estavam certos.
`tests/contracts/rpc-acl.test.mjs` casava o literal `can_by_member`, e
**`can_org_by_member` nao o contem**. Ou seja: o guard reprovava porque a migration tornou
o portao **mais estrito**. `can_org_by_member` so aceita combo de escopo
organization/global, logo nunca e satisfeito por combo escopado a iniciativa.

Ampliei o padrao para `can(?:_org)?_by_member` nos dois pontos, e **injetei o defeito para
provar que nao afrouxei**: removendo o portao de `admin_get_member_details`, o guard reprova
em 2 testes. Verde sem essa prova nao valeria nada.

**Correcao: a lacuna que eu ia reportar nao existe.** `admin_list_member_consents` **e**
coberto - por `tests/contracts/568-consent-records-lgpd-read.test.mjs`, que afirma o portao
`view_pii`, a cerca de organizacao e o log de auditoria. Eu tinha concluido ausencia por ter
procurado so na lista `LGPD_RPCS`, num arquivo so. Mesma classe de erro da #1926.

**O que existe, e e diferente, vale issue propria:** esse guard le um **arquivo de migration
fixado** (`20260805000130_p568_...sql`, linha 31), nao a captura mais recente. As tres
afirmacoes estaticas dele descrevem a funcao como ela era em 05/08, e a migration desta PR a
redefine. Como o arquivo fixado e historia imutavel, o guard fica verde para sempre e nao
consegue ver regressao introduzida por migration posterior. Os tres testes ao vivo do mesmo
arquivo so checam fail-closed de anon e service_role - nenhum afirma a cerca de organizacao
na definicao vigente.

## Medicoes

| verificacao | resultado |
|---|---|
| `npx astro build` | 0 erros |
| `npm run test:structural` | **3602 / 3602** |
| `test:contracts:db` + `DATA_INVARIANT_GATE=1` | **76 / 76**, zero skip |

> Sem o `DATA_INVARIANT_GATE=1` a suite roda 72 e **pula as tres que importam** - o primeiro
> verde que tirei era vazio. As tres so contam medidas em modo estrito.

## Risco a jusante, para quem for mexer na lane depois

A lane `lane/video-reunioes-e-shorts` continua com **a copia original** desta migration, com o
nome antigo. Se ela for mergeada depois desta PR sem remover esse arquivo, a main fica com
**dois arquivos para a versao `20260822120649`**, com nomes diferentes e o mesmo conjunto de
`CREATE FUNCTION`. O ADR-0097 nao reclama (`localVersions` e um Set, a duplicata colapsa), mas
o Phase C escolhe "a captura mais recente por chave (nome, args)" e passa a ter dois candidatos
para as mesmas 6 funcoes.

**Antes de mergear a lane: apagar `supabase/migrations/20260822120649_ghsa_*.sql` dela.** Nao e
perda - o conteudo dos blocos `CREATE FUNCTION` e byte-identico ao que esta aqui, e o cabecalho
que so ela tem e justamente o que nao deve entrar na main.

Refs #1910, #1922
