### PR TITLE
#1932: lote PII/LGPD le a captura vigente, e o lote consertou o scanner

### DIFF
--- a/docs/audit/GUARD_PIN_STALENESS_BASELINE_1932.txt
+++ b/docs/audit/GUARD_PIN_STALENESS_BASELINE_1932.txt
@@ -1,34 +1,38 @@
 # Linha de base do #1932 - guards que fixam uma migration VENCIDA.
 #
-# Cada linha e um par (arquivo de guard | funcao) em que o guard NAO fixa a migration que
-# carrega a definicao mais nova daquela funcao. O guard afirma, portanto, sobre um corpo que
-# a producao pode nao executar mais - e segue verde de qualquer jeito.
+# Cada linha e um par (arquivo de guard | funcao) em que o guard NAO fixa a migration que carrega
+# a definicao mais nova daquela funcao. O guard afirma sobre um corpo que a producao pode nao
+# executar mais - e segue verde de qualquer jeito.
 #
-# ESTA LISTA SO ENCOLHE. `tests/contracts/1932-guard-fixa-captura-vencida.test.mjs` reprova
-# nos DOIS sentidos:
-#   - par novo fora da lista        -> divida nova, conserte o guard (nao adicione aqui)
-#   - entrada que ja nao esta velha -> desculpa vencida, REMOVA a linha
+# ESTA LISTA SO ENCOLHE. tests/contracts/1932-guard-fixa-captura-vencida.test.mjs reprova nos DOIS
+# sentidos: par novo fora da lista (divida nova, conserte o guard) e entrada que ja nao esta velha
+# (desculpa vencida, remova a linha).
 #
-# Consertar um par significa: fazer o guard ler a captura mais nova (helper de resolucao), ou
-# afirmar contra o `prosrc` vivo, ou - se o guard existe para provar entrega historica e nao
-# invariante corrente - reescrever a mensagem para dizer isso e mover a afirmacao de invariante
-# para um guard proprio.
+# CONSERTAR = fazer o guard chamar latestFunctionCapture(ROOT, "nome") para aquela funcao. O
+# scanner reconhece a chamada e o par sai daqui sozinho. Se o guard existe para provar ENTREGA
+# HISTORICA e nao invariante corrente, o conserto e outro: reescrever a mensagem para dizer isso.
 #
-# Gerado em 2026-08-22. Pares: 172. Guards distintos: 102.
+# Regenerado em 2026-08-22, depois do lote de PII/LGPD. Pares: 174. Guards: 104.
+# Movimento nesta volta: -13 / +15.
+#   - as 13 que sairam: os 7 pares de PII/LGPD, parte convertida para a captura vigente e parte
+#     que era FALSO POSITIVO - nome citado so em comentario JS, ou dentro de assert.doesNotMatch,
+#     que afirma AUSENCIA e e o oposto de depender da definicao.
+#   - as 15 que entraram: divida REAL que o scanner nao via. O reconhecimento de migration fixada
+#     passou a cobrir a forma partida - resolve(MIGRATIONS_DIR, "<versao>_x.sql") - e com ela os
+#     arquivos que fixam migration foram de 294 para 334.
 #
-# COBERTURA PARCIAL, e medida: dos 294 arquivos que fixam migration, 184 escrevem ao menos um
-# nome na forma `CREATE OR REPLACE FUNCTION public.X` e 110 (37,4%) nao escrevem nenhum. Esses
-# 110 afirmam sobre o texto fixado por outros caminhos e sao INVISIVEIS para o guard: podem
-# estar fixados em captura vencida sem que nada acuse. Ampliar a extracao e passo separado.
+# COBERTURA PARCIAL, e medida: dos 334 arquivos que fixam migration, 201 escrevem ao menos
+# um nome na forma CREATE OR REPLACE FUNCTION public.X e 133 nao escrevem nenhum. Esses sao
+# INVISIVEIS. O ponto cego tambem existe POR FUNCAO dentro de arquivo visivel: export_my_data
+# estava vencida no guard 568 e so apareceu na revisao manual deste lote.
 tests/contracts/1001-vep-rejection-divergent-bucket.test.mjs|get_vep_divergence_report
 tests/contracts/1022-exit-state-canonical-semantics.test.mjs|admin_offboard_member
-tests/contracts/1022-exit-state-canonical-semantics.test.mjs|validate_status_transition
+tests/contracts/1039-drive-teardown-fatia-b.test.mjs|check_schema_invariants
 tests/contracts/105-my-meetings-widget.test.mjs|get_my_meetings
 tests/contracts/106-chapter-dashboard-pr2.test.mjs|admin_update_setting
 tests/contracts/106-chapter-dashboard-pr3.test.mjs|get_chapter_selection_summary
 tests/contracts/1071-agenda-viva-past-admin-reserved.test.mjs|get_geral_agenda_viva
 tests/contracts/1080-cycle-xp-bucket-taxonomy.test.mjs|get_member_cycle_xp
-tests/contracts/1103-leader-onboarding-role-scoped.test.mjs|consume_onboarding_token
 tests/contracts/1130-vep-role-cohort-reconciliation.test.mjs|get_vep_role_cohort_reconciliation
 tests/contracts/1163-approve-selection-pmi-id-match.test.mjs|approve_selection_application
 tests/contracts/1221-merit-immutable-fatia1.test.mjs|check_schema_invariants
@@ -41,17 +45,21 @@ tests/contracts/1289-move-item-to-board-authority.test.mjs|board_write_authority
 tests/contracts/1290-1291-1286-gp-cohort-visibility.test.mjs|get_cycle_attendance_overview
 tests/contracts/1290-1291-1286-gp-cohort-visibility.test.mjs|get_gp_cohort_health
 tests/contracts/1352-decline-routes-to-picker.test.mjs|review_tribe_request
+tests/contracts/1445-vep-offer-retracted-active-bucket.test.mjs|get_vep_divergence_report
+tests/contracts/1446-selection-dashboard-default-open-cycle.test.mjs|get_selection_dashboard
 tests/contracts/1468-recompute-cutoff-researcher-scope.test.mjs|recompute_application_status
 tests/contracts/1476-wave2-operational-membership-canonical.test.mjs|seal_event_attendance
-tests/contracts/1584-governed-booking-door.test.mjs|resolve_interview_booking_url
+tests/contracts/1496-activity-owner-gate-parity.test.mjs|complete_checklist_item
+tests/contracts/156-attendance-grid-historical-cohort.test.mjs|get_attendance_grid
 tests/contracts/1594-1595-gate-refusal-audit-and-reschedule-door.test.mjs|_dispatch_interview_booking_link
 tests/contracts/1609-1611-booking-entrance-door.test.mjs|selection_consistency_report
+tests/contracts/190-curation-queue-state.test.mjs|get_curation_queue_state
 tests/contracts/193-curation-fsm-cleanup.test.mjs|get_curation_dashboard
+tests/contracts/209-drive-offboarding.test.mjs|check_schema_invariants
+tests/contracts/301-curation-drive-grants.test.mjs|check_schema_invariants
 tests/contracts/425-gamification-cockpit.test.mjs|get_initiative_gamification
 tests/contracts/425-gamification-cockpit.test.mjs|get_tribe_gamification
 tests/contracts/564-events-write-authority-rls.test.mjs|update_future_events_in_group
