### PR TITLE
docs: #1910 - anota os 3 SHAs que a main cita e que nao existem mais

### DIFF
--- a/docs/audit/2026-08-21_AUDITORIA_CI_E_CRITERIOS_DE_MERGE.md
+++ b/docs/audit/2026-08-21_AUDITORIA_CI_E_CRITERIOS_DE_MERGE.md
@@ -79,6 +79,14 @@ Do lado da CI, o mesmo instante:
 | 32481010980 | `claude/1900-cron-jornada-tribo` | `b41217d9` | 21/08 12:15 | **success** |
 | 32492721370 | `claude/1900-cron-jornada-tribo` | `005ee51c` | 21/08 14:32 | **failure** |
 
+> 📌 **Nota de 22/08:** os dois SHAs desta tabela (`b41217d9` e `005ee51c`) **não são mais
+> alcançáveis**: a branch `claude/1900-cron-jornada-tribo` foi apagada na higiene de branches de
+> 22/08 (#1929). Os números de run continuam válidos e resolvem na API do GitHub; os SHAs ficam
+> aqui como **registro do que foi medido**, não como ponteiro navegável. Não reescrevi a tabela:
+> ela documenta o estado no instante da medição, e trocar o SHA falsificaria o registro.
+> Causa distinta da do `9e15d73c` (reescrita de histórico da lane de vídeo), que produz o mesmo
+> sintoma por outro caminho.
+
 E o log do run vermelho nomeia uma unica asserção:
 
 ```

--- a/docs/planning/2026-08-22_handoff_seis_decisoes_executadas_e_o_guard_da_faixa.md
+++ b/docs/planning/2026-08-22_handoff_seis_decisoes_executadas_e_o_guard_da_faixa.md
@@ -79,6 +79,19 @@ E o par de alertas mostra a diferença entre sinal e ruído:
 > único disco**. **Empurrar é urgente e independente do merge** — tira o risco de perda sem
 > antecipar decisão nenhuma. Registrado em #1910.
 
+> ✅ **ADENDO 22/08 (sessão seguinte): a ação acima está encerrada, e o SHA que ela cita morreu.**
+> O `9e15d73c` **não** estava fora do remoto quando isto foi escrito: era ancestral de
+> `origin/lane/video-reunioes-e-shorts`, então nunca esteve em um disco só. Depois a lane teve o
+> histórico reescrito (`ae937c4b`, "registra a sanitizacao de historico"), o que trocou os SHAs:
+> `9e15d73c` **não é mais alcançável por nenhum ref**, e seu sucessor é `3d4bd280`, com o mesmo
+> assunto e o mesmo conteúdo. Nada foi perdido.
+> A captura das migrations, que era o risco real, **landou na main** pela #1931 (`3e4ac649`) com
+> as três versões `20260822032921`, `20260822033913` e `20260822120649`.
+> 📌 **Citar SHA de branch viva num doc que vai para a main é dívida:** a main é permanente e a
+> branch não. Quando ela é reescrita ou apagada, a referência não dá erro, dá **silêncio**.
+> Prefira nomear o conteúdo (assunto do commit, versão da migration, nº da PR) e deixe o SHA como
+> apoio, nunca como a única chave.
+
 ---
 
 ## 4. Três correções em cima do meu próprio trabalho


### PR DESCRIPTION
## O problema

Referencia a SHA morto **nao da erro, da silencio**. Quem le um handoff da main, procura o
commit e nao acha, nao sabe se o commit sumiu ou se leu errado - e anotacao nova pode ser
construida em cima da leitura errada.

A main cita **tres** SHAs que nao sao mais alcancaveis por nenhum ref, por **duas causas
diferentes**.

## Os tres, medidos

| SHA | citado em | causa da orfandade | conteudo se perdeu? |
|---|---|---|---|
| `9e15d73c` | handoff de 22/08, no bloco "ACAO PENDENTE E URGENTE" | reescrita de historico da lane de video (`ae937c4b`) | **nao** - sucessor `3d4bd280` |
| `b41217d9` | auditoria de 21/08, tabela de runs | branch `claude/1900-cron-jornada-tribo` apagada na higiene (#1929) | **nao** - `database.gen.ts` esta na main |
| `005ee51c` | auditoria de 21/08, tabela de runs | idem | **nao** - o handoff que ele escreveu esta na main |

Medido por **alcancabilidade**, nao por existencia de objeto: `git cat-file -e` ainda responde
para os tres neste disco, porque foram buscados antes da reescrita. `git branch -a --contains`
devolve vazio para os tres. Num clone novo, nenhum resolve.

## O aviso do handoff estava errado quando foi escrito

O bloco diz que `9e15d73c` "**nao esta em nenhum remoto**" e pede push urgente porque "a captura
existe em um unico disco". Na hora em que li, `9e15d73c` **era ancestral de**
`origin/lane/video-reunioes-e-shorts` (remoto em `f0d8eafb`). Nunca esteve num disco so.

O que aconteceu **depois** foi outra coisa: a lane teve o historico reescrito, os SHAs mudaram, e
so entao ele ficou inalcancavel. Duas afirmacoes diferentes, com o mesmo sintoma aparente.

O risco real que o aviso tentava nomear - a DDL viva em producao sem `.sql` na main - **foi
fechado** pela #1931 (`3e4ac649`), com as tres versoes `20260822032921`, `20260822033913` e
`20260822120649`.

## O que NAO fiz, e por que

**Nao reescrevi a tabela de runs da auditoria.** Ela documenta o estado no instante da medicao;
trocar o SHA por um vivo falsificaria o registro. Anotei que os ponteiros nao navegam mais e que
os **numeros de run** continuam resolvendo na API - eles sao a chave durave, o SHA era o apoio.

## A licao, gravada no proprio handoff

Citar SHA de **branch viva** num doc que vai para a **main** e divida: a main e permanente, a
branch nao. Prefira nomear o conteudo - assunto do commit, versao da migration, numero da PR - e
deixe o SHA como apoio, nunca como a unica chave.

Refs #1910, #1929, #1931