-tests/contracts/568-consent-records-lgpd-read.test.mjs|admin_list_member_consents
-tests/contracts/568-consent-records-lgpd-read.test.mjs|list_my_consents
 tests/contracts/576-gamification-perf-batch-indexes.test.mjs|get_initiative_gamification
 tests/contracts/576-gamification-perf-batch-indexes.test.mjs|get_tribe_gamification
 tests/contracts/651-governance-parallel-gates.test.mjs|_enqueue_gate_notifications
@@ -62,11 +70,8 @@ tests/contracts/676-recurring-agenda-write-path.test.mjs|update_recurring_meetin
 tests/contracts/676-recurring-meeting-rules.test.mjs|get_recurring_meeting_drift
 tests/contracts/676-recurring-meeting-rules.test.mjs|reconcile_all_recurring_meetings
 tests/contracts/676-recurring-meeting-rules.test.mjs|reconcile_recurring_meeting
-tests/contracts/729-comms-clearance-image-consent-revocation.test.mjs|get_member_comms_card
 tests/contracts/766-pr5-profile-complete-milestone.test.mjs|check_schema_invariants
 tests/contracts/785-confidential-initiative-rls.test.mjs|check_schema_invariants
-tests/contracts/976-pr4-camada5-reaceite.test.mjs|anonymize_premember_applications
-tests/contracts/consent-voice-biometric-ui.test.mjs|give_consent_via_token
 tests/contracts/cutoff-approved-modal-button.test.mjs|get_selection_dashboard
 tests/contracts/cycle4-public-verticals.test.mjs|get_public_platform_stats
 tests/contracts/cycle4-tribe-capacity-ssot.test.mjs|tribe_capacity_limit
@@ -80,8 +85,6 @@ tests/contracts/D4-D5-interview-drift.test.mjs|check_schema_invariants
 tests/contracts/homepage-stats-pre-onboarding.test.mjs|get_member_retention_canonical
 tests/contracts/homepage-stats-pre-onboarding.test.mjs|get_public_platform_stats
 tests/contracts/leader-extra-cohort-separation.test.mjs|recompute_all_active_pert_cutoffs
-tests/contracts/lgpd-art-18-retroactive-deletion.test.mjs|lgpd_execute_retroactive_deletion
-tests/contracts/lgpd-art-18-retroactive-deletion.test.mjs|lgpd_record_retroactive_notification
 tests/contracts/normalize-legacy-contract-volunteer.test.mjs|approve_selection_application
 tests/contracts/p232-229-phase2-leader-extra-visibility.test.mjs|get_application_score_breakdown
 tests/contracts/p232-229-phase2-leader-extra-visibility.test.mjs|get_selection_dashboard
@@ -126,8 +129,6 @@ tests/contracts/p277-419-m3c-engagement-foundation.test.mjs|get_attendance_engag
 tests/contracts/p277-419-m3c-engagement-foundation.test.mjs|get_attendance_reliability_summary
 tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs|get_initiative_gamification
 tests/contracts/p277-419-m4-gamification-cohort-roster.test.mjs|get_tribe_gamification
-tests/contracts/p277-419-m4a-roster-primitive.test.mjs|resolve_initiative_id
-tests/contracts/p277-419-m4a-roster-primitive.test.mjs|resolve_tribe_id
 tests/contracts/p277-419-m4c-clean-stats-cross-roster.test.mjs|exec_cross_initiative_comparison
 tests/contracts/p277-419-m4c-clean-stats-cross-roster.test.mjs|get_initiative_stats
 tests/contracts/p277-419-m4c-clean-stats-cross-roster.test.mjs|get_tribe_stats
@@ -145,13 +146,19 @@ tests/contracts/p282-411-w2-cron-automation.test.mjs|get_cutoff_dispatch_health
 tests/contracts/p282-411-w2-cron-automation.test.mjs|notify_selection_cutoff_approved
 tests/contracts/p472-corr5-consistency-cron.test.mjs|selection_consistency_report
 tests/contracts/p479-canonical-chapter-webinar-metrics.test.mjs|get_chapter_metrics
-tests/contracts/p481-chapter-fork-cleanup.test.mjs|get_public_impact_data
 tests/contracts/p625-c2-members-v4.test.mjs|admin_list_members
 tests/contracts/p697-member-comms-card.test.mjs|get_member_comms_card
 tests/contracts/p705-eval-queue-and-dual-track.test.mjs|get_my_pending_evaluations
 tests/contracts/p708-create-initiative-board-scope.test.mjs|create_initiative
+tests/contracts/rls-members-directory-authoritative.test.mjs|rls_is_authoritative_member
 tests/contracts/sediment-268-a-approval-pipeline-org-id.test.mjs|lock_document_version
 tests/contracts/sediment-268-a-approval-pipeline-org-id.test.mjs|sign_ip_ratification
+tests/contracts/tribe-request-deadline-enforcement.test.mjs|get_my_tribe_request_context
+tests/contracts/tribe-request-deadline-enforcement.test.mjs|request_tribe_assignment
+tests/contracts/tribe-selection-hybrid-pr1.test.mjs|_sync_tribe_id_from_engagement
+tests/contracts/tribe-selection-hybrid-pr1.test.mjs|check_schema_invariants
+tests/contracts/tribe-selection-hybrid-pr1.test.mjs|request_tribe_assignment
+tests/contracts/tribe-selection-hybrid-pr1.test.mjs|review_tribe_request
 tests/contracts/tribe-selection-hybrid-pr2-fe.test.mjs|get_my_tribe_request_context
 tests/contracts/w3a0-chapter-ssot.test.mjs|get_selection_dashboard
 tests/contracts/w3b-ii-members-chapter-derivation.test.mjs|check_schema_invariants

--- a/tests/contracts/1932-guard-fixa-captura-vencida.test.mjs
+++ b/tests/contracts/1932-guard-fixa-captura-vencida.test.mjs
@@ -24,7 +24,7 @@
  * nova, um renomear de diretório) para o conjunto medido virar zero e o teste ficar verde para
  * sempre. `[] == []` é verde. Os pisos transformam esse esvaziamento em reprovação.
  *
- * NÃO diz que os 172 pares são 172 buracos. Diz que são 172 pontos sem contato com a definição
+ * NÃO diz que os 174 pares são 174 buracos. Diz que são 174 pontos sem contato com a definição
  * vigente; cada um só é buraco se a migration posterior mexeu justamente na propriedade afirmada.
  * Fixar continua certo para "esta migration entregou X"; é errado para afirmar invariante
  * corrente de segurança, LGPD ou autoridade.
@@ -32,21 +32,29 @@
  * ⚠️ COBERTURA PARCIAL, MEDIDA — e escrita aqui porque um guard que se lê como completo sendo
  * parcial é a própria classe de defeito que ele existe para pegar. O par (guard, função) só é
  * visível quando o arquivo escreve o nome da função na forma `CREATE OR REPLACE FUNCTION
- * public.X`. Em 22/08, dos **294** arquivos que fixam migration, **184** escrevem ao menos um
- * nome nessa forma e **110 (37,4%) não escrevem nenhum** — afirmam sobre o texto fixado por outros
- * caminhos (`assert.match(body, /can_by_member[\s\S]*view_pii/)`, contagem de policies, presença
- * de GRANT). Esses 110 são invisíveis para este guard e podem estar fixados em captura vencida
- * sem que nada acuse. Ampliar a extração é passo separado: casa com mais formas ao custo de falso
- * positivo, e o valor de hoje é travar o crescimento nos 184 que dá para ver com precisão.
+ * public.X`. Em 22/08, dos **334** arquivos que fixam migration, **201** escrevem ao menos um nome
+ * nessa forma e **133 não escrevem nenhum** — afirmam sobre o texto fixado por outros caminhos
+ * (match direto de trecho, contagem de policies, presença de GRANT). Esses são invisíveis aqui.
+ *
+ * E o ponto cego existe também POR FUNÇÃO dentro de arquivo visível: `export_my_data` estava
+ * vencida no guard `568` (fixada em 05/08, vigente em 20260808000100) e o scanner não a via,
+ * porque aquele arquivo afirma trechos do corpo sem nunca escrever o cabeçalho `CREATE OR REPLACE
+ * FUNCTION public.export_my_data`. Só apareceu na revisão manual do lote de PII/LGPD.
  *
  * Offline (lê repo, não fala com banco). Refs #1932, #1910, #1931.
  */
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
-import { scanStalePins, parseBaseline, pairKey } from '../helpers/guard-pin-staleness.mjs';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  latestFunctionCapture,
+  pairKey,
+  parseBaseline,
+  scanStalePins,
+} from '../helpers/guard-pin-staleness.mjs';
 
 const ROOT = process.cwd();
 const BASELINE_PATH = 'docs/audit/GUARD_PIN_STALENESS_BASELINE_1932.txt';
@@ -140,17 +148,63 @@ test('#1932: o denominador não pode esvaziar (piso contra guard verde por vácu
   );
 });
 
-test('#1932: a instância provada continua detectável (controle positivo)', () => {
-  // Sem um controle positivo, os quatro testes acima passam tanto porque não há dívida nova
-  // quanto porque o scanner deixou de achar qualquer coisa. Este ancora o guard num caso que
-  // sabemos ser verdadeiro, e reprova se a detecção morrer.
-  const alvo = pairKey(
-    'tests/contracts/568-consent-records-lgpd-read.test.mjs',
-    'admin_list_member_consents',
-  );
-  assert.ok(
-    currentSet.has(alvo),
-    'a instância provada do #1932 deixou de ser detectada. Ou o guard 568 foi corrigido ' +
-      `(então remova a entrada de ${BASELINE_PATH} e este controle), ou o scanner quebrou.`,
+test('#1932: controle positivo sintético — a detecção funciona nos DOIS sentidos', () => {
+  // O controle anterior era ancorado na instância provada (`568` / `admin_list_member_consents`).
+  // Ela foi CONSERTADA no lote de PII/LGPD, e um controle que morre quando o defeito é corrigido
+  // não é controle: mede dívida restante, não capacidade de detectar. Este roda sobre um fixture
+  // sintético, então continua valendo mesmo que um dia não sobre dívida nenhuma no repo.
+  const base = mkdtempSync(join(tmpdir(), 'g1932-'));
+  try {
+    const migs = join(base, 'migrations');
+    const tests = join(base, 'tests');
+    mkdirSync(migs);
+    mkdirSync(tests);
+
+    const corpo = (n) =>
+      `CREATE OR REPLACE FUNCTION public.fixture_fn()\nRETURNS void LANGUAGE plpgsql AS $$\nBEGIN\n  -- v${n}\nEND;\n$$;\n`;
+    writeFileSync(join(migs, '20260101000000_antiga.sql'), corpo(1));
+    writeFileSync(join(migs, '20260202000000_nova.sql'), corpo(2));
+
+    // (a) guard que fixa a ANTIGA e afirma a função: tem de ser detectado
+    writeFileSync(
+      join(tests, 'vencido.test.mjs'),
+      `const M = 'supabase/migrations/20260101000000_antiga.sql';\n` +
+        `assert.match(body, /CREATE OR REPLACE FUNCTION public\\.fixture_fn/);\n`,
+    );
+    let r = scanStalePins(base, new Set(), { testsDir: tests, migrationsDir: migs });
+    assert.equal(r.pairs.length, 1, 'guard fixado na captura vencida tem de ser detectado');
+    assert.equal(r.pairs[0].fn, 'fixture_fn');
+    assert.equal(r.pairs[0].newestVersion, '20260202000000');
+
+    // (b) o MESMO guard fixando a captura mais nova: não pode ser detectado (senão o guard acusa
+    //     todo mundo e a linha de base vira ruído)
+    writeFileSync(
+      join(tests, 'vencido.test.mjs'),
+      `const M = 'supabase/migrations/20260202000000_nova.sql';\n` +
+        `assert.match(body, /CREATE OR REPLACE FUNCTION public\\.fixture_fn/);\n`,
+    );
+    r = scanStalePins(base, new Set(), { testsDir: tests, migrationsDir: migs });
+    assert.equal(r.pairs.length, 0, 'guard que aponta para a captura vigente não é dívida');
+
+    // (c) resolvido por `latestFunctionCapture`: também não é dívida, mesmo fixando a antiga
+    writeFileSync(
+      join(tests, 'vencido.test.mjs'),
+      `const M = 'supabase/migrations/20260101000000_antiga.sql';\n` +
+        `const cap = latestFunctionCapture(ROOT, 'fixture_fn');\n` +
+        `assert.match(cap.block, /CREATE OR REPLACE FUNCTION public\\.fixture_fn/);\n`,
+    );
+    r = scanStalePins(base, new Set(), { testsDir: tests, migrationsDir: migs });
+    assert.equal(r.pairs.length, 0, 'guard convertido para a captura vigente sai da dívida sozinho');
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('#1932: latestFunctionCapture LANÇA em vez de devolver vazio', () => {
+  // Vazio seria pior que erro: `doesNotMatch('', /vaza_hash/)` é verde para sempre, e é essa a
+  // forma das afirmações de PII que passaram a depender deste helper.
+  assert.throws(
+    () => latestFunctionCapture(ROOT, 'funcao_que_nenhuma_migration_define'),
+    /nenhuma migration define/,
   );
 });

--- a/tests/contracts/568-consent-records-lgpd-read.test.mjs
+++ b/tests/contracts/568-consent-records-lgpd-read.test.mjs
@@ -19,6 +19,22 @@
  * the auto PUBLIC grant linger).
  *
  * Cross-ref: #568, #564/PR#565, GC-162, LGPD Art. 18 (II access / V confirmation) + Art. 37.
+ *
+ * ── #1932, lote PII/LGPD: as afirmacoes de INVARIANTE CORRENTE leem a captura VIGENTE ──────────
+ * Este arquivo era a instancia provada do #1932. Ele fixava a migration 130 e afirmava
+ * `can_by_member(v_caller_id, 'view_pii')` com a mensagem "admin read gated on view_pii" — linha
+ * que a producao nao executa desde 20260822120649, que trocou o portao pelo `can_org_by_member`,
+ * mais estrito. O guard seguia VERDE.
+ *
+ * Agora cada afirmacao de invariante corrente resolve `latestFunctionCapture(...)`. O que continua
+ * fixado na 130 e so o que e ENTREGA HISTORICA daquela migration (a postura de GRANT que ela
+ * estabeleceu), e esta rotulado como tal. A postura de GRANT VIGENTE quem prova sao os testes de
+ * banco no fim do arquivo, que exercem o anon de verdade.
+ *
+ * ⚠️ `export_my_data` tambem estava desatualizada aqui (fixada na 130, vigente em 20260808000100) e
+ * o scanner do #1932 NAO a via: o arquivo nunca escreve `CREATE OR REPLACE FUNCTION
+ * public.export_my_data`, so afirma trechos do corpo. O ponto cego nao e apenas por arquivo, e por
+ * FUNCAO dentro de arquivo visivel.
  */
 
 import test from 'node:test';
@@ -26,10 +42,19 @@ import assert from 'node:assert/strict';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
+import { latestFunctionCapture } from '../helpers/guard-pin-staleness.mjs';
 
 const ROOT = process.cwd();
+// Fixado DE PROPOSITO: so para o que a migration 130 entregou (postura de GRANT).
 const MIG = resolve(ROOT, 'supabase/migrations/20260805000130_p568_consent_records_lgpd_read_rpcs.sql');
 const body = existsSync(MIG) ? readFileSync(MIG, 'utf8') : '';
+
+// Captura VIGENTE de cada funcao. `latestFunctionCapture` lanca se a funcao sumir, em vez de
+// devolver vazio — um `doesNotMatch('', ...)` seria verde para sempre, e as afirmacoes de PII aqui
+// sao justamente dessa forma ("nao vaza hash").
+const capLmc = latestFunctionCapture(ROOT, 'list_my_consents');
+const capAdm = latestFunctionCapture(ROOT, 'admin_list_member_consents');
+const capExp = latestFunctionCapture(ROOT, 'export_my_data');
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
 const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -37,57 +62,88 @@ const ANON_KEY = process.env.PUBLIC_SUPABASE_ANON_KEY || process.env.SUPABASE_AN
 const svcGated = !!(SUPABASE_URL && SERVICE_KEY);
 const anonGated = !!(SUPABASE_URL && ANON_KEY);
 
-// ── STATIC: list_my_consents (subject self-read) ────────────────────────────────────────
-test('#568 static: list_my_consents is SECDEF + STABLE, anon-revoked, omits hashes, has is_active', () => {
-  assert.ok(existsSync(MIG), 'migration 130 exists');
-  assert.match(body, /CREATE OR REPLACE FUNCTION public\.list_my_consents\(\)/);
-  assert.match(body, /list_my_consents\(\)[\s\S]*?STABLE[\s\S]*?SECURITY DEFINER/);
+// ── VIGENTE: list_my_consents (leitura do proprio titular) ──────────────────────────────
+test('#568 vigente: list_my_consents e SECDEF + STABLE, omite os hashes e publica is_active', () => {
+  assert.match(capLmc.block, /CREATE OR REPLACE FUNCTION public\.list_my_consents\(\)/);
+  assert.match(capLmc.block, /STABLE/, 'leitura do titular e STABLE');
+  assert.match(capLmc.block, /SECURITY DEFINER/);
+  // A visao do TITULAR nao pode expor as evidencias de captura. Antes isto exigia fatiar a
+  // migration entre CREATE e REVOKE porque o arquivo continha as duas funcoes; a captura vigente
+  // ja e so esta funcao, entao a afirmacao vale sobre o bloco inteiro.
+  assert.doesNotMatch(capLmc.block, /email_hash|ip_hash|user_agent_hash/,
+    'list_my_consents (visao do titular) precisa omitir as evidencias de captura');
+  assert.match(capLmc.block, /'is_active', \(cr\.revoked_at IS NULL\)/,
+    'o titular ve um flag consolidado de vigencia');
+});
+
+// ── VIGENTE: admin_list_member_consents (portao + cerca de org + log de acesso) ─────────
+test('#568 vigente: admin_list_member_consents e gateada em view_pii COM escopo de org e loga sempre', () => {
+  assert.match(capAdm.block, /CREATE OR REPLACE FUNCTION public\.admin_list_member_consents\(p_member_id uuid\)/);
+
+  // O portao vigente e o ESCOPADO. Afirmar o nome exato importa: `can_org_by_member` nao contem
+  // `can_by_member`, entao a versao anterior desta linha reprovaria — foi assim que o #1932 achou
+  // este arquivo. A negativa abaixo e o que impede a volta silenciosa ao portao mais fraco.
+  assert.match(capAdm.block, /IF NOT public\.can_org_by_member\(v_caller_id, 'view_pii'\) THEN/,
+    'leitura administrativa gateada em view_pii COM escopo de organizacao');
+  assert.doesNotMatch(capAdm.block, /public\.can_by_member\(v_caller_id, 'view_pii'\)/,
+    'nao pode reverter para o portao amplo can_by_member (perde o escopo de org)');
+
+  // CRITICO: cerca multi-tenant — SECDEF contorna a RLS RESTRICTIVE, e o portao de capacidade nao
+  // limita o ALVO.
+  assert.match(capAdm.block, /v_target_org_id IS NULL OR v_caller_org_id IS NULL OR v_target_org_id <> v_caller_org_id/,
+    'cerca de org: o alvo precisa ser membro da organizacao de quem chama');
+  assert.match(capAdm.block, /RAISE EXCEPTION 'Access denied: target member not in caller organization'/);
+  assert.match(capAdm.block, /AND cr\.organization_id = v_caller_org_id/, 'cerca de org tambem na query');
+
+  // O caminho administrativo (view_pii) DEVE expor as evidencias — inverso da visao do titular.
+  assert.match(capAdm.block, /email_hash[\s\S]*?ip_hash[\s\S]*?user_agent_hash/,
+    'o caminho de auditoria expoe as evidencias de captura');
+});
+
+test('#568 vigente: o log de acesso do admin_list_member_consents nao fica atras de condicional (Art. 37)', () => {
+  const ins = capAdm.block.indexOf('INSERT INTO public.pii_access_log');
+  assert.ok(ins > 0, 'a funcao precisa registrar a leitura em pii_access_log');
+  assert.match(capAdm.block.slice(ins), /'admin_list_member_consents'[\s\S]*?now\(\)/);
+
+  // A versao anterior afirmava `doesNotMatch(body, /p_member_id <> v_caller_id/)` sobre o arquivo
+  // INTEIRO, como proxy de "self-read nao e excluido do log". O proxy quebrou sem que o invariante
+  // quebrasse: a captura vigente usa exatamente essa comparacao na cerca de CAPITULO ("self sempre
+  // permitido"), que nao tem relacao com o log. Varredura de literal no corpo todo nao diz de QUAL
+  // construcao o literal e.
+  //
+  // A afirmacao precisa e posicional: entre o ultimo `END IF;` e o INSERT nao pode abrir condicional.
+  const antes = capAdm.block.slice(0, ins);
+  const ultimoEndIf = antes.lastIndexOf('END IF;');
+  assert.ok(ultimoEndIf > 0, 'esperado ao menos um bloco IF antes do log (os portoes)');
+  const entre = antes.slice(ultimoEndIf + 'END IF;'.length);
+  assert.doesNotMatch(entre, /\bIF\b/,
+    'o log de acesso precisa ser incondicional: nenhuma leitura administrativa pode escapar do registro');
+});
+
+// ── VIGENTE: export_my_data ─────────────────────────────────────────────────────────────
+test('#568 vigente: export_my_data leva consent_records por projecao explicita e usa i.title', () => {
+  assert.match(capExp.block, /'consent_records', COALESCE\(\(/, 'o export inclui consent_records');
+  // projecao explicita (NAO row_to_json), para coluna futura nao ser exportada por acidente
+  const exBlock = capExp.block.slice(capExp.block.lastIndexOf("'consent_records'"));
+  assert.doesNotMatch(exBlock, /row_to_json\(cr\)/, 'consent_records exporta por projecao explicita');
+  // o bug pre-existente: initiatives.name deixou de existir (V4 renomeou para title)
+  assert.doesNotMatch(capExp.block, /'initiative_name', i\.name\b/,
+    'nao pode referenciar i.name (a coluna virou title no V4)');
+  assert.match(capExp.block, /'initiative_name', i\.title\b/, 'engagements usam i.title');
+});
+
+// ── ENTREGA HISTORICA: a postura de ACL que a migration 130 estabeleceu ─────────────────
+// Fixado de proposito. A pergunta aqui e "a 130 entregou isto?", nao "isto vale hoje" — quem
+// responde a segunda sao os testes de banco abaixo, que exercem o anon de verdade. Manter as duas
+// e o ponto: `CREATE OR REPLACE` reconcede EXECUTE a PUBLIC por padrao, entao a postura vigente
+// precisa ser medida, nao deduzida do texto de uma migration.
+test('#568 entrega da migration 130: revoga PUBLIC/anon e concede authenticated + service_role', () => {
+  assert.ok(existsSync(MIG), 'migration 130 existe');
   assert.match(body, /REVOKE EXECUTE ON FUNCTION public\.list_my_consents\(\) FROM PUBLIC, anon;/);
   assert.match(body, /GRANT EXECUTE ON FUNCTION public\.list_my_consents\(\) TO authenticated, service_role;/);
-  // subject view must NOT leak the internal capture hashes (slice the fn body by its CREATE..REVOKE bounds)
-  const lmcBlock = body.slice(
-    body.indexOf('CREATE OR REPLACE FUNCTION public.list_my_consents'),
-    body.indexOf('REVOKE EXECUTE ON FUNCTION public.list_my_consents'));
-  assert.doesNotMatch(lmcBlock, /email_hash|ip_hash|user_agent_hash/,
-    'list_my_consents (subject view) must omit the capture-evidence hashes');
-  assert.match(lmcBlock, /'is_active', \(cr\.revoked_at IS NULL\)/, 'subject sees a consolidated active flag');
-});
-
-// ── STATIC: admin_list_member_consents (view_pii + org fence + audit log) ────────────────
-test('#568 static: admin_list_member_consents is view_pii-gated with an org fence + always logs', () => {
-  assert.match(body, /CREATE OR REPLACE FUNCTION public\.admin_list_member_consents\(p_member_id uuid\)/);
-  assert.match(body, /IF NOT public\.can_by_member\(v_caller_id, 'view_pii'\) THEN/,
-    'admin read gated on view_pii');
-  // CRITICAL: multi-tenant fence — target must be in caller org (SECDEF bypasses the RESTRICTIVE RLS)
-  assert.match(body, /v_target_org_id IS NULL OR v_caller_org_id IS NULL OR v_target_org_id <> v_caller_org_id/,
-    'org fence: target must be a real member in the caller organization');
-  assert.match(body, /RAISE EXCEPTION 'Access denied: target member not in caller organization'/);
-  assert.match(body, /AND cr\.organization_id = v_caller_org_id/, 'row-level org fence on the consent query too');
-  // accountability: log EVERY admin read (no self-read carve-out), with explicit accessed_at.
-  // (The INSERT + the self-read carve-out string are both unique to this function — assert on the
-  // whole body; an earlier indexOf('export_my_data') matched the header comment, slicing to empty.)
-  assert.doesNotMatch(body, /p_member_id <> v_caller_id/, 'self-read must NOT be excluded from the audit log');
-  assert.match(body, /INSERT INTO public\.pii_access_log[\s\S]*?'admin_list_member_consents'[\s\S]*?now\(\)/);
   assert.match(body, /REVOKE EXECUTE ON FUNCTION public\.admin_list_member_consents\(uuid\) FROM PUBLIC, anon;/);
-  // the admin (view_pii) audit path MUST expose the capture-evidence hashes (inverse of the subject view)
-  const admProjBlock = body.slice(
-    body.indexOf('CREATE OR REPLACE FUNCTION public.admin_list_member_consents'),
-    body.indexOf('REVOKE EXECUTE ON FUNCTION public.admin_list_member_consents'));
-  assert.match(admProjBlock, /email_hash[\s\S]*?ip_hash[\s\S]*?user_agent_hash/,
-    'admin audit path exposes the capture-evidence hashes');
-});
-
-// ── STATIC: export_my_data adds consent + fixes the i.name→i.title regression ────────────
-test('#568 static: export_my_data includes consent_records, fixes i.name→i.title, re-asserts grants', () => {
-  assert.match(body, /'consent_records', COALESCE\(\(/, 'export gains a consent_records key');
-  // explicit projection (NOT row_to_json) so future columns are not auto-exported
-  const exBlock = body.slice(body.lastIndexOf("'consent_records'"));
-  assert.doesNotMatch(exBlock, /row_to_json\(cr\)/, 'consent_records export uses explicit projection');
-  // the pre-existing bug: initiatives.name no longer exists (V4 renamed to title)
-  assert.doesNotMatch(body, /'initiative_name', i\.name\b/, 'must NOT reference i.name (column was renamed to title)');
-  assert.match(body, /'initiative_name', i\.title\b/, 'engagements use i.title');
   assert.match(body, /REVOKE EXECUTE ON FUNCTION public\.export_my_data\(\) FROM PUBLIC, anon;/,
-    'CREATE OR REPLACE must re-assert the ACL explicitly (drop the lingering anon auto-grant)');
+    'CREATE OR REPLACE obriga a reafirmar a ACL (derruba o auto-grant de anon)');
 });
 
 // ── DB (gated): anon is revoked on all three; service_role fail-closes ───────────────────

--- a/tests/contracts/729-comms-clearance-image-consent-revocation.test.mjs
+++ b/tests/contracts/729-comms-clearance-image-consent-revocation.test.mjs
@@ -14,26 +14,28 @@
  *
  * NOTE: #729 does NOT close on this migration — the read branch is only reachable once a revocation can
  * be RECORDED (self-service #570 at go-live, or the pending admin RPC gp_record_image_consent_revocation).
+ *
+ * ── #1932, lote PII/LGPD ────────────────────────────────────────────────────────────────────────
+ * Este guard fixava a migration 20260805000314, e `get_member_comms_card` foi redefinida depois em
+ * 20260805000447 (papeis confidenciais, #1383). Todas as afirmacoes daqui sao de INVARIANTE
+ * CORRENTE — "o portao de comunicacao honra revogacao de imagem e NAO usa consent_status" — entao
+ * o arquivo inteiro passa a resolver a captura vigente. Fixar so provaria que a 314 entregou.
  */
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFileSync, existsSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import { dirname, join } from 'node:path';
+import { latestFunctionCapture, maskLineComments } from '../helpers/guard-pin-staleness.mjs';
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const MIGRATION = join(
-  __dirname,
-  '../../supabase/migrations/20260805000314_729_comms_clearance_honor_image_consent_revocation.sql',
-);
-// Defensive read (LL #684): a missing file becomes a clean assertion, not an ENOENT module crash.
-const sql = existsSync(MIGRATION) ? readFileSync(MIGRATION, 'utf8') : '';
-// Executable code only (strip `-- ...` comment lines) — the header/notes discuss consent_status/the
-// #570 model; the gate must not actually USE consent_status (p697 pattern, line 58 there).
-const code = sql.split('\n').filter((l) => !/^\s*--/.test(l)).join('\n');
+// Captura VIGENTE (#1932): a definicao mais nova de get_member_comms_card, nao um arquivo fixado.
+// O helper lanca se a funcao sumir — importa porque metade das afirmacoes aqui e NEGATIVA
+// (`doesNotMatch`), e negativa sobre string vazia e verde para sempre.
+const cap = latestFunctionCapture(process.cwd(), 'get_member_comms_card');
+const sql = cap.block;
+// Codigo executavel apenas: o preambulo discute consent_status e o modelo #570, e o portao nao pode
+// USAR consent_status (padrao p697). Mascarar preserva offsets.
+const code = maskLineComments(sql);
 
 test('#729 (a) migration re-anchors get_member_comms_card as SECDEF with pinned search_path', () => {
-  assert.ok(sql, `migration file missing at expected path: ${MIGRATION}`);
+  assert.ok(sql, `captura vigente vazia (arquivo ${cap.file})`);
   assert.match(sql, /CREATE OR REPLACE FUNCTION public\.get_member_comms_card\(/);
   assert.match(sql, /SECURITY DEFINER/);
   assert.match(sql, /SET search_path TO 'public', 'pg_temp'/);

--- a/tests/contracts/consent-voice-biometric-ui.test.mjs
+++ b/tests/contracts/consent-voice-biometric-ui.test.mjs
@@ -69,6 +69,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
+import { latestFunctionCapture } from '../helpers/guard-pin-staleness.mjs';
 
 const ROOT = process.cwd();
 const MIGRATIONS_DIR = resolve(ROOT, 'supabase/migrations');
@@ -110,10 +111,13 @@ test('p238 #331: migration uses DROP+CREATE for both consent RPCs (not bare CREA
   );
 });
 
-test('p238 #331: give_consent_via_token takes p_evidence jsonb', () => {
-  const body = readFileSync(MIGRATION_FILE, 'utf8');
+// #1932 (lote PII/LGPD): a ASSINATURA vigente e invariante corrente. Fixado na 20260805000022, a
+// funcao foi redefinida na 20260808000300 — a afirmacao descrevia a assinatura de uma captura
+// vencida. O DROP da sobrecarga de 2 args e os blocos de sanity seguem fixados de proposito: sao
+// afirmacoes sobre o que a 022 entregou.
+test('p238 #331: give_consent_via_token takes p_evidence jsonb (captura vigente)', () => {
   assert.match(
-    body,
+    latestFunctionCapture(ROOT, 'give_consent_via_token').block,
     /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.give_consent_via_token\s*\([\s\S]*?p_evidence\s+jsonb\s+DEFAULT\s+NULL/i,
     'give_consent_via_token must take p_evidence jsonb DEFAULT NULL as 3rd arg'
   );

--- a/tests/contracts/lgpd-art-18-retroactive-deletion.test.mjs
+++ b/tests/contracts/lgpd-art-18-retroactive-deletion.test.mjs
@@ -62,6 +62,7 @@ import assert from 'node:assert/strict';
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createClient } from '@supabase/supabase-js';
+import { latestFunctionCapture } from '../helpers/guard-pin-staleness.mjs';
 
 const ROOT = process.cwd();
 const MIGRATIONS_DIR = resolve(ROOT, 'supabase/migrations');
@@ -73,6 +74,14 @@ const DOCS_FILE = resolve(
   ROOT,
   'docs/audit/lgpd-art11-remediation/notification_art18_interim_template.md'
 );
+
+// #1932 (lote PII/LGPD): SECDEF + search_path fixado e INVARIANTE CORRENTE de seguranca, entao
+// resolve a captura vigente. Este arquivo fixava a 20260805000023 e as duas RPCs foram redefinidas
+// na 20260805000024 (hotfix do FK de accessor_id) — as afirmacoes descreviam texto que a producao
+// nao executa mais. O resto do arquivo segue fixando de proposito: sao afirmacoes sobre o que a
+// 023 entregou (blocos de sanity, DROP de sobrecarga).
+const capRecord = latestFunctionCapture(ROOT, 'lgpd_record_retroactive_notification');
+const capDelete = latestFunctionCapture(ROOT, 'lgpd_execute_retroactive_deletion');
 
 const SUPABASE_URL = process.env.SUPABASE_URL || process.env.PUBLIC_SUPABASE_URL;
 const SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -102,17 +111,16 @@ test('p238 #332: migration adds deletion_artifacts jsonb column (IF NOT EXISTS, 
   );
 });
 
-test('p238 #332: both RPCs declared with SECDEF + pinned search_path', () => {
-  const body = readFileSync(MIGRATION_FILE, 'utf8');
+test('p238 #332: both RPCs declared with SECDEF + pinned search_path (captura vigente)', () => {
   // notification RPC
   assert.match(
-    body,
+    capRecord.block,
     /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.lgpd_record_retroactive_notification\s*\([\s\S]*?\)\s+RETURNS\s+jsonb\s+LANGUAGE\s+plpgsql\s+SECURITY\s+DEFINER\s+SET\s+search_path\s*=\s*'public',\s*'pg_temp'/i,
     'lgpd_record_retroactive_notification must be SECDEF with pinned search_path'
   );
   // deletion RPC
   assert.match(
-    body,
+    capDelete.block,
     /CREATE\s+OR\s+REPLACE\s+FUNCTION\s+public\.lgpd_execute_retroactive_deletion\s*\([\s\S]*?\)\s+RETURNS\s+jsonb\s+LANGUAGE\s+plpgsql\s+SECURITY\s+DEFINER\s+SET\s+search_path\s*=\s*'public',\s*'pg_temp'/i,
     'lgpd_execute_retroactive_deletion must be SECDEF with pinned search_path'
   );

--- a/tests/helpers/guard-pin-staleness.mjs
+++ b/tests/helpers/guard-pin-staleness.mjs
@@ -22,6 +22,11 @@
  * autoridade, onde a pergunta é "a função ainda faz X?" e não "a migration fez X?".
  *
  * Consumido por `tests/contracts/1932-guard-fixa-captura-vencida.test.mjs`.
+ *
+ * `latestFunctionCapture()` é a saída (1) da issue: o guard que afirma invariante CORRENTE resolve a
+ * captura mais nova daquela função em vez de fixar um arquivo. Um guard que a usa para a função X
+ * deixa de contar como dívida para X — o scanner reconhece a chamada e considera o par resolvido,
+ * então converter um guard tira a linha da base sozinho, sem edição manual da lista.
  */
 
 import { readdirSync, readFileSync } from 'node:fs';
@@ -38,11 +43,78 @@ const ASSERT_RE = new RegExp(
   'gi',
 );
 
-/** Caminho de migration fixado dentro de um arquivo de teste. Captura só a VERSÃO. */
-const PIN_RE = /supabase\/migrations\/(\d{8,})_[A-Za-z0-9_.\-]*\.sql/g;
+/**
+ * Migration fixada dentro de um arquivo de teste. Captura só a VERSÃO.
+ *
+ * DUAS formas, porque só a primeira era óbvia e a segunda é invisível para ela:
+ *
+ *   a) caminho inteiro num literal   `'supabase/migrations/20260805000130_x.sql'`
+ *   b) nome de arquivo SOZINHO       `resolve(MIGRATIONS_DIR, '20260805000023_x.sql')`
+ *
+ * A forma (b) aparece sempre que o diretório vira uma constante à parte, e nesses arquivos o único
+ * casamento da forma (a) costuma ser a linha do cabeçalho JSDoc que DOCUMENTA a migration. Ou seja:
+ * sem reconhecer (b), o guard lia o comentário e ignorava o código.
+ */
+const PIN_RE = /(?:supabase\/migrations\/|['"`])(\d{8,})_[A-Za-z0-9_.\-]*\.sql/g;
+
+/**
+ * Chamada que RESOLVE a dívida: `latestFunctionCapture(ROOT, 'nome_da_funcao')`. O par (guard, nome)
+ * que aparece aqui lê a captura vigente, então não é dívida — mesmo que o arquivo siga fixando
+ * outras migrations para afirmar entrega histórica.
+ */
+const RESOLVED_RE = /latestFunctionCapture\(\s*[^,)]+,\s*['"`]([a-z_][a-z0-9_]*)['"`]/g;
 
 /** Cabeçalho de definição no lado das migrations. */
 const DEF_RE = /\bCREATE\s+OR\s+REPLACE\s+FUNCTION\s+(?:"?public"?\s*\.\s*)?"?([a-z_][a-z0-9_]*)"?\s*\(/gi;
+
+
+/**
+ * Neutraliza comentários de linha SQL (`-- ...`) PRESERVANDO offsets: cada caractere comentado vira
+ * espaço, e as quebras de linha ficam. Assim a posição achada no texto mascarado indexa o texto
+ * ORIGINAL sem conversão.
+ *
+ * Existe porque o preâmbulo de migration costuma DESCREVER o que a migration faz, e a descrição
+ * contém o cabeçalho literal:
+ *
+ *     --   3. CREATE OR REPLACE FUNCTION public.lgpd_execute_retroactive_deletion(
+ *
+ * Sem mascarar, isso conta como definição: infla o catálogo, pode eleger a migration ERRADA como a
+ * mais nova de uma função, e faz o detector de sobrecarga acusar duas assinaturas onde há uma.
+ */
+export function maskLineComments(sql) {
+  return sql.replace(/--[^\n]*/g, (m) => ' '.repeat(m.length));
+}
+
+
+/**
+ * Neutraliza comentário JS, preservando offsets. Necessário pelo mesmo motivo do lado SQL: o
+ * cabeçalho JSDoc de um guard costuma DESCREVER a migration, e a descrição cita o cabeçalho
+ * literal da função:
+ *
+ *     *   - CREATE OR REPLACE FUNCTION lgpd_execute_retroactive_deletion — PM
+ *
+ * Sem mascarar, o arquivo conta como se afirmasse a definição daquela função, quando não afirma
+ * nada — nem em asserção aparece.
+ *
+ * Bloco `/* … *\/` é mascarado sempre. Linha `//` só quando abre a linha, porque um `//` no meio
+ * da linha pode ser parte de um literal de regex (`/a\/b/`) e mascarar ali comeria código.
+ */
+export function maskJsComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/^([ \t]*)\/\/[^\n]*/gm, (m, indent) => indent + ' '.repeat(m.length - indent.length));
+}
+
+/**
+ * Posições de nome que aparecem dentro de `assert.doesNotMatch(...)`. Ali o nome é afirmado como
+ * AUSENTE — "esta migration não pode redefinir X" — que é entrega histórica legítima e o oposto de
+ * depender da definição de X. Contar como dívida inverte o sentido da asserção.
+ */
+function dentroDeDoesNotMatch(src, idx) {
+  const janela = src.lastIndexOf('assert.', idx);
+  if (janela === -1) return false;
+  return src.startsWith('assert.doesNotMatch', janela);
+}
 
 /**
  * Catálogo: nome de função → a migration MAIS NOVA que a (re)define.
@@ -56,7 +128,7 @@ export function buildNewestDefinitions(migrationsDir) {
 
   for (const file of files) {
     const version = file.split('_')[0];
-    const sql = readFileSync(join(migrationsDir, file), 'utf8');
+    const sql = maskLineComments(readFileSync(join(migrationsDir, file), 'utf8'));
     DEF_RE.lastIndex = 0;
     let m;
     while ((m = DEF_RE.exec(sql)) !== null) {
@@ -91,9 +163,15 @@ export const pairKey = (guard, fn) => `${guard}|${fn}`;
  *
  * @param {string} root        raiz do repo
  * @param {Set<string>} skip   caminhos relativos a ignorar (o próprio guard, p.ex.)
+ * @param {{testsDir?:string, migrationsDir?:string}} dirs  sobrepõe os diretórios — existe para o
+ *        CONTROLE POSITIVO poder rodar sobre um fixture sintético. Sem isso, a única prova de que a
+ *        detecção funciona seria "ainda há dívida real no repo", que deixa de valer justamente
+ *        quando o trabalho termina.
  */
-export function scanStalePins(root, skip = new Set()) {
-  const { newest, migrationFileCount } = buildNewestDefinitions(join(root, 'supabase/migrations'));
+export function scanStalePins(root, skip = new Set(), dirs = {}) {
+  const migrationsDir = dirs.migrationsDir ?? join(root, 'supabase/migrations');
+  const testsDir = dirs.testsDir ?? join(root, 'tests');
+  const { newest, migrationFileCount } = buildNewestDefinitions(migrationsDir);
 
   let filesPinning = 0;
   // Quantos dos que fixam chegam a escrever um nome de função na forma que este scanner enxerga.
@@ -102,21 +180,29 @@ export function scanStalePins(root, skip = new Set()) {
   const pairs = [];
   const guards = new Set();
 
-  for (const abs of walkTests(join(root, 'tests'))) {
+  for (const abs of walkTests(testsDir)) {
     const rel = relative(root, abs);
     if (skip.has(rel)) continue;
 
-    const src = readFileSync(abs, 'utf8');
+    const src = maskJsComments(readFileSync(abs, 'utf8'));
     PIN_RE.lastIndex = 0;
     const pins = new Set([...src.matchAll(PIN_RE)].map((m) => m[1]));
     if (pins.size === 0) continue;
     filesPinning += 1;
 
     ASSERT_RE.lastIndex = 0;
-    const asserted = new Set([...src.matchAll(ASSERT_RE)].map((m) => m[1].toLowerCase()));
+    const asserted = new Set(
+      [...src.matchAll(ASSERT_RE)]
+        .filter((m) => !dentroDeDoesNotMatch(src, m.index))
+        .map((m) => m[1].toLowerCase()),
+    );
     if (asserted.size > 0) filesAsserting += 1;
 
+    RESOLVED_RE.lastIndex = 0;
+    const resolved = new Set([...src.matchAll(RESOLVED_RE)].map((m) => m[1].toLowerCase()));
+
     for (const fn of asserted) {
+      if (resolved.has(fn)) continue; // lê a captura vigente: não é dívida
       const def = newest.get(fn);
       if (!def) continue; // afirma função que nenhuma migration define: fora do escopo deste guard
       if (pins.has(def.version)) continue; // fixa a captura mais nova: em dia
@@ -135,4 +221,75 @@ export function parseBaseline(text) {
     .split('\n')
     .map((l) => l.trim())
     .filter((l) => l && !l.startsWith('#'));
+}
+
+/**
+ * A captura VIGENTE de uma função: o último `CREATE [OR REPLACE] FUNCTION public.<name>` em ordem
+ * cronológica de migration. É o que um guard de invariante corrente deve ler, no lugar de fixar um
+ * arquivo (saída (1) do #1932).
+ *
+ * ⚠️ LANÇA em vez de devolver vazio. Um helper que devolvesse `''` para função inexistente ou
+ * renomeada transformaria toda asserção do guard em `match('', ...)` — vermelho, tudo bem — mas
+ * `doesNotMatch('', ...)` ficaria VERDE, e é justamente a forma das asserções de PII ("não vaza
+ * hash", "não usa o campo errado"). Silêncio nessa direção é o defeito que o #1932 existe para pegar.
+ *
+ * @returns {{file:string, version:string, block:string, body:string}}
+ */
+export function latestFunctionCapture(root, name, migrationsDir = join(root, 'supabase/migrations')) {
+  const files = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql')).sort();
+  const headerRe = new RegExp(
+    `\\bCREATE\\s+(?:OR\\s+REPLACE\\s+)?FUNCTION\\s+(?:"?public"?\\s*\\.\\s*)?"?${name}"?\\s*\\(`,
+    'gi',
+  );
+
+  let hit = null;
+  for (const file of files) {
+    const original = readFileSync(join(migrationsDir, file), 'utf8');
+    // Busca no texto mascarado, fatia no ORIGINAL: o mascaramento preserva offsets de propósito,
+    // para o bloco devolvido conter os comentários que os guards às vezes afirmam.
+    const sql = maskLineComments(original);
+    headerRe.lastIndex = 0;
+    const starts = [];
+    let m;
+    while ((m = headerRe.exec(sql)) !== null) starts.push(m.index);
+    if (starts.length === 0) continue;
+
+    // Sobrecarga: duas assinaturas na MESMA migration tornam "o último bloco" uma escolha cega, e a
+    // escolha errada afirma sobre a função irmã. Nenhum alvo de hoje tem sobrecarga; se aparecer,
+    // este helper precisa passar a casar por assinatura — reprovar é melhor que adivinhar.
+    if (starts.length > 1) {
+      const distintas = new Set(
+        starts.map((i) => sql.slice(i, sql.indexOf(')', i) + 1).replace(/\s+/g, ' ')),
+      );
+      if (distintas.size > 1) {
+        throw new Error(
+          `latestFunctionCapture: ${name} tem ${distintas.size} assinaturas em ${file}. ` +
+            'O helper resolve por NOME e não sabe escolher; case por assinatura antes de usar.',
+        );
+      }
+    }
+
+    const start = starts[starts.length - 1];
+    const after = sql.slice(start);
+    const as = after.match(/\bAS\s+(\$[a-zA-Z_]*\$)/);
+    if (!as) continue;
+    const openAt = as.index + as[0].length;
+    const close = after.indexOf(as[1], openAt);
+    if (close === -1) continue;
+    const semi = after.indexOf(';', close + as[1].length);
+    hit = {
+      file,
+      version: file.split('_')[0],
+      block: original.slice(start, start + (semi === -1 ? close + as[1].length : semi + 1)),
+      body: original.slice(start + openAt, start + close),
+    };
+  }
+
+  if (!hit) {
+    throw new Error(
+      `latestFunctionCapture: nenhuma migration define public.${name}. ` +
+        'Função renomeada/removida, ou o nome está errado no guard.',
+    );
+  }
+  return hit;
 }


### PR DESCRIPTION
Os **7 pares de PII/LGPD** do #1932, que era o primeiro lote da saída (1). Converter cada um expôs **três defeitos no próprio scanner** que a #1936 landou, então a PR entrega as duas coisas.

## O mecanismo

`latestFunctionCapture(ROOT, 'nome')` resolve a definição mais nova em vez de fixar um arquivo. O scanner **reconhece a chamada**, então converter um guard tira a linha da base sozinho - a lista nunca precisa de edição manual, que é o que a faria virar depósito.

Cada arquivo mantém **fixado** o que é entrega histórica daquela migration (postura de GRANT, `DROP` de sobrecarga, blocos de sanity), rotulado como tal.

## Dois achados de conteúdo

**1. O portão do `admin_list_member_consents` é `can_org_by_member`, não `can_by_member`.** Era a instância provada do #1932. A asserção nova afirma o nome escopado **e nega o amplo**, para a volta ao portão fraco reprovar.

**2. A asserção do log de acesso estava errada; o invariante não.** O guard afirmava, sobre o arquivo inteiro, `doesNotMatch(/p_member_id <> v_caller_id/)` com a mensagem "self-read must NOT be excluded from the audit log" (LGPD Art. 37).

O invariante **vale** - conferi no corpo vivo: o `INSERT INTO pii_access_log` é incondicional. Mas a captura vigente usa exatamente essa comparação na **cerca de capítulo** ("self sempre permitido"), que não tem relação com o log. O proxy virou falso positivo.

Varredura de literal no corpo todo não diz de **qual construção** o literal é. Trocado por afirmação posicional: entre o último `END IF;` e o INSERT não pode abrir condicional. Provei que é não-vácua injetando o log atrás de um `IF`.

## Três defeitos do scanner, achados por tentar usar o resultado dele

| defeito | efeito |
|---|---|
| **comentário contava como afirmação** | o preâmbulo de migration *descreve* o que ela faz e cita o cabeçalho literal; o JSDoc de um guard faz o mesmo |
| **`assert.doesNotMatch` contava como dependência** | ali o nome é afirmado **ausente** ("esta migration não pode redefinir X") - o oposto de depender dele |
| **caminho partido era invisível** | `resolve(MIGRATIONS_DIR, '<versao>_x.sql')` nunca casava, e nesses arquivos o único casamento era a linha do JSDoc |

O terceiro é o que mais pesa: arquivos que fixam migration foram de **294 para 334**.

⚠️ **O `976` fica intocado.** O par dele era só um `doesNotMatch` - falso positivo, e fixar ali está certo. Consertar o guard teria sido consertar o que não estava quebrado.

## Linha de base: 172 → **174 pares / 104 guards**, movimento −13 / +15

Ela **subiu**, e isso é a leitura certa: as 13 que saíram são os 7 de PII mais os falsos positivos; as **15 que entraram são dívida real que estava invisível**. Um guard mais preciso enxerga mais, não menos.

## O ponto cego é maior do que eu tinha declarado

`export_my_data` estava vencida no `568` (fixada em 05/08, vigente em `20260808000100`) e **o scanner não a via**: aquele arquivo afirma trechos do corpo sem nunca escrever o cabeçalho. O ponto cego não é só por **arquivo** - é por **função dentro de arquivo visível**. Só apareceu na revisão manual do lote. Número corrigido no guard: **201 de 334** visíveis.

## Controle positivo trocado por fixture sintético

O antigo era ancorado na instância provada, e este lote a consertou. **Controle que morre quando o defeito é corrigido mede dívida restante, não capacidade de detectar.** O novo monta duas migrations e um guard num diretório temporário e exerce os três sentidos: fixado na antiga (detecta), fixado na nova (não detecta), convertido (não detecta).

## Verificação

- **injeções reprovam:** guard novo vencido · **forma partida** · desculpa vencida · entrada órfã
- `latestFunctionCapture` **lança** para função inexistente em vez de devolver vazio - importa porque as afirmações de PII são **negativas**, e `doesNotMatch('', ...)` é verde para sempre
- **ACL viva conferida nas 8 funções:** 7 fechadas a `anon`. `give_consent_via_token` aceita `anon` **por desenho** (GRANT explícito em duas migrations - consentimento por link, sem sessão). Verificado, não é defeito.
- `test:structural` **3608 testes, 0 fail, 0 skipped**; os 4 arquivos do lote **52/64** (12 puladas por credencial, rodam na CI); `npx astro build` completo; partição re-derivada OK

Refs #1932